### PR TITLE
Add FK relationship-coverage guardrail test (#151)

### DIFF
--- a/src/models/README.md
+++ b/src/models/README.md
@@ -280,9 +280,29 @@ class NewEntity(BaseModel):
     happened_at = Column(DateTime(timezone=True), nullable=False)  # With timezone
 ```
 
+### Issue: Missing parent-side relationship breaks flush ordering
+
+**Problem**: A model with a `ForeignKey` column but no `relationship()` may be flushed before its parent in a single-transaction seed, producing `FOREIGN KEY constraint failed` errors that look unrelated to ORM modeling.
+
+**Why**: SQLAlchemy's flush-ordering graph is built from `relationship()` declarations, not raw FK columns. Without a relationship at either end, the unit of work has no signal to flush parent before child. SQLite's `PRAGMA foreign_keys = ON` (set in `tests/fixtures.py`) then rejects the out-of-order INSERT.
+
+**Solution**: Add `relationship(...)` at one end of every domain-edge FK — either the child's many-to-one (`profile.user`) or the parent's collection (`user.profiles`); either is enough to fix flush ordering. The exception is denormalized historical references (e.g. `audit_log.actor_id`) — those go on the `ALLOWED_BARE_FKS` allowlist in `test_fk_relationship_coverage.py` with a one-line justification.
+
+```python
+# Bad - bare FK; flush order is undefined, single-transaction seeds may fail
+class ProviderProfile(BaseModel):
+    user_id = Column(Uuid(as_uuid=True), ForeignKey("users.id"), nullable=False)
+
+# Good - relationship covers the FK; flush order is parent-then-child
+class ProviderProfile(BaseModel):
+    user_id = Column(Uuid(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    user = relationship("User")
+```
+
 ## Tests
 
 - `test_post_kinds.py` — guards the `post_kinds` registry as the single source of truth: asserts `KIND_NAMES` matches the registry, the rendered `kind_check_sql()` matches what `Post.__table_args__` actually produces, the route's `Literal[*KIND_NAMES]` reflects the registry, the inverse `KIND_BY_DETAIL_MODEL` lookup is well-formed, the per-kind relationship-name convention holds, and `KindSpec.detail_fields` exactly matches the underlying detail model's column list (so the introspection-driven derivation can't silently drift from the schema). If a future change re-encodes the kind set inline somewhere, the relevant test here fails.
+- `test_fk_relationship_coverage.py` — guards against the flush-ordering trap above: walks every `ForeignKey` on every mapped class and asserts that at least one end declares a covering `relationship()`, or that the FK appears in the in-file `ALLOWED_BARE_FKS` allowlist with a one-line justification. The allowlist's value is the reason — that documentation is half the point.
 
 Most other model behavior is exercised indirectly through repository and route tests. Add `src/models/test_<model_name>.py` when a model carries non-trivial logic (computed fields, validators, custom `__init__`, etc.) that warrants direct coverage.
 

--- a/src/models/test_fk_relationship_coverage.py
+++ b/src/models/test_fk_relationship_coverage.py
@@ -1,0 +1,60 @@
+"""Guardrail: every FK column has a covering ``relationship()`` at one
+end, or appears in ``ALLOWED_BARE_FKS`` with a justification.
+
+Why: SQLAlchemy's flush-ordering graph is built from ``relationship()``
+declarations, not raw FK columns. A bare FK lets the unit-of-work flush
+child before parent in a single ``session.begin()`` block, which SQLite
+(``PRAGMA foreign_keys = ON`` in ``tests/fixtures.py``) rejects with
+``FOREIGN KEY constraint failed``. See issue #151 for the originating
+incident.
+"""
+
+from src.models import Base
+
+# FK columns intentionally left without a relationship. Add new entries
+# only with a one-line justification — bare FKs are the exception, not
+# the default. Key: ``(table_name, column_name)``. Value: reason.
+ALLOWED_BARE_FKS: dict[tuple[str, str], str] = {
+    ("audit_log", "actor_id"): (
+        "Denormalized historical reference. SET NULL on user delete "
+        "means the row is allowed to dangle; audit rows are never "
+        "navigated via .actor in code."
+    ),
+}
+
+
+def test_every_fk_has_covering_relationship_or_allowlist():
+    """Every FK column on a mapped class must either be reachable via a
+    ``relationship()`` at one of its two ends, or appear in
+    ``ALLOWED_BARE_FKS``. Without one of those, single-transaction seeds
+    of (parent, child) can flush in the wrong order and trip FK
+    enforcement at runtime."""
+    relationship_edges: set[frozenset] = set()
+    for mapper in Base.registry.mappers:
+        for rel in mapper.relationships:
+            relationship_edges.add(frozenset({mapper, rel.mapper}))
+
+    mapper_by_table = {m.local_table: m for m in Base.registry.mappers}
+
+    violations: list[str] = []
+    for mapper in Base.registry.mappers:
+        table = mapper.local_table
+        for column in table.columns:
+            for fk in column.foreign_keys:
+                if (table.name, column.name) in ALLOWED_BARE_FKS:
+                    continue
+
+                referenced_mapper = mapper_by_table.get(fk.column.table)
+                if referenced_mapper is None:
+                    continue
+
+                if frozenset({mapper, referenced_mapper}) in relationship_edges:
+                    continue
+
+                violations.append(
+                    f"{table.name}.{column.name} -> {fk.column.table.name} "
+                    f"has no covering relationship; add one to either side, "
+                    f"or add it to ALLOWED_BARE_FKS with a justification."
+                )
+
+    assert not violations, "\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary

- New introspection test `src/models/test_fk_relationship_coverage.py` that walks every `ForeignKey` on every mapped class and asserts each is covered by a `relationship()` at one end — or appears in an in-file `ALLOWED_BARE_FKS` allowlist with a one-line justification.
- New "Common issues" entry in `src/models/README.md` explaining the flush-ordering trap that motivated the guardrail (originally surfaced in #144 as a `FOREIGN KEY constraint failed` against `provider_profiles.user_id`).
- Only `audit_log.actor_id` is allowlisted (denormalized historical reference, `SET NULL` on user delete, never navigated via `.actor` in code).

The test is pure introspection — no DB, runs in ~20ms, picks up new mappers automatically.

Closes #151.

## Test plan

- [x] `dev test src/models/test_fk_relationship_coverage.py` — passes against current main.
- [x] **Sanity A — missing relationship:** temporarily removed `Post.client_referral_detail`; test failed with `client_referral_details.post_id -> posts has no covering relationship; …`. Restored.
- [x] **Sanity B — missing allowlist:** temporarily emptied `ALLOWED_BARE_FKS`; test failed with `audit_log.actor_id -> users has no covering relationship; …`. Restored.
- [x] `dev test` — full default suite passes (311 passed, 1 skipped).
- [x] `dev lint` — all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)