### PR TITLE
Promote `_promote_to_admin` to `tests/helpers.py` (#62)

### DIFF
--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import Post, User
-from tests.helpers import create_test_user
+from tests.helpers import create_test_user, promote_to_admin
 
 # Mark all tests in this module as async
 pytestmark = pytest.mark.asyncio
@@ -282,19 +282,6 @@ async def test_create_post_unauthenticated_redirects(
 # --- Update (PATCH) ------------------------------------------------------
 
 
-async def _promote_to_admin(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-    user_email: str,
-) -> None:
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            stmt = select(User).filter(User.email == user_email)
-            result = await session.execute(stmt)
-            user = result.scalars().first()
-            assert user is not None, f"Test user {user_email} not found"
-            user.is_superuser = True
-
-
 async def test_owner_can_patch_title_only(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -391,7 +378,7 @@ async def test_admin_can_patch_anyone_post(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     other = create_test_user(username=f"other-{uuid.uuid4()}")
     post = Post(title="orig", body="orig", owner_id=other.id)
     async with db_test_session_manager() as session:
@@ -586,7 +573,7 @@ async def test_admin_can_open_edit_form_for_any_post(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     other = create_test_user(username=f"other-{uuid.uuid4()}")
     post = Post(title="t", body="b", owner_id=other.id)
     async with db_test_session_manager() as session:
@@ -662,7 +649,7 @@ async def test_detail_page_shows_edit_link_for_admin(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     other = create_test_user(username=f"other-{uuid.uuid4()}")
     post = Post(title="t", body="b", owner_id=other.id)
     async with db_test_session_manager() as session:

--- a/src/api/routes/test_users.py
+++ b/src/api/routes/test_users.py
@@ -9,24 +9,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import User
-from tests.helpers import create_test_user
+from tests.helpers import create_test_user, promote_to_admin
 
 # Mark all tests in this module as async
 pytestmark = pytest.mark.asyncio
-
-
-async def _promote_to_admin(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-    user_email: str,
-) -> None:
-    """Mutate a fixture-created user to is_superuser=True."""
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            stmt = select(User).filter(User.email == user_email)
-            result = await session.execute(stmt)
-            user = result.scalars().first()
-            assert user is not None, f"Test user {user_email} not found"
-            user.is_superuser = True
 
 
 # --- Listing -------------------------------------------------------------
@@ -140,7 +126,7 @@ async def test_list_shows_admin_actions_for_admin(
     logged_in_user: User,
 ):
     """Admin viewers see deactivate + delete buttons on each non-self row."""
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     other = create_test_user(username=f"target-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -162,7 +148,7 @@ async def test_list_shows_reactivate_for_deactivated_user(
     logged_in_user: User,
 ):
     """A deactivated user shows 'Reactivate' rather than 'Deactivate'."""
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     other = create_test_user(username=f"target-{uuid.uuid4()}", is_active=False)
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -211,7 +197,7 @@ async def test_detail_shows_admin_actions_for_admin(
     logged_in_user: User,
 ):
     """Admin viewing another user's detail page sees the actions partial."""
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     target = create_test_user(username=f"target-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -246,7 +232,7 @@ async def test_admin_can_deactivate_user(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     target = create_test_user(username=f"target-{uuid.uuid4()}", is_active=True)
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -273,7 +259,7 @@ async def test_admin_can_reactivate_user(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     target = create_test_user(username=f"target-{uuid.uuid4()}", is_active=False)
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -311,7 +297,7 @@ async def test_admin_cannot_deactivate_self(
     logged_in_user: User,
 ):
     """Self-guard: admin acting on their own id is rejected at the logic layer."""
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
 
     response = await authenticated_client.put(
         f"/users/{logged_in_user.id}/activation",
@@ -325,7 +311,7 @@ async def test_activation_404_for_unknown_user(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     response = await authenticated_client.put(
         f"/users/{uuid.uuid4()}/activation",
         json={"state": "deactivated"},
@@ -341,7 +327,7 @@ async def test_admin_can_delete_user(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     target = create_test_user(username=f"target-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -380,7 +366,7 @@ async def test_admin_cannot_delete_self(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     response = await authenticated_client.delete(f"/users/{logged_in_user.id}")
     assert response.status_code == 403
 
@@ -390,6 +376,6 @@ async def test_delete_404_for_unknown_user(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    await _promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
     response = await authenticated_client.delete(f"/users/{uuid.uuid4()}")
     assert response.status_code == 404

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ See [`../CLAUDE.md`](../CLAUDE.md) for the full definition-of-done contract that
 ## What lives here
 
 - **`fixtures.py`** — shared pytest fixtures (`test_client`, `authenticated_client`, `db_test_session_manager`, `logged_in_user`, etc.). Loaded globally via `pytest_plugins = ["tests.fixtures"]` in the repo-root `conftest.py`, so colocated tests anywhere under `src/` can use them.
-- **`helpers.py`** — non-fixture test utilities (e.g. `create_test_user(...)` for building User instances). Import as `from tests.helpers import create_test_user`.
+- **`helpers.py`** — non-fixture test utilities. Currently exports `create_test_user(...)` for building User instances and `promote_to_admin(...)` for flipping `is_superuser=True` on a fixture-created user (used by tests that exercise admin-gated routes). Import as `from tests.helpers import create_test_user, promote_to_admin`.
 - **`README.md`** — this file.
 - **(future) cross-module integration tests** — tests that span multiple layers and don't have a single owning module belong here, not under `src/`.
 
@@ -24,7 +24,8 @@ See [`../CLAUDE.md`](../CLAUDE.md) for the full definition-of-done contract that
 
 | Module | Tests |
 | --- | --- |
-| `src/api/routes/` | `test_auth_routes.py`, `test_users.py` |
+| `src/api/routes/` | `test_auth_routes.py`, `test_users.py`, `test_posts.py` |
+| `src/schemas/` | `test_post.py` |
 | `src/services/` | none yet — gap |
 | `src/repositories/` | none yet — gap |
 | `src/logic/` | none yet — gap |

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,9 @@ import uuid
 from typing import Optional
 from uuid import UUID  # Import UUID
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
 # Need ORM models
 from src.models import User
 
@@ -26,3 +29,23 @@ def create_test_user(
         is_superuser=is_superuser,
         is_verified=is_verified,
     )
+
+
+async def promote_to_admin(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    user_email: str,
+) -> None:
+    """Mutate a fixture-created user to is_superuser=True.
+
+    Used by colocated tests that need an admin actor — the standard
+    `authenticated_client` fixture creates a non-admin user, so tests that
+    exercise admin-gated routes flip the bit on the existing user instead of
+    reauthenticating as a different one.
+    """
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            stmt = select(User).filter(User.email == user_email)
+            result = await session.execute(stmt)
+            user = result.scalars().first()
+            assert user is not None, f"Test user {user_email} not found"
+            user.is_superuser = True


### PR DESCRIPTION
## Summary

Closes #62.

The helper for flipping \`is_superuser=True\` on a fixture-created user was a private function in \`test_users.py\`. PR #57 (posts PATCH) needed the same behavior and copied it into \`test_posts.py\` — duplication.

Promoted to \`promote_to_admin\` in \`tests/helpers.py\` next to the existing \`create_test_user\`. Both test files now import from there. Behavior unchanged at the 14 call sites.

Also refreshed the colocated-tests table in \`tests/README.md\` to include the test files added since (\`test_posts.py\`, \`test_post.py\`).

## Test plan

- [x] \`dev test src/api/routes\` — 78 passed, 1 skipped (covers all 14 \`promote_to_admin\` call sites)
- [x] \`dev lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)