### PR TITLE
Add admin bootstrap CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Every `src/<module>/` has its own README describing what it does, what it doesn'
 ### Supporting documentation
 
 - [`alembic/README.md`](alembic/README.md) — database migrations
-- [`deployment/README.md`](deployment/README.md) — deployment procedures
+- [`deployment/README.md`](deployment/README.md) — deployment procedures, including [bootstrapping the first admin user](deployment/README.md#bootstrapping-an-admin)
 - [`notes/README.md`](notes/README.md) — development notes and planning
 
 ## Prerequisites

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -19,7 +19,8 @@ deployment/
 ├── droplet-files/               # Files deployed to /opt/bedlam-connect/ on droplet
 │   ├── deploy.sh               # Main deployment script (blue-green)
 │   ├── docker-compose.blue-green.yml  # Docker Compose configuration
-│   └── cleanup-docker.sh       # Docker cleanup utility
+│   ├── cleanup-docker.sh       # Docker cleanup utility
+│   └── promote-admin.sh        # Bootstrap/manage admin users on prod
 └── scripts/                    # Helper scripts (future use)
 ```
 
@@ -68,6 +69,23 @@ The `deploy.sh` script implements zero-downtime deployment:
 - Blue instance: `localhost:8001`
 - Green instance: `localhost:8002`
 - Nginx proxies `aimagain.art` to the active instance
+
+## 🔑 Bootstrapping an admin
+
+The app has no admin user out of the box, and admin actions (delete user, deactivate user) require `is_superuser=True`. Promote an existing registered user to admin via the wrapper script that ships with deployment files:
+
+```bash
+ssh user@your-droplet-ip
+cd /opt/bedlam-connect
+./promote-admin you@example.com           # grant
+./promote-admin you@example.com --revoke  # revoke
+```
+
+The wrapper auto-detects the running blue/green container and execs the promotion script inside it — no `docker exec` incantation to remember. It's idempotent (safe to re-run) and refuses on a missing user (won't auto-create from a typo).
+
+**First-run note:** if the wrapper isn't executable after SCP, run `chmod +x promote-admin.sh` once. The script is sourced from [`droplet-files/promote-admin.sh`](droplet-files/promote-admin.sh) and deployed automatically alongside `deploy.sh` and the compose file.
+
+Locally, the equivalent is `dev promote-admin <email>` — see [`../scripts/README.md`](../scripts/README.md).
 
 ## 🚨 Manual deployment (emergency)
 

--- a/deployment/droplet-files/promote-admin.sh
+++ b/deployment/droplet-files/promote-admin.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Bootstrap or manage admin users on the production droplet.
+#
+# Auto-detects the running blue or green container and execs the Python
+# promotion script inside it. No docker-compose knowledge required at the
+# call site.
+#
+# Usage:
+#     ./promote-admin <email>           # grant admin
+#     ./promote-admin <email> --revoke  # revoke admin
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <email> [--revoke]" >&2
+    exit 2
+fi
+
+CONTAINER=""
+for color in blue green; do
+    name="bedlam-connect-$color"
+    if [ -n "$(docker ps --format '{{.Names}}' --filter "name=^${name}$")" ]; then
+        CONTAINER="$name"
+        break
+    fi
+done
+
+if [ -z "$CONTAINER" ]; then
+    echo "❌ No running bedlam-connect container found." >&2
+    echo "   Looked for: bedlam-connect-blue, bedlam-connect-green" >&2
+    echo "   Currently running:" >&2
+    docker ps --format 'table {{.Names}}\t{{.Status}}' >&2
+    exit 1
+fi
+
+echo "🔧 Running promote_admin against $CONTAINER..."
+exec docker exec "$CONTAINER" python scripts/dev/promote_admin.py "$@"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,6 +88,7 @@ Run `dev --help` for the live, authoritative list. As of this writing:
 | `dev lint` | Run black, isort, autoflake, and the title-case checker. Pre-commit runs the same checks automatically. |
 | `dev seed` | Apply any pending Alembic migrations, then seed the dev database with fixture users for manual testing. Migrations run first so a freshly added revision doesn't cause the seed to crash against a stale schema. |
 | `dev routes [prefix]` | Print every HTTP route registered on `src.main:app` grouped by path prefix. Surfaces router shadowing — two `include_router` calls registering handlers on overlapping paths — without spinning up the server. |
+| `dev promote-admin <email> [--revoke]` | Grant or revoke admin (`is_superuser`) status for a user matched by email. Idempotent. Errors if no user matches. Runs inside the dev container. For the prod equivalent see [`deployment/README.md`](../deployment/README.md#bootstrapping-an-admin). |
 
 For per-command flag details, run `dev <command> --help`.
 
@@ -99,6 +100,12 @@ dev --help
 ```
 
 Without `pip install -e .`, the CLI is also runnable directly: `python3 scripts/dev_cli.py <command>` or `./scripts/dev_cli.py <command>`.
+
+### `dev/promote_admin.py`
+
+Async script that flips `is_superuser` on a user matched by email. Used by `dev promote-admin` (local) and `deployment/droplet-files/promote-admin.sh` (production). Idempotent — re-running with the same target value is a no-op. Refuses to auto-create users on a typo (would silently mint a ghost admin).
+
+Tests: [`../tests/test_promote_admin.py`](../tests/test_promote_admin.py).
 
 ### `title_case_check.py`
 

--- a/scripts/dev/promote_admin.py
+++ b/scripts/dev/promote_admin.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Promote (or revoke) a user's admin status by email.
+
+Idempotent:
+  - If the user already has the desired is_superuser value, exits 0 with no change.
+  - If the user does not exist, exits non-zero (no auto-create — a typo would
+    silently mint a ghost admin).
+
+Run inside the app container. On the dev environment, prefer `dev promote-admin
+<email>`. On the production droplet, prefer `./promote-admin <email>` (the
+wrapper at deployment/droplet-files/promote-admin.sh).
+"""
+
+import argparse
+import asyncio
+import sys
+
+from sqlalchemy import select
+
+from src.db import async_session_maker
+from src.models import User
+
+
+async def set_admin(email: str, revoke: bool) -> int:
+    target = not revoke
+    verb = "revoke" if revoke else "promote"
+
+    async with async_session_maker() as session:
+        result = await session.execute(select(User).where(User.email == email))
+        user = result.scalar_one_or_none()
+
+        if user is None:
+            print(f"❌ No user with email {email}", file=sys.stderr)
+            return 1
+
+        if user.is_superuser == target:
+            print(f"⏭️  {email} is_superuser already {target} — nothing to {verb}")
+            return 0
+
+        user.is_superuser = target
+        await session.commit()
+
+        action = "revoked admin from" if revoke else "promoted to admin"
+        print(f"✅ {action} {email} (is_superuser={target})")
+        return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Promote or revoke a user's admin status by email.",
+    )
+    parser.add_argument("email", help="Email address of the user to (de)promote")
+    parser.add_argument(
+        "--revoke",
+        action="store_true",
+        help="Revoke admin status instead of granting it",
+    )
+    args = parser.parse_args()
+    return asyncio.run(set_admin(args.email, args.revoke))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -53,6 +53,55 @@ class CLIRunner:
             print(f"❌ Error running command: {e}")
             return 1
 
+    def is_dev_container_running(self, service_name: str) -> bool:
+        """Check if a docker compose service has any running containers."""
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                DOCKER_COMPOSE_DEV_FILE,
+                "ps",
+                "-q",
+                service_name,
+            ],
+            capture_output=True,
+            text=True,
+            cwd=self.project_root,
+        )
+        return bool(result.stdout.strip())
+
+    def wrap_for_compose(
+        self, service_name: str, container_cmd: List[str]
+    ) -> List[str]:
+        """Wrap a command to run inside the dev container.
+
+        Uses `docker compose exec` if the service is already running, otherwise
+        falls back to `docker compose run --rm --no-deps` for one-off invocations.
+        """
+        if self.is_dev_container_running(service_name):
+            return [
+                "docker",
+                "compose",
+                "-f",
+                DOCKER_COMPOSE_DEV_FILE,
+                "exec",
+                service_name,
+                *container_cmd,
+            ]
+        print("ℹ️  Dev container not running — using one-off `docker compose run`")
+        return [
+            "docker",
+            "compose",
+            "-f",
+            DOCKER_COMPOSE_DEV_FILE,
+            "run",
+            "--rm",
+            "--no-deps",
+            service_name,
+            *container_cmd,
+        ]
+
     def check_docker_installation(self) -> bool:
         """Check if Docker and Docker Compose are available."""
         # Check Docker
@@ -218,47 +267,6 @@ class SeedCommands:
     def __init__(self, runner: CLIRunner):
         self.runner = runner
 
-    def _is_dev_container_running(self) -> bool:
-        result = subprocess.run(
-            [
-                "docker",
-                "compose",
-                "-f",
-                DOCKER_COMPOSE_DEV_FILE,
-                "ps",
-                "-q",
-                self.SERVICE_NAME,
-            ],
-            capture_output=True,
-            text=True,
-            cwd=self.runner.project_root,
-        )
-        return bool(result.stdout.strip())
-
-    def _wrap_for_compose(self, container_cmd: List[str]) -> List[str]:
-        if self._is_dev_container_running():
-            return [
-                "docker",
-                "compose",
-                "-f",
-                DOCKER_COMPOSE_DEV_FILE,
-                "exec",
-                self.SERVICE_NAME,
-                *container_cmd,
-            ]
-        print("ℹ️  Dev container not running — using one-off `docker compose run`")
-        return [
-            "docker",
-            "compose",
-            "-f",
-            DOCKER_COMPOSE_DEV_FILE,
-            "run",
-            "--rm",
-            "--no-deps",
-            self.SERVICE_NAME,
-            *container_cmd,
-        ]
-
     def seed(self) -> int:
         """Seed the dev database with fixture users."""
         # `dev seed` runs in a one-off `docker compose run --no-deps` container
@@ -266,8 +274,9 @@ class SeedCommands:
         # here — otherwise a freshly added revision crashes seed against a
         # stale schema with a raw OperationalError.
         print("🧱 Applying migrations before seeding...")
-        migrate_cmd = self._wrap_for_compose(
-            ["alembic", "-c", "config/alembic.ini", "upgrade", "head"]
+        migrate_cmd = self.runner.wrap_for_compose(
+            self.SERVICE_NAME,
+            ["alembic", "-c", "config/alembic.ini", "upgrade", "head"],
         )
         rc = self.runner.run_command(migrate_cmd)
         if rc != 0:
@@ -275,8 +284,26 @@ class SeedCommands:
             return rc
 
         print("🌱 Seeding fixture users...")
-        seed_cmd = self._wrap_for_compose(["python", "scripts/dev/seed.py"])
+        seed_cmd = self.runner.wrap_for_compose(
+            self.SERVICE_NAME, ["python", "scripts/dev/seed.py"]
+        )
         return self.runner.run_command(seed_cmd)
+
+
+class PromoteAdminCommands:
+    """Promote / revoke admin status by email."""
+
+    SERVICE_NAME = "bedlam-connect-dev"
+
+    def __init__(self, runner: CLIRunner):
+        self.runner = runner
+
+    def run(self, email: str, revoke: bool) -> int:
+        container_cmd = ["python", "scripts/dev/promote_admin.py", email]
+        if revoke:
+            container_cmd.append("--revoke")
+        cmd = self.runner.wrap_for_compose(self.SERVICE_NAME, container_cmd)
+        return self.runner.run_command(cmd)
 
 
 class RoutesCommands:
@@ -411,6 +438,7 @@ class DevCLI:
         self.setup = SetupCommands(self.runner)
         self.seed_cmd = SeedCommands(self.runner)
         self.routes_cmd = RoutesCommands(self.runner)
+        self.promote_admin_cmd = PromoteAdminCommands(self.runner)
 
     def create_parser(self) -> argparse.ArgumentParser:
         """Create the argument parser with all commands."""
@@ -443,6 +471,7 @@ Examples:
         self._add_setup_parser(subparsers)
         self._add_seed_parser(subparsers)
         self._add_routes_parser(subparsers)
+        self._add_promote_admin_parser(subparsers)
 
         return parser
 
@@ -524,6 +553,21 @@ Examples:
             help="Filter by path prefix (e.g. /users)",
         )
         parser.set_defaults(func=lambda args: self.routes_cmd.list_routes(args.prefix))
+
+    def _add_promote_admin_parser(self, subparsers):
+        parser = subparsers.add_parser(
+            "promote-admin",
+            help="Grant or revoke admin (is_superuser) status for a user by email",
+        )
+        parser.add_argument("email", help="Email address of the user to (de)promote")
+        parser.add_argument(
+            "--revoke",
+            action="store_true",
+            help="Revoke admin status instead of granting it",
+        )
+        parser.set_defaults(
+            func=lambda args: self.promote_admin_cmd.run(args.email, args.revoke)
+        )
 
     def run(self) -> int:
         """Run the CLI application."""

--- a/tests/test_promote_admin.py
+++ b/tests/test_promote_admin.py
@@ -1,0 +1,86 @@
+"""Tests for `scripts/dev/promote_admin.py`.
+
+The script flips `is_superuser` on a user matched by email. The admin
+bootstrap CLI on prod uses it, so the no-op-on-missing-user and idempotency
+guarantees are load-bearing — a typo would silently mint a ghost admin
+without them, and re-running the bootstrap should be safe.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from src.models import User
+from tests.fixtures import test_async_session_maker as session_maker
+from tests.helpers import create_test_user
+
+# Load the script as a module without needing scripts/dev on PYTHONPATH.
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "scripts" / "dev" / "promote_admin.py"
+)
+_spec = importlib.util.spec_from_file_location("promote_admin", _SCRIPT)
+promote_admin = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(promote_admin)
+
+
+@pytest.fixture(autouse=True)
+def patch_session_maker(monkeypatch):
+    """Point the script at the in-memory test database."""
+    monkeypatch.setattr(promote_admin, "async_session_maker", session_maker)
+
+
+async def _insert_user(email: str, is_superuser: bool) -> None:
+    async with session_maker() as session:
+        async with session.begin():
+            session.add(create_test_user(email=email, is_superuser=is_superuser))
+
+
+async def _is_superuser(email: str) -> bool:
+    async with session_maker() as session:
+        result = await session.execute(select(User).where(User.email == email))
+        return result.scalar_one().is_superuser
+
+
+async def test_promotes_non_admin_user(db_test_session_manager):
+    await _insert_user("alice@example.com", is_superuser=False)
+
+    rc = await promote_admin.set_admin("alice@example.com", revoke=False)
+
+    assert rc == 0
+    assert await _is_superuser("alice@example.com") is True
+
+
+async def test_promote_is_idempotent(db_test_session_manager):
+    await _insert_user("alice@example.com", is_superuser=True)
+
+    rc = await promote_admin.set_admin("alice@example.com", revoke=False)
+
+    assert rc == 0
+    assert await _is_superuser("alice@example.com") is True
+
+
+async def test_revokes_admin(db_test_session_manager):
+    await _insert_user("alice@example.com", is_superuser=True)
+
+    rc = await promote_admin.set_admin("alice@example.com", revoke=True)
+
+    assert rc == 0
+    assert await _is_superuser("alice@example.com") is False
+
+
+async def test_revoke_is_idempotent(db_test_session_manager):
+    await _insert_user("alice@example.com", is_superuser=False)
+
+    rc = await promote_admin.set_admin("alice@example.com", revoke=True)
+
+    assert rc == 0
+    assert await _is_superuser("alice@example.com") is False
+
+
+async def test_missing_user_returns_error(db_test_session_manager, capsys):
+    rc = await promote_admin.set_admin("ghost@example.com", revoke=False)
+
+    assert rc == 1
+    assert "No user with email ghost@example.com" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Prod currently has no admin user and no in-app way to mint one. This PR adds a CLI-based bootstrap that works the same way locally and on the droplet.
- New script `scripts/dev/promote_admin.py` flips `is_superuser` by email — idempotent, refuses to auto-create on a typo.
- `dev promote-admin <email> [--revoke]` runs it locally; `deployment/droplet-files/promote-admin.sh` runs it on prod (auto-detects the running blue/green container, no docker incantation to remember). The prod wrapper is auto-deployed via the existing SCP step.

## Test plan

- [x] `dev test` (52 passed, 1 skipped) — including 5 new tests for `promote_admin`: promote, revoke, both idempotency cases, missing-user path.
- [x] `dev lint` — all formatters/linters pass.
- [ ] After merge + deploy, on the droplet: `cd /opt/bedlam-connect && ./promote-admin you@example.com` → log in to https://aimagain.art and confirm admin actions are visible.
- [ ] Re-run the same command — confirm idempotent ("already true — nothing to promote").
- [ ] `./promote-admin you@example.com --revoke` → confirm admin actions disappear.
- [ ] `./promote-admin nobody@nowhere.com` → confirm exit 1 and clear error.

## First-run note

The wrapper only exists on the droplet *after* this PR's deploy lands. The very first prod bootstrap therefore still needs a manual `docker exec` (or one-time SCP of the script). After that, the wrapper is automatic on every deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)