### PR TITLE
Add Delete button to post detail owner-actions

### DIFF
--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -682,6 +682,52 @@ async def test_detail_page_hides_edit_link_for_stranger(
     assert tree.css_first("span.owner-actions") is None
 
 
+async def test_detail_page_delete_button_for_owner(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """The owner sees a Delete button wired to DELETE /posts/{id} with a
+    confirmation prompt."""
+    post = Post(title="t", body="b", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    actions = tree.css_first("span.owner-actions")
+    assert actions is not None
+    button = actions.css_first("button")
+    assert button is not None
+    assert button.text().strip() == "Delete"
+    assert button.attributes.get("hx-delete") == f"/posts/{post.id}"
+    assert button.attributes.get("hx-confirm")
+
+
+async def test_detail_page_delete_button_for_admin(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """An admin viewing another user's post sees the Delete button too."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    post = Post(title="t", body="b", owner_id=other.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    button = tree.css_first("span.owner-actions button")
+    assert button is not None
+    assert button.attributes.get("hx-delete") == f"/posts/{post.id}"
+
+
 # --- Audit log -----------------------------------------------------------
 
 

--- a/src/templates/posts/_owner_actions.html
+++ b/src/templates/posts/_owner_actions.html
@@ -11,5 +11,11 @@
 {% if current_user and (current_user.id == post.owner_id or current_user.is_superuser) %}
 <span class="owner-actions" data-post-id="{{ post.id }}">
   <a href="/posts/{{ post.id }}/form">Edit</a>
+  <button
+    type="button"
+    hx-delete="/posts/{{ post.id }}"
+    hx-confirm="Permanently delete this post? This cannot be undone.">
+    Delete
+  </button>
 </span>
 {% endif %}


### PR DESCRIPTION
## Summary
- Adds a Delete button to `src/templates/posts/_owner_actions.html`, next to the existing Edit link. Mirrors the `users/_admin_actions.html` delete pattern: `hx-delete` + `hx-confirm` on a `<button type="button">`.
- The owner-or-superuser visibility gate already in the partial means admins viewing another user's post also see the button. The backend route returns 204 + `HX-Redirect: /posts`, which htmx follows automatically — no client wiring needed.
- Adds two tests asserting the button is rendered with the correct `hx-delete` URL and an `hx-confirm` prompt, for both the owner and admin viewing-someone-else's-post cases. The existing stranger test continues to assert the entire `span.owner-actions` is absent, which transitively covers the button.

Follow-up to PR #74 (the REST endpoint).

## Test plan
- [x] `dev test src/api/routes/test_posts.py` — 57 passed (55 prior + 2 new).
- [x] `dev lint` — clean.
- [ ] Manual browser smoke not run in this session — htmx's confirm prompt and HX-Redirect handling are exercised by the framework, not by these unit tests. Same gap as the existing user-delete button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)