### PR TITLE
Rename test_async_session_maker to silence pytest collection warning

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -25,7 +25,7 @@ from src.schemas.user import UserCreate  # Import UserCreate schema
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
 test_engine = create_async_engine(TEST_DATABASE_URL)
-test_async_session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+async_test_sessionmaker = async_sessionmaker(test_engine, expire_on_commit=False)
 
 
 # Master fixture to manage table creation/dropping and provide session maker
@@ -37,7 +37,7 @@ async def db_test_session_manager() -> (
     async with test_engine.begin() as conn:
         await conn.run_sync(metadata.create_all)
 
-    yield test_async_session_maker  # Provide the session maker to tests
+    yield async_test_sessionmaker  # Provide the session maker to tests
 
     # Drop tables after test finishes
     async with test_engine.begin() as conn:
@@ -45,10 +45,10 @@ async def db_test_session_manager() -> (
 
 
 # Override for the raw AsyncSession dependency
-# Uses the globally defined test_async_session_maker
+# Uses the globally defined async_test_sessionmaker
 # Table lifecycle managed by db_test_session_manager fixture
 async def override_get_db_session() -> AsyncGenerator[AsyncSession, None]:
-    async with test_async_session_maker() as session:
+    async with async_test_sessionmaker() as session:
         yield session
 
 

--- a/tests/test_promote_admin.py
+++ b/tests/test_promote_admin.py
@@ -13,7 +13,7 @@ import pytest
 from sqlalchemy import select
 
 from src.models import User
-from tests.fixtures import test_async_session_maker as session_maker
+from tests.fixtures import async_test_sessionmaker
 from tests.helpers import create_test_user
 
 # Load the script as a module without needing scripts/dev on PYTHONPATH.
@@ -28,17 +28,17 @@ _spec.loader.exec_module(promote_admin)
 @pytest.fixture(autouse=True)
 def patch_session_maker(monkeypatch):
     """Point the script at the in-memory test database."""
-    monkeypatch.setattr(promote_admin, "async_session_maker", session_maker)
+    monkeypatch.setattr(promote_admin, "async_session_maker", async_test_sessionmaker)
 
 
 async def _insert_user(email: str, is_superuser: bool) -> None:
-    async with session_maker() as session:
+    async with async_test_sessionmaker() as session:
         async with session.begin():
             session.add(create_test_user(email=email, is_superuser=is_superuser))
 
 
 async def _is_superuser(email: str) -> bool:
-    async with session_maker() as session:
+    async with async_test_sessionmaker() as session:
         result = await session.execute(select(User).where(User.email == email))
         return result.scalar_one().is_superuser
 


### PR DESCRIPTION
## Summary
- Rename module-level `test_async_session_maker` in `tests/fixtures.py` to `async_test_sessionmaker` so pytest stops trying to collect it as a test on every import.
- Update `tests/test_promote_admin.py` to import the new name directly (drops the `as session_maker` alias that was working around the issue).

Closes #51

## Test plan
- [x] `dev lint` passes
- [x] `dev test` passes (52 passed, 1 skipped)
- [x] `pytest ... 2>&1 | grep -i 'pytestcollection'` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)