### PR TITLE
Add Pact contract pair for post owner-actions Delete button

### DIFF
--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -285,7 +285,7 @@ Colocated alongside the routes:
 
 - `test_auth_routes.py` — registration, login, logout, password reset, session protection (covers `auth_routes.py` and `auth_pages.py`).
 - `test_users.py` — `GET /users` listing behavior (covers `users.py`).
-- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`, `DELETE /posts/{id}`, `GET /posts/form`, and `GET /posts/{id}/form` (covers `posts.py`). Includes owner-or-admin authorization on PATCH and DELETE, the `extra="forbid"` scrub of `owner_id`, route-ordering checks, audit-row before/after assertions for create/update/delete, and `_owner_actions.html` partial visibility on the detail page. Pact contract pairs for both forms live under [`tests/test_contract/`](../../../tests/test_contract/README.md).
+- `test_posts.py` — `GET /posts`, `GET /posts/{id}`, `POST /posts`, `PATCH /posts/{id}`, `DELETE /posts/{id}`, `GET /posts/form`, and `GET /posts/{id}/form` (covers `posts.py`). Includes owner-or-admin authorization on PATCH and DELETE, the `extra="forbid"` scrub of `owner_id`, route-ordering checks, audit-row before/after assertions for create/update/delete, and `_owner_actions.html` partial visibility on the detail page. Pact contract pairs for both forms and the owner-actions Delete button live under [`tests/test_contract/`](../../../tests/test_contract/README.md).
 
 When adding a new route, add (or extend) a `test_*.py` file in this same directory. Shared fixtures (`test_client`, `authenticated_client`, `db_test_session_manager`, `logged_in_user`) come from [`tests/fixtures.py`](../../../tests/fixtures.py); user-construction helpers from [`tests/helpers.py`](../../../tests/helpers.py).
 

--- a/tests/test_contract/README.md
+++ b/tests/test_contract/README.md
@@ -2,7 +2,7 @@
 
 Pact-based contract tests verify that the **shape of the conversation** between an HTML form (consumer) and the API endpoint it posts to (provider) stays in sync. They do **not** verify business behavior — that's what the colocated unit tests under `src/<layer>/test_*.py` are for.
 
-> **Status:** auth (registration), users (admin actions), and posts (create + edit forms) currently have contract test pairs. Add a pair for any new HTML form per the conventions below.
+> **Status:** auth (registration), users (admin actions), and posts (create + edit forms, owner actions) currently have contract test pairs. Add a pair for any new HTML form (or htmx-driven action partial) per the conventions below.
 
 ## Why this directory exists outside the colocated convention
 
@@ -50,14 +50,15 @@ tests/test_contract/
 │       └── playwright_helpers.py      # Pact ↔ Playwright route interception
 └── tests/
     ├── consumer/
-    │   ├── test_auth_form.py          # Registration form contract
-    │   ├── test_user_admin_actions.py # Admin-actions partial contract
-    │   ├── test_post_form.py          # New-post form contract
-    │   └── test_post_edit_form.py     # Edit-post form contract
+    │   ├── test_auth_form.py            # Registration form contract
+    │   ├── test_user_admin_actions.py   # Admin-actions partial contract
+    │   ├── test_post_form.py            # New-post form contract
+    │   ├── test_post_edit_form.py       # Edit-post form contract
+    │   └── test_post_owner_actions.py   # Owner-actions partial contract (Delete)
     ├── provider/
     │   ├── test_auth_verification.py
     │   ├── test_user_admin_actions_verification.py
-    │   └── test_posts_verification.py # Verifies BOTH post create and edit pacts
+    │   └── test_posts_verification.py   # Verifies post create, edit, and owner-actions pacts
     └── shared/
         ├── consumer_test_base.py      # BaseConsumerTest abstract class
         ├── helpers.py                 # Pact + Playwright glue

--- a/tests/test_contract/constants.py
+++ b/tests/test_contract/constants.py
@@ -19,10 +19,12 @@ USER_ACTIVATION_API_PATH = f"/users/{TARGET_USER_ID}/activation"
 
 # Stable post id returned by the post-create handler mock so the consumer can
 # match the response shape and the redirect headers without round-tripping a DB.
-# Also used as the path id for the edit-form pact.
+# Also used as the path id for the edit-form and owner-actions pacts.
 STUB_POST_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
 POST_EDIT_API_PATH = f"/posts/{STUB_POST_ID}"
 POST_EDIT_PAGE_PATH = f"/posts/{STUB_POST_ID}/form"
+POST_DELETE_API_PATH = f"/posts/{STUB_POST_ID}"
+POST_DETAIL_PAGE_PATH = f"/posts/{STUB_POST_ID}"
 
 # Test post data for the create-form contract.
 TEST_POST_TITLE = "Hello from contract test"
@@ -47,6 +49,7 @@ PROVIDER_NAME_USERS = "users-api"
 
 CONSUMER_NAME_POST_CREATE = "post-create-form"
 CONSUMER_NAME_POST_EDIT = "post-edit-form"
+CONSUMER_NAME_POST_OWNER_ACTIONS = "post-owner-actions"
 PROVIDER_NAME_POSTS = "posts-api"
 
 # Timeouts
@@ -57,3 +60,4 @@ PACT_PORT_AUTH = 1234
 PACT_PORT_USER_ACTIVATION = 1235
 PACT_PORT_POST_CREATE = 1236
 PACT_PORT_POST_EDIT = 1237
+PACT_PORT_POST_DELETE = 1238

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -42,11 +42,13 @@ class ConsumerServerConfig:
         auth_pages: bool = True,
         users_admin_actions: bool = False,
         posts_pages: bool = False,
+        posts_owner_actions: bool = False,
         mock_auth: bool = True,
     ):
         self.auth_pages = auth_pages
         self.users_admin_actions = users_admin_actions
         self.posts_pages = posts_pages
+        self.posts_owner_actions = posts_owner_actions
         self.mock_auth = mock_auth
 
 
@@ -116,6 +118,47 @@ def _setup_posts_form_stub(app: FastAPI) -> None:
         )
 
 
+def _setup_post_owner_actions_stub(app: FastAPI) -> None:
+    """Mount a stub page that renders the real `posts/detail.html` template
+    with hardcoded post + current_user, so the `_owner_actions.html` partial
+    is exercised without needing a database. The contract surface is the
+    HTMX-decorated Delete button inside the partial; what we render here is
+    the same partial production code paths render.
+    """
+
+    class _StubUser:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class _StubPost:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    @app.get("/posts/{post_id}")
+    async def post_owner_actions_stub_page(request: Request, post_id: uuid.UUID):
+        owner = _StubUser(id=post_id, username="post_owner")
+        post = _StubPost(
+            id=post_id,
+            title="Stub title",
+            body="Stub body",
+            owner_id=owner.id,
+            owner=owner,
+        )
+        # The mock auth in `run_consumer_server_process` makes current_user a
+        # superuser when `posts_owner_actions=True`, so the partial's
+        # owner-or-admin gate renders the buttons regardless of post.owner_id.
+        current_user = _StubUser(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
+            username="admin_user",
+            is_superuser=True,
+        )
+        return APIResponse.html_response(
+            template_name="posts/detail.html",
+            context={"post": post, "current_user": current_user},
+            request=request,
+        )
+
+
 def setup_consumer_app_routes(app: FastAPI, config: ConsumerServerConfig) -> None:
     if config.auth_pages:
         app.include_router(auth_pages.auth_pages_api_router)
@@ -123,6 +166,8 @@ def setup_consumer_app_routes(app: FastAPI, config: ConsumerServerConfig) -> Non
         _setup_users_admin_actions_stub(app)
     if config.posts_pages:
         _setup_posts_form_stub(app)
+    if config.posts_owner_actions:
+        _setup_post_owner_actions_stub(app)
 
 
 def run_consumer_server_process(
@@ -140,13 +185,13 @@ def run_consumer_server_process(
 
     if config.mock_auth:
         logger.info("Adding mock auth for contract tests")
-        # When the admin-actions stub is mounted, the mock user must be a
-        # superuser so the partial's `{% if current_user.is_superuser %}`
-        # guard renders the buttons.
+        # When an admin/owner-actions stub is mounted, the mock user must be
+        # a superuser so the partial's `is_superuser` (or owner-or-admin)
+        # gate renders the buttons.
         mock_user = create_mock_user(
             email="test@example.com",
             username="contract_test_user",
-            is_superuser=config.users_admin_actions,
+            is_superuser=config.users_admin_actions or config.posts_owner_actions,
         )
         MockAuthManager.setup_mock_auth(
             consumer_app, mock_user, current_active_user, current_admin_user

--- a/tests/test_contract/tests/consumer/test_post_owner_actions.py
+++ b/tests/test_contract/tests/consumer/test_post_owner_actions.py
@@ -1,0 +1,70 @@
+"""Consumer contract: clicking Delete on the post owner-actions partial.
+
+Verifies that the HTMX-decorated button rendered by
+`templates/posts/_owner_actions.html` (mounted via the `posts_owner_actions`
+stub on the consumer server) issues a `DELETE /posts/{id}` and that the
+response carries the `HX-Redirect: /posts` header htmx follows on success.
+The contract surface is the partial plus the consuming detail page; method,
+path, and the redirect header must agree with the route on the provider side.
+"""
+
+import pytest
+from playwright.async_api import Page
+
+from tests.test_contract.constants import (
+    CONSUMER_NAME_POST_OWNER_ACTIONS,
+    NETWORK_TIMEOUT_MS,
+    PACT_PORT_POST_DELETE,
+    POST_DELETE_API_PATH,
+    POST_DETAIL_PAGE_PATH,
+    PROVIDER_NAME_POSTS,
+    PROVIDER_STATE_POST_EXISTS_AND_OWNED,
+)
+from tests.test_contract.tests.shared.helpers import (
+    setup_pact,
+    setup_playwright_pact_interception,
+)
+
+
+@pytest.mark.parametrize(
+    "origin_with_routes",
+    [{"posts_owner_actions": True, "auth_pages": False}],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_consumer_delete_button_click(origin_with_routes: str, page: Page):
+    """Click the Delete button on a stubbed post-detail page; assert the
+    intercepted request matches the contracted shape."""
+    pact = setup_pact(
+        CONSUMER_NAME_POST_OWNER_ACTIONS,
+        PROVIDER_NAME_POSTS,
+        port=PACT_PORT_POST_DELETE,
+    )
+    mock_server_uri = pact.uri
+    detail_page_url = f"{origin_with_routes}{POST_DETAIL_PAGE_PATH}"
+    full_mock_url = f"{mock_server_uri}{POST_DELETE_API_PATH}"
+
+    (
+        pact.given(PROVIDER_STATE_POST_EXISTS_AND_OWNED)
+        .upon_receiving("a request to delete a post via the owner-actions partial")
+        .with_request(method="DELETE", path=POST_DELETE_API_PATH)
+        .will_respond_with(status=204, headers={"HX-Redirect": "/posts"})
+    )
+
+    await setup_playwright_pact_interception(
+        page=page,
+        api_path_to_intercept=POST_DELETE_API_PATH,
+        mock_pact_url=full_mock_url,
+        http_method="DELETE",
+    )
+
+    # Auto-dismiss the `hx-confirm` browser dialog so the click proceeds.
+    page.on("dialog", lambda dialog: dialog.accept())
+
+    with pact:
+        await page.goto(detail_page_url)
+        await page.wait_for_selector("span.owner-actions button")
+        await page.locator("span.owner-actions button", has_text="Delete").click()
+        await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
+
+    # Pact verification happens automatically on context exit.

--- a/tests/test_contract/tests/provider/test_posts_verification.py
+++ b/tests/test_contract/tests/provider/test_posts_verification.py
@@ -1,13 +1,15 @@
-"""Provider verification: POST /posts and PATCH /posts/{id} accept the
-documented request shapes and return the documented responses.
+"""Provider verification: POST /posts, PATCH /posts/{id}, and DELETE
+/posts/{id} accept the documented request shapes and return the documented
+responses.
 
 The route's `current_active_user` dependency is overridden by the provider
-server fixture (auth-mocked). `handle_create_post` and `handle_update_post`
-are monkey-patched out via the combined dependency config so this test
-exercises only the route layer (the "waiter, not chef" split).
+server fixture (auth-mocked). `handle_create_post`, `handle_update_post`,
+and `handle_delete_post` are monkey-patched out via the combined dependency
+config so this test exercises only the route layer (the "waiter, not chef"
+split).
 
-One module-scoped provider server with both mocks applied — both pact files
-verify against the same server.
+One module-scoped provider server with all three mocks applied — every pact
+file verifies against the same server.
 """
 
 import pytest
@@ -22,6 +24,7 @@ from tests.test_contract.tests.shared.provider_verification_base import (
 COMBINED_POSTS_DEPENDENCY_CONFIG = {
     **MockDataFactory.create_post_create_dependency_config(),
     **MockDataFactory.create_post_edit_dependency_config(),
+    **MockDataFactory.create_post_delete_dependency_config(),
 }
 
 
@@ -55,8 +58,19 @@ class PostsEditVerification(_BasePostsVerification):
         return [pytest.mark.provider, pytest.mark.posts]
 
 
+class PostsOwnerActionsVerification(_BasePostsVerification):
+    @property
+    def consumer_name(self) -> str:
+        return "post-owner-actions"
+
+    @property
+    def pytest_marks(self) -> list:
+        return [pytest.mark.provider, pytest.mark.posts]
+
+
 posts_create_verification = PostsCreateVerification()
 posts_edit_verification = PostsEditVerification()
+posts_owner_actions_verification = PostsOwnerActionsVerification()
 
 
 @create_provider_test_decorator(
@@ -73,3 +87,11 @@ def test_provider_posts_create_pact_verification(provider_server: URL):
 def test_provider_posts_edit_pact_verification(provider_server: URL):
     """Verify the post-edit-form Pact contract against the running provider server."""
     posts_edit_verification.verify_pact(provider_server)
+
+
+@create_provider_test_decorator(
+    COMBINED_POSTS_DEPENDENCY_CONFIG, "with_posts_api_mocks"
+)
+def test_provider_posts_owner_actions_pact_verification(provider_server: URL):
+    """Verify the post-owner-actions Pact contract against the running provider server."""
+    posts_owner_actions_verification.verify_pact(provider_server)

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -136,3 +136,15 @@ class MockDataFactory:
                 "return_value_config": post_read
             }
         }
+
+    @classmethod
+    def create_post_delete_dependency_config(cls) -> Dict[str, Any]:
+        """Mock for `handle_delete_post`.
+
+        The route under test (`DELETE /posts/{id}`) discards the handler
+        return value and emits a 204 with `HX-Redirect: /posts`, so `None`
+        is a valid mock return.
+        """
+        return {
+            "src.api.routes.posts.handle_delete_post": {"return_value_config": None}
+        }


### PR DESCRIPTION
## Summary
- Adds a consumer + provider Pact test pair for the Delete button on `_owner_actions.html` (added in #77). Mirrors the `test_user_admin_actions` pair: Playwright drives a stub page rendering `posts/detail.html`, intercepts the htmx-issued `DELETE /posts/{id}`, and verifies the contract round-trip.
- Wires up the supporting infrastructure: `posts_owner_actions` flag on `ConsumerServerConfig`, a stub page route, new constants (`CONSUMER_NAME_POST_OWNER_ACTIONS`, `PACT_PORT_POST_DELETE`, paths), and `MockDataFactory.create_post_delete_dependency_config` (mocks `handle_delete_post` → `None` since the route emits 204 with no body).
- The provider verification reuses the existing `posts-api` server module — all three pacts (create, edit, owner-actions) now verify against one combined-mocks server. Adds a `PostsOwnerActionsVerification` class + decorated test next to the existing two.
- README updates: contract README status line, layout diagram, and the routes README cross-reference.

Follow-up to #77 (Delete button) and #74 (REST endpoint). Closes the contract-test gap noted in CLAUDE.md / RESOURCE_GRAMMAR.md for htmx-driven action partials.

## Test plan
- [x] `dev test tests/test_contract` — 10 passed (5 consumer + 5 provider; up from 8). Includes the new `test_consumer_delete_button_click` and `test_provider_posts_owner_actions_pact_verification`.
- [x] `dev test` — full unit suite still 153 passed, 1 pre-existing skip.
- [x] `dev lint` — clean (after `dev fmt` reformatted the new file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)