### PR TITLE
Fix issue #137: redirect to /posts after login

### DIFF
--- a/src/auth_config.py
+++ b/src/auth_config.py
@@ -39,7 +39,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         response: Optional[Response] = None,
     ):
         print(f"User {user.id} has logged in.")
-        redirect_url = "/users"
+        redirect_url = "/posts"
         next_url = request.query_params.get("next")
         if next_url:
             # Security check: only allow relative URLs that start with "/"


### PR DESCRIPTION
## Summary
- Users are now redirected to /posts after login instead of /users
- The posts feed is the primary destination for users after authentication

## Test plan
- [x] All existing tests pass (307 passed, 1 skipped)
- [x] Linting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)