### PR TITLE
Add HTML create-post form + Pact contract test pair

### DIFF
--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -73,7 +73,7 @@ Routes are organized by domain with consistent delegation patterns.
 | Route File         | Domain               | Primary Responsibilities         | Main Endpoints                                                                                                                  | Dependencies          |
 | ------------------ | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | **users.py**       | User data            | User listing, detail, admin actions | `GET /users`, `GET /users/{id}`, `PUT /users/{id}/activation` (admin), `DELETE /users/{id}` (admin)                          | UserRepository        |
-| **posts.py**       | Posts                | Post listing, detail, create, and partial update (HTML forms to come) | `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`                                                                              | PostRepository        |
+| **posts.py**       | Posts                | Post listing, detail, create, partial update, and create-form page (edit-form page to come) | `GET /posts`, `GET /posts/form`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`                                                                              | PostRepository        |
 | **me.py**          | Current user context | User profile, current-user JSON  | `GET /users/me`, `GET /users/me/profile`                                                                                        | Auth                  |
 | **auth_routes.py** | Authentication API   | Login, register, password reset  | `/auth/*`                                                                                                                       | Authentication logic  |
 | **auth_pages.py**  | Authentication UI    | Login, register forms            | `/login`, `/register`                                                                                                           | Authentication logic  |
@@ -83,7 +83,7 @@ Routes are organized by domain with consistent delegation patterns.
 **Domain route files:**
 
 - `users.py` - User listing and access
-- `posts.py` - Post listing, detail, create, and partial update (`POST /posts` and `PATCH /posts/{id}` are JSON-only for now; the HTML create/edit forms come in follow-up PRs)
+- `posts.py` - Post listing, detail, create, partial update, and the HTML create-form page (`GET /posts/form`); the edit-form page (`GET /posts/{id}/form`) comes in a follow-up PR
 - `me.py` - Current user's profile
 
 **Authentication routes:**
@@ -285,7 +285,7 @@ Colocated alongside the routes:
 
 - `test_auth_routes.py` — registration, login, logout, password reset, session protection (covers `auth_routes.py` and `auth_pages.py`).
 - `test_users.py` — `GET /users` listing behavior (covers `users.py`).
-- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, and `PATCH /posts/{id}` including owner-only authorization, admin override, and the `extra="forbid"` scrub of `owner_id` (covers `posts.py`).
+- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`, and `GET /posts/form` (covers `posts.py`). Includes owner-only authorization, admin override, the `extra="forbid"` scrub of `owner_id`, and a route-ordering check that the literal `form` segment doesn't shadow the `{post_id}` UUID path. The Pact contract pair for the create-form lives under [`tests/test_contract/`](../../../tests/test_contract/README.md).
 
 When adding a new route, add (or extend) a `test_*.py` file in this same directory. Shared fixtures (`test_client`, `authenticated_client`, `db_test_session_manager`, `logged_in_user`) come from [`tests/fixtures.py`](../../../tests/fixtures.py); user-construction helpers from [`tests/helpers.py`](../../../tests/helpers.py).
 

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -9,6 +9,7 @@ from src.auth_config import current_active_user
 from src.logic.post_processing import (
     handle_create_post,
     handle_get_post_detail,
+    handle_get_post_form,
     handle_list_posts,
     handle_update_post,
 )
@@ -38,6 +39,21 @@ async def list_posts(
     )
     return APIResponse.html_response(
         template_name="posts/list.html", context=context, request=request
+    )
+
+
+@router.get("/form")
+async def get_post_form(
+    request: Request,
+    user: User = Depends(current_active_user),
+):
+    """Provides an HTML page with the create-post form.
+
+    Registered before `/{post_id}` so the literal `form` is not parsed as a UUID.
+    """
+    context = await handle_get_post_form(request=request, requesting_user=user)
+    return APIResponse.html_response(
+        template_name="posts/new.html", context=context, request=request
     )
 
 

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -487,3 +487,66 @@ async def test_patch_unauthenticated_redirects(
     )
     assert response.status_code == 302
     assert "/auth/login" in response.headers["location"]
+
+
+# --- Create form page (GET /posts/form) ----------------------------------
+
+
+async def test_get_post_form_renders(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """GET /posts/form renders the form for an authenticated user."""
+    response = await authenticated_client.get("/posts/form")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+
+    tree = HTMLParser(response.text)
+    form = tree.css_first("form")
+    assert form is not None
+    assert form.attributes.get("hx-post") == "/posts"
+    assert form.attributes.get("hx-ext") == "json-enc"
+    assert tree.css_first("input#title") is not None
+    assert tree.css_first("textarea#body") is not None
+
+
+async def test_get_post_form_unauthenticated_redirects(
+    test_client: AsyncClient,
+):
+    response = await test_client.get(
+        "/posts/form",
+        headers={"accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers["location"]
+    assert "next=/posts/form" in response.headers["location"]
+
+
+async def test_form_route_does_not_shadow_detail_route(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Sanity check the /posts/form ordering — a real UUID still hits the detail route."""
+    post = Post(title="t", body="b", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    assert "t" in response.text
+
+
+async def test_list_page_links_to_create_form(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    response = await authenticated_client.get("/posts")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    link = tree.css_first('a[href="/posts/form"]')
+    assert link is not None
+    assert "New post" in link.text()

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -84,7 +84,7 @@ When a real service exists for an entity, move the commit there and update the l
 | Module                    | Purpose                              | Key Functions                  |
 | ------------------------- | ------------------------------------ | ------------------------------ |
 | **user_processing.py**    | User operation coordination          | list users with filtering      |
-| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, commits), update post (owner-or-admin guard, commits) |
+| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, commits), update post (owner-or-admin guard, commits), build create-form context |
 | **auth_processing.py**    | Authentication workflow coordination | user registration processing   |
 
 ## Directory structure

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -35,6 +35,14 @@ async def handle_get_post_detail(
     return {"request": request, "post": post, "current_user": requesting_user}
 
 
+async def handle_get_post_form(
+    request: Request,
+    requesting_user: User,
+):
+    """Builds the template context for the create-post form."""
+    return {"request": request, "current_user": requesting_user}
+
+
 async def handle_create_post(
     payload: PostCreate,
     post_repo: PostRepository,

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -66,6 +66,7 @@ Templates use inheritance for consistent layout and feature-specific customizati
 | **/**      | Base layout and shared | `base.html` - Foundation template                                      |
 | **auth/**  | Authentication pages   | login, register, forgot/reset password                                 |
 | **users/** | User management        | list, detail, `_admin_actions.html` partial (shared by list & detail)  |
+| **posts/** | Posts                  | list, detail, `new.html` (create form)                                 |
 | **me/**    | Personal/profile pages | user profile                                                           |
 
 ### Reusable partial convention
@@ -85,7 +86,13 @@ templates/
 │   ├── forgot_password.html    # Password reset request
 │   └── reset_password.html     # Password reset form
 ├── users/                      # User management templates
-│   └── list.html              # User directory listing
+│   ├── list.html               # User directory listing
+│   ├── detail.html             # User detail page
+│   └── _admin_actions.html     # Reusable admin-actions partial
+├── posts/                      # Post templates
+│   ├── list.html               # Post listing
+│   ├── detail.html             # Post detail
+│   └── new.html                # Create-post form (HTMX json-enc → POST /posts)
 └── me/                         # Personal user pages
     └── profile.html            # User's profile page
 ```

--- a/src/templates/posts/list.html
+++ b/src/templates/posts/list.html
@@ -3,6 +3,8 @@
 {% block content %}
 <h1>Posts</h1>
 
+<p><a href="/posts/form">New post</a></p> {# title-case-ignore: "post" is the noun, not the HTTP method #}
+
 {% if posts %}
 <ul>
   {% for post in posts %}

--- a/src/templates/posts/new.html
+++ b/src/templates/posts/new.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}New post{% endblock %} {# title-case-ignore: "post" is the noun, not the HTTP method #}
+{% block content %}
+<h1>New post</h1> {# title-case-ignore: "post" is the noun, not the HTTP method #}
+<form hx-post="/posts" hx-ext="json-enc">
+  <label for="title">Title:</label><br />
+  <input type="text" id="title" name="title" required /><br />
+  <label for="body">Body:</label><br />
+  <textarea id="body" name="body" required></textarea><br /><br />
+  <input type="submit" value="Create post" />
+</form>
+
+<hr />
+<a href="/posts">Back to posts</a>
+{% endblock %}

--- a/tests/test_contract/README.md
+++ b/tests/test_contract/README.md
@@ -2,7 +2,7 @@
 
 Pact-based contract tests verify that the **shape of the conversation** between an HTML form (consumer) and the API endpoint it posts to (provider) stays in sync. They do **not** verify business behavior — that's what the colocated unit tests under `src/<layer>/test_*.py` are for.
 
-> **Status:** auth (registration) is currently the only resource with a contract test pair. Add a pair for any new HTML form per the conventions below.
+> **Status:** auth (registration), users (admin actions), and posts (create form) currently have contract test pairs. Add a pair for any new HTML form per the conventions below.
 
 ## Why this directory exists outside the colocated convention
 
@@ -50,10 +50,13 @@ tests/test_contract/
 │       └── playwright_helpers.py      # Pact ↔ Playwright route interception
 └── tests/
     ├── consumer/
-    │   ├── pytest.ini
-    │   └── test_auth_form.py          # Registration form contract
+    │   ├── test_auth_form.py          # Registration form contract
+    │   ├── test_user_admin_actions.py # Admin-actions partial contract
+    │   └── test_post_form.py          # New-post form contract
     ├── provider/
-    │   └── test_auth_verification.py  # Verify provider against the registration pact
+    │   ├── test_auth_verification.py
+    │   ├── test_user_admin_actions_verification.py
+    │   └── test_posts_verification.py
     └── shared/
         ├── consumer_test_base.py      # BaseConsumerTest abstract class
         ├── helpers.py                 # Pact + Playwright glue

--- a/tests/test_contract/constants.py
+++ b/tests/test_contract/constants.py
@@ -9,15 +9,26 @@ TEST_USERNAME = "testuser"
 
 # API paths
 REGISTER_API_PATH = "/auth/register"
+POSTS_API_PATH = "/posts"
+POSTS_FORM_PAGE_PATH = "/posts/form"
 
 # Stable target-user id used by the admin-actions stub + activation pact.
 # Matches `STUB_TARGET_USER_ID` in `infrastructure/servers/consumer.py`.
 TARGET_USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 USER_ACTIVATION_API_PATH = f"/users/{TARGET_USER_ID}/activation"
 
+# Stable post id returned by the post-create handler mock so the consumer can
+# match the response shape and the redirect headers without round-tripping a DB.
+STUB_POST_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+# Test post data for the create-form contract.
+TEST_POST_TITLE = "Hello from contract test"
+TEST_POST_BODY = "This is the body of the post."
+
 # Provider states
 PROVIDER_STATE_USER_DOES_NOT_EXIST = f"User {TEST_EMAIL} does not exist"
 PROVIDER_STATE_USER_EXISTS_AND_ACTIVE = f"User {TARGET_USER_ID} exists and is active"
+PROVIDER_STATE_POSTS_ACCEPTS_CREATE = "Posts API accepts a create request"
 
 # Consumer / provider Pact identifiers
 CONSUMER_NAME_REGISTRATION = "registration-form"
@@ -26,9 +37,13 @@ PROVIDER_NAME_AUTH = "auth-api"
 CONSUMER_NAME_USER_ADMIN_ACTIONS = "user-admin-actions"
 PROVIDER_NAME_USERS = "users-api"
 
+CONSUMER_NAME_POST_CREATE = "post-create-form"
+PROVIDER_NAME_POSTS = "posts-api"
+
 # Timeouts
 NETWORK_TIMEOUT_MS = 500
 
 # Pact ports (one port per consumer-provider pair)
 PACT_PORT_AUTH = 1234
 PACT_PORT_USER_ACTIVATION = 1235
+PACT_PORT_POST_CREATE = 1236

--- a/tests/test_contract/infrastructure/config.py
+++ b/tests/test_contract/infrastructure/config.py
@@ -35,4 +35,5 @@ TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 KNOWN_PROVIDER_STATES = [
     "User test.user@example.com does not exist",
     "User 11111111-1111-1111-1111-111111111111 exists and is active",
+    "Posts API accepts a create request",
 ]

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -37,10 +37,12 @@ class ConsumerServerConfig:
         self,
         auth_pages: bool = True,
         users_admin_actions: bool = False,
+        posts_pages: bool = False,
         mock_auth: bool = True,
     ):
         self.auth_pages = auth_pages
         self.users_admin_actions = users_admin_actions
+        self.posts_pages = posts_pages
         self.mock_auth = mock_auth
 
 
@@ -81,11 +83,27 @@ def _setup_users_admin_actions_stub(app: FastAPI) -> None:
         )
 
 
+def _setup_posts_form_stub(app: FastAPI) -> None:
+    """Mount a stub `GET /posts/form` that renders the real `posts/new.html`
+    template. The contract surface is the form's HTMX-decorated submission;
+    the create POST is intercepted by Playwright before it leaves the browser,
+    so no database is needed.
+    """
+
+    @app.get("/posts/form")
+    async def posts_form_stub_page(request: Request):
+        return APIResponse.html_response(
+            template_name="posts/new.html", context={}, request=request
+        )
+
+
 def setup_consumer_app_routes(app: FastAPI, config: ConsumerServerConfig) -> None:
     if config.auth_pages:
         app.include_router(auth_pages.auth_pages_api_router)
     if config.users_admin_actions:
         _setup_users_admin_actions_stub(app)
+    if config.posts_pages:
+        _setup_posts_form_stub(app)
 
 
 def run_consumer_server_process(

--- a/tests/test_contract/tests/consumer/test_post_form.py
+++ b/tests/test_contract/tests/consumer/test_post_form.py
@@ -1,0 +1,89 @@
+"""Consumer contract: filling and submitting the new-post form.
+
+Verifies that the form rendered by `templates/posts/new.html` (mounted via
+the `posts_pages` flag on the consumer server) issues `POST /posts` with a
+JSON body matching `PostCreate` (title + body, no `owner_id`). The contract
+surface is the form template and the route's request shape.
+"""
+
+import pytest
+from pact import Like
+from playwright.async_api import Page
+
+from tests.test_contract.constants import (
+    CONSUMER_NAME_POST_CREATE,
+    NETWORK_TIMEOUT_MS,
+    PACT_PORT_POST_CREATE,
+    POSTS_API_PATH,
+    POSTS_FORM_PAGE_PATH,
+    PROVIDER_NAME_POSTS,
+    PROVIDER_STATE_POSTS_ACCEPTS_CREATE,
+    STUB_POST_ID,
+    TEST_POST_BODY,
+    TEST_POST_TITLE,
+)
+from tests.test_contract.tests.shared.helpers import (
+    setup_pact,
+    setup_playwright_pact_interception,
+)
+
+
+@pytest.mark.parametrize(
+    "origin_with_routes",
+    [{"posts_pages": True, "auth_pages": False}],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_consumer_post_create_form_interaction(
+    origin_with_routes: str, page: Page
+):
+    """Submit the new-post form; assert the intercepted request matches the
+    contracted shape (POST /posts with JSON title + body)."""
+    pact = setup_pact(
+        CONSUMER_NAME_POST_CREATE,
+        PROVIDER_NAME_POSTS,
+        port=PACT_PORT_POST_CREATE,
+    )
+    mock_server_uri = pact.uri
+    form_page_url = f"{origin_with_routes}{POSTS_FORM_PAGE_PATH}"
+    full_mock_url = f"{mock_server_uri}{POSTS_API_PATH}"
+
+    expected_request_headers = {"Content-Type": "application/json"}
+    expected_request_body = {
+        "title": Like(TEST_POST_TITLE),
+        "body": Like(TEST_POST_BODY),
+    }
+    expected_response_body = {"id": Like(str(STUB_POST_ID))}
+
+    (
+        pact.given(PROVIDER_STATE_POSTS_ACCEPTS_CREATE)
+        .upon_receiving("a request to create a post via the new-post form")
+        .with_request(
+            method="POST",
+            path=POSTS_API_PATH,
+            headers=expected_request_headers,
+            body=expected_request_body,
+        )
+        .will_respond_with(
+            status=201,
+            headers={"Content-Type": "application/json"},
+            body=expected_response_body,
+        )
+    )
+
+    await setup_playwright_pact_interception(
+        page=page,
+        api_path_to_intercept=POSTS_API_PATH,
+        mock_pact_url=full_mock_url,
+        http_method="POST",
+    )
+
+    with pact:
+        await page.goto(form_page_url)
+        await page.wait_for_selector("#title")
+        await page.locator("#title").fill(TEST_POST_TITLE)
+        await page.locator("#body").fill(TEST_POST_BODY)
+        await page.locator("input[type='submit']").click()
+        await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
+
+    # Pact verification happens automatically on context exit.

--- a/tests/test_contract/tests/provider/test_posts_verification.py
+++ b/tests/test_contract/tests/provider/test_posts_verification.py
@@ -1,0 +1,48 @@
+"""Provider verification: POST /posts accepts the documented request shape
+and returns the documented response.
+
+The route's `current_active_user` dependency is overridden by the provider
+server fixture (auth-mocked). `handle_create_post` is monkey-patched out via
+`MockDataFactory.create_post_create_dependency_config` so this test exercises
+only the route layer (the "waiter, not chef" split).
+"""
+
+import pytest
+from yarl import URL
+
+from tests.test_contract.tests.shared.mock_data_factory import MockDataFactory
+from tests.test_contract.tests.shared.provider_verification_base import (
+    BaseProviderVerification,
+    create_provider_test_decorator,
+)
+
+
+class PostsVerification(BaseProviderVerification):
+    """Provider verification for the posts API."""
+
+    @property
+    def provider_name(self) -> str:
+        return "posts-api"
+
+    @property
+    def consumer_name(self) -> str:
+        return "post-create-form"
+
+    @property
+    def dependency_config(self):
+        return MockDataFactory.create_post_create_dependency_config()
+
+    @property
+    def pytest_marks(self) -> list:
+        return [pytest.mark.provider, pytest.mark.posts]
+
+
+posts_verification = PostsVerification()
+
+
+@create_provider_test_decorator(
+    posts_verification.dependency_config, "with_posts_api_mocks"
+)
+def test_provider_posts_pact_verification(provider_server: URL):
+    """Verify the post-create-form Pact contract against the running provider server."""
+    posts_verification.verify_pact(provider_server)

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -7,9 +7,11 @@ monkey-patch business-logic handlers, so Pact verification exercises only the
 route layer.
 """
 
+from datetime import datetime, timezone
 from typing import Any, Dict
-from uuid import uuid4
+from uuid import UUID, uuid4
 
+from src.schemas.post import PostRead
 from src.schemas.user import UserRead
 
 
@@ -71,5 +73,46 @@ class MockDataFactory:
         return {
             "src.api.routes.users.handle_set_user_activation": {
                 "return_value_config": user_read
+            }
+        }
+
+    # Stable post id matching `STUB_POST_ID` in `tests/test_contract/constants.py`.
+    MOCK_POST_ID = UUID("22222222-2222-2222-2222-222222222222")
+    MOCK_POST_OWNER_ID = UUID(MOCK_USER_ID)
+
+    @classmethod
+    def create_post_read(
+        cls,
+        post_id: UUID = None,
+        title: str = "stub title",
+        body: str = "stub body",
+        owner_id: UUID = None,
+    ) -> PostRead:
+        now = datetime.now(timezone.utc)
+        return PostRead(
+            id=post_id or cls.MOCK_POST_ID,
+            title=title,
+            body=body,
+            owner_id=owner_id or cls.MOCK_POST_OWNER_ID,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @classmethod
+    def create_post_create_dependency_config(
+        cls, post_read: PostRead = None
+    ) -> Dict[str, Any]:
+        """Mock for `handle_create_post`.
+
+        The route under test (`POST /posts`) reads `id` off the handler's
+        return value to populate the response body and the `Location` /
+        `HX-Redirect` headers. A `PostRead` (or any object with `.id`) suffices.
+        """
+        if post_read is None:
+            post_read = cls.create_post_read()
+
+        return {
+            "src.api.routes.posts.handle_create_post": {
+                "return_value_config": post_read
             }
         }


### PR DESCRIPTION
## Summary

- Mounts `GET /posts/form` rendering a new `posts/new.html` template (HTMX json-enc form posting to `/posts`). Registered before `/{post_id}` so the literal `form` segment isn't parsed as a UUID.
- Adds a "New post" link to `posts/list.html`.
- Wires the Pact contract test pair: a Playwright-driven consumer test asserts the form's request shape, a provider test verifies the route accepts that shape (`handle_create_post` is monkey-patched out — route-shape only, "waiter not chef" per `tests/test_contract/README.md`).
- Contract infra grows by one consumer-server flag (`posts_pages`), one provider state, one mock factory, and a new Pact port — same shape as the user-admin-actions pair.
- Third slice of the four-PR sequence; PR 4 adds the edit form + owner-actions partial.

## Test plan

- [x] `dev test` — 98 passed, 1 skipped (4 new colocated cases including a route-ordering check that the literal `/posts/form` doesn't shadow the `{post_id}` UUID path)
- [x] `dev test tests/test_contract` — 6 passed (3 consumer + 3 provider, including the new `test_post_form.py` ↔ `test_posts_verification.py` pair)
- [x] `dev lint` clean (after adding `{# title-case-ignore #}` comments per the existing convention from `posts/detail.html`)
- [x] `dev routes /posts` shows the new `GET /posts/form` mounted before `GET /posts/{post_id}`
- [ ] Manual smoke (post-merge): visit `/posts/form` in browser, submit, redirected to `/posts/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)