### PR TITLE
Add `PATCH /posts/{id}` partial-update endpoint (JSON-only)

### DIFF
--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -73,7 +73,7 @@ Routes are organized by domain with consistent delegation patterns.
 | Route File         | Domain               | Primary Responsibilities         | Main Endpoints                                                                                                                  | Dependencies          |
 | ------------------ | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | **users.py**       | User data            | User listing, detail, admin actions | `GET /users`, `GET /users/{id}`, `PUT /users/{id}/activation` (admin), `DELETE /users/{id}` (admin)                          | UserRepository        |
-| **posts.py**       | Posts                | Post listing, detail, and create (PATCH/edit-form to come) | `GET /posts`, `GET /posts/{id}`, `POST /posts`                                                                              | PostRepository        |
+| **posts.py**       | Posts                | Post listing, detail, create, and partial update (HTML forms to come) | `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`                                                                              | PostRepository        |
 | **me.py**          | Current user context | User profile, current-user JSON  | `GET /users/me`, `GET /users/me/profile`                                                                                        | Auth                  |
 | **auth_routes.py** | Authentication API   | Login, register, password reset  | `/auth/*`                                                                                                                       | Authentication logic  |
 | **auth_pages.py**  | Authentication UI    | Login, register forms            | `/login`, `/register`                                                                                                           | Authentication logic  |
@@ -83,7 +83,7 @@ Routes are organized by domain with consistent delegation patterns.
 **Domain route files:**
 
 - `users.py` - User listing and access
-- `posts.py` - Post listing, detail, and create (`POST /posts` is JSON-only for now; the HTML create form and PATCH come in follow-up PRs)
+- `posts.py` - Post listing, detail, create, and partial update (`POST /posts` and `PATCH /posts/{id}` are JSON-only for now; the HTML create/edit forms come in follow-up PRs)
 - `me.py` - Current user's profile
 
 **Authentication routes:**
@@ -285,7 +285,7 @@ Colocated alongside the routes:
 
 - `test_auth_routes.py` — registration, login, logout, password reset, session protection (covers `auth_routes.py` and `auth_pages.py`).
 - `test_users.py` — `GET /users` listing behavior (covers `users.py`).
-- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, and `POST /posts` including the `extra="forbid"` scrub of `owner_id` (covers `posts.py`).
+- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, and `PATCH /posts/{id}` including owner-only authorization, admin override, and the `extra="forbid"` scrub of `owner_id` (covers `posts.py`).
 
 When adding a new route, add (or extend) a `test_*.py` file in this same directory. Shared fixtures (`test_client`, `authenticated_client`, `db_test_session_manager`, `logged_in_user`) come from [`tests/fixtures.py`](../../../tests/fixtures.py); user-construction helpers from [`tests/helpers.py`](../../../tests/helpers.py).
 

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -10,11 +10,12 @@ from src.logic.post_processing import (
     handle_create_post,
     handle_get_post_detail,
     handle_list_posts,
+    handle_update_post,
 )
 from src.models import User
 from src.repositories.dependencies import get_post_repository
 from src.repositories.post_repository import PostRepository
-from src.schemas.post import PostCreate
+from src.schemas.post import PostCreate, PostUpdate
 
 posts_api_router = APIRouter(prefix="/posts")
 router = BaseRouter(router=posts_api_router, default_tags=["posts"])
@@ -80,4 +81,29 @@ async def create_post(
         status_code=status.HTTP_201_CREATED,
         content={"id": str(created.id)},
         headers={"Location": location, "HX-Redirect": location},
+    )
+
+
+@router.patch("/{post_id}")
+async def patch_post(
+    post_id: UUID,
+    payload: PostUpdate,
+    post_repo: PostRepository = Depends(get_post_repository),
+    user: User = Depends(current_active_user),
+):
+    """Partially updates a post. Owner-only; admins may edit any post.
+
+    Server-managed fields (`id`, `owner_id`, `created_at`, `updated_at`) are
+    rejected by the schema's `extra="forbid"`. The body must include at least
+    one of `title`/`body`.
+    """
+    updated = await handle_update_post(
+        post_id=post_id,
+        payload=payload,
+        post_repo=post_repo,
+        requesting_user=user,
+    )
+    return JSONResponse(
+        content={"id": str(updated.id), "title": updated.title, "body": updated.body},
+        headers={"HX-Refresh": "true"},
     )

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -277,3 +277,213 @@ async def test_create_post_unauthenticated_redirects(
     )
     assert response.status_code == 302
     assert "/auth/login" in response.headers["location"]
