### PR TITLE
Redirect to post detail page after post update

### DIFF
--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -215,9 +215,10 @@ async def patch_post(
         audit_repo=audit_repo,
         requesting_user=user,
     )
+    location = f"/posts/{updated.id}"
     return JSONResponse(
         content=_patch_response_body(updated),
-        headers={"HX-Refresh": "true"},
+        headers={"HX-Redirect": location},
     )
 
 

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -971,7 +971,7 @@ async def test_owner_can_patch_client_referral_description(
         data={"kind": "client_referral", "description": new_description},
     )
     assert response.status_code == 200
-    assert response.headers.get("HX-Refresh") == "true"
+    assert response.headers.get("HX-Redirect") == f"/posts/{post.id}"
     body = response.json()
     assert body["kind"] == "client_referral"
     assert body["description"] == new_description
@@ -1313,7 +1313,7 @@ async def test_owner_can_patch_provider_availability_practice_name(
         },
     )
     assert response.status_code == 200
-    assert response.headers.get("HX-Refresh") == "true"
+    assert response.headers.get("HX-Redirect") == f"/posts/{post.id}"
     body = response.json()
     assert body["kind"] == "provider_availability"
     assert body["practice_name"] == new_practice_name


### PR DESCRIPTION
## Summary

Resolves #136. When a user submits an update to a post via the edit form, they are now redirected to the post's detail page instead of staying on the form.

## Changes

- **Route**: Changed `PATCH /posts/{id}` response from `HX-Refresh: true` to `HX-Redirect: /posts/{id}`
- **Tests**: Updated assertions in post update tests to verify redirect behavior

## Test plan

- [x] All post update tests pass
- [x] Verified the redirect behavior for both client_referral and provider_availability post kinds
- [x] All linting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)