### PR TITLE
Require `kind` on the wire (note-only) — prep for adding more kinds

### DIFF
--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -181,7 +181,7 @@ async def test_create_post_happy_path(
     body = f"body-{uuid.uuid4()}"
 
     response = await authenticated_client.post(
-        "/posts", json={"title": title, "body": body}
+        "/posts", json={"kind": "note", "title": title, "body": body}
     )
 
     assert response.status_code == 201
@@ -210,7 +210,8 @@ async def test_create_post_strips_whitespace(
 ):
     """Title and body are trimmed before persistence."""
     response = await authenticated_client.post(
-        "/posts", json={"title": "  hello  ", "body": "  world  "}
+        "/posts",
+        json={"kind": "note", "title": "  hello  ", "body": "  world  "},
     )
     assert response.status_code == 201
     new_id = uuid.UUID(response.json()["id"])
@@ -236,7 +237,7 @@ async def test_create_post_rejects_owner_id_in_payload(
 
     response = await authenticated_client.post(
         "/posts",
-        json={"title": "t", "body": "b", "owner_id": str(other.id)},
+        json={"kind": "note", "title": "t", "body": "b", "owner_id": str(other.id)},
     )
     assert response.status_code == 422
 
@@ -252,7 +253,7 @@ async def test_create_post_rejects_unknown_field(
 ):
     """Unknown fields are rejected with 422."""
     response = await authenticated_client.post(
-        "/posts", json={"title": "t", "body": "b", "evil": True}
+        "/posts", json={"kind": "note", "title": "t", "body": "b", "evil": True}
     )
     assert response.status_code == 422
 
@@ -260,11 +261,13 @@ async def test_create_post_rejects_unknown_field(
 @pytest.mark.parametrize(
     "payload",
     [
-        {"body": "no title"},
-        {"title": "no body"},
-        {},
-        {"title": "", "body": "b"},
-        {"title": "t", "body": "   "},
+        {"kind": "note", "body": "no title"},
+        {"kind": "note", "title": "no body"},
+        {"kind": "note"},
+        {"kind": "note", "title": "", "body": "b"},
+        {"kind": "note", "title": "t", "body": "   "},
+        {"title": "t", "body": "b"},  # missing kind
+        {"kind": "not_a_kind", "title": "t", "body": "b"},  # invalid kind
     ],
 )
 async def test_create_post_missing_or_empty_fields_422(
@@ -282,7 +285,7 @@ async def test_create_post_unauthenticated_redirects(
     """Anonymous request to POST /posts is redirected to login (HTML auth flow)."""
     response = await test_client.post(
         "/posts",
-        json={"title": "t", "body": "b"},
+        json={"kind": "note", "title": "t", "body": "b"},
         headers={"accept": "text/html"},
         follow_redirects=False,
     )
@@ -307,7 +310,7 @@ async def test_owner_can_patch_title_only(
 
     new_title = f"new-{uuid.uuid4()}"
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"title": new_title}
+        f"/posts/{post.id}", json={"kind": "note", "title": new_title}
     )
 
     assert response.status_code == 200
@@ -335,7 +338,7 @@ async def test_owner_can_patch_body_only(
             session.add(post)
 
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"body": "fresh"}
+        f"/posts/{post.id}", json={"kind": "note", "body": "fresh"}
     )
     assert response.status_code == 200
     assert response.json()["title"] == original_title
@@ -353,7 +356,7 @@ async def test_owner_can_patch_both_fields(
             session.add(post)
 
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"title": "T2", "body": "B2"}
+        f"/posts/{post.id}", json={"kind": "note", "title": "T2", "body": "B2"}
     )
     assert response.status_code == 200
     assert response.json()["title"] == "T2"
@@ -374,7 +377,7 @@ async def test_non_owner_cannot_patch_post(
             session.add(post)
 
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"title": "hijack"}
+        f"/posts/{post.id}", json={"kind": "note", "title": "hijack"}
     )
     assert response.status_code == 403
 
@@ -398,7 +401,7 @@ async def test_admin_can_patch_anyone_post(
             session.add(post)
 
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"title": "moderated"}
+        f"/posts/{post.id}", json={"kind": "note", "title": "moderated"}
     )
     assert response.status_code == 200
     assert response.json()["title"] == "moderated"
