### PR TITLE
Fix htmx 2.x compatibility warning in json-enc extension

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -6,7 +6,7 @@
       src="https://unpkg.com/htmx.org@2.0.4"
       integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"
       crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx.org/dist/ext/json-enc.js"></script>
+    <script src="https://unpkg.com/htmx.org@2.0.4/dist/ext/json-enc.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     {% block head %}{% endblock %} {% if is_development %}
     <!-- LiveReload script for development hot reloading -->


### PR DESCRIPTION
## Summary

Pin json-enc extension to htmx 2.0.4 to match the core library version. Previously, the extension was loading the htmx 1.x version, causing a browser warning: "You are using an htmx 1 extension with htmx 2.0.4."

## Test plan

- [x] Existing tests pass (309 passed, 1 skipped)
- [x] No linting issues

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)