+
+
+# --- Update (PATCH) ------------------------------------------------------
+
+
+async def _promote_to_admin(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    user_email: str,
+) -> None:
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            stmt = select(User).filter(User.email == user_email)
+            result = await session.execute(stmt)
+            user = result.scalars().first()
+            assert user is not None, f"Test user {user_email} not found"
+            user.is_superuser = True
+
+
+async def test_owner_can_patch_title_only(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """PATCH with only `title` updates title and leaves body untouched."""
+    original_body = f"body-{uuid.uuid4()}"
+    post = Post(title="orig", body=original_body, owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    new_title = f"new-{uuid.uuid4()}"
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"title": new_title}
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("HX-Refresh") == "true"
+    body = response.json()
+    assert body["title"] == new_title
+    assert body["body"] == original_body
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(select(Post).filter(Post.id == post.id))
+        refreshed = result.scalars().first()
+        assert refreshed.title == new_title
+        assert refreshed.body == original_body
+
+
+async def test_owner_can_patch_body_only(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    original_title = f"title-{uuid.uuid4()}"
+    post = Post(title=original_title, body="orig", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"body": "fresh"}
+    )
+    assert response.status_code == 200
+    assert response.json()["title"] == original_title
+    assert response.json()["body"] == "fresh"
+
+
+async def test_owner_can_patch_both_fields(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    post = Post(title="t", body="b", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"title": "T2", "body": "B2"}
+    )
+    assert response.status_code == 200
+    assert response.json()["title"] == "T2"
+    assert response.json()["body"] == "B2"
+
+
+async def test_non_owner_cannot_patch_post(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A non-owner non-admin gets 403 and the post is not mutated."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="orig", body="orig", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"title": "hijack"}
+    )
+    assert response.status_code == 403
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(select(Post).filter(Post.id == post.id))
+        refreshed = result.scalars().first()
+        assert refreshed.title == "orig"
+
+
+async def test_admin_can_patch_anyone_post(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="orig", body="orig", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"title": "moderated"}
+    )
+    assert response.status_code == 200
+    assert response.json()["title"] == "moderated"
+
+
+async def test_patch_404_for_unknown_post(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    response = await authenticated_client.patch(
+        f"/posts/{uuid.uuid4()}", json={"title": "x"}
+    )
+    assert response.status_code == 404
+
+
+async def test_patch_rejects_owner_id_in_payload(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Even the owner cannot reassign owner_id via PATCH (server-managed)."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}",
+        json={"title": "t2", "owner_id": str(other.id)},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"title": None, "body": None},
+        {"title": "   "},
+        {"body": ""},
+    ],
+)
+async def test_patch_invalid_body_422(
+    payload,
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    post = Post(title="t", body="b", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.patch(f"/posts/{post.id}", json=payload)
+    assert response.status_code == 422
+
+
+async def test_patch_rejects_unknown_field(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    post = Post(title="t", body="b", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"title": "x", "evil": True}
+    )
+    assert response.status_code == 422
+
+
+async def test_patch_unauthenticated_redirects(
+    test_client: AsyncClient,
+):
+    response = await test_client.patch(
+        f"/posts/{uuid.uuid4()}",
+        json={"title": "t"},
+        headers={"accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers["location"]

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -84,7 +84,7 @@ When a real service exists for an entity, move the commit there and update the l
 | Module                    | Purpose                              | Key Functions                  |
 | ------------------------- | ------------------------------------ | ------------------------------ |
 | **user_processing.py**    | User operation coordination          | list users with filtering      |
-| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, commits) |
+| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, commits), update post (owner-or-admin guard, commits) |
 | **auth_processing.py**    | Authentication workflow coordination | user registration processing   |
 
 ## Directory structure

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -3,10 +3,10 @@ from uuid import UUID
 
 from fastapi import Request
 
-from src.api.common.exceptions import NotFoundError
+from src.api.common.exceptions import ForbiddenError, NotFoundError
 from src.models import Post, User
 from src.repositories.post_repository import PostRepository
-from src.schemas.post import PostCreate
+from src.schemas.post import PostCreate, PostUpdate
 
 logger = logging.getLogger(__name__)
 
@@ -50,3 +50,25 @@ async def handle_create_post(
     await post_repo.session.commit()
     logger.info(f"Handler: user {requesting_user.id} created post {created.id}")
     return created
+
+
+async def handle_update_post(
+    post_id: UUID,
+    payload: PostUpdate,
+    post_repo: PostRepository,
+    requesting_user: User,
+) -> Post:
+    """Patches a post owned by the requesting user (or by anyone, if the
+    requester is a superuser). 404 if missing, 403 if not authorized.
+    """
+    post = await post_repo.get_post_by_id(post_id)
+    if post is None:
+        raise NotFoundError(detail="Post not found")
+
+    if post.owner_id != requesting_user.id and not requesting_user.is_superuser:
+        raise ForbiddenError(detail="Only the owner or an admin can edit this post")
+
+    updated = await post_repo.update_post(post, title=payload.title, body=payload.body)
+    await post_repo.session.commit()
+    logger.info(f"Handler: user {requesting_user.id} updated post {updated.id}")
+    return updated

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -62,7 +62,7 @@ Each repository manages one primary domain entity with related data access opera
 | Repository         | Primary Entity | Key Responsibilities                                                          |
 | ------------------ | -------------- | ----------------------------------------------------------------------------- |
 | **UserRepository** | User           | User lookup, listing, activation toggle, hard delete                          |
-| **PostRepository** | Post           | Post lookup by id, list all posts (newest first), persist a new post (caller commits) |
+| **PostRepository** | Post           | Post lookup by id, list all posts (newest first), persist a new post, partial update (caller commits) |
 
 ## Directory structure
 

--- a/src/repositories/post_repository.py
+++ b/src/repositories/post_repository.py
@@ -31,3 +31,20 @@ class PostRepository(BaseRepository):
         await self.session.flush()
         await self.session.refresh(post)
         return post
+
+    async def update_post(
+        self,
+        post: Post,
+        *,
+        title: str | None = None,
+        body: str | None = None,
+    ) -> Post:
+        """Mutates only the fields that were provided and flushes; the caller commits."""
+        if title is not None:
+            post.title = title
+        if body is not None:
+            post.body = body
+        self.session.add(post)
+        await self.session.flush()
+        await self.session.refresh(post)
+        return post

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -62,14 +62,14 @@ Schemas act as the data contract layer between HTTP and business logic.
 | Schema File | Domain    | Responsibilities                             | Schema Types                                             |
 | ----------- | --------- | -------------------------------------------- | -------------------------------------------------------- |
 | **user.py** | User data | User CRUD plus activation state-axis subresource (extends FastAPI Users) | UserRead, UserCreate, UserUpdate, UserActivationUpdate   |
-| **post.py** | Posts     | Post read + create validation (`extra="forbid"` rejects `owner_id` and other server-managed fields; whitespace-only `title`/`body` rejected) | PostRead, PostCreate |
+| **post.py** | Posts     | Post read + create + partial-update validation (`extra="forbid"` rejects `owner_id` and other server-managed fields; whitespace-only `title`/`body` rejected; `PostUpdate` requires at least one field) | PostRead, PostCreate, PostUpdate |
 
 ## Directory structure
 
 **Domain schema files:**
 
 - `user.py` - User schemas extending FastAPI Users base schemas
-- `post.py` - Post schemas: `PostRead` (response) and `PostCreate` (request, `extra="forbid"`)
+- `post.py` - Post schemas: `PostRead` (response), `PostCreate` (request, `extra="forbid"`), and `PostUpdate` (PATCH body, `extra="forbid"`, at-least-one-field)
 
 ## Implementation patterns
 
@@ -238,7 +238,7 @@ UserUpdate
 
 Colocated tests live alongside the schema modules:
 
-- `test_post.py` — exercises `PostCreate` validators and the `extra="forbid"` boundary (rejects `owner_id`, unknown fields, empty/whitespace `title`/`body`).
+- `test_post.py` — exercises `PostCreate` and `PostUpdate` validators and the `extra="forbid"` boundary (rejects `owner_id`, unknown fields, empty/whitespace `title`/`body`; `PostUpdate` requires at least one field).
 
 Add `src/schemas/test_<schema_name>.py` when a schema has non-trivial validators or computed fields whose behavior isn't obvious from the field definitions.
 

--- a/src/schemas/post.py
+++ b/src/schemas/post.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 
 class PostRead(BaseModel):
@@ -28,3 +28,26 @@ class PostCreate(BaseModel):
         if not v:
             raise ValueError("must not be empty")
         return v
+
+
+class PostUpdate(BaseModel):
+    title: str | None = None
+    body: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("title", "body")
+    @classmethod
+    def _strip_and_require_non_empty(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> "PostUpdate":
+        if self.title is None and self.body is None:
+            raise ValueError("at least one of title, body must be provided")
+        return self

--- a/src/schemas/test_post.py
+++ b/src/schemas/test_post.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 from pydantic import ValidationError
 
-from src.schemas.post import PostCreate
+from src.schemas.post import PostCreate, PostUpdate
 
 
 def test_post_create_accepts_title_and_body():
@@ -42,3 +42,55 @@ def test_post_create_rejects_owner_id():
 def test_post_create_rejects_unknown_fields():
     with pytest.raises(ValidationError):
         PostCreate(title="t", body="b", evil=True)
+
+
+# --- PostUpdate ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"title": "new"},
+        {"body": "new"},
+        {"title": "t", "body": "b"},
+    ],
+)
+def test_post_update_accepts_partial_fields(payload):
+    p = PostUpdate(**payload)
+    assert p.title == payload.get("title")
+    assert p.body == payload.get("body")
+
+
+def test_post_update_strips_whitespace():
+    p = PostUpdate(title="  hi  ")
+    assert p.title == "hi"
+    assert p.body is None
+
+
+@pytest.mark.parametrize("payload", [{}, {"title": None, "body": None}])
+def test_post_update_requires_at_least_one_field(payload):
+    with pytest.raises(ValidationError):
+        PostUpdate(**payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"title": "   "},
+        {"body": ""},
+        {"title": "t", "body": "   "},
+    ],
+)
+def test_post_update_rejects_whitespace_only(payload):
+    with pytest.raises(ValidationError):
+        PostUpdate(**payload)
+
+
+def test_post_update_rejects_owner_id():
+    with pytest.raises(ValidationError):
+        PostUpdate(title="t", owner_id=uuid.uuid4())
+
+
+def test_post_update_rejects_unknown_field():
+    with pytest.raises(ValidationError):
+        PostUpdate(title="t", evil=True)


### PR DESCRIPTION
## Summary

- Adds `PostUpdate` schema (both fields optional, at-least-one required, `extra="forbid"`, whitespace-only rejected) and `PATCH /posts/{id}` route returning JSON + `HX-Refresh`.
- Authorization at the logic layer: post owner can edit; admins (`is_superuser`) can edit any post. Mirrors the self-guard shape from `handle_set_user_activation`.
- Second slice of the four-PR sequence; HTML create/edit forms and contract test pairs land in PRs 3 and 4.
- PATCH is the right verb here — `RESOURCE_GRAMMAR.md:22` makes the rule explicit, and partial edits shouldn't force clients to round-trip the whole representation.

## Test plan

- [x] `dev test` — 94 passed, 1 skipped (13 new route cases + 11 new schema cases on top of PR #56)
- [x] `dev lint` clean
- [x] `dev routes /posts` shows `PATCH /posts/{post_id}` mounted alongside the existing three routes
- [ ] Manual smoke (post-merge): PATCH as owner with `{"title":"x"}` → 200 + `HX-Refresh`; PATCH as non-owner → 403; PATCH with `owner_id` in payload → 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)