### PR TITLE
Add `dev test contract` shortcut + document contract tests in DoD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ If a layer has no README or no test file yet, **create them as part of the chang
 
 A Stop hook checks the diff at end-of-turn and surfaces a reminder when source files change without their README/test. The hook is a soft prompt, not a hard block — but ignoring it should be a deliberate decision (e.g. typo fix, log message tweak), not an oversight.
 
+**Contract tests are not run by default.** `tests/test_contract` is excluded from the default `dev test` collection (see [`tests/test_contract/README.md`](tests/test_contract/README.md)). If you change templates, route response shapes, or anything mock data factories in `tests/test_contract` assume, also run `dev test contract` before pushing — otherwise CI is the first place the breakage surfaces.
+
 ## One source of truth — link, don't copy
 
 Each fact has exactly **one home**: the README closest to the code or config that the fact describes. Other docs link to it; they never restate it.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,7 @@ Run `dev --help` for the live, authoritative list. As of this writing:
 | `dev down [--volumes]` | Stop the development environment (optionally drop volumes). |
 | `dev logs [-f] [service]` | Show logs from the dev environment, optionally following or scoped to one service. |
 | `dev restart [service]` | Restart the whole dev environment or a single service. |
-| `dev test [-v] [--tb MODE] [-m MARKERS] [-k KEYWORDS] [path ...]` | Run pytest. Each `path` can be a directory, a file, or a `file::testname` selector; pass several to run unrelated targets in one invocation. |
+| `dev test [-v] [--tb MODE] [-m MARKERS] [-k KEYWORDS] [path ...]` | Run pytest. Each `path` can be a directory, a file, or a `file::testname` selector; pass several to run unrelated targets in one invocation. The literal token `contract` is a shortcut that expands to `tests/test_contract` — that directory is excluded from default collection (see [`../tests/test_contract/README.md`](../tests/test_contract/README.md)) and is easy to forget the path to. |
 | `dev lint` | Run black, isort, autoflake, and the title-case checker. Pre-commit runs the same checks automatically. |
 | `dev fmt` | Auto-fix formatting in place by running `black .` and `isort .` in write mode. The natural pre-commit companion to `dev lint`. |
 | `dev seed` | Apply any pending Alembic migrations, then seed the dev database with fixture users for manual testing. Migrations run first so a freshly added revision doesn't cause the seed to crash against a stale schema. |

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -201,6 +201,12 @@ class DevCommands:
 class TestCommands:
     """Test-related commands."""
 
+    # Shortcut aliases for test paths. `dev test contract` expands to the full
+    # path because `tests/test_contract` is excluded from default `pytest`
+    # collection (`addopts` in `pyproject.toml`) and a regression in #100
+    # showed the path is easy to forget.
+    PATH_ALIASES = {"contract": "tests/test_contract"}
+
     def __init__(self, runner: CLIRunner):
         self.runner = runner
 
@@ -225,7 +231,7 @@ class TestCommands:
         if keywords:
             cmd.extend(["-k", keywords])
         if paths:
-            cmd.extend(paths)
+            cmd.extend(self.PATH_ALIASES.get(p, p) for p in paths)
 
         return self.runner.run_command(cmd)
 

--- a/scripts/test_dev_cli.py
+++ b/scripts/test_dev_cli.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import List, Optional
 
-from scripts.dev_cli import CLIRunner
+from scripts.dev_cli import CLIRunner, TestCommands
 
 
 def test_clirunner_resolves_project_root_from_cwd(tmp_path: Path, monkeypatch):
@@ -17,3 +18,31 @@ def test_clirunner_resolves_project_root_from_cwd(tmp_path: Path, monkeypatch):
 
     runner = CLIRunner()
     assert runner.project_root == subroot.resolve()
+
+
+class _RecordingRunner:
+    """Stand-in for CLIRunner that captures the pytest command instead of running it."""
+
+    def __init__(self) -> None:
+        self.last_cmd: Optional[List[str]] = None
+
+    def run_command(self, cmd: List[str], cwd: Optional[Path] = None) -> int:
+        self.last_cmd = cmd
+        return 0
+
+
+def test_run_tests_expands_contract_alias_to_full_path():
+    runner = _RecordingRunner()
+    TestCommands(runner).run_tests(paths=["contract"])
+    assert runner.last_cmd == ["pytest", "tests/test_contract"]
+
+
+def test_run_tests_leaves_non_alias_paths_untouched():
+    runner = _RecordingRunner()
+    TestCommands(runner).run_tests(paths=["tests/foo", "contract", "tests/bar.py"])
+    assert runner.last_cmd == [
+        "pytest",
+        "tests/foo",
+        "tests/test_contract",
+        "tests/bar.py",
+    ]


### PR DESCRIPTION
## Summary
- `dev test contract` now expands to `pytest tests/test_contract` via a single-entry alias map in `TestCommands`. Other paths pass through unchanged.
- `CLAUDE.md` definition-of-done now flags contract tests as not run by default and points at the shortcut for template / route-shape / mock-factory changes.
- `scripts/README.md` documents the alias inline on the `dev test` row.

Closes #101.

## Why
`tests/test_contract` is excluded from default pytest collection (`addopts = ... --ignore=tests/test_contract`). The only previous signal it existed locally was the GitHub Actions config — neither `CLAUDE.md` nor `scripts/README.md` mentioned it. #100 lost ~3 minutes of CI feedback to this gap.

## Test plan
- [x] `dev test scripts/test_dev_cli.py` passes (3 tests, including 2 new ones for the alias)
- [x] `dev test contract --tb no -k <bogus>` collects 10 items from `tests/test_contract` (proves alias resolves end-to-end through the CLI)
- [x] `dev lint` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)