### PR TITLE
Derive audit before/after from Pydantic snapshot schemas

### DIFF
--- a/src/api/routes/test_auth_routes.py
+++ b/src/api/routes/test_auth_routes.py
@@ -322,6 +322,8 @@ async def test_register_writes_audit_row(
         assert row.after == {
             "username": "audittarget",
             "email": "audit-target@example.com",
+            "is_active": True,
+            "is_superuser": False,
         }
 
 

--- a/src/logic/auth_processing.py
+++ b/src/logic/auth_processing.py
@@ -9,7 +9,7 @@ from src.auth_config import get_user_manager
 from src.logic.audit import AuditAction, record_audit
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository
-from src.schemas.user import UserCreate, UserRead
+from src.schemas.user import UserAuditSnapshot, UserCreate, UserRead
 
 logger = logging.getLogger(__name__)
 
@@ -41,10 +41,7 @@ async def handle_registration(
         resource_id=created_user.id,
         action=AuditAction.REGISTER,
         before=None,
-        after={
-            "username": created_user.username,
-            "email": created_user.email,
-        },
+        after=UserAuditSnapshot.model_validate(created_user).model_dump(mode="json"),
     )
     await audit_repo.session.commit()
     return created_user

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -8,18 +8,18 @@ from src.logic.audit import AuditAction, record_audit
 from src.models import Post, User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.post_repository import PostRepository
-from src.schemas.post import PostCreate, PostUpdate
+from src.schemas.post import PostAuditSnapshot, PostCreate, PostUpdate
 
 logger = logging.getLogger(__name__)
 
 
 def _snapshot_post(post: Post) -> dict:
-    """Capture the user-meaningful fields of a post for audit before/after."""
-    return {
-        "title": post.title,
-        "body": post.body,
-        "owner_id": str(post.owner_id),
-    }
+    """Capture the user-meaningful fields of a post for audit before/after.
+
+    Field set is defined by `PostAuditSnapshot` — adding a relevant field
+    to that schema flows here automatically.
+    """
+    return PostAuditSnapshot.model_validate(post).model_dump(mode="json")
 
 
 async def handle_list_posts(

--- a/src/logic/user_processing.py
+++ b/src/logic/user_processing.py
@@ -8,24 +8,29 @@ from src.logic.audit import AuditAction, record_audit
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.user_repository import UserRepository
-from src.schemas.user import UserActivationUpdate
+from src.schemas.user import (
+    UserActivationAuditSnapshot,
+    UserActivationUpdate,
+    UserAuditSnapshot,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def _snapshot_user_activation(user: User) -> dict:
-    """Capture just the activation axis for audit before/after."""
-    return {"is_active": user.is_active}
+    """Capture just the activation axis for audit before/after.
+
+    Field set is defined by `UserActivationAuditSnapshot`.
+    """
+    return UserActivationAuditSnapshot.model_validate(user).model_dump(mode="json")
 
 
 def _snapshot_user(user: User) -> dict:
-    """Capture user-meaningful fields for `delete_user` audit `before`."""
-    return {
-        "username": user.username,
-        "email": user.email,
-        "is_active": user.is_active,
-        "is_superuser": user.is_superuser,
-    }
+    """Capture user-meaningful fields for `delete_user` audit `before`.
+
+    Field set is defined by `UserAuditSnapshot`.
+    """
+    return UserAuditSnapshot.model_validate(user).model_dump(mode="json")
 
 
 async def handle_list_users(

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -61,8 +61,8 @@ Schemas act as the data contract layer between HTTP and business logic.
 
 | Schema File | Domain    | Responsibilities                             | Schema Types                                             |
 | ----------- | --------- | -------------------------------------------- | -------------------------------------------------------- |
-| **user.py** | User data | User CRUD plus activation state-axis subresource (extends FastAPI Users) | UserRead, UserCreate, UserUpdate, UserActivationUpdate   |
-| **post.py** | Posts     | Post read + create + partial-update validation (`extra="forbid"` rejects `owner_id` and other server-managed fields; whitespace-only `title`/`body` rejected; `PostUpdate` requires at least one field) | PostRead, PostCreate, PostUpdate |
+| **user.py** | User data | User CRUD plus activation state-axis subresource (extends FastAPI Users) and audit snapshots | UserRead, UserCreate, UserUpdate, UserActivationUpdate, UserAuditSnapshot, UserActivationAuditSnapshot |
+| **post.py** | Posts     | Post read + create + partial-update validation + audit snapshot (`extra="forbid"` rejects `owner_id` and other server-managed fields; whitespace-only `title`/`body` rejected; `PostUpdate` requires at least one field) | PostRead, PostCreate, PostUpdate, PostAuditSnapshot |
 
 ## Directory structure
 

--- a/src/schemas/post.py
+++ b/src/schemas/post.py
@@ -51,3 +51,19 @@ class PostUpdate(BaseModel):
         if self.title is None and self.body is None:
             raise ValueError("at least one of title, body must be provided")
         return self
+
+
+class PostAuditSnapshot(BaseModel):
+    """Audit `before`/`after` projection for posts.
+
+    Captures the user-meaningful fields that mutations to a `Post` can
+    change. The id lives in `audit_log.resource_id` already, so it's not
+    duplicated here. Adding a field requires updating this class — the
+    handler picks it up automatically via `model_dump`.
+    """
+
+    title: str
+    body: str
+    owner_id: uuid.UUID
+
+    model_config = ConfigDict(from_attributes=True)

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from fastapi_users import schemas
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 
 class UserRead(schemas.BaseUser):
@@ -20,3 +20,27 @@ class UserActivationUpdate(BaseModel):
     """Body for `PUT /users/{id}/activation` — sets the user's activation state."""
 
     state: Literal["active", "deactivated"]
+
+
+class UserActivationAuditSnapshot(BaseModel):
+    """Audit `before`/`after` projection for the `/users/{id}/activation`
+    state-axis subresource. Captures only the field this mutation can change.
+    """
+
+    is_active: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserAuditSnapshot(BaseModel):
+    """Audit `before`/`after` projection for full-record user mutations
+    (currently only `delete_user` and `register`). The id lives in
+    `audit_log.resource_id` already, so it's not duplicated here.
+    """
+
+    username: str
+    email: EmailStr
+    is_active: bool
+    is_superuser: bool
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary

Replaces hand-rolled snapshot dicts in the logic layer with Pydantic classes that own the projection. Second of three follow-ups improving the audit-log discipline shipped in #67–#70.

## Why

Three private snapshot helpers (\`_snapshot_post\`, \`_snapshot_user\`, \`_snapshot_user_activation\`) each duplicated knowledge of "which fields belong in the audit." Adding a field to \`Post\` or \`User\` required remembering to update the dict — drift was inevitable.

## What

Three new classes in \`src/schemas/\`:

- \`PostAuditSnapshot\` — \`title\`, \`body\`, \`owner_id\`
- \`UserAuditSnapshot\` — \`username\`, \`email\`, \`is_active\`, \`is_superuser\`
- \`UserActivationAuditSnapshot\` — \`is_active\` only

Each is \`from_attributes=True\`, so \`model_validate(orm_obj).model_dump(mode="json")\` produces the same dict shape the handlers were building by hand — with UUID/datetime serialization handled consistently.

## Behavioural side effect

Registration's audit \`after\` payload now includes \`is_active\` and \`is_superuser\` (previously: only \`username\` + \`email\`). The richer snapshot is correct — initial state is auditable. Test updated.

All other audit shapes (post create/update, user activation, user delete) match exactly what was produced before. Existing test assertions pass without changes.

## Test plan

- [x] \`dev test\` — 128 passed, 1 skipped
- [x] \`dev lint\` clean

## Follow-up

- Audit-discipline enforcement (#5 from the critique) — meta-test that fails if a \`handle_*\` commits without recording an audit. Final PR in this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)