### PR TITLE
Add `POST /posts` create endpoint (JSON-only)

### DIFF
--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -73,7 +73,7 @@ Routes are organized by domain with consistent delegation patterns.
 | Route File         | Domain               | Primary Responsibilities         | Main Endpoints                                                                                                                  | Dependencies          |
 | ------------------ | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | **users.py**       | User data            | User listing, detail, admin actions | `GET /users`, `GET /users/{id}`, `PUT /users/{id}/activation` (admin), `DELETE /users/{id}` (admin)                          | UserRepository        |
-| **posts.py**       | Posts                | Post listing and detail (READ only — write endpoints to come) | `GET /posts`, `GET /posts/{id}`                                                                                              | PostRepository        |
+| **posts.py**       | Posts                | Post listing, detail, and create (PATCH/edit-form to come) | `GET /posts`, `GET /posts/{id}`, `POST /posts`                                                                              | PostRepository        |
 | **me.py**          | Current user context | User profile, current-user JSON  | `GET /users/me`, `GET /users/me/profile`                                                                                        | Auth                  |
 | **auth_routes.py** | Authentication API   | Login, register, password reset  | `/auth/*`                                                                                                                       | Authentication logic  |
 | **auth_pages.py**  | Authentication UI    | Login, register forms            | `/login`, `/register`                                                                                                           | Authentication logic  |
@@ -83,7 +83,7 @@ Routes are organized by domain with consistent delegation patterns.
 **Domain route files:**
 
 - `users.py` - User listing and access
-- `posts.py` - Post listing and detail (read-only; write endpoints come later)
+- `posts.py` - Post listing, detail, and create (`POST /posts` is JSON-only for now; the HTML create form and PATCH come in follow-up PRs)
 - `me.py` - Current user's profile
 
 **Authentication routes:**
@@ -285,7 +285,7 @@ Colocated alongside the routes:
 
 - `test_auth_routes.py` — registration, login, logout, password reset, session protection (covers `auth_routes.py` and `auth_pages.py`).
 - `test_users.py` — `GET /users` listing behavior (covers `users.py`).
-- `test_posts.py` — `GET /posts` and `GET /posts/{id}` (covers `posts.py`).
+- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, and `POST /posts` including the `extra="forbid"` scrub of `owner_id` (covers `posts.py`).
 
 When adding a new route, add (or extend) a `test_*.py` file in this same directory. Shared fixtures (`test_client`, `authenticated_client`, `db_test_session_manager`, `logged_in_user`) come from [`tests/fixtures.py`](../../../tests/fixtures.py); user-construction helpers from [`tests/helpers.py`](../../../tests/helpers.py).
 

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -1,14 +1,20 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, status
+from fastapi.responses import JSONResponse
 
 from src.api.common import APIResponse, BaseRouter
 from src.auth_config import current_active_user
-from src.logic.post_processing import handle_get_post_detail, handle_list_posts
+from src.logic.post_processing import (
+    handle_create_post,
+    handle_get_post_detail,
+    handle_list_posts,
+)
 from src.models import User
 from src.repositories.dependencies import get_post_repository
 from src.repositories.post_repository import PostRepository
+from src.schemas.post import PostCreate
 
 posts_api_router = APIRouter(prefix="/posts")
 router = BaseRouter(router=posts_api_router, default_tags=["posts"])
