### PR TITLE
Drive contract-test post stubs from the kinds registry (#116)

### DIFF
--- a/tests/test_contract/README.md
+++ b/tests/test_contract/README.md
@@ -89,7 +89,7 @@ When you add a new HTML form (per [`src/api/routes/RESOURCE_GRAMMAR.md`](../../s
 1. **Add a flag** to `ConsumerServerConfig` in `infrastructure/servers/consumer.py` and a corresponding `app.include_router(...)` call so the consumer server can mount your form's page route.
 2. **Add constants** for the API path, provider state, consumer/provider Pact names, and a unique Pact port to `constants.py`. Append the provider state string to `KNOWN_PROVIDER_STATES` in `infrastructure/config.py`.
 3. **Write the consumer test** (`tests/consumer/test_<resource>_form.py`) — drive the form with Playwright and assert the intercepted request matches a Pact expectation.
-4. **Add a `MockDataFactory.create_<resource>_dependency_config()`** mapping the route's business-logic handler import path (the one used by `from ... import` inside the route module) to a mock return value.
+4. **Add a `MockDataFactory.create_<resource>_dependency_config()`** mapping the route's business-logic handler import path (the one used by `from ... import` inside the route module) to a mock return value. For Post-shaped stubs, use `make_post_stub(kind, **field_overrides)` from `tests/shared/mock_data_factory.py` — it reads the per-kind detail relationship and field tuple from `REGISTERED_KINDS` in [`src/models/post_kinds.py`](../../src/models/post_kinds.py), so adding/renaming a kind's fields doesn't require touching contract test code.
 5. **Write the provider test** (`tests/provider/test_<resource>_verification.py`) — subclass `BaseProviderVerification` and call `verify_pact(provider_server)` under the dependency-override decorator.
 
 ## Related documentation

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -95,10 +95,7 @@ def _setup_posts_form_stub(app: FastAPI) -> None:
     HTMX-decorated submissions; the create POST and edit PATCH are intercepted
     by Playwright before they leave the browser, so no database is needed.
     """
-
-    class _StubAttrs:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
+    from ..tests.shared.mock_data_factory import make_post_stub
 
     @app.get("/posts/form")
     async def posts_form_stub_page(request: Request):
@@ -108,12 +105,11 @@ def _setup_posts_form_stub(app: FastAPI) -> None:
 
     @app.get("/posts/{post_id}/form")
     async def posts_edit_form_stub_page(request: Request, post_id: uuid.UUID):
-        # `posts/edit.html` reads `post.note_detail.title/body` after the
-        # parent/detail split — mirror that shape here so the template renders.
-        post = _StubAttrs(
-            id=post_id,
-            kind="note",
-            note_detail=_StubAttrs(title="Stub title", body="Stub body"),
+        # The note edit-form template reads `post.note_detail.title/body`;
+        # `make_post_stub` populates that off `REGISTERED_KINDS` so a kind
+        # rename is a single-edit change in `src/models/post_kinds.py`.
+        post = make_post_stub(
+            "note", post_id=post_id, title="Stub title", body="Stub body"
         )
         return APIResponse.html_response(
             template_name="posts/edit.html", context={"post": post}, request=request
@@ -127,6 +123,7 @@ def _setup_post_owner_actions_stub(app: FastAPI) -> None:
     HTMX-decorated Delete button inside the partial; what we render here is
     the same partial production code paths render.
     """
+    from ..tests.shared.mock_data_factory import make_post_stub
 
     class _StubAttrs:
         def __init__(self, **kwargs):
@@ -134,15 +131,17 @@ def _setup_post_owner_actions_stub(app: FastAPI) -> None:
 
     @app.get("/posts/{post_id}")
     async def post_owner_actions_stub_page(request: Request, post_id: uuid.UUID):
-        owner = _StubAttrs(id=post_id, username="post_owner")
-        # `posts/detail.html` reads `post.note_detail.title/body` after the
-        # parent/detail split — mirror that shape so the template renders.
-        post = _StubAttrs(
-            id=post_id,
-            kind="note",
-            note_detail=_StubAttrs(title="Stub title", body="Stub body"),
-            owner_id=owner.id,
-            owner=owner,
+        # The detail template reads the per-kind detail relationship;
+        # `make_post_stub` populates it off `REGISTERED_KINDS`. Owner id
+        # equals post id here so the partial's owner-or-admin gate is a
+        # don't-care (current_user is a superuser).
+        post = make_post_stub(
+            "note",
+            post_id=post_id,
+            owner_id=post_id,
+            owner_username="post_owner",
+            title="Stub title",
+            body="Stub body",
         )
         # The mock auth in `run_consumer_server_process` makes current_user a
         # superuser when `posts_owner_actions=True`, so the partial's

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -95,7 +95,7 @@ def _setup_posts_form_stub(app: FastAPI) -> None:
     HTMX-decorated submissions; the create POST and edit PATCH are intercepted
     by Playwright before they leave the browser, so no database is needed.
     """
-    from ..tests.shared.mock_data_factory import make_post_stub
+    from ...tests.shared.mock_data_factory import make_post_stub
 
     @app.get("/posts/form")
     async def posts_form_stub_page(request: Request):
@@ -123,7 +123,7 @@ def _setup_post_owner_actions_stub(app: FastAPI) -> None:
     HTMX-decorated Delete button inside the partial; what we render here is
     the same partial production code paths render.
     """
-    from ..tests.shared.mock_data_factory import make_post_stub
+    from ...tests.shared.mock_data_factory import make_post_stub
 
     class _StubAttrs:
         def __init__(self, **kwargs):

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -5,6 +5,12 @@ handler paths to mock configuration. The provider server fixture
 (`tests/test_contract/conftest.py::provider_server`) consumes this mapping to
 monkey-patch business-logic handlers, so Pact verification exercises only the
 route layer.
+
+`make_post_stub(kind, **field_overrides)` is the registry-backed builder
+for Post-shaped `SimpleNamespace` stubs — the per-kind detail
+relationship name and field tuple come from `REGISTERED_KINDS` in
+`src/models/post_kinds.py`, so adding/renaming a kind's fields does not
+require touching contract test code.
 """
 
 from datetime import datetime, timezone
@@ -12,7 +18,54 @@ from types import SimpleNamespace
 from typing import Any, Dict
 from uuid import UUID, uuid4
 
+from src.models import REGISTERED_KINDS
 from src.schemas.user import UserRead
+
+
+def make_post_stub(
+    kind: str,
+    *,
+    post_id: UUID | None = None,
+    owner_id: UUID | None = None,
+    owner_username: str = "post_owner",
+    **field_overrides: Any,
+) -> SimpleNamespace:
+    """Return a Post-shaped `SimpleNamespace` stub for `kind`.
+
+    The right per-kind detail relationship is populated (driven by
+    `REGISTERED_KINDS[kind]`); the other kinds' detail relationships are
+    set to `None` so template `{% if post.X %}` checks behave correctly.
+
+    Detail fields default to `f"stub {field}"`; override individually
+    via `**field_overrides`. Unknown overrides for the kind are passed
+    through onto the detail `SimpleNamespace` (caller's responsibility
+    not to send cross-kind fields).
+    """
+    spec = REGISTERED_KINDS[kind]
+    detail_values: dict[str, Any] = {f: f"stub {f}" for f in spec.detail_fields}
+    detail_values.update(field_overrides)
+    detail = SimpleNamespace(**detail_values)
+
+    pid = post_id or uuid4()
+    oid = owner_id or uuid4()
+    now = datetime.now(timezone.utc)
+
+    other_relationships = {
+        other_spec.detail_relationship: None
+        for other_kind, other_spec in REGISTERED_KINDS.items()
+        if other_kind != kind
+    }
+
+    return SimpleNamespace(
+        id=pid,
+        kind=kind,
+        owner_id=oid,
+        owner=SimpleNamespace(id=oid, username=owner_username),
+        created_at=now,
+        updated_at=now,
+        **{spec.detail_relationship: detail},
+        **other_relationships,
+    )
 
 
 class MockDataFactory:
@@ -83,28 +136,25 @@ class MockDataFactory:
     @classmethod
     def create_post_read(
         cls,
-        post_id: UUID = None,
-        title: str = "stub title",
-        body: str = "stub body",
-        owner_id: UUID = None,
+        kind: str = "note",
+        *,
+        post_id: UUID | None = None,
+        owner_id: UUID | None = None,
+        **field_overrides: Any,
     ) -> SimpleNamespace:
-        """Build a Post-shaped mock for `kind='note'` consumed by the
-        route layer.
+        """Build a Post-shaped mock consumed by the route layer.
 
-        The route reads `.id`, `.kind`, `.note_detail.title`, and
-        `.note_detail.body` off the handler return value to build the
-        PATCH/POST response. A `SimpleNamespace` mimics the shape without
-        requiring a SQLAlchemy session, which contract tests don't have.
+        Thin wrapper over `make_post_stub` that pins the post id and
+        owner id to the contract-test stable values. The route under
+        test reads `.id`, `.kind`, and the per-kind detail relationship
+        off the return value to build the response. Override per-kind
+        fields via `**field_overrides`.
         """
-        now = datetime.now(timezone.utc)
-        return SimpleNamespace(
-            id=post_id or cls.MOCK_POST_ID,
-            kind="note",
+        return make_post_stub(
+            kind,
+            post_id=post_id or cls.MOCK_POST_ID,
             owner_id=owner_id or cls.MOCK_POST_OWNER_ID,
-            note_detail=SimpleNamespace(title=title, body=body),
-            client_referral_detail=None,
-            created_at=now,
-            updated_at=now,
+            **field_overrides,
         )
 
     @classmethod


### PR DESCRIPTION
Closes #116. Off `main`. Builds on #115 (the kinds registry).

## Summary

Adds `make_post_stub(kind, **field_overrides)` to `tests/test_contract/tests/shared/mock_data_factory.py` and migrates the three sites that previously hand-built note-shaped Post stubs to use it. The helper reads the per-kind detail relationship and field tuple from `REGISTERED_KINDS` in `src/models/post_kinds.py`, so adding or renaming a kind's fields no longer cascades into contract-test infrastructure.

## What changed

**New helper:** `make_post_stub(kind, *, post_id, owner_id, owner_username, **field_overrides) -> SimpleNamespace`
- Populates the right detail relationship per `REGISTERED_KINDS[kind]`
- Sets the *other* kinds' detail relationships to `None` (so template `{% if post.X %}` checks behave correctly)
- Detail fields default to `f"stub {field}"`; override individually via kwargs

**Migrated sites:**
- `tests/test_contract/infrastructure/servers/consumer.py:_setup_posts_form_stub` — edit-form stub now uses `make_post_stub("note", ...)`
- `tests/test_contract/infrastructure/servers/consumer.py:_setup_post_owner_actions_stub` — same
- `tests/test_contract/tests/shared/mock_data_factory.py:MockDataFactory.create_post_read` — thin wrapper that delegates to `make_post_stub` after pinning the contract-test stable post id and owner id. Existing callers (`create_post_create_dependency_config`, `create_post_edit_dependency_config`) keep working unchanged.

**Backwards compat:** `MockDataFactory.create_post_read()` defaults to `kind="note"` so the existing dependency-config builders for create/edit don't need to pass `kind` explicitly. Their `title="patched title", body="patched body"` overrides flow through `**field_overrides`.

## Verification

```
$ grep -rn "note_detail\|client_referral_detail\|provider_availability_detail" tests/test_contract/
tests/test_contract/infrastructure/servers/consumer.py:108:        # The note edit-form template reads `post.note_detail.title/body`;
```

Only a doc comment remains. The model-shape duplication is gone.

## Test plan

- [x] `dev lint` clean
- [x] `pytest src/ tests/ --ignore=tests/test_contract` — 240 passed (no regression)
- [x] Smoke-tested `make_post_stub` manually for note, client_referral, provider_availability — correct relationship populated, other relationships are `None`, field overrides work
- [ ] CI green (contract-tests job will exercise the actual stubs)

## Follow-ups

- #117 — collapse per-form contract-pair scaffolding into a manifest. That's the other duplication problem the contract layer has (per-pair sprawl across constants/config/server-flag/factory/test).
- After #117 lands: a "remove note" PR will demonstrate the cumulative payoff of #115 + #116 + #117 vs the original 28-file removal (closed #114).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XRkzwmtKei7jCcbtUX9W8i)_