### PR TITLE
Audit-log retrofit: users (#63 PR C)

### DIFF
--- a/src/api/routes/test_users.py
+++ b/src/api/routes/test_users.py
@@ -8,7 +8,8 @@ from sqlalchemy import select
 # Import session maker type for hinting
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.models import User
+from src.models import AuditLog, User
+from src.repositories.audit_repository import AuditRepository
 from tests.helpers import create_test_user, promote_to_admin
 
 # Mark all tests in this module as async
@@ -379,3 +380,124 @@ async def test_delete_404_for_unknown_user(
     await promote_to_admin(db_test_session_manager, logged_in_user.email)
     response = await authenticated_client.delete(f"/users/{uuid.uuid4()}")
     assert response.status_code == 404
+
+
+# --- Audit log -----------------------------------------------------------
+
+
+async def test_set_user_activation_writes_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Each successful PUT /users/{id}/activation writes one audit row
+    capturing before/after activation state, with the admin as actor."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    target = create_test_user(username=f"target-{uuid.uuid4()}", is_active=True)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(target)
+
+    response = await authenticated_client.put(
+        f"/users/{target.id}/activation",
+        json={"state": "deactivated"},
+    )
+    assert response.status_code == 200
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(resource_type="user", resource_id=target.id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.actor_id == logged_in_user.id
+        assert row.action == "set_user_activation"
+        assert row.before == {"is_active": True}
+        assert row.after == {"is_active": False}
+
+
+async def test_failed_activation_writes_no_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A 403 (admin self-guard) leaves no audit trail."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+
+    response = await authenticated_client.put(
+        f"/users/{logged_in_user.id}/activation",
+        json={"state": "deactivated"},
+    )
+    assert response.status_code == 403
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(
+            resource_type="user", resource_id=logged_in_user.id
+        )
+        assert rows == []
+
+
+async def test_delete_user_writes_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Each successful DELETE /users/{id} writes one audit row capturing
+    the user's pre-delete state in `before`, with `after=None`."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    target_username = f"target-{uuid.uuid4()}"
+    target = create_test_user(
+        username=target_username, is_active=True, is_superuser=False
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(target)
+    target_id = target.id
+    target_email = target.email
+
+    response = await authenticated_client.delete(f"/users/{target_id}")
+    assert response.status_code == 204
+
+    async with db_test_session_manager() as session:
+        # User row gone
+        result = await session.execute(select(User).filter(User.id == target_id))
+        assert result.scalars().first() is None
+
+        # Audit row preserved with the admin as actor
+        result = await session.execute(
+            select(AuditLog).filter(
+                AuditLog.resource_type == "user",
+                AuditLog.resource_id == target_id,
+            )
+        )
+        rows = result.scalars().all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.actor_id == logged_in_user.id
+        assert row.action == "delete_user"
+        assert row.before == {
+            "username": target_username,
+            "email": target_email,
+            "is_active": True,
+            "is_superuser": False,
+        }
+        assert row.after is None
+
+
+async def test_failed_delete_writes_no_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Self-delete attempts get 403; no audit row written."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+
+    response = await authenticated_client.delete(f"/users/{logged_in_user.id}")
+    assert response.status_code == 403
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(
+            resource_type="user", resource_id=logged_in_user.id
+        )
+        assert rows == []

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -13,7 +13,8 @@ from src.logic.user_processing import (
     handle_set_user_activation,
 )
 from src.models import User
-from src.repositories.dependencies import get_user_repository
+from src.repositories.audit_repository import AuditRepository
+from src.repositories.dependencies import get_audit_repository, get_user_repository
 from src.repositories.user_repository import UserRepository
 from src.schemas.user import UserActivationUpdate
 
@@ -66,6 +67,7 @@ async def set_user_activation(
     user_id: UUID,
     payload: UserActivationUpdate,
     user_repo: UserRepository = Depends(get_user_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
     admin: User = Depends(current_admin_user),
 ):
     """Admin-only: activate or deactivate a user."""
@@ -73,6 +75,7 @@ async def set_user_activation(
         user_id=user_id,
         payload=payload,
         user_repo=user_repo,
+        audit_repo=audit_repo,
         requesting_user=admin,
     )
     return JSONResponse(
@@ -89,12 +92,14 @@ async def set_user_activation(
 async def delete_user(
     user_id: UUID,
     user_repo: UserRepository = Depends(get_user_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
     admin: User = Depends(current_admin_user),
 ):
     """Admin-only: hard-delete a user."""
     await handle_delete_user(
         user_id=user_id,
         user_repo=user_repo,
+        audit_repo=audit_repo,
         requesting_user=admin,
     )
     return Response(

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -83,9 +83,9 @@ When a real service exists for an entity, move the commit there and update the l
 
 | Module                    | Purpose                              | Key Functions                  |
 | ------------------------- | ------------------------------------ | ------------------------------ |
-| **user_processing.py**    | User operation coordination          | list users with filtering      |
+| **user_processing.py**    | User operation coordination          | list users with filtering, set activation (writes audit row, commits), delete user (audit row recorded before the delete fires; commits) |
 | **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, writes audit row, commits), update post (owner-or-admin guard, before/after audit snapshot, commits), build create- and edit-form contexts |
-| **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. Wired into post handlers; PRs C/D wire users and auth. |
+| **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. Wired into post and user handlers; PR D wires auth. |
 | **auth_processing.py**    | Authentication workflow coordination | user registration processing   |
 
 ## Directory structure

--- a/src/logic/user_processing.py
+++ b/src/logic/user_processing.py
@@ -4,11 +4,28 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
+from src.logic.audit import record_audit
 from src.models import User
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.user_repository import UserRepository
 from src.schemas.user import UserActivationUpdate
 
 logger = logging.getLogger(__name__)
+
+
+def _snapshot_user_activation(user: User) -> dict:
+    """Capture just the activation axis for audit before/after."""
+    return {"is_active": user.is_active}
+
+
+def _snapshot_user(user: User) -> dict:
+    """Capture user-meaningful fields for `delete_user` audit `before`."""
+    return {
+        "username": user.username,
+        "email": user.email,
+        "is_active": user.is_active,
+        "is_superuser": user.is_superuser,
+    }
 
 
 async def handle_list_users(
@@ -71,9 +88,11 @@ async def handle_set_user_activation(
     user_id: UUID,
     payload: UserActivationUpdate,
     user_repo: UserRepository,
+    audit_repo: AuditRepository,
     requesting_user: User,
 ) -> User:
-    """Admin-only: set a user's activation state.
+    """Admin-only: set a user's activation state. Writes an audit row in the
+    same transaction.
 
     Self-guard lives here so direct API calls can't bypass the template's
     `{% if %}` hide. The route's `current_admin_user` dep blocks non-admins.
@@ -90,7 +109,17 @@ async def handle_set_user_activation(
     logger.info(
         f"Handler: admin {requesting_user.id} setting activation={payload.state} on user {target.id}"
     )
+    before = _snapshot_user_activation(target)
     updated = await user_repo.set_user_activation(target, is_active=is_active)
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="user",
+        resource_id=updated.id,
+        action="set_user_activation",
+        before=before,
+        after=_snapshot_user_activation(updated),
+    )
     await user_repo.session.commit()
     return updated
 
@@ -98,9 +127,12 @@ async def handle_set_user_activation(
 async def handle_delete_user(
     user_id: UUID,
     user_repo: UserRepository,
+    audit_repo: AuditRepository,
     requesting_user: User,
 ) -> None:
-    """Admin-only: hard-delete a user row.
+    """Admin-only: hard-delete a user row. Writes an audit row in the same
+    transaction (recorded before the delete fires so the actor FK is still
+    valid; the row's `before` captures the soon-to-be-gone state).
 
     Self-guard mirrors `handle_set_user_activation`; the route dep blocks non-admins.
     """
@@ -111,5 +143,16 @@ async def handle_delete_user(
         raise ForbiddenError(detail="Admins cannot delete their own account here")
 
     logger.info(f"Handler: admin {requesting_user.id} hard-deleting user {target.id}")
+    before = _snapshot_user(target)
+    target_id = target.id
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="user",
+        resource_id=target_id,
+        action="delete_user",
+        before=before,
+        after=None,
+    )
     await user_repo.delete_user(target)
     await user_repo.session.commit()


### PR DESCRIPTION
## Summary

Third slice of #63. Wires \`record_audit\` into the user-mutation handlers (\`handle_set_user_activation\` and \`handle_delete_user\`).

- **Activation** — \`action="set_user_activation"\`, \`before/after\` both flip the boolean. Self-guard short-circuits before the audit call (no leaked rows on 403).
- **Delete** — \`action="delete_user"\`, \`before\` captures full pre-delete user state, \`after=None\`. Audit row is recorded **before** the user delete fires so the actor FK is still valid at the point of insert; the row survives the cascade because \`actor_id\` has \`ON DELETE SET NULL\`.
- **Snapshot shapes** — \`_snapshot_user_activation\` (\`{is_active}\` only) for the activation-axis subresource; \`_snapshot_user\` (\`{username, email, is_active, is_superuser}\`) for the full delete-user audit.

## Test plan

- [x] \`dev test\` — 126 passed, 1 skipped (4 new audit assertions on top of existing user tests)
- [x] \`dev lint\` clean
- [x] Failure paths covered: admin self-guard on both activation and delete writes no audit row

## Follow-ups

- **PR D** — \`handle_registration\` (and password / email handlers, if present). That closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)