### PR TITLE
Enforce audit-log discipline with an AST meta-test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,11 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    # Keep in sync with the black version installed via pyproject.toml so
+    # pre-commit and `dev lint`/CI agree on style. Version drift caused one
+    # CI flap on PR #73 — pre-commit's older black approved a file that
+    # CI's newer black rejected.
+    rev: 26.3.1
     hooks:
       - id: black
         language_version: python3.11

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -283,6 +283,7 @@ async def handle_get_users(user_repo: UserRepository, requesting_user: User):
 Colocated tests live alongside the logic modules:
 
 - `test_audit.py` — exercises the `record_audit(...)` helper: round-trip via the repo, no commit (handler owns commit), null-actor support.
+- `test_audit_discipline.py` — static AST check that fails if any `handle_*` in `*_processing.py` calls `.commit()` without `record_audit(...)`. Enforces `RESOURCE_GRAMMAR.md:135` so a future contributor can't silently skip the audit row. Opt out with `audit-discipline-ignore: <reason>` in the handler's docstring.
 
 When adding or changing a processing function, create `src/logic/test_<file>.py` next to it. Most processing functions can be unit-tested directly with mocks or with the in-memory `db_test_session_manager` fixture for the repositories they depend on.
 

--- a/src/logic/test_audit_discipline.py
+++ b/src/logic/test_audit_discipline.py
@@ -1,0 +1,168 @@
+"""Static check that mutation handlers obey the audit-log discipline.
+
+Per `RESOURCE_GRAMMAR.md:135`, every mutation handler MUST write an audit
+row in the same transaction as the mutation. The discipline is easy to
+forget on a new handler — this test makes "forgot the audit call" a CI
+failure instead of a code-review catch.
+
+The check parses each `*_processing.py` in `src/logic/`, walks every
+`async def handle_*` function, and fails the test if the function calls
+`.commit()` without also calling `record_audit(...)`.
+
+Opt-out: add `audit-discipline-ignore` to the function's docstring with a
+brief reason. Use sparingly — the rule is the rule for a good reason.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+LOGIC_DIR = Path(__file__).parent
+PROCESSING_FILES = sorted(LOGIC_DIR.glob("*_processing.py"))
+
+
+def _has_call_named(node: ast.AST, name: str) -> bool:
+    """True if the subtree rooted at `node` contains a call to `name`.
+
+    Matches both bare names (`record_audit(...)`) and attribute calls
+    (`audit_repo.session.commit()`).
+    """
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        func = sub.func
+        if isinstance(func, ast.Name) and func.id == name:
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == name:
+            return True
+    return False
+
+
+def _is_opted_out(func: ast.AsyncFunctionDef) -> bool:
+    docstring = ast.get_docstring(func) or ""
+    return "audit-discipline-ignore" in docstring
+
+
+def _mutation_handlers(path: Path) -> list[ast.AsyncFunctionDef]:
+    """All `async def handle_*` definitions in a logic-layer file."""
+    tree = ast.parse(path.read_text())
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name.startswith("handle_")
+    ]
+
+
+def _all_handlers() -> list[tuple[Path, ast.AsyncFunctionDef]]:
+    pairs: list[tuple[Path, ast.AsyncFunctionDef]] = []
+    for path in PROCESSING_FILES:
+        for func in _mutation_handlers(path):
+            pairs.append((path, func))
+    return pairs
+
+
+HANDLERS = _all_handlers()
+
+
+@pytest.mark.parametrize(
+    "path,func",
+    HANDLERS,
+    ids=[f"{p.name}::{f.name}" for p, f in HANDLERS],
+)
+def test_handler_obeys_audit_discipline(path: Path, func: ast.AsyncFunctionDef) -> None:
+    """A `handle_*` that calls `.commit()` MUST also call `record_audit(...)`.
+
+    The check is intentionally conservative — read-only handlers (no commit)
+    pass trivially; mutation handlers without the audit call fail with a
+    pointer to RESOURCE_GRAMMAR.md and the opt-out mechanism.
+    """
+    if _is_opted_out(func):
+        pytest.skip(f"{func.name} opted out via audit-discipline-ignore")
+
+    commits = _has_call_named(func, "commit")
+    audits = _has_call_named(func, "record_audit")
+
+    if commits and not audits:
+        pytest.fail(
+            f"{path.name}::{func.name} calls .commit() without record_audit. "
+            "Mutation handlers MUST write an audit row in the same transaction "
+            "(RESOURCE_GRAMMAR.md:135). Either add a `record_audit(...)` call "
+            "before the commit, or — if this handler legitimately doesn't "
+            "mutate — annotate its docstring with `audit-discipline-ignore: "
+            "<reason>`."
+        )
+
+
+def test_check_finds_handlers() -> None:
+    """Sanity: at least one mutation handler must be discovered, otherwise
+    the parametrize collected nothing and the discipline check is silently
+    a no-op."""
+    assert len(HANDLERS) > 0, "no handle_* functions found in src/logic/"
+
+
+def test_at_least_one_handler_actually_audits() -> None:
+    """Sanity: at least one handler in the codebase calls record_audit.
+    If this fails, the import-graph or AST walk is broken — not a discipline
+    failure, a self-test failure.
+    """
+    auditing = [
+        (path, func) for path, func in HANDLERS if _has_call_named(func, "record_audit")
+    ]
+    assert auditing, (
+        "no handler calls record_audit — either the AST walk is broken or "
+        "the audit retrofit hasn't shipped"
+    )
+
+
+# --- Self-tests: prove the check catches what it claims to catch ---------
+
+
+def _parse_handler(source: str) -> ast.AsyncFunctionDef:
+    tree = ast.parse(source)
+    handler = tree.body[0]
+    assert isinstance(handler, ast.AsyncFunctionDef)
+    return handler
+
+
+def test_check_flags_handler_that_commits_without_audit() -> None:
+    """A regression in the check itself shows up here, not in production."""
+    bad = _parse_handler(
+        """
+async def handle_bad(repo, user):
+    await repo.do_thing()
+    await repo.session.commit()
+    return None
+"""
+    )
+    assert _has_call_named(bad, "commit")
+    assert not _has_call_named(bad, "record_audit")
+
+
+def test_check_approves_handler_that_audits_then_commits() -> None:
+    good = _parse_handler(
+        """
+async def handle_good(repo, audit_repo, user):
+    await record_audit(audit_repo, action=AuditAction.X)
+    await repo.session.commit()
+    return None
+"""
+    )
+    assert _has_call_named(good, "commit")
+    assert _has_call_named(good, "record_audit")
+
+
+def test_check_skips_handler_with_opt_out_in_docstring() -> None:
+    opted_out = _parse_handler(
+        '''
+async def handle_special(repo):
+    """Read-only consistency commit.
+
+    audit-discipline-ignore: this handler doesn't mutate; the .commit()
+    is a savepoint release, no audit row warranted.
+    """
+    await repo.session.commit()
+    return None
+'''
+    )
+    assert _is_opted_out(opted_out)

--- a/src/logic/test_audit_discipline.py
+++ b/src/logic/test_audit_discipline.py
@@ -127,34 +127,29 @@ def _parse_handler(source: str) -> ast.AsyncFunctionDef:
 
 def test_check_flags_handler_that_commits_without_audit() -> None:
     """A regression in the check itself shows up here, not in production."""
-    bad = _parse_handler(
-        """
+    bad = _parse_handler("""
 async def handle_bad(repo, user):
     await repo.do_thing()
     await repo.session.commit()
     return None
-"""
-    )
+""")
     assert _has_call_named(bad, "commit")
     assert not _has_call_named(bad, "record_audit")
 
 
 def test_check_approves_handler_that_audits_then_commits() -> None:
-    good = _parse_handler(
-        """
+    good = _parse_handler("""
 async def handle_good(repo, audit_repo, user):
     await record_audit(audit_repo, action=AuditAction.X)
     await repo.session.commit()
     return None
-"""
-    )
+""")
     assert _has_call_named(good, "commit")
     assert _has_call_named(good, "record_audit")
 
 
 def test_check_skips_handler_with_opt_out_in_docstring() -> None:
-    opted_out = _parse_handler(
-        '''
+    opted_out = _parse_handler('''
 async def handle_special(repo):
     """Read-only consistency commit.
 
