### PR TITLE
Silently skip binary files in title-case checker (closes #84)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ lint = [
     "isort",
     "autoflake",
     "pre-commit",
+    "pathspec",
 ]
 
 # Full application with all runtime dependencies

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -144,6 +144,8 @@ python scripts/dev/title_case_check.py README.md notes/
 - **HTML files** (`.html`, `.htm`): Headers (`<h1>`, `<h2>`, etc.) and `<title>` tags
 - **Jinja templates** (`.jinja`, `.jinja2`): HTML headers and `{% block title %}` blocks
 
+Files under `data/` and binary extensions (`.db`, `.sqlite`, `.sqlite3`) are silently skipped, as is anything that fails a utf-8 read.
+
 #### 📝 **Exception handling**
 
 **Line-level exceptions:**

--- a/scripts/dev/test_title_case_check.py
+++ b/scripts/dev/test_title_case_check.py
@@ -1,0 +1,37 @@
+"""Tests for scripts/dev/title_case_check.py.
+
+These exercise the checker as a subprocess (the same way `dev lint` invokes
+it) so we catch stdout/stderr noise that wouldn't show up in unit tests of
+the class methods.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = PROJECT_ROOT / "scripts" / "dev" / "title_case_check.py"
+
+
+def test_title_case_check_silently_skips_binary_files(tmp_path):
+    """A non-utf8 .db file must not produce 'Error reading' or 'can't decode' noise."""
+    db_file = tmp_path / "fake.db"
+    db_file.write_bytes(b"\x86\xff\x00binary")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--check-only",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+    assert "Error reading" not in combined, combined
+    assert "can't decode" not in combined, combined

--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -68,6 +68,13 @@ class TitleCaseChecker:
         ".jinja2": "jinja",
     }
 
+    # Binary file extensions to silently skip without attempting to read
+    BINARY_EXTENSIONS = {
+        ".db",
+        ".sqlite",
+        ".sqlite3",
+    }
+
     # Words that should remain capitalized (proper nouns, acronyms, etc.)
     ALWAYS_CAPITALIZE = {
         "API",
@@ -219,6 +226,20 @@ class TitleCaseChecker:
 
     def should_ignore_file(self, file_path: Path) -> bool:
         """Check if entire file should be ignored based on .titleignore file or gitignore."""
+        # Skip known binary extensions silently — these are never text content
+        # we'd want to title-case-check, and reading them produces utf-8 noise.
+        if file_path.suffix.lower() in self.BINARY_EXTENSIONS:
+            return True
+
+        # Skip anything under a top-level data/ directory — these are runtime
+        # artifacts (sqlite DBs, fixtures), not source files.
+        try:
+            parts = file_path.resolve().parts
+        except OSError:
+            parts = file_path.parts
+        if "data" in parts:
+            return True
+
         # Check gitignore first
         if self._is_gitignored(file_path):
             return True
@@ -403,8 +424,8 @@ class TitleCaseChecker:
 
         try:
             content = file_path.read_text(encoding="utf-8")
-        except Exception as e:
-            print(f"Error reading {file_path}: {e}", file=sys.stderr)
+        except (UnicodeDecodeError, OSError):
+            # Binary or unreadable file — silently skip, no diagnostic noise.
             return []
 
         file_type = self._get_file_type(file_path, content)


### PR DESCRIPTION
## Summary

- `scripts/dev/title_case_check.py` now skips files under `data/` and binary extensions (`.db`, `.sqlite`, `.sqlite3`) before attempting a utf-8 read, and a utf-8 decode failure is a silent skip rather than a printed error. This eliminates the two `Error reading data/...db: 'utf-8' codec can't decode byte 0x86` lines that `dev lint` printed every run.
- `pathspec` is now listed in the `lint` optional-dependency extras so `dev lint` no longer emits the `Warning: pathspec library not available` line in environments that install via `[lint]`.
- New `scripts/dev/test_title_case_check.py` covers the binary-skip path by invoking the checker as a subprocess against a fake `.db` file and asserting no `Error reading` / `can't decode` noise on either stream.

## Test plan

- [x] `pytest scripts/dev` — all 8 tests pass (7 existing migrate tests + 1 new title-case test).
- [x] `pytest` — full suite, 163 passed / 1 skipped.
- [x] `python3 scripts/dev/title_case_check.py --check-only` — no `Error reading` lines, no `pathspec library not available` warning, exit 0.
- [x] Manual: temp `.md` with a Title Case Heading is still flagged as a violation.

Closes #84