### PR TITLE
Mount alembic/ in docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,7 @@ services:
       - ./data:/app/data
       - ./src:/app/src
       - ./scripts:/app/scripts # Mount scripts for development startup
+      - ./alembic:/app/alembic # Mount migrations so new revisions don't need an image rebuild
     command: ['/app/scripts/runtime/start-dev.sh'] # Override with dev startup script
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/health']


### PR DESCRIPTION
## Summary
- Adds `./alembic:/app/alembic` to the dev compose volume list so new migration files reach the container without `--build`.
- Same dev-loop ergonomics as `src/` edits; no production impact (production builds the image fresh).

Closes #44.

## Test plan
- [ ] Add a new migration on the host, run `dev up` (no `--build`), confirm the container picks it up via `alembic upgrade head` instead of crashlooping with `Can't locate revision identified by ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)