@@ -163,6 +158,5 @@ async def handle_special(repo):
     """
     await repo.session.commit()
     return None
-'''
-    )
+''')
     assert _is_opted_out(opted_out)


### PR DESCRIPTION
## Summary

Final follow-up from the audit-log critique. Makes "every mutation handler MUST write an audit row" (\`RESOURCE_GRAMMAR.md:135\`) a CI-enforced rule instead of a code-review discipline.

## What

\`src/logic/test_audit_discipline.py\` parses each \`*_processing.py\`, walks every \`async def handle_*\` function via \`ast\`, and fails if the function calls \`.commit()\` without also calling \`record_audit(...)\`. Each handler shows up as its own parametrized test case in the report — failures point at the exact function.

Three self-tests prove the check itself works:
- Synthetic "commits without auditing" handler → flagged.
- Synthetic "audits then commits" handler → approved.
- Handler with \`audit-discipline-ignore: <reason>\` in its docstring → skipped (opt-out for rare cases).

Two sanity tests guard against the parametrize collecting nothing or the AST walk silently breaking — either would turn the discipline check into a no-op.

## Why this approach

Considered alternatives:

- **Decorator** (\`@audited(action=...)\`) — substantial API change, didn't fit the codebase's functional style.
- **SQLAlchemy event listener** — runtime-only, can't catch missing audits in dead-code branches.
- **Regex linting** — fragile against multi-line function bodies.

AST is the right tool for "structural rule about source code." Stdlib only, no new deps.

## Test plan

- [x] \`dev test\` — 144 passed, 1 skipped (16 new tests: 11 handler checks + 2 self-tests + 3 self-tests for the check)
- [x] \`dev lint\` clean
- [x] All 5 mutation handlers (post create/update, user activation/delete, register) pass the check
- [x] All 6 read-only handlers (list/detail/form pages) pass trivially (no commit, no audit needed)

## Closes

Third and final follow-up from my audit-log critique. With this in, \`RESOURCE_GRAMMAR.md:135\` is enforced by CI rather than discipline alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)