### PR TITLE
Add `dev fmt` subcommand for auto-fixing formatting

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,11 +86,14 @@ Run `dev --help` for the live, authoritative list. As of this writing:
 | `dev restart [service]` | Restart the whole dev environment or a single service. |
 | `dev test [-v] [--tb MODE] [-m MARKERS] [-k KEYWORDS] [path]` | Run pytest. `path` can be a directory, a file, or a `file::testname` selector. |
 | `dev lint` | Run black, isort, autoflake, and the title-case checker. Pre-commit runs the same checks automatically. |
+| `dev fmt` | Auto-fix formatting in place by running `black .` and `isort .` in write mode. The natural pre-commit companion to `dev lint`. |
 | `dev seed` | Apply any pending Alembic migrations, then seed the dev database with fixture users for manual testing. Migrations run first so a freshly added revision doesn't cause the seed to crash against a stale schema. |
 | `dev routes [prefix]` | Print every HTTP route registered on `src.main:app` grouped by path prefix. Surfaces router shadowing — two `include_router` calls registering handlers on overlapping paths — without spinning up the server. |
 | `dev promote-admin <email> [--revoke]` | Grant or revoke admin (`is_superuser`) status for a user matched by email. Idempotent. Errors if no user matches. Runs inside the dev container. For the prod equivalent see [`deployment/README.md`](../deployment/README.md#bootstrapping-an-admin). |
 
 For per-command flag details, run `dev <command> --help`.
+
+Recommended local workflow: write code → `dev fmt` → `dev test`.
 
 #### Installation
 

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -258,6 +258,29 @@ class QualityCommands:
 
         return exit_code
 
+    def fmt(self) -> int:
+        """Auto-fix formatting by running black and isort in write mode."""
+        print("🎨 Applying formatters...")
+
+        steps = [
+            ("📝 Formatting code with black...", ["black", "."]),
+            ("🔤 Sorting imports with isort...", ["isort", "."]),
+        ]
+
+        exit_code = 0
+        for description, cmd in steps:
+            print(description)
+            result = self.runner.run_command(cmd)
+            if result != 0:
+                exit_code = result
+
+        if exit_code == 0:
+            print("✅ Formatting applied")
+        else:
+            print("❌ Formatting failed")
+
+        return exit_code
+
 
 class SeedCommands:
     """Database seeding commands."""
@@ -468,6 +491,7 @@ Examples:
         # Other commands
         self._add_test_parser(subparsers)
         self._add_lint_parser(subparsers)
+        self._add_fmt_parser(subparsers)
         self._add_setup_parser(subparsers)
         self._add_seed_parser(subparsers)
         self._add_routes_parser(subparsers)
@@ -531,6 +555,12 @@ Examples:
     def _add_lint_parser(self, subparsers):
         parser = subparsers.add_parser("lint", help="Run linting checks")
         parser.set_defaults(func=lambda args: self.quality.lint())
+
+    def _add_fmt_parser(self, subparsers):
+        parser = subparsers.add_parser(
+            "fmt", help="Auto-fix formatting (runs black and isort in write mode)"
+        )
+        parser.set_defaults(func=lambda args: self.quality.fmt())
 
     def _add_setup_parser(self, subparsers):
         parser = subparsers.add_parser("setup", help="Set up development environment")


### PR DESCRIPTION
## Summary

- Adds a `dev fmt` subcommand that runs `black .` and `isort .` in write mode (the auto-fix counterpart to `dev lint`).
- Wires it into argparse via `_add_fmt_parser`, mirroring the lint setup.
- Documents the new command in the canonical CLI table in `scripts/README.md` and recommends the `write → dev fmt → dev test` local workflow.
- Existing `dev lint` behavior is unchanged.

Closes #50.

## Test plan

- [x] `dev lint` passes.
- [x] `dev test` passes (52 passed, 1 skipped).
- [x] `dev fmt` reformats a file with intentional formatting violations and exits 0.
- [x] `dev fmt` exits 0 cleanly when no changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)