### PR TITLE
Fix issue #152: add class-of-bug sorting fields to per-PR retro template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,11 @@ Each entry should be issue-shaped:
 ### <one-line title>
 **Friction:** what slowed me down, with a concrete example.
 **Fix:** the specific change that would prevent it (file, command, config).
+**Why didn't existing patterns prevent this?** <one sentence — if an existing pattern *should* have prevented this and you didn't follow it, that's a class-of-bug signal>
+**Could this class recur elsewhere?** <name the audit you'd run, or write "no, one-off" — forces the audit step *before* filing>
 **Effort:** small / medium / large.
 ```
+
+The two middle fields are sorting questions, not approval gates. Most entries will answer "no existing pattern applies" and "no, one-off" in ten words and move on. The *signal* is when the answer to the first is "an existing pattern applies and I didn't follow it" — that's the fork between filing a doc note and filing a structural-prevention issue. The second field forces an audit before generalizing, so retro entries don't imply current bugs that don't actually exist.
 
 Cover the single biggest time sink, any missing/misleading tool or doc, and anything that worked unexpectedly well (so it gets repeated).


### PR DESCRIPTION
## Summary
- Add two fields to the per-PR retrospective template in `CLAUDE.md`: "Why didn't existing patterns prevent this?" and "Could this class recur elsewhere?"
- Add a framing paragraph clarifying they are sorting questions, not approval gates — most entries answer in ten words; the signal is when an existing pattern was bypassed.
- Forward-looking only (no past retro entries updated). Closes #152.

## Test plan
- [x] `dev lint` passes
- [ ] Read the updated `## Per-PR retrospective` section end-to-end and confirm new fields are clearly required and the framing paragraph follows
- [ ] Confirm surrounding prose ("Before declaring a PR complete...", "Cover the single biggest time sink...") still reads cleanly with the longer template

🤖 Generated with [Claude Code](https://claude.com/claude-code)