### PR TITLE
Add Classless CSS framework stylesheet

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -8,6 +8,7 @@
       crossorigin="anonymous"></script>
     <script src="https://unpkg.com/htmx.org@2.0.4/dist/ext/json-enc.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/digitallytailored/classless@latest/classless.min.css">
     {% block head %}{% endblock %} {% if is_development %}
     <!-- LiveReload script for development hot reloading -->
     <script>


### PR DESCRIPTION
## Summary
- Adds Classless CSS framework stylesheet to the base template
- Provides minimal default styling for HTML elements
- Loaded from jsdelivr CDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)