### PR TITLE
Type audit actions with an AuditAction enum

### DIFF
--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -8,9 +8,15 @@ mutation is. The handler still owns the commit.
 
 `actor_id` is `None` for unauthenticated mutations (e.g. self-signup); the
 schema permits it.
+
+`AuditAction` is the closed vocabulary of mutation kinds. Add a member here
+when wiring `record_audit` into a new mutation handler; never reuse an
+existing value for a different semantic — values are persisted forever and
+existing rows depend on the meaning being stable.
 """
 
 import logging
+from enum import Enum
 from typing import Any
 from uuid import UUID
 
@@ -20,13 +26,28 @@ from src.repositories.audit_repository import AuditRepository
 logger = logging.getLogger(__name__)
 
 
+class AuditAction(str, Enum):
+    """Closed vocabulary of mutation actions recorded in the audit log.
+
+    Inherits from `str` so values serialize transparently into the
+    `audit_log.action` column and equality comparisons against raw strings
+    keep working (`AuditAction.CREATE_POST == "create_post"` is True).
+    """
+
+    CREATE_POST = "create_post"
+    UPDATE_POST = "update_post"
+    SET_USER_ACTIVATION = "set_user_activation"
+    DELETE_USER = "delete_user"
+    REGISTER = "register"
+
+
 async def record_audit(
     audit_repo: AuditRepository,
     *,
     actor_id: UUID | None,
     resource_type: str,
     resource_id: UUID,
-    action: str,
+    action: AuditAction,
     before: dict[str, Any] | None = None,
     after: dict[str, Any] | None = None,
 ) -> AuditLog:
@@ -39,5 +60,5 @@ async def record_audit(
         before=before,
         after=after,
     )
-    logger.info(f"Audit: actor={actor_id} {action} {resource_type}/{resource_id}")
+    logger.info(f"Audit: actor={actor_id} {action.value} {resource_type}/{resource_id}")
     return row

--- a/src/logic/auth_processing.py
+++ b/src/logic/auth_processing.py
@@ -6,7 +6,7 @@ from fastapi_users import models
 from fastapi_users.manager import BaseUserManager, UserManagerDependency
 
 from src.auth_config import get_user_manager
-from src.logic.audit import record_audit
+from src.logic.audit import AuditAction, record_audit
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository
 from src.schemas.user import UserCreate, UserRead
@@ -39,7 +39,7 @@ async def handle_registration(
         actor_id=None,  # self-signup has no authenticated actor
         resource_type="user",
         resource_id=created_user.id,
-        action="register",
+        action=AuditAction.REGISTER,
         before=None,
         after={
             "username": created_user.username,

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
-from src.logic.audit import record_audit
+from src.logic.audit import AuditAction, record_audit
 from src.models import Post, User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.post_repository import PostRepository
@@ -91,7 +91,7 @@ async def handle_create_post(
         actor_id=requesting_user.id,
         resource_type="post",
         resource_id=created.id,
-        action="create_post",
+        action=AuditAction.CREATE_POST,
         before=None,
         after=_snapshot_post(created),
     )
@@ -127,7 +127,7 @@ async def handle_update_post(
         actor_id=requesting_user.id,
         resource_type="post",
         resource_id=updated.id,
-        action="update_post",
+        action=AuditAction.UPDATE_POST,
         before=before,
         after=_snapshot_post(updated),
     )

--- a/src/logic/test_audit.py
+++ b/src/logic/test_audit.py
@@ -11,7 +11,7 @@ import uuid
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.logic.audit import record_audit
+from src.logic.audit import AuditAction, record_audit
 from src.repositories.audit_repository import AuditRepository
 from tests.helpers import create_test_user
 
@@ -36,7 +36,7 @@ async def test_record_audit_round_trips_through_repo(
             actor_id=actor.id,
             resource_type="post",
             resource_id=resource_id,
-            action="create_post",
+            action=AuditAction.CREATE_POST,
             before=None,
             after={"title": "x"},
         )
@@ -44,7 +44,7 @@ async def test_record_audit_round_trips_through_repo(
 
         fetched = await repo.get_by_id(row.id)
         assert fetched is not None
-        assert fetched.action == "create_post"
+        assert fetched.action == AuditAction.CREATE_POST
         assert fetched.before is None
         assert fetched.after == {"title": "x"}
 
@@ -69,7 +69,7 @@ async def test_record_audit_does_not_commit(
             actor_id=actor.id,
             resource_type="post",
             resource_id=resource_id,
-            action="create_post",
+            action=AuditAction.CREATE_POST,
             after={"title": "x"},
         )
         await session.rollback()
@@ -96,7 +96,7 @@ async def test_record_audit_accepts_null_actor(
             actor_id=None,
             resource_type="user",
             resource_id=resource_id,
-            action="register",
+            action=AuditAction.REGISTER,
             after={"email": "new@example.com"},
         )
         await session.commit()

--- a/src/logic/user_processing.py
+++ b/src/logic/user_processing.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
-from src.logic.audit import record_audit
+from src.logic.audit import AuditAction, record_audit
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.user_repository import UserRepository
@@ -116,7 +116,7 @@ async def handle_set_user_activation(
         actor_id=requesting_user.id,
         resource_type="user",
         resource_id=updated.id,
-        action="set_user_activation",
+        action=AuditAction.SET_USER_ACTIVATION,
         before=before,
         after=_snapshot_user_activation(updated),
     )
@@ -150,7 +150,7 @@ async def handle_delete_user(
         actor_id=requesting_user.id,
         resource_type="user",
         resource_id=target_id,
-        action="delete_user",
+        action=AuditAction.DELETE_USER,
         before=before,
         after=None,
     )


### PR DESCRIPTION
## Summary

Replaces free-form audit action strings with a closed \`AuditAction(str, Enum)\` in \`src/logic/audit.py\`. First of three follow-ups improving the audit-log discipline shipped in #67–#70.

## Why

\`action="create_post"\` was a typo risk with no completion or enforcement; the only documentation of valid values lived implicitly across five mutation handlers. A typo would silently produce a new "action category" no consumer would know to query.

## Design notes

- \`AuditAction\` inherits from \`str\` so existing rows (persisted as plain strings) stay queryable and equality against literals stays True. No migration needed.
- The enum is the public contract of \`record_audit(...)\`. The lower-level \`AuditRepository.record(...)\` keeps a permissive \`str\` type — \`AuditAction\` flows through transparently.
- \`logger.info\` now formats with \`action.value\` for clean log output.

## Test plan

- [x] \`dev test\` — 128 passed, 1 skipped
- [x] \`dev lint\` clean
- [x] No DB migration; existing audit rows match the enum values

## Follow-ups in this batch

- Snapshot schemas (Pydantic-derived \`before\`/\`after\` instead of hand-rolled dicts).
- Audit-discipline enforcement (meta-test that fails if a \`handle_*\` commits without recording an audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)