@@ -409,7 +412,7 @@ async def test_patch_404_for_unknown_post(
     logged_in_user: User,
 ):
     response = await authenticated_client.patch(
-        f"/posts/{uuid.uuid4()}", json={"title": "x"}
+        f"/posts/{uuid.uuid4()}", json={"kind": "note", "title": "x"}
     )
     assert response.status_code == 404
 
@@ -429,7 +432,7 @@ async def test_patch_rejects_owner_id_in_payload(
 
     response = await authenticated_client.patch(
         f"/posts/{post.id}",
-        json={"title": "t2", "owner_id": str(other.id)},
+        json={"kind": "note", "title": "t2", "owner_id": str(other.id)},
     )
     assert response.status_code == 422
 
@@ -437,10 +440,12 @@ async def test_patch_rejects_owner_id_in_payload(
 @pytest.mark.parametrize(
     "payload",
     [
-        {},
-        {"title": None, "body": None},
-        {"title": "   "},
-        {"body": ""},
+        {"kind": "note"},
+        {"kind": "note", "title": None, "body": None},
+        {"kind": "note", "title": "   "},
+        {"kind": "note", "body": ""},
+        {"title": "x"},  # missing kind
+        {"kind": "not_a_kind", "title": "x"},  # invalid kind
     ],
 )
 async def test_patch_invalid_body_422(
@@ -469,7 +474,7 @@ async def test_patch_rejects_unknown_field(
             session.add(post)
 
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"title": "x", "evil": True}
+        f"/posts/{post.id}", json={"kind": "note", "title": "x", "evil": True}
     )
     assert response.status_code == 422
 
@@ -479,7 +484,7 @@ async def test_patch_unauthenticated_redirects(
 ):
     response = await test_client.patch(
         f"/posts/{uuid.uuid4()}",
-        json={"title": "t"},
+        json={"kind": "note", "title": "t"},
         headers={"accept": "text/html"},
         follow_redirects=False,
     )
@@ -751,7 +756,7 @@ async def test_create_post_writes_audit_row(
     body = f"body-{uuid.uuid4()}"
 
     response = await authenticated_client.post(
-        "/posts", json={"title": title, "body": body}
+        "/posts", json={"kind": "note", "title": title, "body": body}
     )
     assert response.status_code == 201
     new_id = uuid.UUID(response.json()["id"])
@@ -785,7 +790,7 @@ async def test_patch_post_writes_audit_row_with_before_and_after(
             session.add(post)
 
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"title": "new title"}
+        f"/posts/{post.id}", json={"kind": "note", "title": "new title"}
     )
     assert response.status_code == 200
 
@@ -818,7 +823,7 @@ async def test_failed_create_writes_no_audit_row(
     """A 422 (schema rejection) must not leak an audit row — the discipline
     requires audit lands iff the mutation does."""
     response = await authenticated_client.post(
-        "/posts", json={"title": "t", "body": "b", "evil": True}
+        "/posts", json={"kind": "note", "title": "t", "body": "b", "evil": True}
     )
     assert response.status_code == 422
 
@@ -845,7 +850,7 @@ async def test_unauthorized_patch_writes_no_audit_row(
             session.add(post)
 
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"title": "hijack"}
+        f"/posts/{post.id}", json={"kind": "note", "title": "hijack"}
     )
     assert response.status_code == 403
 
@@ -871,7 +876,7 @@ async def test_admin_patch_audit_actor_is_admin_not_owner(
             session.add(post)
 
     response = await authenticated_client.patch(
-        f"/posts/{post.id}", json={"title": "moderated"}
+        f"/posts/{post.id}", json={"kind": "note", "title": "moderated"}
     )
     assert response.status_code == 200
 

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -62,7 +62,7 @@ Schemas act as the data contract layer between HTTP and business logic.
 | Schema File | Domain    | Responsibilities                             | Schema Types                                             |
 | ----------- | --------- | -------------------------------------------- | -------------------------------------------------------- |
 | **user.py** | User data | User CRUD plus activation state-axis subresource (extends FastAPI Users) and audit snapshots | UserRead, UserCreate, UserUpdate, UserActivationUpdate, UserAuditSnapshot, UserActivationAuditSnapshot |
-| **post.py** | Posts     | Post read + create + partial-update validation + audit snapshot (`extra="forbid"` rejects `owner_id` and other server-managed fields; whitespace-only `title`/`body` rejected; `PostUpdate` requires at least one field). `PostAuditSnapshot` dereferences `title`/`body` through `Post.note_detail` (the `kind='note'` detail row) and includes `kind` so audit before/after stays a complete projection of mutable fields. | PostRead, PostCreate, PostUpdate, PostAuditSnapshot |
+| **post.py** | Posts     | Post read + create + partial-update validation + audit snapshot. `kind` is required on every wire payload (`Literal["note"]` today; the only accepted value, prep for adding more kinds). `extra="forbid"` rejects `owner_id` and other server-managed fields; whitespace-only `title`/`body` rejected; `PostUpdate` requires `kind` plus at least one mutable field. `PostAuditSnapshot` dereferences `title`/`body` through `Post.note_detail` and includes `kind` so audit before/after stays a complete projection. | PostRead, PostCreate, PostUpdate, PostAuditSnapshot |
 
 ## Directory structure
 

--- a/src/schemas/post.py
+++ b/src/schemas/post.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
@@ -8,13 +9,17 @@ class PostRead(BaseModel):
     """Flat read projection of a `Post` + its kind-specific detail row.
 
     The wire shape stays flat (`title`, `body` at the top level) while the
-    storage shape is parent + per-kind detail. The `model_validator` below
-    flattens through `post.note_detail` when given a SQLAlchemy `Post`, so
-    callers can do `PostRead.model_validate(post)` without knowing the
-    parent/detail split.
+    storage shape is parent + per-kind detail. `kind` is the discriminator
+    field every post-shaped resource carries — today the only allowed
+    value is `'note'`; the next PR widens it as additional kinds are
+    introduced. The `model_validator` below flattens through
+    `post.note_detail` when given a SQLAlchemy `Post`, so callers can do
+    `PostRead.model_validate(post)` without knowing the parent/detail
+    split.
     """
 
     id: uuid.UUID
+    kind: Literal["note"]
     title: str
     body: str
     owner_id: uuid.UUID
@@ -29,6 +34,7 @@ class PostRead(BaseModel):
         if hasattr(data, "note_detail") and data.note_detail is not None:
             return {
                 "id": data.id,
+                "kind": data.kind,
                 "title": data.note_detail.title,
                 "body": data.note_detail.body,
                 "owner_id": data.owner_id,
@@ -39,6 +45,16 @@ class PostRead(BaseModel):
 
 
 class PostCreate(BaseModel):
+    """Create-post payload.
+
+    `kind` is the discriminator the wire format carries forward to
+    distinguish post-shaped resources. Today the only accepted value is
+    `'note'`; making the field required (rather than defaulting it
+    server-side) is the prep step before adding a second kind — every
+    client must announce which kind it's submitting.
+    """
+
+    kind: Literal["note"]
     title: str
     body: str
 
@@ -54,6 +70,14 @@ class PostCreate(BaseModel):
 
 
 class PostUpdate(BaseModel):
+    """Partial-update payload.
+
+    `kind` is required so the server can verify the client's view of the
+    resource matches the persisted kind (a future PR uses this to reject
+    cross-kind PATCHes). Today the only accepted value is `'note'`.
+    """
+
+    kind: Literal["note"]
     title: str | None = None
     body: str | None = None
 
@@ -90,7 +114,7 @@ class PostAuditSnapshot(BaseModel):
     if it lives on a detail row, the validator below.
     """
 
-    kind: str
+    kind: Literal["note"]
     title: str
     body: str
     owner_id: uuid.UUID

--- a/src/schemas/test_post.py
+++ b/src/schemas/test_post.py
@@ -5,29 +5,44 @@ from pydantic import ValidationError
 
 from src.schemas.post import PostCreate, PostUpdate
 
+# --- PostCreate ----------------------------------------------------------
 
-def test_post_create_accepts_title_and_body():
-    p = PostCreate(title="hello", body="world")
+
+def test_post_create_accepts_kind_title_and_body():
+    p = PostCreate(kind="note", title="hello", body="world")
+    assert p.kind == "note"
     assert p.title == "hello"
     assert p.body == "world"
 
 
 def test_post_create_strips_surrounding_whitespace():
-    p = PostCreate(title="  hi  ", body="  there  ")
+    p = PostCreate(kind="note", title="  hi  ", body="  there  ")
     assert p.title == "hi"
     assert p.body == "there"
 
 
+def test_post_create_requires_kind():
+    """`kind` is required on the wire — prep step before adding more kinds."""
+    with pytest.raises(ValidationError):
+        PostCreate(title="t", body="b")
+
+
+def test_post_create_rejects_other_kinds():
+    """Today only `'note'` is accepted; future PRs widen the Literal."""
+    with pytest.raises(ValidationError):
+        PostCreate(kind="not_a_kind", title="t", body="b")
+
+
 @pytest.mark.parametrize("field", ["title", "body"])
 def test_post_create_rejects_empty_or_whitespace(field):
-    payload = {"title": "t", "body": "b", field: "   "}
+    payload = {"kind": "note", "title": "t", "body": "b", field: "   "}
     with pytest.raises(ValidationError):
         PostCreate(**payload)
 
 
 @pytest.mark.parametrize("missing", ["title", "body"])
 def test_post_create_requires_both_fields(missing):
-    payload = {"title": "t", "body": "b"}
+    payload = {"kind": "note", "title": "t", "body": "b"}
     payload.pop(missing)
     with pytest.raises(ValidationError):
         PostCreate(**payload)
@@ -36,12 +51,12 @@ def test_post_create_requires_both_fields(missing):
 def test_post_create_rejects_owner_id():
     """owner_id is server-managed; clients sending it must be rejected."""
     with pytest.raises(ValidationError):
-        PostCreate(title="t", body="b", owner_id=uuid.uuid4())
+        PostCreate(kind="note", title="t", body="b", owner_id=uuid.uuid4())
 
 
 def test_post_create_rejects_unknown_fields():
     with pytest.raises(ValidationError):
-        PostCreate(title="t", body="b", evil=True)
+        PostCreate(kind="note", title="t", body="b", evil=True)
 
 
 # --- PostUpdate ----------------------------------------------------------
@@ -50,24 +65,37 @@ def test_post_create_rejects_unknown_fields():
 @pytest.mark.parametrize(
     "payload",
     [
-        {"title": "new"},
-        {"body": "new"},
-        {"title": "t", "body": "b"},
+        {"kind": "note", "title": "new"},
+        {"kind": "note", "body": "new"},
+        {"kind": "note", "title": "t", "body": "b"},
     ],
 )
 def test_post_update_accepts_partial_fields(payload):
     p = PostUpdate(**payload)
+    assert p.kind == "note"
     assert p.title == payload.get("title")
     assert p.body == payload.get("body")
 
 
 def test_post_update_strips_whitespace():
-    p = PostUpdate(title="  hi  ")
+    p = PostUpdate(kind="note", title="  hi  ")
     assert p.title == "hi"
     assert p.body is None
 
 
-@pytest.mark.parametrize("payload", [{}, {"title": None, "body": None}])
+def test_post_update_requires_kind():
+    with pytest.raises(ValidationError):
+        PostUpdate(title="hi")
+
+
+def test_post_update_rejects_other_kinds():
+    with pytest.raises(ValidationError):
+        PostUpdate(kind="not_a_kind", title="t")
+
+
+@pytest.mark.parametrize(
+    "payload", [{"kind": "note"}, {"kind": "note", "title": None, "body": None}]
+)
 def test_post_update_requires_at_least_one_field(payload):
     with pytest.raises(ValidationError):
         PostUpdate(**payload)
@@ -76,9 +104,9 @@ def test_post_update_requires_at_least_one_field(payload):
 @pytest.mark.parametrize(
     "payload",
     [
-        {"title": "   "},
-        {"body": ""},
-        {"title": "t", "body": "   "},
+        {"kind": "note", "title": "   "},
+        {"kind": "note", "body": ""},
+        {"kind": "note", "title": "t", "body": "   "},
     ],
 )
 def test_post_update_rejects_whitespace_only(payload):
@@ -88,9 +116,9 @@ def test_post_update_rejects_whitespace_only(payload):
 
 def test_post_update_rejects_owner_id():
     with pytest.raises(ValidationError):
-        PostUpdate(title="t", owner_id=uuid.uuid4())
+        PostUpdate(kind="note", title="t", owner_id=uuid.uuid4())
 
 
 def test_post_update_rejects_unknown_field():
     with pytest.raises(ValidationError):
-        PostUpdate(title="t", evil=True)
+        PostUpdate(kind="note", title="t", evil=True)

--- a/src/templates/posts/edit.html
+++ b/src/templates/posts/edit.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1>Edit post</h1>
 <form hx-patch="/posts/{{ post.id }}" hx-ext="json-enc">
+  <input type="hidden" name="kind" value="note" />
   <label for="title">Title:</label><br />
   <input type="text" id="title" name="title" value="{{ post.note_detail.title }}" required /><br />
   <label for="body">Body:</label><br />

--- a/src/templates/posts/new.html
+++ b/src/templates/posts/new.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1>New post</h1>
 <form hx-post="/posts" hx-ext="json-enc">
+  <input type="hidden" name="kind" value="note" />
   <label for="title">Title:</label><br />
   <input type="text" id="title" name="title" required /><br />
   <label for="body">Body:</label><br />

--- a/tests/test_contract/tests/consumer/test_post_edit_form.py
+++ b/tests/test_contract/tests/consumer/test_post_edit_form.py
@@ -2,8 +2,9 @@
 
 Verifies that the form rendered by `templates/posts/edit.html` (mounted via
 the `posts_pages` flag on the consumer server) issues `PATCH /posts/{id}`
-with a JSON body matching `PostUpdate` (title + body, no `owner_id`). The
-contract surface is the form template and the route's request shape.
+with a JSON body matching `PostUpdate` (kind + title + body, no
+`owner_id`). The hidden `<input name="kind" value="note">` in the form
+template is what gets the discriminator into the body.
 """
 
 import pytest
@@ -48,6 +49,7 @@ async def test_consumer_post_edit_form_interaction(origin_with_routes: str, page
 
     expected_request_headers = {"Content-Type": "application/json"}
     expected_request_body = {
+        "kind": Like("note"),
         "title": Like(EDITED_POST_TITLE),
         "body": Like(EDITED_POST_BODY),
     }

--- a/tests/test_contract/tests/consumer/test_post_form.py
+++ b/tests/test_contract/tests/consumer/test_post_form.py
@@ -2,8 +2,9 @@
 
 Verifies that the form rendered by `templates/posts/new.html` (mounted via
 the `posts_pages` flag on the consumer server) issues `POST /posts` with a
-JSON body matching `PostCreate` (title + body, no `owner_id`). The contract
-surface is the form template and the route's request shape.
+JSON body matching `PostCreate` (kind + title + body, no `owner_id`). The
+hidden `<input name="kind" value="note">` in the form template is what
+gets the discriminator into the body.
 """
 
 import pytest
@@ -50,6 +51,7 @@ async def test_consumer_post_create_form_interaction(
 
     expected_request_headers = {"Content-Type": "application/json"}
     expected_request_body = {
+        "kind": Like("note"),
         "title": Like(TEST_POST_TITLE),
         "body": Like(TEST_POST_BODY),
     }

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -91,6 +91,7 @@ class MockDataFactory:
         now = datetime.now(timezone.utc)
         return PostRead(
             id=post_id or cls.MOCK_POST_ID,
+            kind="note",
             title=title,
             body=body,
             owner_id=owner_id or cls.MOCK_POST_OWNER_ID,


### PR DESCRIPTION
Adds `kind: Literal["note"]` as a required field on `PostCreate`, `PostUpdate`, and `PostRead`, and adds a hidden `<input name="kind" value="note">` to the create and edit form templates. The audit snapshot already carried `kind`; this just promotes it to a required field on the request side too.

No behavior change today (only one kind exists). The point is to land the wire change in a small standalone PR so the next PR — which adds `client_referral` as a second kind — can use a textbook discriminated union without a backward-compat escape hatch for missing `kind`.