### PR TITLE
Stop title-case checker from rewriting 'post' to 'POST' (#61)

### DIFF
--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -105,6 +105,16 @@ class TitleCaseChecker:
         "Python",
         "JavaScript",
         "TypeScript",
+        "Pact",  # Contract testing framework
+    }
+
+    # HTTP methods are ambiguous: they overlap with common English words
+    # ("post", "get", "put", "delete", "head", "options", "patch", "trace",
+    # "connect"). Treating them like ALWAYS_CAPITALIZE causes false positives
+    # in template prose ("New post" → "New POST"). We preserve uppercase when
+    # the source already wrote it that way (e.g. docs: "POST /users") but
+    # leave lowercase occurrences alone to be normalized as ordinary words.
+    HTTP_METHODS = {
         "POST",
         "GET",
         "PUT",
@@ -114,7 +124,6 @@ class TitleCaseChecker:
         "OPTIONS",
         "TRACE",
         "CONNECT",
-        "Pact",  # Contract testing framework
     }
 
     # Exception patterns (regex patterns to ignore)
@@ -306,9 +315,16 @@ class TitleCaseChecker:
             # Remove punctuation for checking
             clean_word = re.sub(r"[^\w]", "", word)
 
+            # HTTP methods: preserve when source is uppercase (doc style),
+            # otherwise treat as a regular English word.
+            is_http_method = clean_word.upper() in self.HTTP_METHODS
+            if is_http_method and clean_word.isupper():
+                result_words.append(word)
+                continue
+
             if i == 0:
                 # First word: capitalize first letter only, unless it's a special word
-                if clean_word.upper() in capitalize_map:
+                if not is_http_method and clean_word.upper() in capitalize_map:
                     proper_case = capitalize_map[clean_word.upper()]
                     result_words.append(word.replace(clean_word, proper_case))
                 else:
@@ -322,7 +338,7 @@ class TitleCaseChecker:
                         result_words.append(word)
             else:
                 # Other words: only capitalize if in ALWAYS_CAPITALIZE
-                if clean_word.upper() in capitalize_map:
+                if not is_http_method and clean_word.upper() in capitalize_map:
                     proper_case = capitalize_map[clean_word.upper()]
                     result_words.append(word.replace(clean_word, proper_case))
                 else:

--- a/src/templates/posts/detail.html
+++ b/src/templates/posts/detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Post: {{ post.title }}{% endblock %} {# title-case-ignore: "Post" is the noun, not the HTTP method #}
+{% block title %}Post: {{ post.title }}{% endblock %}
 {% block content %}
 <h1>{{ post.title }}</h1>
 <p>by <a href="/users/{{ post.owner_id }}">{{ post.owner.username }}</a></p>

--- a/src/templates/posts/edit.html
+++ b/src/templates/posts/edit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block title %}Edit post: {{ post.title }}{% endblock %} {# title-case-ignore: "post" is the noun, not the HTTP method #}
+{% block title %}Edit post: {{ post.title }}{% endblock %}
 {% block content %}
-<h1>Edit post</h1> {# title-case-ignore: "post" is the noun, not the HTTP method #}
+<h1>Edit post</h1>
 <form hx-patch="/posts/{{ post.id }}" hx-ext="json-enc">
   <label for="title">Title:</label><br />
   <input type="text" id="title" name="title" value="{{ post.title }}" required /><br />

--- a/src/templates/posts/list.html
+++ b/src/templates/posts/list.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>Posts</h1>
 
-<p><a href="/posts/form">New post</a></p> {# title-case-ignore: "post" is the noun, not the HTTP method #}
+<p><a href="/posts/form">New post</a></p>
 
 {% if posts %}
 <ul>

--- a/src/templates/posts/new.html
+++ b/src/templates/posts/new.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% block title %}New post{% endblock %} {# title-case-ignore: "post" is the noun, not the HTTP method #}
+{% block title %}New post{% endblock %}
 {% block content %}
-<h1>New post</h1> {# title-case-ignore: "post" is the noun, not the HTTP method #}
+<h1>New post</h1>
 <form hx-post="/posts" hx-ext="json-enc">
   <label for="title">Title:</label><br />
   <input type="text" id="title" name="title" required /><br />


### PR DESCRIPTION
## Summary

Closes #61.

HTTP methods overlap with common English words. Treating them like \`ALWAYS_CAPITALIZE\` caused false positives — every 'New post' / 'Edit post' line accumulated during the posts CRUD sequence needed a \`{# title-case-ignore #}\` comment.

This PR splits \`HTTP_METHODS\` into a separate set with context-aware handling: preserve uppercase when the source already wrote it that way (\`POST /users\` in docs stays correct) but treat lowercase occurrences as ordinary English words.

Drops the four accumulated ignore comments in \`src/templates/posts/{list,new,edit,detail}.html\`.

## Test plan

- [x] \`dev lint\` passes (templates without ignore comments are now clean)
- [x] \`dev test src/api/routes/test_posts.py\` — 42 passed (no behavior change)
- [x] Manual sanity check on the conversion function:
  - 'New post' → 'New post' ✓
  - 'POST /users' → 'POST /users' ✓ (uppercase preserved)
  - 'Use the API' → 'Use the API' ✓
  - 'GET /users returns' → 'GET /users returns' ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)