### PR TITLE
Resolve dev CLI project root from cwd, not install location (closes #89)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,9 +108,11 @@ dev --help
 
 Without `pip install -e .`, the CLI is also runnable directly: `python3 scripts/dev_cli.py <command>` or `./scripts/dev_cli.py <command>`.
 
+The `dev` CLI auto-detects the current project root by walking up from the caller's cwd looking for a `pyproject.toml`, so it operates on the worktree you're sitting in rather than the install-time checkout.
+
 #### Tests <!-- title-case-ignore -->
 
-Tests for `scripts/dev/*` live colocated as `scripts/dev/test_*.py`, matching the `src/<layer>/test_*.py` pattern in [`../CLAUDE.md`](../CLAUDE.md). Pytest discovers them via the `scripts` entry in `pyproject.toml`'s `testpaths`. Run only the dev CLI tests with `dev test scripts/dev`.
+Tests for `scripts/dev/*` live colocated as `scripts/dev/test_*.py`, matching the `src/<layer>/test_*.py` pattern in [`../CLAUDE.md`](../CLAUDE.md). Tests for `scripts/dev_cli.py` itself live as `scripts/test_dev_cli.py`. Pytest discovers them via the `scripts` entry in `pyproject.toml`'s `testpaths`. Run only the dev CLI tests with `dev test scripts/`.
 
 ### `dev/promote_admin.py`
 

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -29,11 +29,19 @@ DEVELOPMENT=true
 """
 
 
+def _resolve_project_root() -> Path:
+    cwd = Path.cwd().resolve()
+    for candidate in [cwd, *cwd.parents]:
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    return Path(__file__).resolve().parent.parent
+
+
 class CLIRunner:
     """Handles command execution and common utilities."""
 
     def __init__(self):
-        self.project_root = Path(__file__).parent.parent
+        self.project_root = _resolve_project_root()
 
     def run_command(self, cmd: List[str], cwd: Optional[Path] = None) -> int:
         """Run a command and return its exit code."""

--- a/scripts/test_dev_cli.py
+++ b/scripts/test_dev_cli.py
@@ -1,0 +1,19 @@
+"""Tests for scripts/dev_cli.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.dev_cli import CLIRunner
+
+
+def test_clirunner_resolves_project_root_from_cwd(tmp_path: Path, monkeypatch):
+    subroot = tmp_path / "subroot"
+    nested = subroot / "deep" / "nested"
+    nested.mkdir(parents=True)
+    (subroot / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+
+    monkeypatch.chdir(nested)
+
+    runner = CLIRunner()
+    assert runner.project_root == subroot.resolve()


### PR DESCRIPTION
## Summary

- `CLIRunner.__init__` previously set `self.project_root = Path(__file__).parent.parent`, which always resolved to the main checkout when `dev` is installed via `pip install -e .`. From a worktree, `dev test` / `dev lint` silently ran against the main checkout's files, so new tests went uncollected and edits could land on the wrong branch.
- New `_resolve_project_root()` walks upward from `Path.cwd()` looking for a `pyproject.toml`; falls back to the existing install-time location if none is found in any ancestor.
- Adds `scripts/test_dev_cli.py` with one test that uses `monkeypatch.chdir` to assert the resolver finds the nearest ancestor with `pyproject.toml`.

## Test plan

- [x] `python3 -m pytest scripts/test_dev_cli.py -v` passes (bare pytest invokes the worktree's edits).
- [x] `python3 -m pytest scripts/dev/test_migrate.py -v` — existing migrate tests still pass.
- [x] `python3 scripts/dev_cli.py test scripts/` — both test files green; working directory printed is the worktree, confirming the resolver picked up the worktree's `pyproject.toml`.
- [x] `python3 scripts/dev_cli.py lint` — clean.
- [x] Smoke: `cd /tmp && python3 <worktree>/scripts/dev_cli.py routes /users` — fallback to install-time location works (no `pyproject.toml` in `/tmp` ancestors).

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)