### PR TITLE
Rename data/aimagain.db references to data/bedlam-connect.db

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -93,7 +93,7 @@ Run `dev --help` for the live, authoritative list. As of this writing:
 | `dev migrate generate "<message>"` | Generate a new Alembic revision via `--autogenerate` (host mode, requires `DATABASE_URL`). Review the generated file under `alembic/versions/` before applying. |
 | `dev migrate up` | Apply all pending Alembic migrations against the host DB (`alembic upgrade head`). |
 | `dev migrate down [N]` | Reverse `N` migrations against the host DB. `N` defaults to 1. |
-| `dev migrate roundtrip [--scratch <path>]` | Sanity-check a migration end-to-end against a throwaway sqlite DB at `/tmp/bedlam-migrate-roundtrip.db` (override with `--scratch`): upgrade head → downgrade -1 → upgrade head. Removes the scratch file on success; leaves it on failure for inspection. Never touches `data/aimagain.db`. |
+| `dev migrate roundtrip [--scratch <path>]` | Sanity-check a migration end-to-end against a throwaway sqlite DB at `/tmp/bedlam-migrate-roundtrip.db` (override with `--scratch`): upgrade head → downgrade -1 → upgrade head. Removes the scratch file on success; leaves it on failure for inspection. Never touches `data/bedlam-connect.db`. |
 
 For per-command flag details, run `dev <command> --help`.
 

--- a/scripts/dev/test_migrate.py
+++ b/scripts/dev/test_migrate.py
@@ -181,7 +181,7 @@ def test_post_write_hooks_format_generated_revision(runner: CLIRunner, temp_db: 
 
 def test_roundtrip_uses_explicit_scratch(runner: CLIRunner, tmp_path: Path):
     scratch = tmp_path / "scratch.db"
-    dev_db = PROJECT_ROOT / "data" / "aimagain.db"
+    dev_db = PROJECT_ROOT / "data" / "bedlam-connect.db"
     dev_mtime = dev_db.stat().st_mtime if dev_db.exists() else None
 
     rc = migrate.roundtrip(runner, scratch_path=str(scratch))
@@ -191,7 +191,7 @@ def test_roundtrip_uses_explicit_scratch(runner: CLIRunner, tmp_path: Path):
     if dev_mtime is not None:
         assert (
             dev_db.stat().st_mtime == dev_mtime
-        ), "roundtrip must not touch data/aimagain.db"
+        ), "roundtrip must not touch data/bedlam-connect.db"
 
 
 def test_roundtrip_default_scratch(runner: CLIRunner):


### PR DESCRIPTION
## Summary

Drops the last two repo references to the legacy DB filename `data/aimagain.db`. Compose default and prod were already on `data/bedlam-connect.db`; this just cleans up:

- `scripts/README.md` — the `dev migrate roundtrip` note
- `scripts/dev/test_migrate.py` — its corresponding mtime guard

Domain references (`aimagain.art` in `deployment/`) intentionally left alone — that's a separate ops migration.

## Test plan

- [x] `dev test scripts/dev/test_migrate.py` — 11 passed
- [x] Local dev container restarted against `data/bedlam-connect.db`, migrations replay cleanly
- [ ] Anyone with a local `.env` pinning DATABASE_URL to `aimagain.db` will need to update it (gitignored, so not in the diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)