### PR TITLE
Accept multiple paths in 'dev test' (closes #75)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,7 @@ Run `dev --help` for the live, authoritative list. As of this writing:
 | `dev down [--volumes]` | Stop the development environment (optionally drop volumes). |
 | `dev logs [-f] [service]` | Show logs from the dev environment, optionally following or scoped to one service. |
 | `dev restart [service]` | Restart the whole dev environment or a single service. |
-| `dev test [-v] [--tb MODE] [-m MARKERS] [-k KEYWORDS] [path]` | Run pytest. `path` can be a directory, a file, or a `file::testname` selector. |
+| `dev test [-v] [--tb MODE] [-m MARKERS] [-k KEYWORDS] [path ...]` | Run pytest. Each `path` can be a directory, a file, or a `file::testname` selector; pass several to run unrelated targets in one invocation. |
 | `dev lint` | Run black, isort, autoflake, and the title-case checker. Pre-commit runs the same checks automatically. |
 | `dev fmt` | Auto-fix formatting in place by running `black .` and `isort .` in write mode. The natural pre-commit companion to `dev lint`. |
 | `dev seed` | Apply any pending Alembic migrations, then seed the dev database with fixture users for manual testing. Migrations run first so a freshly added revision doesn't cause the seed to crash against a stale schema. |

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -202,7 +202,7 @@ class TestCommands:
         tb: Optional[str] = None,
         markers: Optional[str] = None,
         keywords: Optional[str] = None,
-        path: Optional[str] = None,
+        paths: Optional[List[str]] = None,
     ) -> int:
         """Run tests with specified options."""
         print("🧪 Running tests...")
@@ -216,8 +216,8 @@ class TestCommands:
             cmd.extend(["-m", markers])
         if keywords:
             cmd.extend(["-k", keywords])
-        if path:
-            cmd.append(path)
+        if paths:
+            cmd.extend(paths)
 
         return self.runner.run_command(cmd)
 
@@ -545,10 +545,14 @@ Examples:
         parser.add_argument(
             "-k", "--keywords", help="Run tests matching keyword expressions"
         )
-        parser.add_argument("path", nargs="?", help="Test path or file")
+        parser.add_argument(
+            "paths",
+            nargs="*",
+            help="One or more test paths or files (forwarded to pytest)",
+        )
         parser.set_defaults(
             func=lambda args: self.test.run_tests(
-                args.verbose, args.tb, args.markers, args.keywords, args.path
+                args.verbose, args.tb, args.markers, args.keywords, args.paths
             )
         )
 


### PR DESCRIPTION
## Summary
- Switches the `path` positional in `scripts/dev_cli.py` from `nargs="?"` to `nargs="*"` and forwards the list straight to pytest. Pytest already accepts multiple paths; the CLI was the only thing forcing one-at-a-time invocations.
- Updates the `dev test` row in `scripts/README.md` to read `[path ...]` with a note that several can be passed.

Closes #75.

## Test plan
- [x] `dev test src/api/routes/test_posts.py src/logic/test_audit_discipline.py` — runs both files in one invocation (72 passed).
- [x] `dev test src/logic/test_audit.py` — single path still works.
- [x] `dev test` — zero-path case still runs the full suite (153 passed, 1 pre-existing skip).
- [x] `dev test --help` — shows `paths ...` and the updated description.
- [x] `dev lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)