### PR TITLE
Audit-log retrofit: posts (#63 PR B)

### DIFF
--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -15,7 +15,8 @@ from src.logic.post_processing import (
     handle_update_post,
 )
 from src.models import User
-from src.repositories.dependencies import get_post_repository
+from src.repositories.audit_repository import AuditRepository
+from src.repositories.dependencies import get_audit_repository, get_post_repository
 from src.repositories.post_repository import PostRepository
 from src.schemas.post import PostCreate, PostUpdate
 
@@ -102,6 +103,7 @@ async def get_post(
 async def create_post(
     payload: PostCreate,
     post_repo: PostRepository = Depends(get_post_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
     user: User = Depends(current_active_user),
 ):
     """Creates a post owned by the authenticated user.
@@ -112,6 +114,7 @@ async def create_post(
     created = await handle_create_post(
         payload=payload,
         post_repo=post_repo,
+        audit_repo=audit_repo,
         requesting_user=user,
     )
     location = f"/posts/{created.id}"
@@ -127,6 +130,7 @@ async def patch_post(
     post_id: UUID,
     payload: PostUpdate,
     post_repo: PostRepository = Depends(get_post_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
     user: User = Depends(current_active_user),
 ):
     """Partially updates a post. Owner-only; admins may edit any post.
@@ -139,6 +143,7 @@ async def patch_post(
         post_id=post_id,
         payload=payload,
         post_repo=post_repo,
+        audit_repo=audit_repo,
         requesting_user=user,
     )
     return JSONResponse(

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -6,7 +6,8 @@ from selectolax.parser import HTMLParser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.models import Post, User
+from src.models import AuditLog, Post, User
+from src.repositories.audit_repository import AuditRepository
 from tests.helpers import create_test_user, promote_to_admin
 
 # Mark all tests in this module as async
@@ -679,3 +680,146 @@ async def test_detail_page_hides_edit_link_for_stranger(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert tree.css_first("span.owner-actions") is None
+
+
+# --- Audit log -----------------------------------------------------------
+
+
+async def test_create_post_writes_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Each successful POST /posts writes exactly one audit row."""
+    title = f"audited-{uuid.uuid4()}"
+    body = f"body-{uuid.uuid4()}"
+
+    response = await authenticated_client.post(
+        "/posts", json={"title": title, "body": body}
+    )
+    assert response.status_code == 201
+    new_id = uuid.UUID(response.json()["id"])
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(resource_type="post", resource_id=new_id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.actor_id == logged_in_user.id
+        assert row.action == "create_post"
+        assert row.before is None
+        assert row.after == {
+            "title": title,
+            "body": body,
+            "owner_id": str(logged_in_user.id),
+        }
+
+
+async def test_patch_post_writes_audit_row_with_before_and_after(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Each successful PATCH /posts/{id} writes one audit row capturing
+    pre- and post-mutation snapshots."""
+    post = Post(title="orig title", body="orig body", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"title": "new title"}
+    )
+    assert response.status_code == 200
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(resource_type="post", resource_id=post.id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.actor_id == logged_in_user.id
+        assert row.action == "update_post"
+        assert row.before == {
+            "title": "orig title",
+            "body": "orig body",
+            "owner_id": str(logged_in_user.id),
+        }
+        assert row.after == {
+            "title": "new title",
+            "body": "orig body",
+            "owner_id": str(logged_in_user.id),
+        }
+
+
+async def test_failed_create_writes_no_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A 422 (schema rejection) must not leak an audit row — the discipline
+    requires audit lands iff the mutation does."""
+    response = await authenticated_client.post(
+        "/posts", json={"title": "t", "body": "b", "evil": True}
+    )
+    assert response.status_code == 422
+
+    async with db_test_session_manager() as session:
+        # No specific resource_id to query — assert the post-typed audit
+        # table is empty.
+        result = await session.execute(
+            select(AuditLog).filter(AuditLog.resource_type == "post")
+        )
+        assert result.scalars().first() is None
+
+
+async def test_unauthorized_patch_writes_no_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A 403 must not leak an audit row."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"title": "hijack"}
+    )
+    assert response.status_code == 403
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(resource_type="post", resource_id=post.id)
+        assert rows == []
+
+
+async def test_admin_patch_audit_actor_is_admin_not_owner(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """When an admin edits another user's post, the audit row's actor is
+    the admin (the requester), not the post owner."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.patch(
+        f"/posts/{post.id}", json={"title": "moderated"}
+    )
+    assert response.status_code == 200
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(resource_type="post", resource_id=post.id)
+        assert len(rows) == 1
+        assert rows[0].actor_id == logged_in_user.id  # admin, not other
+        assert rows[0].after["title"] == "moderated"
+        assert rows[0].after["owner_id"] == str(other.id)

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -84,8 +84,8 @@ When a real service exists for an entity, move the commit there and update the l
 | Module                    | Purpose                              | Key Functions                  |
 | ------------------------- | ------------------------------------ | ------------------------------ |
 | **user_processing.py**    | User operation coordination          | list users with filtering      |
-| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, commits), update post (owner-or-admin guard, commits), build create- and edit-form contexts (edit form runs the same owner-or-admin guard) |
-| **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. PRs B/C/D wire the existing handlers to call this. |
+| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, writes audit row, commits), update post (owner-or-admin guard, before/after audit snapshot, commits), build create- and edit-form contexts |
+| **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. Wired into post handlers; PRs C/D wire users and auth. |
 | **auth_processing.py**    | Authentication workflow coordination | user registration processing   |
 
 ## Directory structure

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -4,11 +4,22 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
+from src.logic.audit import record_audit
 from src.models import Post, User
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.post_repository import PostRepository
 from src.schemas.post import PostCreate, PostUpdate
 
 logger = logging.getLogger(__name__)
+
+
+def _snapshot_post(post: Post) -> dict:
+    """Capture the user-meaningful fields of a post for audit before/after."""
+    return {
+        "title": post.title,
+        "body": post.body,
+        "owner_id": str(post.owner_id),
+    }
 
 
 async def handle_list_posts(
@@ -64,15 +75,26 @@ async def handle_get_post_edit_form(
 async def handle_create_post(
     payload: PostCreate,
     post_repo: PostRepository,
+    audit_repo: AuditRepository,
     requesting_user: User,
 ) -> Post:
-    """Creates a post owned by the requesting user; commits on success."""
+    """Creates a post owned by the requesting user; writes an audit row in
+    the same transaction; commits on success."""
     post = Post(
         title=payload.title,
         body=payload.body,
         owner_id=requesting_user.id,
     )
     created = await post_repo.create_post(post)
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="post",
+        resource_id=created.id,
+        action="create_post",
+        before=None,
+        after=_snapshot_post(created),
+    )
     await post_repo.session.commit()
     logger.info(f"Handler: user {requesting_user.id} created post {created.id}")
     return created
@@ -82,10 +104,14 @@ async def handle_update_post(
     post_id: UUID,
     payload: PostUpdate,
     post_repo: PostRepository,
+    audit_repo: AuditRepository,
     requesting_user: User,
 ) -> Post:
     """Patches a post owned by the requesting user (or by anyone, if the
-    requester is a superuser). 404 if missing, 403 if not authorized.
+    requester is a superuser). Writes an audit row capturing before/after
+    snapshots in the same transaction; commits on success.
+
+    404 if missing, 403 if not authorized.
     """
     post = await post_repo.get_post_by_id(post_id)
     if post is None:
@@ -94,7 +120,17 @@ async def handle_update_post(
     if post.owner_id != requesting_user.id and not requesting_user.is_superuser:
         raise ForbiddenError(detail="Only the owner or an admin can edit this post")
 
+    before = _snapshot_post(post)
     updated = await post_repo.update_post(post, title=payload.title, body=payload.body)
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="post",
+        resource_id=updated.id,
+        action="update_post",
+        before=before,
+        after=_snapshot_post(updated),
+    )
     await post_repo.session.commit()
     logger.info(f"Handler: user {requesting_user.id} updated post {updated.id}")
     return updated


### PR DESCRIPTION
## Summary

Second slice of #63. Wires \`record_audit\` (from PR A, merged in #67) into the post-mutation handlers. Each successful create or update now writes one audit row in the same transaction as the mutation, so audit lands iff the mutation does.

- **Create** — \`before=None\`, \`after=_snapshot_post(created)\`. Action \`create_post\`, actor is the requester.
- **Update** — \`before=_snapshot_post(post)\` captured pre-mutation, \`after=_snapshot_post(updated)\`. Action \`update_post\`. Authorization (owner-or-admin) still gates the mutation, so 403 short-circuits before the audit call.
- **Snapshot shape** — \`{"title": ..., "body": ..., "owner_id": ...}\`. \`id\` is in \`resource_id\` already, no need to duplicate.
- **Wiring** — \`AuditRepository\` injected via FastAPI \`Depends\` alongside \`PostRepository\`. Both share the request-scoped \`get_db_session\`, so commit on either persists both rows atomically.

## Test plan

- [x] \`dev test\` — 122 passed, 1 skipped (5 new audit assertions on top of existing post tests)
- [x] \`dev lint\` clean
- [x] New tests cover the failure paths too: 422 (schema reject) writes no row; 403 (unauthorized patch) writes no row; admin-edits-others'-post records the admin as actor (not the owner)

## Follow-ups

- **PR C** — \`handle_set_user_activation\` and \`handle_delete_user\`.
- **PR D** — \`handle_registration\` (and password / email if present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)