### PR TITLE
Add DELETE /posts/{post_id} with owner-or-admin authorization

### DIFF
--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -73,7 +73,7 @@ Routes are organized by domain with consistent delegation patterns.
 | Route File         | Domain               | Primary Responsibilities         | Main Endpoints                                                                                                                  | Dependencies          |
 | ------------------ | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | **users.py**       | User data            | User listing, detail, admin actions | `GET /users`, `GET /users/{id}`, `PUT /users/{id}/activation` (admin), `DELETE /users/{id}` (admin)                          | UserRepository        |
-| **posts.py**       | Posts                | Post listing, detail, create, partial update, and create/edit form pages | `GET /posts`, `GET /posts/form`, `GET /posts/{id}`, `GET /posts/{id}/form`, `POST /posts`, `PATCH /posts/{id}`                                                                              | PostRepository        |
+| **posts.py**       | Posts                | Post listing, detail, create, partial update, hard delete, and create/edit form pages | `GET /posts`, `GET /posts/form`, `GET /posts/{id}`, `GET /posts/{id}/form`, `POST /posts`, `PATCH /posts/{id}`, `DELETE /posts/{id}`                                                                              | PostRepository        |
 | **me.py**          | Current user context | User profile, current-user JSON  | `GET /users/me`, `GET /users/me/profile`                                                                                        | Auth                  |
 | **auth_routes.py** | Authentication API   | Login, register, password reset  | `/auth/*`                                                                                                                       | Authentication logic  |
 | **auth_pages.py**  | Authentication UI    | Login, register forms            | `/login`, `/register`                                                                                                           | Authentication logic  |
@@ -83,7 +83,7 @@ Routes are organized by domain with consistent delegation patterns.
 **Domain route files:**
 
 - `users.py` - User listing and access
-- `posts.py` - Post listing, detail, create, partial update, and both HTML form pages (`GET /posts/form`, `GET /posts/{id}/form`)
+- `posts.py` - Post listing, detail, create, partial update, hard delete, and both HTML form pages (`GET /posts/form`, `GET /posts/{id}/form`)
 - `me.py` - Current user's profile
 
 **Authentication routes:**
@@ -285,7 +285,7 @@ Colocated alongside the routes:
 
 - `test_auth_routes.py` — registration, login, logout, password reset, session protection (covers `auth_routes.py` and `auth_pages.py`).
 - `test_users.py` — `GET /users` listing behavior (covers `users.py`).
-- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`, `GET /posts/form`, and `GET /posts/{id}/form` (covers `posts.py`). Includes owner-only authorization, admin override, the `extra="forbid"` scrub of `owner_id`, route-ordering checks, and `_owner_actions.html` partial visibility on the detail page. Pact contract pairs for both forms live under [`tests/test_contract/`](../../../tests/test_contract/README.md).
+- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`, `DELETE /posts/{id}`, `GET /posts/form`, and `GET /posts/{id}/form` (covers `posts.py`). Includes owner-or-admin authorization on PATCH and DELETE, the `extra="forbid"` scrub of `owner_id`, route-ordering checks, audit-row before/after assertions for create/update/delete, and `_owner_actions.html` partial visibility on the detail page. Pact contract pairs for both forms live under [`tests/test_contract/`](../../../tests/test_contract/README.md).
 
 When adding a new route, add (or extend) a `test_*.py` file in this same directory. Shared fixtures (`test_client`, `authenticated_client`, `db_test_session_manager`, `logged_in_user`) come from [`tests/fixtures.py`](../../../tests/fixtures.py); user-construction helpers from [`tests/helpers.py`](../../../tests/helpers.py).
 

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -1,13 +1,14 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Request, Response, status
 from fastapi.responses import JSONResponse
 
 from src.api.common import APIResponse, BaseRouter
 from src.auth_config import current_active_user
 from src.logic.post_processing import (
     handle_create_post,
+    handle_delete_post,
     handle_get_post_detail,
     handle_get_post_edit_form,
     handle_get_post_form,
@@ -149,4 +150,26 @@ async def patch_post(
     return JSONResponse(
         content={"id": str(updated.id), "title": updated.title, "body": updated.body},
         headers={"HX-Refresh": "true"},
+    )
+
+
+@router.delete("/{post_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_post(
+    post_id: UUID,
+    post_repo: PostRepository = Depends(get_post_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+    user: User = Depends(current_active_user),
+):
+    """Hard-deletes a post. Owner-only; admins may delete any post.
+    404 if missing, 403 if not authorized.
+    """
+    await handle_delete_post(
+        post_id=post_id,
+        post_repo=post_repo,
+        audit_repo=audit_repo,
+        requesting_user=user,
+    )
+    return Response(
+        status_code=status.HTTP_204_NO_CONTENT,
+        headers={"HX-Redirect": "/posts"},
     )

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -823,3 +823,174 @@ async def test_admin_patch_audit_actor_is_admin_not_owner(
         assert rows[0].actor_id == logged_in_user.id  # admin, not other
         assert rows[0].after["title"] == "moderated"
         assert rows[0].after["owner_id"] == str(other.id)
+
+
+# --- Delete (DELETE) -----------------------------------------------------
+
+
+async def test_owner_can_delete_own_post(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """DELETE by the owner returns 204, removes the row, and sets HX-Redirect."""
+    post = Post(title="t", body="b", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.delete(f"/posts/{post.id}")
+    assert response.status_code == 204
+    assert response.headers.get("HX-Redirect") == "/posts"
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(select(Post).filter(Post.id == post.id))
+        assert result.scalars().first() is None
+
+
+async def test_admin_can_delete_anyone_post(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """An admin can hard-delete a post owned by another user."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.delete(f"/posts/{post.id}")
+    assert response.status_code == 204
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(select(Post).filter(Post.id == post.id))
+        assert result.scalars().first() is None
+
+
+async def test_non_owner_cannot_delete_post(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A non-owner non-admin gets 403 and the post is preserved."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="orig", body="orig", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.delete(f"/posts/{post.id}")
+    assert response.status_code == 403
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(select(Post).filter(Post.id == post.id))
+        refreshed = result.scalars().first()
+        assert refreshed is not None
+        assert refreshed.title == "orig"
+
+
+async def test_delete_404_for_unknown_post(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    response = await authenticated_client.delete(f"/posts/{uuid.uuid4()}")
+    assert response.status_code == 404
+
+
+async def test_delete_unauthenticated_redirects(
+    test_client: AsyncClient,
+):
+    response = await test_client.delete(
+        f"/posts/{uuid.uuid4()}",
+        headers={"accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers["location"]
+
+
+async def test_delete_post_writes_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Each successful DELETE writes one audit row capturing the pre-delete
+    state in `before`, with `after=None`."""
+    title = f"doomed-{uuid.uuid4()}"
+    body = f"body-{uuid.uuid4()}"
+    post = Post(title=title, body=body, owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+    post_id = post.id
+
+    response = await authenticated_client.delete(f"/posts/{post_id}")
+    assert response.status_code == 204
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(resource_type="post", resource_id=post_id)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.actor_id == logged_in_user.id
+        assert row.action == "delete_post"
+        assert row.before == {
+            "title": title,
+            "body": body,
+            "owner_id": str(logged_in_user.id),
+        }
+        assert row.after is None
+
+
+async def test_unauthorized_delete_writes_no_audit_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A 403 on DELETE must not leak an audit row."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.delete(f"/posts/{post.id}")
+    assert response.status_code == 403
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(resource_type="post", resource_id=post.id)
+        assert rows == []
+
+
+async def test_admin_delete_audit_actor_is_admin_not_owner(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """When an admin deletes another user's post, the audit row's actor is
+    the admin (the requester), not the post owner."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+    post_id = post.id
+
+    response = await authenticated_client.delete(f"/posts/{post_id}")
+    assert response.status_code == 204
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(resource_type="post", resource_id=post_id)
+        assert len(rows) == 1
+        assert rows[0].actor_id == logged_in_user.id  # admin, not other
+        assert rows[0].before["owner_id"] == str(other.id)
+        assert rows[0].after is None

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -84,7 +84,7 @@ When a real service exists for an entity, move the commit there and update the l
 | Module                    | Purpose                              | Key Functions                  |
 | ------------------------- | ------------------------------------ | ------------------------------ |
 | **user_processing.py**    | User operation coordination          | list users with filtering, set activation (writes audit row, commits), delete user (audit row recorded before the delete fires; commits) |
-| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, writes audit row, commits), update post (owner-or-admin guard, before/after audit snapshot, commits), build create- and edit-form contexts |
+| **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets owner_id, writes audit row, commits), update post (owner-or-admin guard, before/after audit snapshot, commits), delete post (owner-or-admin guard, audit row recorded before the delete fires with `after=None`, commits), build create- and edit-form contexts |
 | **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. Wired into all current mutation handlers (posts, users, auth registration). |
 | **auth_processing.py**    | Authentication workflow coordination | user registration processing (writes a `register` audit row with `actor_id=None`; best-effort atomicity since fastapi-users commits internally) |
 

--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -36,6 +36,7 @@ class AuditAction(str, Enum):
 
     CREATE_POST = "create_post"
     UPDATE_POST = "update_post"
+    DELETE_POST = "delete_post"
     SET_USER_ACTIVATION = "set_user_activation"
     DELETE_USER = "delete_user"
     REGISTER = "register"

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -134,3 +134,39 @@ async def handle_update_post(
     await post_repo.session.commit()
     logger.info(f"Handler: user {requesting_user.id} updated post {updated.id}")
     return updated
+
+
+async def handle_delete_post(
+    post_id: UUID,
+    post_repo: PostRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> None:
+    """Hard-deletes a post owned by the requesting user (or any post, if the
+    requester is a superuser). Writes an audit row capturing the pre-delete
+    state in `before` (with `after=None`) in the same transaction; commits
+    on success.
+
+    404 if missing, 403 if not authorized.
+    """
+    post = await post_repo.get_post_by_id(post_id)
+    if post is None:
+        raise NotFoundError(detail="Post not found")
+
+    if post.owner_id != requesting_user.id and not requesting_user.is_superuser:
+        raise ForbiddenError(detail="Only the owner or an admin can delete this post")
+
+    before = _snapshot_post(post)
+    target_id = post.id
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="post",
+        resource_id=target_id,
+        action=AuditAction.DELETE_POST,
+        before=before,
+        after=None,
+    )
+    await post_repo.delete_post(post)
+    await post_repo.session.commit()
+    logger.info(f"Handler: user {requesting_user.id} deleted post {target_id}")

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -62,7 +62,7 @@ Each repository manages one primary domain entity with related data access opera
 | Repository         | Primary Entity | Key Responsibilities                                                          |
 | ------------------ | -------------- | ----------------------------------------------------------------------------- |
 | **UserRepository** | User           | User lookup, listing, activation toggle, hard delete                          |
-| **PostRepository** | Post           | Post lookup by id, list all posts (newest first), persist a new post, partial update (caller commits) |
+| **PostRepository** | Post           | Post lookup by id, list all posts (newest first), persist a new post, partial update, hard delete (caller commits) |
 | **AuditRepository** | AuditLog | Append-only writes (`record(...)`), single-row read, list-by-resource. No update or delete methods — audit rows are immutable. |
 
 ## Directory structure

--- a/src/repositories/post_repository.py
+++ b/src/repositories/post_repository.py
@@ -48,3 +48,8 @@ class PostRepository(BaseRepository):
         await self.session.flush()
         await self.session.refresh(post)
         return post
+
+    async def delete_post(self, post: Post) -> None:
+        """Deletes a post and flushes; the caller commits."""
+        await self.session.delete(post)
+        await self.session.flush()


### PR DESCRIPTION
## Summary
- Adds `DELETE /posts/{post_id}` returning 204 with `HX-Redirect: /posts`. The owner or any superuser may delete; non-owner non-admin gets 403, missing post gets 404.
- Mirrors the existing PATCH auth pattern and the `DELETE /users/{id}` audit shape: pre-delete snapshot recorded with `after=None` in the same transaction as the delete.
- Wires the new `DELETE_POST` AuditAction, `PostRepository.delete_post`, and `handle_delete_post` handler. Layer READMEs updated to match.

## Test plan
- [x] `dev test src/api/routes/test_posts.py` — 8 new DELETE cases (owner / admin / non-owner / 404 / unauthenticated redirect / audit row / no audit on 403 / admin-actor-not-owner). 55 file-local tests pass.
- [x] `dev test src/logic/test_audit_discipline.py` — AST meta-test recognizes `handle_delete_post` and approves the `record_audit` + `commit` ordering.
- [x] `dev test` — full suite 153 passed, 1 pre-existing skip.
- [x] `dev lint` — clean.
- [x] `dev routes /posts` — confirms `DELETE /posts/{post_id}` is mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)