### PR TITLE
Audit-log retrofit: auth registration (#63 PR D — closes #63)

### DIFF
--- a/src/api/routes/auth_routes.py
+++ b/src/api/routes/auth_routes.py
@@ -8,6 +8,8 @@ from fastapi_users.router.common import ErrorCode, ErrorModel
 from src.api.common import BaseRouter
 from src.auth_config import get_user_manager
 from src.logic.auth_processing import handle_registration
+from src.repositories.audit_repository import AuditRepository
+from src.repositories.dependencies import get_audit_repository
 from src.schemas.user import UserCreate, UserRead
 
 # router = APIRouter() # Old raw APIRouter
@@ -73,6 +75,7 @@ async def register_request_handler(
     request_data: UserCreate,
     request: Request,
     user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
 ):
     """
     Handles the core logic for user registration, delegated from the route handler.
@@ -80,6 +83,9 @@ async def register_request_handler(
     """
     logger.debug(f"Handling registration for email: {request_data.email}")
     result = await handle_registration(
-        request_data=request_data, request=request, user_manager=user_manager
+        request_data=request_data,
+        request=request,
+        user_manager=user_manager,
+        audit_repo=audit_repo,
     )
     return result

--- a/src/api/routes/test_auth_routes.py
+++ b/src/api/routes/test_auth_routes.py
@@ -2,9 +2,11 @@ import pytest
 from fastapi_users.db import SQLAlchemyUserDatabase
 from httpx import AsyncClient
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.models import User
+from src.models import AuditLog, User
+from src.repositories.audit_repository import AuditRepository
 
 # Mark all tests in this module as async
 pytestmark = pytest.mark.asyncio
@@ -285,3 +287,66 @@ async def test_unauthorized_redirect_follows_to_login_page(test_client: AsyncCli
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
     assert "<h1>Login</h1>" in response.text
+
+
+# --- Audit log -----------------------------------------------------------
+
+
+async def test_register_writes_audit_row(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Each successful POST /auth/register writes one audit row with
+    actor_id=None (self-signup has no authenticated actor)."""
+    register_data = {
+        "email": "audit-target@example.com",
+        "password": "password123",
+        "username": "audittarget",
+    }
+    response = await test_client.post("/auth/register", json=register_data)
+    assert response.status_code == 201
+    new_user_id = response.json()["id"]
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        from uuid import UUID
+
+        rows = await repo.list_for_resource(
+            resource_type="user", resource_id=UUID(new_user_id)
+        )
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.actor_id is None  # self-signup
+        assert row.action == "register"
+        assert row.before is None
+        assert row.after == {
+            "username": "audittarget",
+            "email": "audit-target@example.com",
+        }
+
+
+async def test_failed_register_writes_no_audit_row(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A 400 (duplicate email) must not leak an audit row."""
+    register_data = {
+        "email": logged_in_user.email,  # already exists via logged_in_user fixture
+        "password": "newpassword",
+        "username": "duplicate",
+    }
+    response = await test_client.post("/auth/register", json=register_data)
+    assert response.status_code == 400
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(AuditLog)
+            .filter(AuditLog.action == "register")
+            .filter(AuditLog.after["email"].as_string() == logged_in_user.email)
+        )
+        rows = result.scalars().all()
+        # The original logged_in_user was created via the test fixture, not
+        # the /auth/register route, so no audit row exists for that email.
+        # The duplicate attempt likewise must not have written one.
+        assert rows == []

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -85,8 +85,8 @@ When a real service exists for an entity, move the commit there and update the l
 | ------------------------- | ------------------------------------ | ------------------------------ |
 | **user_processing.py**    | User operation coordination          | list users with filtering, set activation (writes audit row, commits), delete user (audit row recorded before the delete fires; commits) |
 | **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, writes audit row, commits), update post (owner-or-admin guard, before/after audit snapshot, commits), build create- and edit-form contexts |
-| **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. Wired into post and user handlers; PR D wires auth. |
-| **auth_processing.py**    | Authentication workflow coordination | user registration processing   |
+| **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. Wired into all current mutation handlers (posts, users, auth registration). |
+| **auth_processing.py**    | Authentication workflow coordination | user registration processing (writes a `register` audit row with `actor_id=None`; best-effort atomicity since fastapi-users commits internally) |
 
 ## Directory structure
 

--- a/src/logic/auth_processing.py
+++ b/src/logic/auth_processing.py
@@ -6,6 +6,9 @@ from fastapi_users import models
 from fastapi_users.manager import BaseUserManager, UserManagerDependency
 
 from src.auth_config import get_user_manager
+from src.logic.audit import record_audit
+from src.repositories.audit_repository import AuditRepository
+from src.repositories.dependencies import get_audit_repository
 from src.schemas.user import UserCreate, UserRead
 
 logger = logging.getLogger(__name__)
@@ -17,6 +20,31 @@ async def handle_registration(
     request_data: UserCreate,
     request: Request,
     user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
 ) -> UserRead:
+    """Register a new user, then write an audit row.
+
+    Best-effort atomicity. `fastapi_users`' `user_manager.create` commits
+    internally via `SQLAlchemyUserDatabase.create`, so the audit insert
+    that follows is a separate transaction on the same session. If the
+    audit insert fails after the user is committed, we have a user without
+    a matching audit row — surfaced in logs and as a 500 to the caller,
+    but not rolled back. Authenticated mutation handlers (post create/edit,
+    user activation/delete) get true atomicity via shared transactions; this
+    is the one exception.
+    """
     created_user = await user_manager.create(request_data, safe=True, request=request)
+    await record_audit(
+        audit_repo,
+        actor_id=None,  # self-signup has no authenticated actor
+        resource_type="user",
+        resource_id=created_user.id,
+        action="register",
+        before=None,
+        after={
+            "username": created_user.username,
+            "email": created_user.email,
+        },
+    )
+    await audit_repo.session.commit()
     return created_user


### PR DESCRIPTION
## Summary

Final slice of #63. Wires \`record_audit\` into \`handle_registration\`, completing the audit-log discipline mandated by \`RESOURCE_GRAMMAR.md:135\` for all current mutation handlers.

- **Action** — \`register\`. \`actor_id=None\` because self-signup has no authenticated actor at the time of registration.
- **Snapshot** — \`before=None\`, \`after={"username": ..., "email": ...}\`.

## Atomicity caveat (documented in the handler)

Registration is the **one** audit point that is **not** same-transaction with its mutation. \`fastapi_users.user_manager.create\` commits internally via \`SQLAlchemyUserDatabase.create\`, so the subsequent \`record_audit\` is a separate transaction on the same session. If the audit insert fails after the user is committed, we surface a 500 but the user persists — caught in logs, not rolled back.

All other authenticated mutation handlers (post create/edit, user activation/delete) get true atomicity via shared transactions on the same \`get_db_session\`-scoped session.

## Test plan

- [x] \`dev test\` — 128 passed, 1 skipped (2 new audit assertions on auth)
- [x] \`dev lint\` clean
- [x] Failure path covered: duplicate-email register (400) writes no audit row

## Closes

This closes #63 — every current mutation now writes an audit row, satisfying the discipline \`RESOURCE_GRAMMAR.md:135\` mandates. Future mutation handlers should follow the same pattern (call \`record_audit\` before commit; same-transaction unless using fastapi-users-style internal commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)