### PR TITLE
Run alembic upgrade head before dev seed

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,7 +86,7 @@ Run `dev --help` for the live, authoritative list. As of this writing:
 | `dev restart [service]` | Restart the whole dev environment or a single service. |
 | `dev test [-v] [--tb MODE] [-m MARKERS] [-k KEYWORDS] [path]` | Run pytest. `path` can be a directory, a file, or a `file::testname` selector. |
 | `dev lint` | Run black, isort, autoflake, and the title-case checker. Pre-commit runs the same checks automatically. |
-| `dev seed` | Seed the dev database with fixture users for manual testing. |
+| `dev seed` | Apply any pending Alembic migrations, then seed the dev database with fixture users for manual testing. Migrations run first so a freshly added revision doesn't cause the seed to crash against a stale schema. |
 | `dev routes [prefix]` | Print every HTTP route registered on `src.main:app` grouped by path prefix. Surfaces router shadowing — two `include_router` calls registering handlers on overlapping paths — without spinning up the server. |
 
 For per-command flag details, run `dev <command> --help`.

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -235,35 +235,48 @@ class SeedCommands:
         )
         return bool(result.stdout.strip())
 
-    def seed(self) -> int:
-        """Seed the dev database with fixture users."""
-        print("🌱 Seeding fixture users...")
-
-        seed_cmd = ["python", "scripts/dev/seed.py"]
+    def _wrap_for_compose(self, container_cmd: List[str]) -> List[str]:
         if self._is_dev_container_running():
-            cmd = [
+            return [
                 "docker",
                 "compose",
                 "-f",
                 DOCKER_COMPOSE_DEV_FILE,
                 "exec",
                 self.SERVICE_NAME,
-                *seed_cmd,
+                *container_cmd,
             ]
-        else:
-            print("ℹ️  Dev container not running — using one-off `docker compose run`")
-            cmd = [
-                "docker",
-                "compose",
-                "-f",
-                DOCKER_COMPOSE_DEV_FILE,
-                "run",
-                "--rm",
-                "--no-deps",
-                self.SERVICE_NAME,
-                *seed_cmd,
-            ]
-        return self.runner.run_command(cmd)
+        print("ℹ️  Dev container not running — using one-off `docker compose run`")
+        return [
+            "docker",
+            "compose",
+            "-f",
+            DOCKER_COMPOSE_DEV_FILE,
+            "run",
+            "--rm",
+            "--no-deps",
+            self.SERVICE_NAME,
+            *container_cmd,
+        ]
+
+    def seed(self) -> int:
+        """Seed the dev database with fixture users."""
+        # `dev seed` runs in a one-off `docker compose run --no-deps` container
+        # that bypasses start-dev.sh, so migrations must be applied explicitly
+        # here — otherwise a freshly added revision crashes seed against a
+        # stale schema with a raw OperationalError.
+        print("🧱 Applying migrations before seeding...")
+        migrate_cmd = self._wrap_for_compose(
+            ["alembic", "-c", "config/alembic.ini", "upgrade", "head"]
+        )
+        rc = self.runner.run_command(migrate_cmd)
+        if rc != 0:
+            print("❌ Migrations failed — aborting seed.")
+            return rc
+
+        print("🌱 Seeding fixture users...")
+        seed_cmd = self._wrap_for_compose(["python", "scripts/dev/seed.py"])
+        return self.runner.run_command(seed_cmd)
 
 
 class RoutesCommands:


### PR DESCRIPTION
## Summary
- `dev seed` now applies any pending Alembic migrations before invoking `seed.py`, inside the same compose context (works for both the running-container `exec` path and the one-off `run --rm --no-deps` path).
- Replaces the cryptic `sqlalchemy.exc.OperationalError: no such table: ...` failure mode that hit users immediately after adding a new migration.
- Aborts cleanly with a clear message if migrations fail, instead of attempting to seed against a stale schema.

Closes #45.

## Test plan
- [ ] Add a new migration, run `dev seed` against a stopped dev container — confirm it applies the migration via the one-off `docker compose run` and then seeds successfully.
- [ ] Run `dev seed` while `dev up` is running — confirm migrations + seed both run via `docker compose exec`.
- [ ] Force a bad migration and confirm the seed step is skipped with the "Migrations failed — aborting seed." message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)