### PR TITLE
Drive every cross-cutting `kind` site from a single registry (#115)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -147,6 +147,8 @@ This is the cross-module checklist. The detailed step-by-step (with code snippet
 6. **Route** — wire up the HTTP endpoint that delegates to the logic handler. See [`api/routes/README.md`](api/routes/README.md#implementation-patterns).
 7. **Template (if rendering HTML)** — add the Jinja2 template. See [`templates/README.md`](templates/README.md).
 
+For entities with a discriminator-based polymorphic shape (like `Post` / `kind`), see [`models/post_kinds.py`](models/post_kinds.py) for the registry pattern that drives every cross-cutting site (CHECK constraint, route Literal, template selection, dispatch ladders) from one source. Adding a new discriminator value is a one-file change there plus the per-variant Pydantic classes and templates — no edits in routes, repositories, or logic.
+
 ### Dependency injection pattern
 
 Repositories use dependency injection through FastAPI's `Depends()`. Routes inject the repository, then call the logic handler — there is no service layer in between for current entities.

--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -74,7 +74,7 @@ Routes are organized by domain with consistent delegation patterns.
 | Route File         | Domain               | Primary Responsibilities         | Main Endpoints                                                                                                                  | Dependencies          |
 | ------------------ | -------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
 | **users.py**       | User data            | User listing, detail, admin actions | `GET /users`, `GET /users/{id}`, `PUT /users/{id}/activation` (admin), `DELETE /users/{id}` (admin)                          | UserRepository        |
-| **posts.py**       | Posts                | Post listing, detail, create, partial update, hard delete, and per-kind create/edit form pages | `GET /posts`, `GET /posts/form?kind={note,client_referral,provider_availability}`, `GET /posts/{id}`, `GET /posts/{id}/form`, `POST /posts`, `PATCH /posts/{id}`, `DELETE /posts/{id}` | PostRepository        |
+| **posts.py**       | Posts                | Post listing, detail, create, partial update, hard delete, and per-kind create/edit form pages | `GET /posts`, `GET /posts/form?kind=…` (kinds from `REGISTERED_KINDS`), `GET /posts/{id}`, `GET /posts/{id}/form`, `POST /posts`, `PATCH /posts/{id}`, `DELETE /posts/{id}` | PostRepository        |
 | **me.py**          | Current user context | User profile, current-user JSON  | `GET /users/me`, `GET /users/me/profile`                                                                                        | Auth                  |
 | **auth_routes.py** | Authentication API   | Login, register, password reset  | `/auth/*`                                                                                                                       | Authentication logic  |
 | **auth_pages.py**  | Authentication UI    | Login, register forms            | `/login`, `/register`                                                                                                           | Authentication logic  |
@@ -84,7 +84,7 @@ Routes are organized by domain with consistent delegation patterns.
 **Domain route files:**
 
 - `users.py` - User listing and access
-- `posts.py` - Post listing, detail, create, partial update, hard delete, and per-kind HTML form pages. `GET /posts/form?kind={note,client_referral,provider_availability}` selects the create-form template (`Literal` validator → 422 on unknown kinds); `GET /posts/{id}/form` selects the edit-form template from the persisted `post.kind`. `POST /posts` accepts a kind-discriminated body (`kind` required); `PATCH /posts/{id}` rejects payloads whose `kind` doesn't match the persisted post.
+- `posts.py` - Post listing, detail, create, partial update, hard delete, and per-kind HTML form pages. `GET /posts/form?kind=…` selects the create-form template (`Literal[*KIND_NAMES]` from [`src/models/post_kinds.py`](../../models/post_kinds.py) → 422 on unknown kinds); `GET /posts/{id}/form` reads `spec.edit_template` from the same registry given the persisted `post.kind`. `POST /posts` accepts a kind-discriminated body (`kind` required); `PATCH /posts/{id}` rejects payloads whose `kind` doesn't match the persisted post. The `_patch_response_body` flatten reads the per-kind detail relationship + fields from `REGISTERED_KINDS`.
 - `me.py` - Current user's profile
 
 **Authentication routes:**

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -16,7 +16,7 @@ from src.logic.post_processing import (
     handle_list_posts,
     handle_update_post,
 )
-from src.models import User
+from src.models import KIND_NAMES, REGISTERED_KINDS, User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository, get_post_repository
 from src.repositories.post_repository import PostRepository
@@ -27,45 +27,18 @@ router = BaseRouter(router=posts_api_router, default_tags=["posts"])
 logger = logging.getLogger(__name__)
 
 
-# Per-kind create-form templates. The list is closed: a `kind` query
-# value not in here yields a 422 from FastAPI's Literal validator,
-# avoiding any chance of arbitrary template selection from the URL.
-_CREATE_FORM_TEMPLATES: dict[str, str] = {
-    "note": "posts/new.html",
-    "client_referral": "posts/new_client_referral.html",
-    "provider_availability": "posts/new_provider_availability.html",
-}
-_EDIT_FORM_TEMPLATES: dict[str, str] = {
-    "note": "posts/edit.html",
-    "client_referral": "posts/edit_client_referral.html",
-    "provider_availability": "posts/edit_provider_availability.html",
-}
-
-
 def _patch_response_body(post) -> dict:
     """Per-kind flat response body for `PATCH /posts/{id}`. The wire
     shape mirrors the POST/GET projection's flat fields so HTMX clients
-    don't have to know about parent/detail."""
-    if post.kind == "note":
-        return {
-            "id": str(post.id),
-            "kind": "note",
-            "title": post.note_detail.title,
-            "body": post.note_detail.body,
-        }
-    if post.kind == "client_referral":
-        return {
-            "id": str(post.id),
-            "kind": "client_referral",
-            "description": post.client_referral_detail.description,
-        }
-    if post.kind == "provider_availability":
-        return {
-            "id": str(post.id),
-            "kind": "provider_availability",
-            "practice_name": post.provider_availability_detail.practice_name,
-        }
-    raise ValueError(f"unsupported post kind: {post.kind!r}")
+    don't have to know about parent/detail. Per-kind detail relationship
+    + fields come from `REGISTERED_KINDS` in `src/models/post_kinds.py`."""
+    spec = REGISTERED_KINDS[post.kind]
+    detail = getattr(post, spec.detail_relationship)
+    return {
+        "id": str(post.id),
+        "kind": post.kind,
+        **{f: getattr(detail, f) for f in spec.detail_fields},
+    }
 
 
 @router.get("")
@@ -90,19 +63,21 @@ async def list_posts(
 @router.get("/form")
 async def get_post_form(
     request: Request,
-    kind: Literal["note", "client_referral", "provider_availability"] = Query("note"),
+    kind: Literal[*KIND_NAMES] = Query(KIND_NAMES[0]),
     user: User = Depends(current_active_user),
 ):
     """Provides an HTML page with the create-post form for the given
-    `kind` (default `'note'`). Unsupported kinds 422 via FastAPI's
-    Literal validator.
+    `kind` (default: first registered kind). Unsupported kinds 422 via
+    FastAPI's Literal validator. The kind set comes from `REGISTERED_KINDS`.
 
     Registered before `/{post_id}` so the literal `form` is not parsed
     as a UUID.
     """
     context = await handle_get_post_form(request=request, requesting_user=user)
     return APIResponse.html_response(
-        template_name=_CREATE_FORM_TEMPLATES[kind], context=context, request=request
+        template_name=REGISTERED_KINDS[kind].create_template,
+        context=context,
+        request=request,
     )
 
 
@@ -126,7 +101,7 @@ async def get_post_edit_form(
     )
     post_kind = context["post"].kind
     return APIResponse.html_response(
-        template_name=_EDIT_FORM_TEMPLATES[post_kind],
+        template_name=REGISTERED_KINDS[post_kind].edit_template,
         context=context,
         request=request,
     )
@@ -161,11 +136,10 @@ async def create_post(
 ):
     """Creates a post owned by the authenticated user.
 
-    The body is a discriminated union on `kind`: pre-existing note
-    payloads (`{title, body}`) keep working without sending the field;
-    `client_referral` payloads must include `kind: "client_referral"`.
-    `owner_id` is server-set from the session; clients sending it (or
-    any other unknown field) are rejected with 422 by the schema.
+    The body is a discriminated union on `kind`: clients must include
+    a `kind` matching one of the registered variants. `owner_id` is
+    server-set from the session; clients sending it (or any other
+    unknown field) are rejected with 422 by the schema.
     """
     created = await handle_create_post(
         payload=payload,

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -573,7 +573,7 @@ async def test_list_page_links_to_create_form(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    link = tree.css_first('a[href="/posts/form"]')
+    link = tree.css_first('a[href="/posts/form?kind=note"]')
     assert link is not None
     assert "New note" in link.text()
     cr_link = tree.css_first('a[href="/posts/form?kind=client_referral"]')

--- a/src/logic/post_processing.py
+++ b/src/logic/post_processing.py
@@ -5,13 +5,7 @@ from fastapi import Request
 
 from src.api.common.exceptions import BadRequestError, ForbiddenError, NotFoundError
 from src.logic.audit import AuditAction, record_audit
-from src.models import (
-    ClientReferralDetail,
-    NoteDetail,
-    Post,
-    ProviderAvailabilityDetail,
-    User,
-)
+from src.models import REGISTERED_KINDS, Post, User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.post_repository import PostRepository
 from src.schemas.post import (
@@ -25,6 +19,9 @@ from src.schemas.post import (
 )
 
 logger = logging.getLogger(__name__)
+
+PostCreatePayload = NoteCreate | ClientReferralCreate | ProviderAvailabilityCreate
+PostUpdatePayload = NoteUpdate | ClientReferralUpdate | ProviderAvailabilityUpdate
 
 
 def _snapshot_post(post: Post) -> dict:
@@ -42,9 +39,18 @@ async def handle_list_posts(
     post_repo: PostRepository,
     requesting_user: User,
 ):
-    """Loads all posts (newest first) and returns the template context."""
+    """Loads all posts (newest first) and returns the template context.
+
+    Includes the registered post kinds in the context so the list page
+    can render its per-kind "New X" links from a single source of truth.
+    """
     posts = await post_repo.list_posts()
-    return {"request": request, "posts": posts, "current_user": requesting_user}
+    return {
+        "request": request,
+        "posts": posts,
+        "current_user": requesting_user,
+        "post_kinds": list(REGISTERED_KINDS.values()),
+    }
 
 
 async def handle_get_post_detail(
@@ -88,7 +94,7 @@ async def handle_get_post_edit_form(
 
 
 async def handle_create_post(
-    payload: NoteCreate | ClientReferralCreate | ProviderAvailabilityCreate,
+    payload: PostCreatePayload,
     post_repo: PostRepository,
     audit_repo: AuditRepository,
     requesting_user: User,
@@ -96,21 +102,14 @@ async def handle_create_post(
     """Creates a post owned by the requesting user; writes an audit row in
     the same transaction; commits on success.
 
-    Dispatches on `payload.kind` (set by the discriminated union in
-    `src/schemas/post.py`) to build the right per-kind detail row. New
-    kinds add a branch here.
+    Dispatches via the `REGISTERED_KINDS` registry: the `kind` discriminator
+    on the payload picks the spec, and the spec's `detail_model` +
+    `detail_fields` build the right detail row. Adding a new kind means
+    a registry entry — no edits here.
     """
-    if isinstance(payload, NoteCreate):
-        post = Post(kind="note", owner_id=requesting_user.id)
-        detail = NoteDetail(title=payload.title, body=payload.body)
-    elif isinstance(payload, ClientReferralCreate):
-        post = Post(kind="client_referral", owner_id=requesting_user.id)
-        detail = ClientReferralDetail(description=payload.description)
-    elif isinstance(payload, ProviderAvailabilityCreate):
-        post = Post(kind="provider_availability", owner_id=requesting_user.id)
-        detail = ProviderAvailabilityDetail(practice_name=payload.practice_name)
-    else:  # pragma: no cover — schema discriminator should make this unreachable
-        raise BadRequestError(detail=f"unsupported post kind: {payload.kind!r}")
+    spec = REGISTERED_KINDS[payload.kind]
+    post = Post(kind=payload.kind, owner_id=requesting_user.id)
+    detail = spec.detail_model(**{f: getattr(payload, f) for f in spec.detail_fields})
 
     created = await post_repo.create_post(post, detail)
     await record_audit(
@@ -129,7 +128,7 @@ async def handle_create_post(
 
 async def handle_update_post(
     post_id: UUID,
-    payload: NoteUpdate | ClientReferralUpdate | ProviderAvailabilityUpdate,
+    payload: PostUpdatePayload,
     post_repo: PostRepository,
     audit_repo: AuditRepository,
     requesting_user: User,
@@ -141,7 +140,7 @@ async def handle_update_post(
     The payload's `kind` must match the persisted post's `kind` — `kind`
     is part of the resource identity once created and cannot be migrated
     via PATCH. 404 if missing, 403 if not authorized, 400 on kind
-    mismatch.
+    mismatch. Per-kind field set comes from `REGISTERED_KINDS`.
     """
     post = await post_repo.get_post_by_id(post_id)
     if post is None:
@@ -158,15 +157,12 @@ async def handle_update_post(
             )
         )
 
+    spec = REGISTERED_KINDS[payload.kind]
     before = _snapshot_post(post)
-    if isinstance(payload, NoteUpdate):
-        updated = await post_repo.update_post(
-            post, title=payload.title, body=payload.body
-        )
-    elif isinstance(payload, ClientReferralUpdate):
-        updated = await post_repo.update_post(post, description=payload.description)
-    else:  # ProviderAvailabilityUpdate
-        updated = await post_repo.update_post(post, practice_name=payload.practice_name)
+    updated = await post_repo.update_post(
+        post,
+        **{f: getattr(payload, f) for f in spec.detail_fields},
+    )
     await record_audit(
         audit_repo,
         actor_id=requesting_user.id,

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -64,14 +64,29 @@ Each model maps to a database table with explicit relationships managed by SQLAl
 
 `Post` is the parent table for any post-shaped resource. It carries identity, ownership, timestamps, and a `kind` discriminator. Kind-specific fields live in their own detail table keyed by `post_id` (PK + FK with `ON DELETE CASCADE`).
 
-Kinds today: `note` (→ `note_details`), `client_referral` (→ `client_referral_details`), and `provider_availability` (→ `provider_availability_details`). The two non-note kinds are MVP shape — full intake forms per [`../../notes/forms_spec.md`](../../notes/forms_spec.md) follow. Adding a new kind means: (a) widen the CHECK on `posts.kind`, (b) add a new detail table, (c) add a `relationship(..., uselist=False, cascade="all, delete-orphan", lazy="selectin")` on `Post`. Detail rows have no `id` of their own — `post_id` is both PK and FK, enforcing 1:1.
+Kinds today: `note` (→ `note_details`), `client_referral` (→ `client_referral_details`), and `provider_availability` (→ `provider_availability_details`). The two non-note kinds are MVP shape — full intake forms per [`../../notes/forms_spec.md`](../../notes/forms_spec.md) follow. Detail rows have no `id` of their own — `post_id` is both PK and FK, enforcing 1:1.
+
+### The `post_kinds` registry
+
+The set of allowed kinds — and the per-kind detail relationship + field metadata used across the codebase — lives in [`post_kinds.py`](post_kinds.py) as `REGISTERED_KINDS: dict[str, KindSpec]`. Every cross-cutting site reads from it:
+
+- `Post.__table_args__` builds its `CheckConstraint` from `kind_check_sql()` — the SQL is derived from `KIND_NAMES`.
+- The route's `Literal[*KIND_NAMES]` for `GET /posts/form?kind=…` is derived.
+- The form-template selection in `src/api/routes/posts.py` reads `spec.create_template` / `spec.edit_template`.
+- `src/repositories/post_repository.py:_attach_detail` looks up by detail-class via `KIND_BY_DETAIL_MODEL`; `update_post` writes to `spec.detail_relationship` for the post's kind.
+- `src/logic/post_processing.py:handle_create_post` and `handle_update_post` dispatch via `REGISTERED_KINDS[payload.kind]` instead of `isinstance` ladders.
+- `src/schemas/post.py:_flatten_post_to_dict` reads the relationship + field tuple from the registry (so `PostRead`, `PostAuditSnapshot` flatten through it).
+- `src/templates/posts/list.html` receives `post_kinds` in its context and renders the per-kind "New X" links from it.
+
+Adding a kind is therefore: (1) a registry entry in `post_kinds.py`, (2) a new detail model file + a `relationship(...)` line on `Post`, (3) the four Pydantic variant classes in `src/schemas/post.py`, (4) the per-kind templates under `src/templates/posts/`, (5) an Alembic migration. Removing a kind is the inverse. No edits in routes, repositories, or logic — those layers are registry-driven. The consistency tests in [`test_post_kinds.py`](test_post_kinds.py) guard against re-encoding the kind set inline anywhere new.
 
 ## Directory structure
 
 **Core model files:**
 
 - `user.py` - User authentication and profile (extends FastAPI Users)
-- `post.py` - Parent row for posts: kind discriminator + owner FK; one detail table per kind
+- `post.py` - Parent row for posts: kind discriminator + owner FK; one detail table per kind. CHECK constraint is derived from `post_kinds.py`.
+- `post_kinds.py` - `REGISTERED_KINDS` registry: per-kind detail model, relationship name, field tuple, templates, list label. Single source of truth for the kind set.
 - `note_detail.py` - `kind='note'` detail (title + body); 1:1 with `posts` via `post_id`
 - `client_referral_detail.py` - `kind='client_referral'` detail (description; MVP); 1:1 with `posts` via `post_id`
 - `provider_availability_detail.py` - `kind='provider_availability'` detail (practice_name; MVP); 1:1 with `posts` via `post_id`
@@ -260,7 +275,9 @@ class NewEntity(BaseModel):
 
 ## Tests
 
-**TODO** — no colocated tests yet. Most model behavior is exercised indirectly through repository and route tests. Add `src/models/test_<model_name>.py` when a model carries non-trivial logic (computed fields, validators, custom `__init__`, etc.) that warrants direct coverage.
+- `test_post_kinds.py` — guards the `post_kinds` registry as the single source of truth: asserts `KIND_NAMES` matches the registry, the rendered `kind_check_sql()` matches what `Post.__table_args__` actually produces, the route's `Literal[*KIND_NAMES]` reflects the registry, the inverse `KIND_BY_DETAIL_MODEL` lookup is well-formed, and the per-kind relationship-name convention holds. If a future change re-encodes the kind set inline somewhere, the relevant test here fails.
+
+Most other model behavior is exercised indirectly through repository and route tests. Add `src/models/test_<model_name>.py` when a model carries non-trivial logic (computed fields, validators, custom `__init__`, etc.) that warrants direct coverage.
 
 When changing a model's schema, generate an Alembic migration as part of the same change — see [`../../CLAUDE.md`](../../CLAUDE.md).
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -3,6 +3,13 @@ from .base import Base, BaseModel, metadata
 from .client_referral_detail import ClientReferralDetail
 from .note_detail import NoteDetail
 from .post import Post
+from .post_kinds import (
+    KIND_BY_DETAIL_MODEL,
+    KIND_NAMES,
+    REGISTERED_KINDS,
+    KindSpec,
+    kind_check_sql,
+)
 from .provider_availability_detail import ProviderAvailabilityDetail
 from .user import User
 
@@ -11,9 +18,14 @@ __all__ = [
     "Base",
     "BaseModel",
     "ClientReferralDetail",
+    "KIND_BY_DETAIL_MODEL",
+    "KIND_NAMES",
+    "KindSpec",
     "NoteDetail",
     "Post",
     "ProviderAvailabilityDetail",
+    "REGISTERED_KINDS",
     "User",
+    "kind_check_sql",
     "metadata",
 ]

--- a/src/models/post.py
+++ b/src/models/post.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.types import Uuid
 
 from .base import BaseModel
+from .post_kinds import kind_check_sql
 
 
 class Post(BaseModel):
@@ -10,20 +11,15 @@ class Post(BaseModel):
 
     Carries identity, ownership, timestamps, and the `kind` discriminator.
     Kind-specific fields live in a per-kind detail table joined on
-    `post_id`. Kinds today: `'note'` (→ `NoteDetail`), `'client_referral'`
-    (→ `ClientReferralDetail`), `'provider_availability'`
-    (→ `ProviderAvailabilityDetail`). Adding a kind means widening the
-    CHECK here, adding a detail table, and adding a `relationship(...)`
-    below.
+    `post_id`. The set of allowed kinds — and the per-kind detail
+    relationship + field metadata used across the codebase — lives in
+    [`post_kinds.py`](post_kinds.py); the CHECK constraint here is
+    derived from it via `kind_check_sql()`. Adding a kind means adding
+    a registry entry there and a `relationship(...)` line below.
     """
 
     __tablename__ = "posts"
-    __table_args__ = (
-        CheckConstraint(
-            "kind IN ('note', 'client_referral', 'provider_availability')",
-            name="ck_posts_kind",
-        ),
-    )
+    __table_args__ = (CheckConstraint(kind_check_sql(), name="ck_posts_kind"),)
 
     kind = Column(Text, nullable=False)
     owner_id = Column(

--- a/src/models/post_kinds.py
+++ b/src/models/post_kinds.py
@@ -1,0 +1,94 @@
+"""Single source of truth for post kinds.
+
+`REGISTERED_KINDS` registers each kind's name, its per-kind detail
+SQLAlchemy model, the relationship attribute on `Post` that points at
+that detail, the detail row's user-facing fields, and the templates and
+labels the route/template layers render for the kind.
+
+Adding a kind requires:
+
+1. A new entry in `REGISTERED_KINDS` here.
+2. A new detail model under `src/models/<kind>_detail.py`, plus a
+   `relationship(...)` line on `Post`.
+3. The four Pydantic variant classes in `src/schemas/post.py`
+   (Read, Create, Update, AuditSnapshot).
+4. The `posts/new_<kind>.html` and `posts/edit_<kind>.html` templates.
+5. An Alembic migration that creates the detail table and widens the
+   `posts.kind` CHECK.
+
+After that, every cross-cutting site reads from this registry: the
+model's `CheckConstraint`, the route's `Literal` for the form `?kind=`
+query parameter, the create/edit form-template dicts, the per-kind
+flatten in `_patch_response_body` and `_flatten_post_to_dict`, the
+repository's `_attach_detail` and `update_post`, and both logic-layer
+dispatch ladders (`handle_create_post`, `handle_update_post`).
+
+Removing a kind is the inverse: delete the registry entry, the detail
+model + relationship, the four Pydantic classes, the templates, and ship
+a migration that drops the detail table and narrows the CHECK. No edits
+in routes, repositories, or logic.
+"""
+
+from dataclasses import dataclass
+from typing import Final
+
+from .client_referral_detail import ClientReferralDetail
+from .note_detail import NoteDetail
+from .provider_availability_detail import ProviderAvailabilityDetail
+
+
+@dataclass(frozen=True)
+class KindSpec:
+    """Per-kind metadata. See module docstring for the registration contract."""
+
+    name: str
+    detail_model: type
+    detail_relationship: str
+    detail_fields: tuple[str, ...]
+    list_label: str
+    create_template: str
+    edit_template: str
+
+
+REGISTERED_KINDS: Final[dict[str, KindSpec]] = {
+    "note": KindSpec(
+        name="note",
+        detail_model=NoteDetail,
+        detail_relationship="note_detail",
+        detail_fields=("title", "body"),
+        list_label="note",
+        create_template="posts/new.html",
+        edit_template="posts/edit.html",
+    ),
+    "client_referral": KindSpec(
+        name="client_referral",
+        detail_model=ClientReferralDetail,
+        detail_relationship="client_referral_detail",
+        detail_fields=("description",),
+        list_label="client referral",
+        create_template="posts/new_client_referral.html",
+        edit_template="posts/edit_client_referral.html",
+    ),
+    "provider_availability": KindSpec(
+        name="provider_availability",
+        detail_model=ProviderAvailabilityDetail,
+        detail_relationship="provider_availability_detail",
+        detail_fields=("practice_name",),
+        list_label="provider availability",
+        create_template="posts/new_provider_availability.html",
+        edit_template="posts/edit_provider_availability.html",
+    ),
+}
+
+KIND_NAMES: Final[tuple[str, ...]] = tuple(REGISTERED_KINDS)
+
+KIND_BY_DETAIL_MODEL: Final[dict[type, KindSpec]] = {
+    spec.detail_model: spec for spec in REGISTERED_KINDS.values()
+}
+
+
+def kind_check_sql() -> str:
+    """SQL fragment for the `posts.kind` CHECK constraint, derived from
+    `KIND_NAMES`. Used by `models/post.py` at class-definition time so
+    the constraint stays in lockstep with the registry."""
+    return "kind IN (" + ", ".join(repr(k) for k in KIND_NAMES) + ")"

--- a/src/models/test_post_kinds.py
+++ b/src/models/test_post_kinds.py
@@ -1,0 +1,69 @@
+"""Tests guarding the post-kinds registry as the single source of truth.
+
+The registry in `src/models/post_kinds.py` claims to drive every
+cross-cutting site (model CHECK, route Literal, form-template dicts,
+detail-class lookup). These tests assert that claim — if a future
+change re-encodes the kind set inline somewhere, the relevant test here
+fails.
+"""
+
+from typing import get_args
+
+from src.api.routes.posts import get_post_form
+from src.models import (
+    KIND_BY_DETAIL_MODEL,
+    KIND_NAMES,
+    REGISTERED_KINDS,
+    Post,
+    kind_check_sql,
+)
+
+
+def test_kind_names_matches_registered_kinds():
+    """`KIND_NAMES` is the registered-kinds dict's keys, in declaration order."""
+    assert KIND_NAMES == tuple(REGISTERED_KINDS)
+
+
+def test_kind_check_sql_matches_registry():
+    """The CHECK SQL fragment lists exactly the registered kinds."""
+    expected = "kind IN (" + ", ".join(repr(k) for k in KIND_NAMES) + ")"
+    assert kind_check_sql() == expected
+
+
+def test_post_check_constraint_uses_registry():
+    """The `Post` model's CHECK constraint is derived from the registry, so
+    its `sqltext` matches `kind_check_sql()`. Guards against someone
+    inlining a literal CHECK string that drifts from the registry."""
+    constraints = [c for c in Post.__table__.constraints if c.name == "ck_posts_kind"]
+    assert len(constraints) == 1
+    # SQLAlchemy stores the CHECK as a TextClause; comparing the rendered SQL.
+    rendered = str(constraints[0].sqltext.text)
+    assert rendered == kind_check_sql()
+
+
+def test_kind_by_detail_model_inverse_matches_registry():
+    """Every registered detail-model class is present in the inverse map,
+    and the inverse map lookup returns the same spec as the forward
+    registry."""
+    assert {spec.detail_model for spec in REGISTERED_KINDS.values()} == set(
+        KIND_BY_DETAIL_MODEL
+    )
+    for spec in REGISTERED_KINDS.values():
+        assert KIND_BY_DETAIL_MODEL[spec.detail_model] is spec
+
+
+def test_form_route_literal_matches_registry():
+    """The `?kind=` Query parameter on `GET /posts/form` is typed as
+    `Literal[*KIND_NAMES]`; the FastAPI signature must reflect that."""
+    annotations = get_post_form.__annotations__
+    literal_args = get_args(annotations["kind"])
+    assert set(literal_args) == set(KIND_NAMES)
+
+
+def test_each_spec_detail_relationship_matches_kind_name():
+    """Per-kind detail relationships follow the `<kind>_detail` convention.
+    This is convention, not enforcement — if a future kind needs a
+    different relationship name, drop this test for that kind. But while
+    every kind agrees, asserting it catches typos."""
+    for kind, spec in REGISTERED_KINDS.items():
+        assert spec.detail_relationship == f"{kind}_detail"

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -261,7 +261,7 @@ async def handle_list_entities_for_user(user: User, repo: [Entity]Repository):
 Colocated tests live alongside the repositories:
 
 - `test_audit_repository.py` — exercises append-only writes, FK `SET NULL` on actor delete, and list-by-resource ordering against the in-memory test DB.
-- `test_post_repository.py` — exercises parent + detail create/update/delete for every registered kind (`note`, `client_referral`, `provider_availability`), including a raw-SQL DELETE that proves the FK CASCADE fires (not just the ORM cascade). Also covers the `posts.kind` CHECK constraint rejecting unregistered kinds. Relies on `PRAGMA foreign_keys = ON` being set globally by the test engine fixture.
+- `test_post_repository.py` — exercises parent + detail create/update/delete for every registered kind (`note`, `client_referral`, `provider_availability`), including a raw-SQL DELETE that proves the FK CASCADE fires (not just the ORM cascade). Also covers the `posts.kind` CHECK constraint rejecting unregistered kinds. Relies on `PRAGMA foreign_keys = ON` being set globally by the test engine fixture. Per-kind dispatch in `_attach_detail` and `update_post` is registry-driven via `REGISTERED_KINDS` / `KIND_BY_DETAIL_MODEL` from [`src/models/post_kinds.py`](../models/post_kinds.py); the registry-consistency tests live with the registry, not here.
 
 When adding a new repository method, extend (or create) `src/repositories/test_<repo_name>.py` and exercise it via the `db_test_session_manager` fixture from [`tests/fixtures.py`](../../tests/fixtures.py).
 

--- a/src/repositories/post_repository.py
+++ b/src/repositories/post_repository.py
@@ -1,10 +1,12 @@
-from typing import Sequence
+from typing import Any, Sequence
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import (
+    KIND_BY_DETAIL_MODEL,
+    REGISTERED_KINDS,
     ClientReferralDetail,
     NoteDetail,
     Post,
@@ -19,16 +21,12 @@ PostDetail = NoteDetail | ClientReferralDetail | ProviderAvailabilityDetail
 def _attach_detail(post: Post, detail: PostDetail) -> None:
     """Wire a fresh detail row up to its parent on the right relationship.
 
-    Adding a new `kind` means adding its detail class here.
-    """
-    if isinstance(detail, NoteDetail):
-        post.note_detail = detail
-    elif isinstance(detail, ClientReferralDetail):
-        post.client_referral_detail = detail
-    elif isinstance(detail, ProviderAvailabilityDetail):
-        post.provider_availability_detail = detail
-    else:
+    The detail-class-to-relationship mapping is the registry in
+    `src/models/post_kinds.py` — adding a new kind there is enough."""
+    spec = KIND_BY_DETAIL_MODEL.get(type(detail))
+    if spec is None:
         raise TypeError(f"unsupported detail type: {type(detail).__name__}")
+    setattr(post, spec.detail_relationship, detail)
 
 
 class PostRepository(BaseRepository):
@@ -62,41 +60,26 @@ class PostRepository(BaseRepository):
         await self.session.refresh(post)
         return post
 
-    async def update_post(
-        self,
-        post: Post,
-        *,
-        title: str | None = None,
-        body: str | None = None,
-        description: str | None = None,
-        practice_name: str | None = None,
-    ) -> Post:
-        """Mutates only the per-kind fields that were provided and flushes;
+    async def update_post(self, post: Post, **detail_fields: Any) -> Post:
+        """Mutates the per-kind detail fields that were provided and flushes;
         the caller commits.
 
-        - `title` / `body` are written to `post.note_detail` (kind='note').
-        - `description` is written to `post.client_referral_detail`
-          (kind='client_referral').
-        - `practice_name` is written to `post.provider_availability_detail`
-          (kind='provider_availability').
+        `detail_fields` is keyed by the field names on the post's
+        per-kind detail row (the `KindSpec.detail_fields` for `post.kind`
+        in `src/models/post_kinds.py`). Fields whose value is `None` and
+        fields that don't belong to the post's kind are silently skipped
+        — the calling logic layer is responsible for rejecting cross-kind
+        writes at the route boundary with a 400.
 
-        `post.kind` is intentionally not a parameter and never written by
-        this method — kind is part of the resource identity and is fixed
-        at create time. Cross-kind writes (e.g. `title` on a
-        client_referral) are silently skipped here; the calling logic
-        layer rejects them at the route boundary with a 400.
+        `post.kind` is intentionally not writable here: kind is part of
+        the resource identity and is fixed at create time.
         """
-        if post.kind == "note":
-            if title is not None:
-                post.note_detail.title = title
-            if body is not None:
-                post.note_detail.body = body
-        elif post.kind == "client_referral":
-            if description is not None:
-                post.client_referral_detail.description = description
-        elif post.kind == "provider_availability":
-            if practice_name is not None:
-                post.provider_availability_detail.practice_name = practice_name
+        spec = REGISTERED_KINDS[post.kind]
+        detail = getattr(post, spec.detail_relationship)
+        for field_name, value in detail_fields.items():
+            if value is None or field_name not in spec.detail_fields:
+                continue
+            setattr(detail, field_name, value)
         self.session.add(post)
         await self.session.flush()
         await self.session.refresh(post)

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -62,14 +62,14 @@ Schemas act as the data contract layer between HTTP and business logic.
 | Schema File | Domain    | Responsibilities                             | Schema Types                                             |
 | ----------- | --------- | -------------------------------------------- | -------------------------------------------------------- |
 | **user.py** | User data | User CRUD plus activation state-axis subresource (extends FastAPI Users) and audit snapshots | UserRead, UserCreate, UserUpdate, UserActivationUpdate, UserAuditSnapshot, UserActivationAuditSnapshot |
-| **post.py** | Posts     | `PostCreate`/`PostUpdate`/`PostRead`/`PostAuditSnapshot` are kind-discriminated unions keyed on the (required) `kind` field. Create/Update variants apply `extra="forbid"`, strip whitespace, and (for partial update) require at least one mutable field. Read and AuditSnapshot variants share a single `_flatten_post_to_dict` helper driven by `_KIND_DETAILS` (one entry per kind: detail-relationship name + field tuple), so adding a kind only adds one registry row + four small variant classes. `post_audit_snapshot(post)` validates a SQLAlchemy `Post` against the audit union and returns a JSON-mode dump. | Note*, ClientReferral*, ProviderAvailability* variants of Create/Update/Read/AuditSnapshot, plus the discriminated-union aliases PostCreate/PostUpdate/PostRead/PostAuditSnapshot and the helper `post_audit_snapshot` |
+| **post.py** | Posts     | `PostCreate`/`PostUpdate`/`PostRead`/`PostAuditSnapshot` are kind-discriminated unions keyed on the (required) `kind` field. Create/Update variants apply `extra="forbid"`, strip whitespace, and (for partial update) require at least one mutable field. Read and AuditSnapshot variants share a single `_flatten_post_to_dict` helper that reads the per-kind detail relationship and field tuple from `REGISTERED_KINDS` in [`src/models/post_kinds.py`](../models/post_kinds.py) — adding a kind there is what wires the flatten path up. `post_audit_snapshot(post)` validates a SQLAlchemy `Post` against the audit union and returns a JSON-mode dump. | Note*, ClientReferral*, ProviderAvailability* variants of Create/Update/Read/AuditSnapshot, plus the discriminated-union aliases PostCreate/PostUpdate/PostRead/PostAuditSnapshot and the helper `post_audit_snapshot` |
 
 ## Directory structure
 
 **Domain schema files:**
 
 - `user.py` - User schemas extending FastAPI Users base schemas
-- `post.py` - Per-kind post schemas wrapped in discriminated-union aliases (`PostCreate`/`PostUpdate`/`PostRead`/`PostAuditSnapshot`) keyed on the required `kind` field. The Read and AuditSnapshot variants share one `_flatten_post_to_dict` helper driven by a `_KIND_DETAILS` registry; adding a new kind means registering its detail relationship + field names there, adding the four schema variants, and adding them to the unions.
+- `post.py` - Per-kind post schemas wrapped in discriminated-union aliases (`PostCreate`/`PostUpdate`/`PostRead`/`PostAuditSnapshot`) keyed on the required `kind` field. The Read and AuditSnapshot variants share one `_flatten_post_to_dict` helper that reads from `REGISTERED_KINDS` in [`src/models/post_kinds.py`](../models/post_kinds.py); adding a new kind means a registry entry there plus the four Pydantic variant classes here.
 
 ## Implementation patterns
 

--- a/src/schemas/post.py
+++ b/src/schemas/post.py
@@ -3,19 +3,17 @@
 `Post` is a parent row with a `kind` discriminator and a per-kind detail
 table. The wire surface mirrors that shape: `PostCreate` / `PostUpdate`
 / `PostRead` / `PostAuditSnapshot` are kind-discriminated unions on the
-(required) `kind` field. `kind` is required on every payload — the prep
-PR (`require-kind-on-wire`) made that the contract before this PR added
-a second kind.
+(required) `kind` field.
 
 `post_audit_snapshot(post)` validates a SQLAlchemy `Post` against the
 union and returns a JSON-mode dump for the audit row.
 
-`_KIND_DETAILS` is the single registry mapping each `kind` to its detail
-relationship and detail-row fields. Adding a new kind means: (a) register
-it here, (b) add the four schema variants (Read, Create, Update,
-AuditSnapshot) and the discriminated unions below, (c) add a relationship
-+ CHECK widening in `src/models/post.py`. The four variants share one
-`_flatten_post_to_dict` helper so per-kind validators are 2 lines each.
+The per-kind detail relationship + fields live in
+[`src/models/post_kinds.py`](../models/post_kinds.py) — this module's
+`_flatten_post_to_dict` reads from that registry. Adding a kind here
+means the four Pydantic variant classes (Read/Create/Update/
+AuditSnapshot) plus their entry in the discriminated unions; everything
+else flows from the registry.
 """
 
 import uuid
@@ -31,17 +29,9 @@ from pydantic import (
     model_validator,
 )
 
-# --- Per-kind detail registry & shared flatten helper --------------------
+from src.models import REGISTERED_KINDS
 
-
-_KIND_DETAILS: dict[str, tuple[str, tuple[str, ...]]] = {
-    "note": ("note_detail", ("title", "body")),
-    "client_referral": ("client_referral_detail", ("description",)),
-    "provider_availability": (
-        "provider_availability_detail",
-        ("practice_name",),
-    ),
-}
+# --- Shared flatten helper ----------------------------------------------
 
 
 def _flatten_post_to_dict(post) -> dict | None:
@@ -54,13 +44,13 @@ def _flatten_post_to_dict(post) -> dict | None:
     audit-snapshot variants share this helper; Pydantic silently drops
     fields that aren't declared on a given variant (neither Read nor
     AuditSnapshot uses `extra="forbid"`), so the same flat dict feeds
-    both shapes.
+    both shapes. Per-kind metadata comes from `REGISTERED_KINDS`.
     """
     kind = getattr(post, "kind", None)
-    if kind not in _KIND_DETAILS:
+    spec = REGISTERED_KINDS.get(kind)
+    if spec is None:
         return None
-    detail_attr, detail_fields = _KIND_DETAILS[kind]
-    detail = getattr(post, detail_attr, None)
+    detail = getattr(post, spec.detail_relationship, None)
     if detail is None:
         return None
     return {
@@ -69,7 +59,7 @@ def _flatten_post_to_dict(post) -> dict | None:
         "owner_id": getattr(post, "owner_id", None),
         "created_at": getattr(post, "created_at", None),
         "updated_at": getattr(post, "updated_at", None),
-        **{f: getattr(detail, f) for f in detail_fields},
+        **{f: getattr(detail, f) for f in spec.detail_fields},
     }
 
 

--- a/src/templates/posts/README.md
+++ b/src/templates/posts/README.md
@@ -4,7 +4,7 @@ Jinja templates for the post CRUD flows. HTMX-driven; forms submit JSON via `hx-
 
 ## Files
 
-- `list.html` — listing page (`GET /posts`). Shows newest-first; branches on `post.kind` to render a kind-appropriate row label. Links to every per-kind create form (`/posts/form`, `/posts/form?kind=client_referral`, `/posts/form?kind=provider_availability`).
+- `list.html` — listing page (`GET /posts`). Shows newest-first; branches on `post.kind` to render a kind-appropriate row label. The "New X" links at the top are rendered from `post_kinds` (a list of `KindSpec` from [`src/models/post_kinds.py`](../../models/post_kinds.py), passed in by `handle_list_posts`), so adding a registered kind automatically adds its create-form link.
 - `detail.html` — single-post read view (`GET /posts/{id}`). Branches on `post.kind` to render the right detail block. Includes `_owner_actions.html`.
 - `new.html` — create form for `kind='note'` (`GET /posts/form` → `POST /posts`).
 - `new_client_referral.html` — create form for `kind='client_referral'`. Submits a hidden `kind` field.
@@ -22,6 +22,5 @@ Templates dereference through the right relationship per branch: `{{ post.note_d
 
 When a new kind ships:
 
-1. Add `posts/new_<kind>.html` and register it in `_CREATE_FORM_TEMPLATES` in [`src/api/routes/posts.py`](../../api/routes/posts.py).
-2. Add `posts/edit_<kind>.html` and register it in `_EDIT_FORM_TEMPLATES`.
-3. Add a `{% elif post.kind == "<kind>" %}` branch in `list.html` and `detail.html`.
+1. Add `posts/new_<kind>.html` and `posts/edit_<kind>.html`. Register their paths on the kind's `KindSpec` in [`src/models/post_kinds.py`](../../models/post_kinds.py); the route layer reads `spec.create_template` / `spec.edit_template` from there.
+2. Add a `{% elif post.kind == "<kind>" %}` branch in `list.html` and `detail.html` for the per-kind body rendering. (The "New X" link in `list.html` follows automatically via the registry-driven loop.)

--- a/src/templates/posts/list.html
+++ b/src/templates/posts/list.html
@@ -4,11 +4,10 @@
 <h1>Posts</h1>
 
 <p>
-  <a href="/posts/form">New note</a>
-  ·
-  <a href="/posts/form?kind=client_referral">New client referral</a>
-  ·
-  <a href="/posts/form?kind=provider_availability">New provider availability</a>
+{%- for spec in post_kinds -%}
+{%- if not loop.first %} · {% endif -%}
+<a href="/posts/form?kind={{ spec.name }}">New {{ spec.list_label }}</a>
+{%- endfor %}
 </p>
 
 {% if posts %}


### PR DESCRIPTION
Closes #115. Off `main`. Once this lands, the "remove note" PR (which closed #114 referenced) becomes a small follow-up that demonstrates the payoff.

## Summary

Introduces `src/models/post_kinds.py` as the single source of truth for the post `kind` set + per-kind metadata, and routes every cross-cutting site to read from it. **All three current kinds (note, client_referral, provider_availability) are registered** — this is a pure refactor, no behavior change.

Before: ten+ sites encoded the kind set or its layout independently — model CHECK, route Literal, two form-template dicts, `_patch_response_body`, `_attach_detail`, `update_post` field-name branches, `handle_create_post`/`handle_update_post` `isinstance` ladders, schema `_KIND_DETAILS`. Adding or removing a kind meant remembering to hit each one.

After: registry entry → everything follows. Routes/repositories/logic don't know about specific kinds at all; they dispatch by name through the registry.

## What's in the registry

```python
@dataclass(frozen=True)
class KindSpec:
    name: str
    detail_model: type
    detail_relationship: str
    detail_fields: tuple[str, ...]
    list_label: str
    create_template: str
    edit_template: str

REGISTERED_KINDS: dict[str, KindSpec]
KIND_NAMES: tuple[str, ...]
KIND_BY_DETAIL_MODEL: dict[type, KindSpec]

def kind_check_sql() -> str: ...
```

## Sites migrated

- `src/models/post.py:Post.__table_args__` → `CheckConstraint(kind_check_sql())`
- `src/api/routes/posts.py:get_post_form` → `kind: Literal[*KIND_NAMES] = Query(KIND_NAMES[0])`
- `src/api/routes/posts.py:get_post_form` template → `REGISTERED_KINDS[kind].create_template`
- `src/api/routes/posts.py:get_post_edit_form` template → `REGISTERED_KINDS[post_kind].edit_template`
- `src/api/routes/posts.py:_patch_response_body` → generic flatten via `spec.detail_relationship` + `spec.detail_fields`
- `src/repositories/post_repository.py:_attach_detail` → `KIND_BY_DETAIL_MODEL[type(detail)]` + `setattr`
- `src/repositories/post_repository.py:update_post` → takes `**detail_fields`, writes via `spec.detail_relationship`
- `src/logic/post_processing.py:handle_create_post` → `spec.detail_model(**…)`; no more `isinstance` ladder
- `src/logic/post_processing.py:handle_update_post` → same dispatch pattern
- `src/schemas/post.py:_flatten_post_to_dict` → reads `spec.detail_relationship`/`spec.detail_fields`; the standalone `_KIND_DETAILS` dict is gone
- `src/templates/posts/list.html` → `{% for spec in post_kinds %}` for the "New X" links (passed by `handle_list_posts`)

Hand-written and intentionally so:
- The four Pydantic variant classes per kind (per-kind validation rules can't be generated)
- The `relationship(...)` lines on `Post` (clarity > magic)
- The per-kind body in `list.html` / `detail.html` (different content per kind)
- Migration files (snapshots of a moment in time)

## Behavior change worth flagging

The "New note" link in `list.html` was previously a bare `/posts/form` (relying on the route default). It's now `/posts/form?kind=note` to match the other links. The route still accepts both shapes — only the rendered `href` changed. One test in `test_posts.py` updated to match.

## Tests

New `src/models/test_post_kinds.py` (6 tests) guards the registry as the source of truth:
- `KIND_NAMES` matches `REGISTERED_KINDS` keys
- `kind_check_sql()` matches the rendered CHECK on `Post.__table_args__`
- The form route's `Literal` annotation reflects `KIND_NAMES`
- `KIND_BY_DETAIL_MODEL` is the well-formed inverse
- Per-kind relationship names follow the convention

If anyone later inlines a literal CHECK string or hand-types a `Literal["note", ...]`, the test fails.

## Test plan

- [x] `dev lint` clean
- [x] `pytest src/ tests/ --ignore=tests/test_contract` — 240 passed (up from 234; the +6 are the new registry-consistency tests)
- [x] `dev migrate roundtrip` clean
- [ ] CI green

## Follow-ups

After this lands:
- A "remove note" PR off `main` should be small — that's the demo of whether the refactor made cross-cutting kind-changes easier. Compare to the previous attempt (closed #114, 28 files).
- #116 — drive contract-test post stubs from `REGISTERED_KINDS`.
- #117 — collapse per-form contract-pair scaffolding into a manifest.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRkzwmtKei7jCcbtUX9W8i)_