### PR TITLE
Add Pico CSS drop-in styling framework

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -8,7 +8,10 @@
       crossorigin="anonymous"></script>
     <script src="https://unpkg.com/htmx.org@2.0.4/dist/ext/json-enc.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/digitallytailored/classless@latest/classless.min.css">
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.classless.jade.min.css"
+    >
     {% block head %}{% endblock %} {% if is_development %}
     <!-- LiveReload script for development hot reloading -->
     <script>


### PR DESCRIPTION
## Summary
- Adds Pico CSS to base template for clean default styling
- Provides semantic HTML styling without custom classes
- Minimal, modern CSS framework

## Test plan
- [x] Linting passes
- Visual inspection can verify styling is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)