### PR TITLE
Make scripts/dev/ importable as a package

### DIFF
--- a/scripts/dev/__init__.py
+++ b/scripts/dev/__init__.py
@@ -1,0 +1,1 @@
+"""Dev scripts package — importable so tests don't need importlib boilerplate."""

--- a/tests/README.md
+++ b/tests/README.md
@@ -110,6 +110,10 @@ async def test_with_extra_user(authenticated_client, db_test_session_manager):
     # ...
 ```
 
+## Testing scripts under `scripts/dev/`
+
+`scripts/` and `scripts/dev/` are regular Python packages (each has an `__init__.py`), so test files can import script modules with a normal `from scripts.dev import promote_admin` rather than loading them via `importlib.util.spec_from_file_location`. The scripts remain runnable as standalone files (e.g. `python scripts/dev/seed.py`) — the package marker doesn't change that.
+
 ## Related documentation
 
 - [`../CLAUDE.md`](../CLAUDE.md) — the doc/test/code coupling contract

--- a/tests/test_promote_admin.py
+++ b/tests/test_promote_admin.py
@@ -6,23 +6,13 @@ guarantees are load-bearing — a typo would silently mint a ghost admin
 without them, and re-running the bootstrap should be safe.
 """
 
-import importlib.util
-from pathlib import Path
-
 import pytest
 from sqlalchemy import select
 
+from scripts.dev import promote_admin
 from src.models import User
 from tests.fixtures import async_test_sessionmaker
 from tests.helpers import create_test_user
-
-# Load the script as a module without needing scripts/dev on PYTHONPATH.
-_SCRIPT = (
-    Path(__file__).resolve().parent.parent / "scripts" / "dev" / "promote_admin.py"
-)
-_spec = importlib.util.spec_from_file_location("promote_admin", _SCRIPT)
-promote_admin = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(promote_admin)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_title_case_check.py
+++ b/tests/test_title_case_check.py
@@ -7,18 +7,10 @@ mistaken for level-1 headings, which causes spurious lint failures and was
 the source of recurring friction during agent-driven doc edits.
 """
 
-import importlib.util
 import textwrap
 from pathlib import Path
 
-# Load the script as a module without depending on it being on PYTHONPATH.
-_SCRIPT = (
-    Path(__file__).resolve().parent.parent / "scripts" / "dev" / "title_case_check.py"
-)
-_spec = importlib.util.spec_from_file_location("title_case_check", _SCRIPT)
-_module = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_module)
-TitleCaseChecker = _module.TitleCaseChecker
+from scripts.dev.title_case_check import TitleCaseChecker
 
 
 def _write_md(tmp_path: Path, body: str) -> Path:


### PR DESCRIPTION
## Summary

- Add `scripts/dev/__init__.py` so `scripts/dev/` is a proper Python package.
- Refactor `tests/test_title_case_check.py` and `tests/test_promote_admin.py` to use plain `from scripts.dev import ...` imports instead of `importlib.util.spec_from_file_location` boilerplate.
- Document the pattern in `tests/README.md`.

Went with **Option A** (preferred). `scripts/__init__.py` already existed and `pyproject.toml`'s `[tool.setuptools.packages.find]` already includes `scripts*`, so adding the `dev/` package marker was sufficient. No pytest discovery issues; existing 52 passed / 1 skipped count is unchanged. The scripts remain runnable as standalone files because they use absolute `from src...` imports, not relative imports.

Closes #52

## Test plan

- [x] `dev lint` passes
- [x] `dev test` passes (52 passed, 1 skipped — same as before)
- [x] `scripts/dev_cli.py` still invokes scripts via `python scripts/dev/<name>.py` paths, which work regardless of package status