### PR TITLE
Hint to run dev migrate up first when DB is behind head (closes #82)

### DIFF
--- a/scripts/dev/migrate.py
+++ b/scripts/dev/migrate.py
@@ -11,6 +11,8 @@ read DATABASE_URL from the environment.
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 from typing import TYPE_CHECKING, Literal, Optional
 
 if TYPE_CHECKING:
@@ -48,8 +50,52 @@ def run_alembic(
     return runner.run_command(cmd)
 
 
+def _db_is_at_head() -> bool:
+    """Return True iff `alembic current` matches `alembic heads` (host mode).
+
+    Loads `.env` so DATABASE_URL is populated the same way `run_alembic`
+    sees it. Returns False when the alembic_version table doesn't exist
+    yet (fresh DB) — that DB is "behind" head.
+    """
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    def _first_token(stdout: str) -> str:
+        for line in stdout.splitlines():
+            stripped = line.strip()
+            if stripped:
+                return stripped.split()[0]
+        return ""
+
+    current = subprocess.run(
+        ["alembic", "-c", ALEMBIC_CONFIG, "current"],
+        capture_output=True,
+        text=True,
+    )
+    heads = subprocess.run(
+        ["alembic", "-c", ALEMBIC_CONFIG, "heads"],
+        capture_output=True,
+        text=True,
+    )
+    if current.returncode != 0 or heads.returncode != 0:
+        return False
+    current_token = _first_token(current.stdout)
+    heads_token = _first_token(heads.stdout)
+    if not current_token or not heads_token:
+        return False
+    return current_token == heads_token
+
+
 def generate(runner: "CLIRunner", message: str) -> int:
     """`alembic revision --autogenerate -m <message>` against the host DB."""
+    if not _db_is_at_head():
+        print(
+            "ℹ️ Database is behind head. Run `dev migrate up` first, "
+            "then re-run generate.",
+            file=sys.stderr,
+        )
+        return 1
     return run_alembic(
         runner, ["revision", "--autogenerate", "-m", message], mode="host"
     )

--- a/scripts/dev/test_migrate.py
+++ b/scripts/dev/test_migrate.py
@@ -121,6 +121,31 @@ def test_generate_creates_revision_file(runner: CLIRunner, temp_db: Path):
     assert "test_step_b_revision" in next(iter(new_files))
 
 
+def test_generate_hints_when_db_behind_head(runner: CLIRunner, temp_db: Path, capsys):
+    # Fresh DB, never upgraded — should bail with a hint, not call alembic revision.
+    before = {p.name for p in VERSIONS_DIR.iterdir() if p.is_file()}
+    rc = migrate.generate(runner, "behind_head_test")
+    assert rc != 0
+    captured = capsys.readouterr()
+    assert "behind head" in captured.err
+    after = {p.name for p in VERSIONS_DIR.iterdir() if p.is_file()}
+    assert (
+        after == before
+    ), f"no new revision file should be created, got {after - before}"
+
+
+def test_generate_succeeds_when_db_at_head(runner: CLIRunner, temp_db: Path):
+    assert migrate.up(runner) == 0
+
+    before = {p.name for p in VERSIONS_DIR.iterdir() if p.is_file()}
+    rc = migrate.generate(runner, "at_head_succeeds")
+    assert rc == 0
+    after = {p.name for p in VERSIONS_DIR.iterdir() if p.is_file()}
+    new_files = after - before
+    assert len(new_files) == 1, f"expected one new revision file, got {new_files}"
+    assert "at_head_succeeds" in next(iter(new_files))
+
+
 def test_roundtrip_uses_explicit_scratch(runner: CLIRunner, tmp_path: Path):
     scratch = tmp_path / "scratch.db"
     dev_db = PROJECT_ROOT / "data" / "aimagain.db"


### PR DESCRIPTION
## Summary
- `dev migrate generate` now pre-checks that the host DB is at alembic heads before invoking `alembic revision --autogenerate`
- When the DB is behind, prints a clear hint to stderr and exits non-zero — no more opaque `FAILED: Target database is not up to date.` from alembic
- Adds two tests to `scripts/dev/test_migrate.py` covering the bail path and the at-head success path

## Test plan
- [x] `pytest scripts/dev/test_migrate.py` — 9/9 green (existing 7 + 2 new)
- [x] Full `pytest` — all green
- [x] Manual: fresh DB → `migrate.generate` prints hint, rc=1, creates no file
- [x] Manual: after `migrate.up` → `migrate.generate` succeeds, creates file

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)