### PR TITLE
Enable SQLite FK enforcement at engine init

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -6,7 +6,7 @@ from typing import Any
 from dotenv import load_dotenv
 from fastapi import Depends
 from fastapi_users.db import SQLAlchemyUserDatabase
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from .models import User, metadata
@@ -19,6 +19,17 @@ if not DATABASE_URL:
 
 engine = create_async_engine(DATABASE_URL)
 async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+
+@event.listens_for(engine.sync_engine, "connect")
+def _enable_sqlite_foreign_keys(dbapi_connection, connection_record):
+    """SQLite ships with FK enforcement off by default; turn it on for every
+    new connection. No-op for non-SQLite engines (e.g. future Postgres)."""
+    if engine.dialect.name != "sqlite":
+        return
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys = ON")
+    cursor.close()
 
 
 # Dependency to get the raw SQLAlchemy AsyncSession

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -265,6 +265,7 @@ class [Entity]Service:
 Colocated tests live alongside the repositories:
 
 - `test_audit_repository.py` — exercises append-only writes, FK `SET NULL` on actor delete, and list-by-resource ordering against the in-memory test DB.
+- `test_post_repository.py` — exercises parent + detail create/update/delete, including a raw-SQL DELETE that proves the FK CASCADE fires (not just the ORM cascade). Relies on `PRAGMA foreign_keys = ON` being set globally by the test engine fixture.
 
 When adding a new repository method, extend (or create) `src/repositories/test_<repo_name>.py` and exercise it via the `db_test_session_manager` fixture from [`tests/fixtures.py`](../../tests/fixtures.py).
 

--- a/src/repositories/test_audit_repository.py
+++ b/src/repositories/test_audit_repository.py
@@ -233,9 +233,7 @@ async def test_actor_set_null_when_user_deleted(
         )
         await session.commit()
 
-    # Delete the actor with FK enforcement enabled (SQLite needs the pragma).
     async with db_test_session_manager() as session:
-        await session.execute(__import__("sqlalchemy").text("PRAGMA foreign_keys = ON"))
         target = await session.get(User, actor.id)
         await session.delete(target)
         await session.commit()

--- a/src/repositories/test_post_repository.py
+++ b/src/repositories/test_post_repository.py
@@ -8,8 +8,9 @@ detail row (not the parent), delete cascades the detail via the FK.
 import uuid
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import bindparam, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.types import Uuid
 
 from src.models import NoteDetail, Post
 from src.repositories.post_repository import PostRepository
@@ -132,4 +133,42 @@ async def test_delete_post_cascades_detail(
             .first()
         )
         assert post_row is None
+        assert detail_row is None
+
+
+async def test_raw_sql_delete_post_cascades_via_fk(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """A raw-SQL DELETE bypasses the ORM cascade — only the FK CASCADE can
+    remove the detail row. Proves `PRAGMA foreign_keys = ON` is in effect."""
+    owner = await _seed_owner(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        repo = PostRepository(session)
+        created = await repo.create_post(
+            Post(kind="note", owner_id=owner.id),
+            NoteDetail(title="t", body="b"),
+        )
+        await session.commit()
+        post_id = created.id
+
+    async with db_test_session_manager() as session:
+        await session.execute(
+            text("DELETE FROM posts WHERE id = :pid").bindparams(
+                bindparam("pid", type_=Uuid(as_uuid=True))
+            ),
+            {"pid": post_id},
+        )
+        await session.commit()
+
+    async with db_test_session_manager() as session:
+        detail_row = (
+            (
+                await session.execute(
+                    select(NoteDetail).filter(NoteDetail.post_id == post_id)
+                )
+            )
+            .scalars()
+            .first()
+        )
         assert detail_row is None

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,6 +87,8 @@ Any fixture defined at module level in `tests/fixtures.py` is then available to 
 
 The `db_test_session_manager` fixture (in `tests/fixtures.py`) creates an in-memory SQLite database, runs `metadata.create_all()` before each test, and drops everything after. Each test starts with a clean schema.
 
+The test engine registers a `connect` listener that runs `PRAGMA foreign_keys = ON` on every new SQLite connection — same as the production engine in `src/db.py`. Without it, FK constraints (e.g. `ON DELETE CASCADE`, `ON DELETE SET NULL`) are defined but silently un-enforced, and tests that depend on them would pass for the wrong reason.
+
 ### Authenticated requests
 
 Use `authenticated_client` to make requests as a pre-created test user. Use `logged_in_user` to get the corresponding `User` ORM object.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,6 +5,7 @@ from asyncstdlib import anext
 from fastapi import Depends, FastAPI
 from fastapi_users.db import SQLAlchemyUserDatabase
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from src.core.templating import templates  # Import the global templates object
@@ -26,6 +27,17 @@ TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
 test_engine = create_async_engine(TEST_DATABASE_URL)
 async_test_sessionmaker = async_sessionmaker(test_engine, expire_on_commit=False)
+
+
+@event.listens_for(test_engine.sync_engine, "connect")
+def _enable_sqlite_foreign_keys(dbapi_connection, connection_record):
+    """Mirror src/db.py — FK enforcement must be on for tests to catch the
+    same constraint violations as production."""
+    if test_engine.dialect.name != "sqlite":
+        return
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys = ON")
+    cursor.close()
 
 
 # Master fixture to manage table creation/dropping and provide session maker


### PR DESCRIPTION
## Summary

- Register a `connect`-event handler on both the production engine (`src/db.py`) and the test engine (`tests/fixtures.py`) that runs `PRAGMA foreign_keys = ON` on every new SQLite connection. The handler is a no-op for non-SQLite dialects, so it stays safe when the project moves to Postgres.
- Drop the inline `PRAGMA` from `test_actor_set_null_when_user_deleted` — the global handler covers it now.
- Add `test_raw_sql_delete_post_cascades_via_fk`: a raw-SQL `DELETE FROM posts WHERE id = ?` that proves the FK `CASCADE` itself fires (not just the ORM cascade). Without the pragma, this test would leave the `note_details` row dangling.

Closes #104.

## Test plan

- [x] `dev test` — 173 passed, 1 skipped
- [x] `dev lint` — all checks passed
- [x] New `test_raw_sql_delete_post_cascades_via_fk` passes (would fail without the pragma)
- [x] Existing `test_actor_set_null_when_user_deleted` still passes after dropping the inline pragma

## Per-PR retrospective

### Issue scope was crisp and self-contained
**Friction:** None — the issue spelled out the fix, the smell that motivated it, and the definition of done with a checklist. The smell (one inline PRAGMA in `test_audit_repository.py`) was a load-bearing breadcrumb that confirmed the global state was off.
**Fix:** Keep filing issues this shape: problem statement with concrete examples, proposed fix with code sketch, explicit DoD, and out-of-scope notes.
**Effort:** small.

### `event.listens_for(engine.sync_engine, "connect")` vs. `Engine` class
**Friction:** The issue text suggested `event.listens_for(Engine, "connect")` (class-level), which would fire for every engine in the process and would be redundantly registered if both `src/db.py` and `tests/fixtures.py` did it. Per-engine registration via `engine.sync_engine` is more localized.
**Fix:** None needed — judgment call, called it out here so future readers don't read the issue text and assume the class-level form is the convention.
**Effort:** small.

### README colocation rule caught two doc updates
**Friction:** None — the rule worked as intended. Touching `tests/fixtures.py` and `src/repositories/test_post_repository.py` flagged `tests/README.md` and `src/repositories/README.md` for review, both of which had a relevant sentence that benefited from one new line.
**Fix:** Keep the Stop hook + colocation rule as-is.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)