@@ -50,4 +56,28 @@ async def get_post(
     )
     return APIResponse.html_response(
         template_name="posts/detail.html", context=context, request=request
+    )
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_post(
+    payload: PostCreate,
+    post_repo: PostRepository = Depends(get_post_repository),
+    user: User = Depends(current_active_user),
+):
+    """Creates a post owned by the authenticated user.
+
+    `owner_id` is server-set from the session; clients sending it (or any
+    other unknown field) are rejected with 422 by the schema.
+    """
+    created = await handle_create_post(
+        payload=payload,
+        post_repo=post_repo,
+        requesting_user=user,
+    )
+    location = f"/posts/{created.id}"
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={"id": str(created.id)},
+        headers={"Location": location, "HX-Redirect": location},
     )

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -3,6 +3,7 @@ import uuid
 import pytest
 from httpx import AsyncClient
 from selectolax.parser import HTMLParser
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import Post, User
@@ -154,3 +155,125 @@ async def test_get_post_detail_malformed_uuid_422(
     """GET /posts/{not-a-uuid} returns 422 (FastAPI path validation)."""
     response = await authenticated_client.get("/posts/not-a-uuid")
     assert response.status_code == 422
+
+
+# --- Create --------------------------------------------------------------
+
+
+async def test_create_post_happy_path(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """POST /posts persists the post owned by the session user and returns 201
+    with Location + HX-Redirect headers."""
+    title = f"new-{uuid.uuid4()}"
+    body = f"body-{uuid.uuid4()}"
+
+    response = await authenticated_client.post(
+        "/posts", json={"title": title, "body": body}
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert "id" in payload
+    new_id = uuid.UUID(payload["id"])
+    expected_location = f"/posts/{new_id}"
+    assert response.headers.get("Location") == expected_location
+    assert response.headers.get("HX-Redirect") == expected_location
+
+    # Persisted, owned by the logged-in user
+    async with db_test_session_manager() as session:
+        result = await session.execute(select(Post).filter(Post.id == new_id))
+        persisted = result.scalars().first()
+        assert persisted is not None
+        assert persisted.title == title
+        assert persisted.body == body
+        assert persisted.owner_id == logged_in_user.id
+
+
+async def test_create_post_strips_whitespace(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Title and body are trimmed before persistence."""
+    response = await authenticated_client.post(
+        "/posts", json={"title": "  hello  ", "body": "  world  "}
+    )
+    assert response.status_code == 201
+    new_id = uuid.UUID(response.json()["id"])
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(select(Post).filter(Post.id == new_id))
+        persisted = result.scalars().first()
+        assert persisted.title == "hello"
+        assert persisted.body == "world"
+
+
+async def test_create_post_rejects_owner_id_in_payload(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A client sending owner_id is rejected with 422 (extra='forbid'); no
+    post is persisted."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+
+    response = await authenticated_client.post(
+        "/posts",
+        json={"title": "t", "body": "b", "owner_id": str(other.id)},
+    )
+    assert response.status_code == 422
+
+    # Nothing persisted
+    async with db_test_session_manager() as session:
+        result = await session.execute(select(Post))
+        assert result.scalars().first() is None
+
+
+async def test_create_post_rejects_unknown_field(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """Unknown fields are rejected with 422."""
+    response = await authenticated_client.post(
+        "/posts", json={"title": "t", "body": "b", "evil": True}
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"body": "no title"},
+        {"title": "no body"},
+        {},
+        {"title": "", "body": "b"},
+        {"title": "t", "body": "   "},
+    ],
+)
+async def test_create_post_missing_or_empty_fields_422(
+    payload,
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    response = await authenticated_client.post("/posts", json=payload)
+    assert response.status_code == 422
+
+
+async def test_create_post_unauthenticated_redirects(
+    test_client: AsyncClient,
+):
+    """Anonymous request to POST /posts is redirected to login (HTML auth flow)."""
+    response = await test_client.post(
+        "/posts",
+        json={"title": "t", "body": "b"},
+        headers={"accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers["location"]

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -84,7 +84,7 @@ When a real service exists for an entity, move the commit there and update the l
 | Module                    | Purpose                              | Key Functions                  |
 | ------------------------- | ------------------------------------ | ------------------------------ |
 | **user_processing.py**    | User operation coordination          | list users with filtering      |
-| **post_processing.py**    | Post operation coordination          | list posts, get post detail    |
+| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, commits) |
 | **auth_processing.py**    | Authentication workflow coordination | user registration processing   |
 
 ## Directory structure

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -4,8 +4,9 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import NotFoundError
-from src.models import User
+from src.models import Post, User
 from src.repositories.post_repository import PostRepository
+from src.schemas.post import PostCreate
 
 logger = logging.getLogger(__name__)
 
@@ -32,3 +33,20 @@ async def handle_get_post_detail(
         raise NotFoundError(detail="Post not found")
 
     return {"request": request, "post": post, "current_user": requesting_user}
+
+
+async def handle_create_post(
+    payload: PostCreate,
+    post_repo: PostRepository,
+    requesting_user: User,
+) -> Post:
+    """Creates a post owned by the requesting user; commits on success."""
+    post = Post(
+        title=payload.title,
+        body=payload.body,
+        owner_id=requesting_user.id,
+    )
+    created = await post_repo.create_post(post)
+    await post_repo.session.commit()
+    logger.info(f"Handler: user {requesting_user.id} created post {created.id}")
+    return created

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -62,7 +62,7 @@ Each repository manages one primary domain entity with related data access opera
 | Repository         | Primary Entity | Key Responsibilities                                                          |
 | ------------------ | -------------- | ----------------------------------------------------------------------------- |
 | **UserRepository** | User           | User lookup, listing, activation toggle, hard delete                          |
-| **PostRepository** | Post           | Post lookup by id, list all posts (newest first)                              |
+| **PostRepository** | Post           | Post lookup by id, list all posts (newest first), persist a new post (caller commits) |
 
 ## Directory structure
 

--- a/src/repositories/post_repository.py
+++ b/src/repositories/post_repository.py
@@ -24,3 +24,10 @@ class PostRepository(BaseRepository):
         stmt = select(Post).order_by(Post.created_at.desc())
         result = await self.session.execute(stmt)
         return result.scalars().all()
+
+    async def create_post(self, post: Post) -> Post:
+        """Persists a new post and flushes; the caller commits."""
+        self.session.add(post)
+        await self.session.flush()
+        await self.session.refresh(post)
+        return post

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -62,14 +62,14 @@ Schemas act as the data contract layer between HTTP and business logic.
 | Schema File | Domain    | Responsibilities                             | Schema Types                                             |
 | ----------- | --------- | -------------------------------------------- | -------------------------------------------------------- |
 | **user.py** | User data | User CRUD plus activation state-axis subresource (extends FastAPI Users) | UserRead, UserCreate, UserUpdate, UserActivationUpdate   |
-| **post.py** | Posts     | Post read serialization (read-only endpoints for now; create/update added with write endpoints) | PostRead |
+| **post.py** | Posts     | Post read + create validation (`extra="forbid"` rejects `owner_id` and other server-managed fields; whitespace-only `title`/`body` rejected) | PostRead, PostCreate |
 
 ## Directory structure
 
 **Domain schema files:**
 
 - `user.py` - User schemas extending FastAPI Users base schemas
-- `post.py` - Post response schema (`PostRead`)
+- `post.py` - Post schemas: `PostRead` (response) and `PostCreate` (request, `extra="forbid"`)
 
 ## Implementation patterns
 
@@ -236,7 +236,11 @@ UserUpdate
 
 ## Tests
 
-**TODO** — no colocated tests yet. Schema validation is implicitly exercised by route tests. Add `src/schemas/test_<schema_name>.py` when a schema has non-trivial validators or computed fields whose behavior isn't obvious from the field definitions.
+Colocated tests live alongside the schema modules:
+
+- `test_post.py` — exercises `PostCreate` validators and the `extra="forbid"` boundary (rejects `owner_id`, unknown fields, empty/whitespace `title`/`body`).
+
+Add `src/schemas/test_<schema_name>.py` when a schema has non-trivial validators or computed fields whose behavior isn't obvious from the field definitions.
 
 ## Related documentation
 

--- a/src/schemas/post.py
+++ b/src/schemas/post.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class PostRead(BaseModel):
@@ -13,3 +13,18 @@ class PostRead(BaseModel):
     updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class PostCreate(BaseModel):
+    title: str
+    body: str
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("title", "body")
+    @classmethod
+    def _strip_and_require_non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v

--- a/src/schemas/test_post.py
+++ b/src/schemas/test_post.py
@@ -1,0 +1,44 @@
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from src.schemas.post import PostCreate
+
+
+def test_post_create_accepts_title_and_body():
+    p = PostCreate(title="hello", body="world")
+    assert p.title == "hello"
+    assert p.body == "world"
+
+
+def test_post_create_strips_surrounding_whitespace():
+    p = PostCreate(title="  hi  ", body="  there  ")
+    assert p.title == "hi"
+    assert p.body == "there"
+
+
+@pytest.mark.parametrize("field", ["title", "body"])
+def test_post_create_rejects_empty_or_whitespace(field):
+    payload = {"title": "t", "body": "b", field: "   "}
+    with pytest.raises(ValidationError):
+        PostCreate(**payload)
+
+
+@pytest.mark.parametrize("missing", ["title", "body"])
+def test_post_create_requires_both_fields(missing):
+    payload = {"title": "t", "body": "b"}
+    payload.pop(missing)
+    with pytest.raises(ValidationError):
+        PostCreate(**payload)
+
+
+def test_post_create_rejects_owner_id():
+    """owner_id is server-managed; clients sending it must be rejected."""
+    with pytest.raises(ValidationError):
+        PostCreate(title="t", body="b", owner_id=uuid.uuid4())
+
+
+def test_post_create_rejects_unknown_fields():
+    with pytest.raises(ValidationError):
+        PostCreate(title="t", body="b", evil=True)


### PR DESCRIPTION
## Summary

- Adds `PostCreate` schema (title, body required; `extra="forbid"` so `owner_id`/timestamps/unknown fields are rejected with 422 instead of silently dropped) and `POST /posts` route. `owner_id` is server-set from the authenticated session.
- First slice of the four-PR sequence agreed for post writes; HTML create form, `PATCH /posts/{id}`, and the contract test pair land in follow-up PRs.
- No publication lifecycle — see `src/api/routes/RESOURCE_GRAMMAR.md` (lifecycle is opt-in, posts don't need it yet).

## Test plan

- [x] `dev test` — 70 passed, 1 skipped (10 new route cases + 8 new schema cases)
- [x] `dev lint` clean
- [x] `dev routes /posts` shows `POST /posts` mounted alongside the existing two GETs
- [ ] Manual smoke (post-merge): `dev seed` then `curl -X POST -H 'Cookie: ...' -H 'Content-Type: application/json' -d '{"title":"hi","body":"there"}' http://localhost:8000/posts` returns 201 with `Location` header; sending `owner_id` returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)