### PR TITLE
Raise clear error when DATABASE_URL is unset (closes #81)

### DIFF
--- a/alembic/README.md
+++ b/alembic/README.md
@@ -114,6 +114,12 @@ if DATABASE_URL:
         DATABASE_URL = DATABASE_URL.replace("sqlite+aiosqlite://", "sqlite://")
     config.set_main_option("sqlalchemy.url", DATABASE_URL)
 
+if DATABASE_URL is None and not config.get_main_option("sqlalchemy.url"):
+    raise RuntimeError(
+        "DATABASE_URL is not set. For local development, run `dev setup` "
+        "to create a .env file, or export DATABASE_URL directly."
+    )
+
 target_metadata = metadata
 ```
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -31,6 +31,12 @@ if DATABASE_URL:
         DATABASE_URL = DATABASE_URL.replace("sqlite+aiosqlite://", "sqlite://")
     config.set_main_option("sqlalchemy.url", DATABASE_URL)
 
+if DATABASE_URL is None and not config.get_main_option("sqlalchemy.url"):
+    raise RuntimeError(
+        "DATABASE_URL is not set. For local development, run `dev setup` "
+        "to create a .env file, or export DATABASE_URL directly."
+    )
+
 target_metadata = metadata
 
 

--- a/scripts/dev/test_migrate.py
+++ b/scripts/dev/test_migrate.py
@@ -152,6 +152,19 @@ def test_roundtrip_default_scratch(runner: CLIRunner):
             default_path.unlink()
 
 
+def test_alembic_env_raises_clear_error_when_database_url_unset():
+    env = {k: v for k, v in os.environ.items() if k != "DATABASE_URL"}
+    result = subprocess.run(
+        ["alembic", "-c", "config/alembic.ini", "current"],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "DATABASE_URL is not set" in result.stderr
+
+
 def test_roundtrip_restores_database_url(runner: CLIRunner, tmp_path: Path):
     """roundtrip must restore the prior DATABASE_URL even on failure."""
     scratch = tmp_path / "scratch.db"


### PR DESCRIPTION
## Summary
- `alembic/env.py` now raises a clear `RuntimeError` when neither `DATABASE_URL` nor `sqlalchemy.url` is set, replacing an opaque `KeyError: 'url'` from deep inside SQLAlchemy.
- The guard fires only when both sources are empty, so alembic's offline mode and other tooling that sets the URL via the config object still work.
- Added one integration test in `scripts/dev/test_migrate.py` that invokes `alembic` in a subprocess with `DATABASE_URL` stripped from the environment and asserts the new message.

## Test plan
- [x] `dev test scripts/dev` passes (8/8, including the new test).
- [x] `dev test` passes overall (163 passed, 1 skipped).
- [x] `dev lint` clean.
- [x] Manual: `env -u DATABASE_URL alembic -c config/alembic.ini current` exits non-zero with the new clear message instead of a SQLAlchemy traceback.
- [x] Manual: `dev migrate up` still works with `DATABASE_URL` set normally.

Closes #81