### PR TITLE
Add HTML edit-post form + owner-actions partial + Pact pair

### DIFF
--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -73,7 +73,7 @@ Routes are organized by domain with consistent delegation patterns.
 | Route File         | Domain               | Primary Responsibilities         | Main Endpoints                                                                                                                  | Dependencies          |
 | ------------------ | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | **users.py**       | User data            | User listing, detail, admin actions | `GET /users`, `GET /users/{id}`, `PUT /users/{id}/activation` (admin), `DELETE /users/{id}` (admin)                          | UserRepository        |
-| **posts.py**       | Posts                | Post listing, detail, create, partial update, and create-form page (edit-form page to come) | `GET /posts`, `GET /posts/form`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`                                                                              | PostRepository        |
+| **posts.py**       | Posts                | Post listing, detail, create, partial update, and create/edit form pages | `GET /posts`, `GET /posts/form`, `GET /posts/{id}`, `GET /posts/{id}/form`, `POST /posts`, `PATCH /posts/{id}`                                                                              | PostRepository        |
 | **me.py**          | Current user context | User profile, current-user JSON  | `GET /users/me`, `GET /users/me/profile`                                                                                        | Auth                  |
 | **auth_routes.py** | Authentication API   | Login, register, password reset  | `/auth/*`                                                                                                                       | Authentication logic  |
 | **auth_pages.py**  | Authentication UI    | Login, register forms            | `/login`, `/register`                                                                                                           | Authentication logic  |
@@ -83,7 +83,7 @@ Routes are organized by domain with consistent delegation patterns.
 **Domain route files:**
 
 - `users.py` - User listing and access
-- `posts.py` - Post listing, detail, create, partial update, and the HTML create-form page (`GET /posts/form`); the edit-form page (`GET /posts/{id}/form`) comes in a follow-up PR
+- `posts.py` - Post listing, detail, create, partial update, and both HTML form pages (`GET /posts/form`, `GET /posts/{id}/form`)
 - `me.py` - Current user's profile
 
 **Authentication routes:**
@@ -285,7 +285,7 @@ Colocated alongside the routes:
 
 - `test_auth_routes.py` — registration, login, logout, password reset, session protection (covers `auth_routes.py` and `auth_pages.py`).
 - `test_users.py` — `GET /users` listing behavior (covers `users.py`).
-- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`, and `GET /posts/form` (covers `posts.py`). Includes owner-only authorization, admin override, the `extra="forbid"` scrub of `owner_id`, and a route-ordering check that the literal `form` segment doesn't shadow the `{post_id}` UUID path. The Pact contract pair for the create-form lives under [`tests/test_contract/`](../../../tests/test_contract/README.md).
+- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`, `GET /posts/form`, and `GET /posts/{id}/form` (covers `posts.py`). Includes owner-only authorization, admin override, the `extra="forbid"` scrub of `owner_id`, route-ordering checks, and `_owner_actions.html` partial visibility on the detail page. Pact contract pairs for both forms live under [`tests/test_contract/`](../../../tests/test_contract/README.md).
 
 When adding a new route, add (or extend) a `test_*.py` file in this same directory. Shared fixtures (`test_client`, `authenticated_client`, `db_test_session_manager`, `logged_in_user`) come from [`tests/fixtures.py`](../../../tests/fixtures.py); user-construction helpers from [`tests/helpers.py`](../../../tests/helpers.py).
 

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -9,6 +9,7 @@ from src.auth_config import current_active_user
 from src.logic.post_processing import (
     handle_create_post,
     handle_get_post_detail,
+    handle_get_post_edit_form,
     handle_get_post_form,
     handle_list_posts,
     handle_update_post,
@@ -54,6 +55,27 @@ async def get_post_form(
     context = await handle_get_post_form(request=request, requesting_user=user)
     return APIResponse.html_response(
         template_name="posts/new.html", context=context, request=request
+    )
+
+
+@router.get("/{post_id}/form")
+async def get_post_edit_form(
+    post_id: UUID,
+    request: Request,
+    post_repo: PostRepository = Depends(get_post_repository),
+    user: User = Depends(current_active_user),
+):
+    """Provides an HTML page with the edit-post form. Owner-only; admins may
+    edit any post. 404 if missing, 403 if not authorized.
+    """
+    context = await handle_get_post_edit_form(
+        request=request,
+        post_id=post_id,
+        post_repo=post_repo,
+        requesting_user=user,
+    )
+    return APIResponse.html_response(
+        template_name="posts/edit.html", context=context, request=request
     )
 
 

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -550,3 +550,145 @@ async def test_list_page_links_to_create_form(
     link = tree.css_first('a[href="/posts/form"]')
     assert link is not None
     assert "New post" in link.text()
+
+
+# --- Edit form page (GET /posts/{id}/form) -------------------------------
+
+
+async def test_owner_can_open_edit_form(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """The owner sees the edit form pre-filled with current values."""
+    post = Post(title="orig title", body="orig body", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    form = tree.css_first("form")
+    assert form is not None
+    assert form.attributes.get("hx-patch") == f"/posts/{post.id}"
+    assert form.attributes.get("hx-ext") == "json-enc"
+    title_input = tree.css_first("input#title")
+    assert title_input is not None
+    assert title_input.attributes.get("value") == "orig title"
+    body_textarea = tree.css_first("textarea#body")
+    assert body_textarea is not None
+    assert "orig body" in body_textarea.text()
+
+
+async def test_admin_can_open_edit_form_for_any_post(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}/form")
+    assert response.status_code == 200
+
+
+async def test_non_owner_cannot_open_edit_form(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}/form")
+    assert response.status_code == 403
+
+
+async def test_edit_form_404_for_unknown_post(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    response = await authenticated_client.get(f"/posts/{uuid.uuid4()}/form")
+    assert response.status_code == 404
+
+
+async def test_edit_form_unauthenticated_redirects(
+    test_client: AsyncClient,
+):
+    response = await test_client.get(
+        f"/posts/{uuid.uuid4()}/form",
+        headers={"accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers["location"]
+
+
+# --- Owner-actions partial visibility on detail page ---------------------
+
+
+async def test_detail_page_shows_edit_link_for_owner(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    post = Post(title="t", body="b", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    actions = tree.css_first("span.owner-actions")
+    assert actions is not None
+    edit_link = actions.css_first("a")
+    assert edit_link is not None
+    assert edit_link.attributes.get("href") == f"/posts/{post.id}/form"
+
+
+async def test_detail_page_shows_edit_link_for_admin(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first("span.owner-actions") is not None
+
+
+async def test_detail_page_hides_edit_link_for_stranger(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first("span.owner-actions") is None

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -84,7 +84,7 @@ When a real service exists for an entity, move the commit there and update the l
 | Module                    | Purpose                              | Key Functions                  |
 | ------------------------- | ------------------------------------ | ------------------------------ |
 | **user_processing.py**    | User operation coordination          | list users with filtering      |
-| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, commits), update post (owner-or-admin guard, commits), build create-form context |
+| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, commits), update post (owner-or-admin guard, commits), build create- and edit-form contexts (edit form runs the same owner-or-admin guard) |
 | **auth_processing.py**    | Authentication workflow coordination | user registration processing   |
 
 ## Directory structure

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -43,6 +43,24 @@ async def handle_get_post_form(
     return {"request": request, "current_user": requesting_user}
 
 
+async def handle_get_post_edit_form(
+    request: Request,
+    post_id: UUID,
+    post_repo: PostRepository,
+    requesting_user: User,
+):
+    """Loads a post for the edit-form page. 404 if missing, 403 if the
+    requester is neither owner nor admin (mirrors `handle_update_post`)."""
+    post = await post_repo.get_post_by_id(post_id)
+    if post is None:
+        raise NotFoundError(detail="Post not found")
+
+    if post.owner_id != requesting_user.id and not requesting_user.is_superuser:
+        raise ForbiddenError(detail="Only the owner or an admin can edit this post")
+
+    return {"request": request, "post": post, "current_user": requesting_user}
+
+
 async def handle_create_post(
     payload: PostCreate,
     post_repo: PostRepository,

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -66,7 +66,7 @@ Templates use inheritance for consistent layout and feature-specific customizati
 | **/**      | Base layout and shared | `base.html` - Foundation template                                      |
 | **auth/**  | Authentication pages   | login, register, forgot/reset password                                 |
 | **users/** | User management        | list, detail, `_admin_actions.html` partial (shared by list & detail)  |
-| **posts/** | Posts                  | list, detail, `new.html` (create form)                                 |
+| **posts/** | Posts                  | list, detail, `new.html` + `edit.html` (forms), `_owner_actions.html` partial (shared by detail) |
 | **me/**    | Personal/profile pages | user profile                                                           |
 
 ### Reusable partial convention
@@ -91,8 +91,10 @@ templates/
 │   └── _admin_actions.html     # Reusable admin-actions partial
 ├── posts/                      # Post templates
 │   ├── list.html               # Post listing
-│   ├── detail.html             # Post detail
-│   └── new.html                # Create-post form (HTMX json-enc → POST /posts)
+│   ├── detail.html             # Post detail (includes _owner_actions.html)
+│   ├── new.html                # Create-post form (HTMX json-enc → POST /posts)
+│   ├── edit.html               # Edit-post form (HTMX json-enc → PATCH /posts/{id})
+│   └── _owner_actions.html     # Reusable owner-actions partial (Edit link)
 └── me/                         # Personal user pages
     └── profile.html            # User's profile page
 ```

--- a/src/templates/posts/_owner_actions.html
+++ b/src/templates/posts/_owner_actions.html
@@ -1,0 +1,15 @@
+{# Reusable owner actions for a post.
+
+   Required context:
+     post         — the post being acted on
+     current_user — the requesting user (owner gate + admin override)
+
+   Renders nothing unless current_user is the owner OR a superuser.
+   Backend authz lives in src/logic/post_processing.py — this `{% if %}`
+   is presentation only.
+#}
+{% if current_user and (current_user.id == post.owner_id or current_user.is_superuser) %}
+<span class="owner-actions" data-post-id="{{ post.id }}">
+  <a href="/posts/{{ post.id }}/form">Edit</a>
+</span>
+{% endif %}

--- a/src/templates/posts/detail.html
+++ b/src/templates/posts/detail.html
@@ -6,6 +6,8 @@
 
 <div class="post-body">{{ post.body }}</div>
 
+{% include "posts/_owner_actions.html" %}
+
 <hr />
 <a href="/posts">Back to posts</a>
 {% endblock %}

--- a/src/templates/posts/edit.html
+++ b/src/templates/posts/edit.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Edit post: {{ post.title }}{% endblock %} {# title-case-ignore: "post" is the noun, not the HTTP method #}
+{% block content %}
+<h1>Edit post</h1> {# title-case-ignore: "post" is the noun, not the HTTP method #}
+<form hx-patch="/posts/{{ post.id }}" hx-ext="json-enc">
+  <label for="title">Title:</label><br />
+  <input type="text" id="title" name="title" value="{{ post.title }}" required /><br />
+  <label for="body">Body:</label><br />
+  <textarea id="body" name="body" required>{{ post.body }}</textarea><br /><br />
+  <input type="submit" value="Save changes" />
+</form>
+
+<hr />
+<a href="/posts/{{ post.id }}">Cancel</a>
+{% endblock %}

--- a/tests/test_contract/README.md
+++ b/tests/test_contract/README.md
@@ -2,7 +2,7 @@
 
 Pact-based contract tests verify that the **shape of the conversation** between an HTML form (consumer) and the API endpoint it posts to (provider) stays in sync. They do **not** verify business behavior — that's what the colocated unit tests under `src/<layer>/test_*.py` are for.
 
-> **Status:** auth (registration), users (admin actions), and posts (create form) currently have contract test pairs. Add a pair for any new HTML form per the conventions below.
+> **Status:** auth (registration), users (admin actions), and posts (create + edit forms) currently have contract test pairs. Add a pair for any new HTML form per the conventions below.
 
 ## Why this directory exists outside the colocated convention
 
@@ -52,11 +52,12 @@ tests/test_contract/
     ├── consumer/
     │   ├── test_auth_form.py          # Registration form contract
     │   ├── test_user_admin_actions.py # Admin-actions partial contract
-    │   └── test_post_form.py          # New-post form contract
+    │   ├── test_post_form.py          # New-post form contract
+    │   └── test_post_edit_form.py     # Edit-post form contract
     ├── provider/
     │   ├── test_auth_verification.py
     │   ├── test_user_admin_actions_verification.py
-    │   └── test_posts_verification.py
+    │   └── test_posts_verification.py # Verifies BOTH post create and edit pacts
     └── shared/
         ├── consumer_test_base.py      # BaseConsumerTest abstract class
         ├── helpers.py                 # Pact + Playwright glue

--- a/tests/test_contract/constants.py
+++ b/tests/test_contract/constants.py
@@ -19,16 +19,24 @@ USER_ACTIVATION_API_PATH = f"/users/{TARGET_USER_ID}/activation"
 
 # Stable post id returned by the post-create handler mock so the consumer can
 # match the response shape and the redirect headers without round-tripping a DB.
+# Also used as the path id for the edit-form pact.
 STUB_POST_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+POST_EDIT_API_PATH = f"/posts/{STUB_POST_ID}"
+POST_EDIT_PAGE_PATH = f"/posts/{STUB_POST_ID}/form"
 
 # Test post data for the create-form contract.
 TEST_POST_TITLE = "Hello from contract test"
 TEST_POST_BODY = "This is the body of the post."
+EDITED_POST_TITLE = "Edited title"
+EDITED_POST_BODY = "Edited body"
 
 # Provider states
 PROVIDER_STATE_USER_DOES_NOT_EXIST = f"User {TEST_EMAIL} does not exist"
 PROVIDER_STATE_USER_EXISTS_AND_ACTIVE = f"User {TARGET_USER_ID} exists and is active"
 PROVIDER_STATE_POSTS_ACCEPTS_CREATE = "Posts API accepts a create request"
+PROVIDER_STATE_POST_EXISTS_AND_OWNED = (
+    f"Post {STUB_POST_ID} exists and is owned by the requester"
+)
 
 # Consumer / provider Pact identifiers
 CONSUMER_NAME_REGISTRATION = "registration-form"
@@ -38,6 +46,7 @@ CONSUMER_NAME_USER_ADMIN_ACTIONS = "user-admin-actions"
 PROVIDER_NAME_USERS = "users-api"
 
 CONSUMER_NAME_POST_CREATE = "post-create-form"
+CONSUMER_NAME_POST_EDIT = "post-edit-form"
 PROVIDER_NAME_POSTS = "posts-api"
 
 # Timeouts
@@ -47,3 +56,4 @@ NETWORK_TIMEOUT_MS = 500
 PACT_PORT_AUTH = 1234
 PACT_PORT_USER_ACTIVATION = 1235
 PACT_PORT_POST_CREATE = 1236
+PACT_PORT_POST_EDIT = 1237

--- a/tests/test_contract/infrastructure/config.py
+++ b/tests/test_contract/infrastructure/config.py
@@ -36,4 +36,5 @@ KNOWN_PROVIDER_STATES = [
     "User test.user@example.com does not exist",
     "User 11111111-1111-1111-1111-111111111111 exists and is active",
     "Posts API accepts a create request",
+    "Post 22222222-2222-2222-2222-222222222222 exists and is owned by the requester",
 ]

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -24,6 +24,10 @@ from .base import ServerManager, setup_health_check_route
 # the pact path against a known target id without round-tripping a database.
 STUB_TARGET_USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 
+# Stable UUID used by the post-edit stub page; matches `STUB_POST_ID` in
+# `tests/test_contract/constants.py`.
+STUB_POST_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
 
 class ConsumerServerConfig:
     """Toggles for which page routes the consumer server should mount.
@@ -84,16 +88,31 @@ def _setup_users_admin_actions_stub(app: FastAPI) -> None:
 
 
 def _setup_posts_form_stub(app: FastAPI) -> None:
-    """Mount a stub `GET /posts/form` that renders the real `posts/new.html`
-    template. The contract surface is the form's HTMX-decorated submission;
-    the create POST is intercepted by Playwright before it leaves the browser,
-    so no database is needed.
+    """Mount stub pages that render the real `posts/new.html` and
+    `posts/edit.html` templates. The contract surface is the forms'
+    HTMX-decorated submissions; the create POST and edit PATCH are intercepted
+    by Playwright before they leave the browser, so no database is needed.
     """
+
+    class _StubPost:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
 
     @app.get("/posts/form")
     async def posts_form_stub_page(request: Request):
         return APIResponse.html_response(
             template_name="posts/new.html", context={}, request=request
+        )
+
+    @app.get("/posts/{post_id}/form")
+    async def posts_edit_form_stub_page(request: Request, post_id: uuid.UUID):
+        post = _StubPost(
+            id=post_id,
+            title="Stub title",
+            body="Stub body",
+        )
+        return APIResponse.html_response(
+            template_name="posts/edit.html", context={"post": post}, request=request
         )
 
 

--- a/tests/test_contract/tests/consumer/test_post_edit_form.py
+++ b/tests/test_contract/tests/consumer/test_post_edit_form.py
@@ -1,0 +1,91 @@
+"""Consumer contract: filling and submitting the edit-post form.
+
+Verifies that the form rendered by `templates/posts/edit.html` (mounted via
+the `posts_pages` flag on the consumer server) issues `PATCH /posts/{id}`
+with a JSON body matching `PostUpdate` (title + body, no `owner_id`). The
+contract surface is the form template and the route's request shape.
+"""
+
+import pytest
+from pact import Like
+from playwright.async_api import Page
+
+from tests.test_contract.constants import (
+    CONSUMER_NAME_POST_EDIT,
+    EDITED_POST_BODY,
+    EDITED_POST_TITLE,
+    NETWORK_TIMEOUT_MS,
+    PACT_PORT_POST_EDIT,
+    POST_EDIT_API_PATH,
+    POST_EDIT_PAGE_PATH,
+    PROVIDER_NAME_POSTS,
+    PROVIDER_STATE_POST_EXISTS_AND_OWNED,
+    STUB_POST_ID,
+)
+from tests.test_contract.tests.shared.helpers import (
+    setup_pact,
+    setup_playwright_pact_interception,
+)
+
+
+@pytest.mark.parametrize(
+    "origin_with_routes",
+    [{"posts_pages": True, "auth_pages": False}],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_consumer_post_edit_form_interaction(origin_with_routes: str, page: Page):
+    """Submit the edit-post form; assert the intercepted request matches the
+    contracted shape (PATCH /posts/{id} with JSON title + body)."""
+    pact = setup_pact(
+        CONSUMER_NAME_POST_EDIT,
+        PROVIDER_NAME_POSTS,
+        port=PACT_PORT_POST_EDIT,
+    )
+    mock_server_uri = pact.uri
+    edit_page_url = f"{origin_with_routes}{POST_EDIT_PAGE_PATH}"
+    full_mock_url = f"{mock_server_uri}{POST_EDIT_API_PATH}"
+
+    expected_request_headers = {"Content-Type": "application/json"}
+    expected_request_body = {
+        "title": Like(EDITED_POST_TITLE),
+        "body": Like(EDITED_POST_BODY),
+    }
+    expected_response_body = {
+        "id": Like(str(STUB_POST_ID)),
+        "title": Like(EDITED_POST_TITLE),
+        "body": Like(EDITED_POST_BODY),
+    }
+
+    (
+        pact.given(PROVIDER_STATE_POST_EXISTS_AND_OWNED)
+        .upon_receiving("a request to edit a post via the edit-post form")
+        .with_request(
+            method="PATCH",
+            path=POST_EDIT_API_PATH,
+            headers=expected_request_headers,
+            body=expected_request_body,
+        )
+        .will_respond_with(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=expected_response_body,
+        )
+    )
+
+    await setup_playwright_pact_interception(
+        page=page,
+        api_path_to_intercept=POST_EDIT_API_PATH,
+        mock_pact_url=full_mock_url,
+        http_method="PATCH",
+    )
+
+    with pact:
+        await page.goto(edit_page_url)
+        await page.wait_for_selector("#title")
+        await page.locator("#title").fill(EDITED_POST_TITLE)
+        await page.locator("#body").fill(EDITED_POST_BODY)
+        await page.locator("input[type='submit']").click()
+        await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
+
+    # Pact verification happens automatically on context exit.

--- a/tests/test_contract/tests/provider/test_posts_verification.py
+++ b/tests/test_contract/tests/provider/test_posts_verification.py
@@ -1,10 +1,13 @@
-"""Provider verification: POST /posts accepts the documented request shape
-and returns the documented response.
+"""Provider verification: POST /posts and PATCH /posts/{id} accept the
+documented request shapes and return the documented responses.
 
 The route's `current_active_user` dependency is overridden by the provider
-server fixture (auth-mocked). `handle_create_post` is monkey-patched out via
-`MockDataFactory.create_post_create_dependency_config` so this test exercises
-only the route layer (the "waiter, not chef" split).
+server fixture (auth-mocked). `handle_create_post` and `handle_update_post`
+are monkey-patched out via the combined dependency config so this test
+exercises only the route layer (the "waiter, not chef" split).
+
+One module-scoped provider server with both mocks applied — both pact files
+verify against the same server.
 """
 
 import pytest
@@ -16,33 +19,57 @@ from tests.test_contract.tests.shared.provider_verification_base import (
     create_provider_test_decorator,
 )
 
+COMBINED_POSTS_DEPENDENCY_CONFIG = {
+    **MockDataFactory.create_post_create_dependency_config(),
+    **MockDataFactory.create_post_edit_dependency_config(),
+}
 
-class PostsVerification(BaseProviderVerification):
-    """Provider verification for the posts API."""
 
+class _BasePostsVerification(BaseProviderVerification):
     @property
     def provider_name(self) -> str:
         return "posts-api"
 
     @property
+    def dependency_config(self):
+        return COMBINED_POSTS_DEPENDENCY_CONFIG
+
+
+class PostsCreateVerification(_BasePostsVerification):
+    @property
     def consumer_name(self) -> str:
         return "post-create-form"
-
-    @property
-    def dependency_config(self):
-        return MockDataFactory.create_post_create_dependency_config()
 
     @property
     def pytest_marks(self) -> list:
         return [pytest.mark.provider, pytest.mark.posts]
 
 
-posts_verification = PostsVerification()
+class PostsEditVerification(_BasePostsVerification):
+    @property
+    def consumer_name(self) -> str:
+        return "post-edit-form"
+
+    @property
+    def pytest_marks(self) -> list:
+        return [pytest.mark.provider, pytest.mark.posts]
+
+
+posts_create_verification = PostsCreateVerification()
+posts_edit_verification = PostsEditVerification()
 
 
 @create_provider_test_decorator(
-    posts_verification.dependency_config, "with_posts_api_mocks"
+    COMBINED_POSTS_DEPENDENCY_CONFIG, "with_posts_api_mocks"
 )
-def test_provider_posts_pact_verification(provider_server: URL):
+def test_provider_posts_create_pact_verification(provider_server: URL):
     """Verify the post-create-form Pact contract against the running provider server."""
-    posts_verification.verify_pact(provider_server)
+    posts_create_verification.verify_pact(provider_server)
+
+
+@create_provider_test_decorator(
+    COMBINED_POSTS_DEPENDENCY_CONFIG, "with_posts_api_mocks"
+)
+def test_provider_posts_edit_pact_verification(provider_server: URL):
+    """Verify the post-edit-form Pact contract against the running provider server."""
+    posts_edit_verification.verify_pact(provider_server)

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -116,3 +116,23 @@ class MockDataFactory:
                 "return_value_config": post_read
             }
         }
+
+    @classmethod
+    def create_post_edit_dependency_config(
+        cls, post_read: PostRead = None
+    ) -> Dict[str, Any]:
+        """Mock for `handle_update_post`.
+
+        The route under test (`PATCH /posts/{id}`) reads `id`, `title`, and
+        `body` off the handler's return value and packs them into the JSON
+        response, so a `PostRead` (or any object exposing those attributes) is
+        sufficient.
+        """
+        if post_read is None:
+            post_read = cls.create_post_read(title="patched title", body="patched body")
+
+        return {
+            "src.api.routes.posts.handle_update_post": {
+                "return_value_config": post_read
+            }
+        }


### PR DESCRIPTION
## Summary

- Mounts `GET /posts/{id}/form` rendering a new `posts/edit.html` template (HTMX json-enc PATCH to `/posts/{id}`). Authz at the logic layer mirrors `handle_update_post` — owner-only with admin override; 404 for missing, 403 for stranger.
- Adds `posts/_owner_actions.html` partial (Edit link, owner-or-admin visibility) included in `posts/detail.html`. Same shape as `users/_admin_actions.html`.
- Wires the Pact contract test pair: a Playwright-driven consumer test asserts the edit form's request shape; the provider verifier file gains a second class so the create + edit pacts both verify against one provider server with both handlers monkey-patched.
- Closes the four-PR sequence for posts CRUD + forms (PRs #56, #57, #58, this one).

## Test plan

- [x] `dev test` — 106 passed, 1 skipped (8 new colocated cases: edit-form 200/403/404, anon redirect, prefill correctness, partial visibility for owner/admin/stranger)
- [x] `dev test tests/test_contract` — 8 passed (4 consumer + 4 provider). The new edit-form pact verifies against the same provider fixture as the create pact, saving a redundant subprocess spin.
- [x] `dev lint` clean
- [x] `dev routes /posts` shows all six routes mounted in the right order (form before `{post_id}`)
- [ ] Manual smoke (post-merge): visit a post you own → "Edit" link visible → click → prefilled form → save → redirected back to detail with updated content. As a stranger, no link visible; direct `/posts/{id}/form` URL returns 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)