### PR TITLE
Auto-format generated revisions via post_write_hooks (closes #83)

### DIFF
--- a/config/alembic.ini
+++ b/config/alembic.ini
@@ -72,17 +72,15 @@ version_path_separator = os
 # on newly generated revision scripts.  See the documentation for further
 # detail and examples
 
-# format using "black" - use the console_scripts runner, against the "black" entrypoint
-# hooks = black
-# black.type = console_scripts
-# black.entrypoint = black
-# black.options = -l 79 REVISION_SCRIPT_FILENAME
+hooks = black, isort
 
-# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
-# hooks = ruff
-# ruff.type = exec
-# ruff.executable = %(here)s/.venv/bin/ruff
-# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+black.type = console_scripts
+black.entrypoint = black
+black.options = -l 88 REVISION_SCRIPT_FILENAME
+
+isort.type = console_scripts
+isort.entrypoint = isort
+isort.options = --profile black REVISION_SCRIPT_FILENAME
 
 # Logging configuration
 [loggers]

--- a/scripts/dev/test_migrate.py
+++ b/scripts/dev/test_migrate.py
@@ -146,6 +146,39 @@ def test_generate_succeeds_when_db_at_head(runner: CLIRunner, temp_db: Path):
     assert "at_head_succeeds" in next(iter(new_files))
 
 
+def test_post_write_hooks_format_generated_revision(runner: CLIRunner, temp_db: Path):
+    # Autogenerate requires the DB to be at head before running.
+    assert migrate.up(runner) == 0
+
+    before = {p.name for p in VERSIONS_DIR.iterdir() if p.is_file()}
+    rc = migrate.generate(runner, "test_post_write_hooks_step_c")
+    assert rc == 0
+    after = {p.name for p in VERSIONS_DIR.iterdir() if p.is_file()}
+    new_files = after - before
+    assert len(new_files) == 1, f"expected one new revision file, got {new_files}"
+    new_file = VERSIONS_DIR / next(iter(new_files))
+
+    black_check = subprocess.run(
+        ["black", "--check", str(new_file)],
+        check=False,
+        capture_output=True,
+    )
+    assert black_check.returncode == 0, (
+        "post_write_hook 'black' did not format the generated revision: "
+        f"{black_check.stderr.decode()}"
+    )
+
+    isort_check = subprocess.run(
+        ["isort", "--check-only", "--profile", "black", str(new_file)],
+        check=False,
+        capture_output=True,
+    )
+    assert isort_check.returncode == 0, (
+        "post_write_hook 'isort' did not format the generated revision: "
+        f"{isort_check.stderr.decode()}"
+    )
+
+
 def test_roundtrip_uses_explicit_scratch(runner: CLIRunner, tmp_path: Path):
     scratch = tmp_path / "scratch.db"
     dev_db = PROJECT_ROOT / "data" / "aimagain.db"


### PR DESCRIPTION
## Summary
- Enable `black` and `isort` post_write_hooks in `config/alembic.ini` so freshly autogenerated revisions are formatted in place and pass `dev lint` without manual cleanup.
- Black is run with `-l 88` (matches `[tool.black]` in `pyproject.toml`); isort runs with `--profile black`.
- Add `test_post_write_hooks_format_generated_revision` to `scripts/dev/test_migrate.py` covering the contract: a freshly generated revision passes `black --check` and `isort --check-only --profile black`.

## Test plan
- [x] `dev migrate generate` against the dev DB produced a revision file that passed `black --check` and `isort --check-only --profile black`.
- [x] `dev lint` clean.
- [x] `pytest scripts/dev` 100% green (8/8, including the new test).
- [x] `pytest` 100% green overall (163 passed, 1 skipped).

Closes #83