### PR TITLE
Add provider profile logic handlers and audit actions (#147)

### DIFF
--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -83,16 +83,18 @@ async def handle_set_user_activation(user_id, payload, user_repo, requesting_use
 | ------------------------- | ------------------------------------ | ------------------------------ |
 | **user_processing.py**    | User operation coordination          | list users with filtering, set activation (writes audit row, commits), delete user (audit row recorded before the delete fires; commits) |
 | **post_processing.py**    | Post operation coordination          | list posts, get post detail, create post (server-sets `owner_id`, dispatches on `payload.kind` to build the matching detail row — `NoteDetail` or `ClientReferralDetail` — writes audit row, commits), update post (owner-or-admin guard, 400 on `payload.kind` ≠ `post.kind` since kind is part of resource identity, before/after audit snapshot via `post_audit_snapshot`, commits), delete post (owner-or-admin guard, audit row recorded before the delete fires with `after=None`, commits — CASCADE removes the detail), build create- and edit-form contexts |
-| **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. Wired into all current mutation handlers (posts, users, auth registration). |
+| **provider_profile_processing.py** | Provider-profile + credential sub-table coordination | list / get / get-mine / create / update / delete profile (owner-or-admin guard on mutations, single audit row per top-level mutation; create accepts inline licensures/educations/certifications and the `CREATE_PROVIDER_PROFILE` snapshot embeds them; delete cascades sub-rows in the DB and emits one `DELETE_PROVIDER_PROFILE` row whose `before` captures the full nested state). Plus create/update/delete handlers for each of the three credential sub-tables, each one verifying that the URL's `profile_id` matches the sub-row's `profile_id` (404 on mismatch). New `AuditAction` values for all twelve mutations live in [`audit.py`](audit.py). |
+| **audit.py**              | Audit-log helper                     | `record_audit(...)` — append-only mutation row per `RESOURCE_GRAMMAR.md:135`; flushes inside the caller's transaction so the audit lands atomically with the mutation. Wired into all current mutation handlers (posts, users, auth registration, provider profiles + credentials). |
 | **auth_processing.py**    | Authentication workflow coordination | user registration processing (writes a `register` audit row with `actor_id=None`; best-effort atomicity since fastapi-users commits internally) |
 
 ## Directory structure
 
 ```
 logic/
-├── user_processing.py          # User operation coordination
-├── post_processing.py          # Post operation coordination
-└── auth_processing.py          # Authentication process coordination
+├── user_processing.py                # User operation coordination
+├── post_processing.py                # Post operation coordination
+├── provider_profile_processing.py    # Provider profile + credential sub-tables
+└── auth_processing.py                # Authentication process coordination
 ```
 
 ## Implementation patterns

--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -40,6 +40,18 @@ class AuditAction(str, Enum):
     SET_USER_ACTIVATION = "set_user_activation"
     DELETE_USER = "delete_user"
     REGISTER = "register"
+    CREATE_PROVIDER_PROFILE = "create_provider_profile"
+    UPDATE_PROVIDER_PROFILE = "update_provider_profile"
+    DELETE_PROVIDER_PROFILE = "delete_provider_profile"
+    CREATE_LICENSURE = "create_licensure"
+    UPDATE_LICENSURE = "update_licensure"
+    DELETE_LICENSURE = "delete_licensure"
+    CREATE_EDUCATION = "create_education"
+    UPDATE_EDUCATION = "update_education"
+    DELETE_EDUCATION = "delete_education"
+    CREATE_CERTIFICATION = "create_certification"
+    UPDATE_CERTIFICATION = "update_certification"
+    DELETE_CERTIFICATION = "delete_certification"
 
 
 async def record_audit(

--- a/src/logic/provider_profile_processing.py
+++ b/src/logic/provider_profile_processing.py
@@ -1,0 +1,503 @@
+"""Provider-profile orchestration handlers.
+
+One file per resource family — the parent profile plus its three credential
+sub-tables (licensure, education, certification). Each mutation handler
+owns the transaction commit and writes a single audit row covering the
+mutation, per `RESOURCE_GRAMMAR.md:135` and the discipline enforced in
+`test_audit_discipline.py`.
+
+Authorization is uniform: a provider can mutate only their own profile and
+its sub-rows; a superuser can mutate any. Read handlers are open to any
+authenticated user.
+
+Sub-resource handlers also assert that the URL's `profile_id` matches the
+sub-row's `profile_id`. Without this, `/profiles/A/licensures/B` would
+silently mutate a licensure belonging to a different profile.
+"""
+
+import logging
+from typing import Any, Sequence
+from uuid import UUID
+
+from src.api.common.exceptions import BadRequestError, ForbiddenError, NotFoundError
+from src.logic.audit import AuditAction, record_audit
+from src.models import (
+    ProviderCertification,
+    ProviderEducation,
+    ProviderLicensure,
+    ProviderProfile,
+    User,
+)
+from src.repositories.audit_repository import AuditRepository
+from src.repositories.provider_profile_repository import ProviderProfileRepository
+from src.schemas.provider_profile import (
+    ProviderCertificationAuditSnapshot,
+    ProviderCertificationCreate,
+    ProviderCertificationUpdate,
+    ProviderEducationAuditSnapshot,
+    ProviderEducationCreate,
+    ProviderEducationUpdate,
+    ProviderLicensureAuditSnapshot,
+    ProviderLicensureCreate,
+    ProviderLicensureUpdate,
+    ProviderProfileAuditSnapshot,
+    ProviderProfileCreate,
+    ProviderProfileUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --- Snapshot helpers ----------------------------------------------------
+
+
+def _snapshot_profile(profile: ProviderProfile) -> dict[str, Any]:
+    return ProviderProfileAuditSnapshot.model_validate(profile).model_dump(mode="json")
+
+
+def _snapshot_licensure(licensure: ProviderLicensure) -> dict[str, Any]:
+    return ProviderLicensureAuditSnapshot.model_validate(licensure).model_dump(
+        mode="json"
+    )
+
+
+def _snapshot_education(education: ProviderEducation) -> dict[str, Any]:
+    return ProviderEducationAuditSnapshot.model_validate(education).model_dump(
+        mode="json"
+    )
+
+
+def _snapshot_certification(cert: ProviderCertification) -> dict[str, Any]:
+    return ProviderCertificationAuditSnapshot.model_validate(cert).model_dump(
+        mode="json"
+    )
+
+
+# --- Authorization helper ------------------------------------------------
+
+
+def _assert_can_mutate(profile: ProviderProfile, user: User) -> None:
+    if profile.user_id != user.id and not user.is_superuser:
+        raise ForbiddenError(
+            detail="Only the profile owner or an admin can perform this action"
+        )
+
+
+async def _load_profile_or_404(
+    profile_id: UUID, repo: ProviderProfileRepository
+) -> ProviderProfile:
+    profile = await repo.get_by_id(profile_id)
+    if profile is None:
+        raise NotFoundError(detail="Provider profile not found")
+    return profile
+
+
+# --- Profile handlers ----------------------------------------------------
+
+
+async def handle_list_profiles(
+    repo: ProviderProfileRepository,
+    *,
+    license_type: str | None = None,
+    issuing_state: str | None = None,
+) -> Sequence[ProviderProfile]:
+    """Public listing — no auth gate, no audit, no commit."""
+    return await repo.list_profiles(
+        license_type=license_type, issuing_state=issuing_state
+    )
+
+
+async def handle_get_profile(
+    profile_id: UUID,
+    repo: ProviderProfileRepository,
+    requesting_user: User,
+) -> ProviderProfile:
+    """Authenticated read of any profile by id; 404 if missing."""
+    return await _load_profile_or_404(profile_id, repo)
+
+
+async def handle_get_my_profile(
+    repo: ProviderProfileRepository,
+    requesting_user: User,
+) -> ProviderProfile:
+    """Returns the requesting user's profile; 404 if they have not created one yet
+    (profiles are not auto-created on registration)."""
+    profile = await repo.get_by_user_id(requesting_user.id)
+    if profile is None:
+        raise NotFoundError(detail="You do not have a provider profile yet")
+    return profile
+
+
+async def handle_create_profile(
+    payload: ProviderProfileCreate,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> ProviderProfile:
+    """Creates the requesting user's profile plus any inline credential sub-rows.
+
+    400 if the user already has a profile (the `uq_provider_profiles_user_id`
+    constraint would catch this at the DB; we surface a clean message
+    instead of an integrity error). One `CREATE_PROVIDER_PROFILE` audit row
+    is written whose `after` snapshot includes the inline sub-rows — the
+    snapshot schema embeds the nested credential lists, so a single row
+    captures the full create.
+    """
+    if await repo.get_by_user_id(requesting_user.id) is not None:
+        raise BadRequestError(detail="User already has a provider profile")
+
+    profile_fields = payload.model_dump(
+        exclude={"licensures", "educations", "certifications"}
+    )
+    created = await repo.create_profile(user_id=requesting_user.id, **profile_fields)
+
+    for licensure in payload.licensures:
+        await repo.add_licensure(created, **licensure.model_dump())
+    for education in payload.educations:
+        await repo.add_education(created, **education.model_dump())
+    for certification in payload.certifications:
+        await repo.add_certification(created, **certification.model_dump())
+
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_profile",
+        resource_id=created.id,
+        action=AuditAction.CREATE_PROVIDER_PROFILE,
+        before=None,
+        after=_snapshot_profile(created),
+    )
+    await repo.session.commit()
+    logger.info(
+        f"Handler: user {requesting_user.id} created provider profile {created.id}"
+    )
+    return created
+
+
+async def handle_update_profile(
+    profile_id: UUID,
+    payload: ProviderProfileUpdate,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> ProviderProfile:
+    """Patches practice/availability fields on the profile. Owner-or-admin only."""
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    before = _snapshot_profile(profile)
+    updated = await repo.update_profile(
+        profile, **payload.model_dump(exclude_unset=True)
+    )
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_profile",
+        resource_id=updated.id,
+        action=AuditAction.UPDATE_PROVIDER_PROFILE,
+        before=before,
+        after=_snapshot_profile(updated),
+    )
+    await repo.session.commit()
+    logger.info(
+        f"Handler: user {requesting_user.id} updated provider profile {updated.id}"
+    )
+    return updated
+
+
+async def handle_delete_profile(
+    profile_id: UUID,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> None:
+    """Hard-deletes the profile (sub-rows cascade). Owner-or-admin only.
+
+    The audit row is recorded before the delete fires so the actor FK is
+    still valid; `before` captures the full profile including sub-rows.
+    No per-sub-row audit rows — the parent's nested snapshot is the
+    durable record.
+    """
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    before = _snapshot_profile(profile)
+    target_id = profile.id
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_profile",
+        resource_id=target_id,
+        action=AuditAction.DELETE_PROVIDER_PROFILE,
+        before=before,
+        after=None,
+    )
+    await repo.delete_profile(profile)
+    await repo.session.commit()
+    logger.info(
+        f"Handler: user {requesting_user.id} deleted provider profile {target_id}"
+    )
+
+
+# --- Licensure handlers --------------------------------------------------
+
+
+async def handle_create_licensure(
+    profile_id: UUID,
+    payload: ProviderLicensureCreate,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> ProviderLicensure:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    created = await repo.add_licensure(profile, **payload.model_dump())
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_licensure",
+        resource_id=created.id,
+        action=AuditAction.CREATE_LICENSURE,
+        before=None,
+        after=_snapshot_licensure(created),
+    )
+    await repo.session.commit()
+    return created
+
+
+async def handle_update_licensure(
+    profile_id: UUID,
+    licensure_id: UUID,
+    payload: ProviderLicensureUpdate,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> ProviderLicensure:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    licensure = await repo.get_licensure_by_id(licensure_id)
+    if licensure is None or licensure.profile_id != profile.id:
+        raise NotFoundError(detail="Licensure not found")
+
+    before = _snapshot_licensure(licensure)
+    updated = await repo.update_licensure(
+        licensure, **payload.model_dump(exclude_unset=True)
+    )
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_licensure",
+        resource_id=updated.id,
+        action=AuditAction.UPDATE_LICENSURE,
+        before=before,
+        after=_snapshot_licensure(updated),
+    )
+    await repo.session.commit()
+    return updated
+
+
+async def handle_delete_licensure(
+    profile_id: UUID,
+    licensure_id: UUID,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> None:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    licensure = await repo.get_licensure_by_id(licensure_id)
+    if licensure is None or licensure.profile_id != profile.id:
+        raise NotFoundError(detail="Licensure not found")
+
+    before = _snapshot_licensure(licensure)
+    target_id = licensure.id
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_licensure",
+        resource_id=target_id,
+        action=AuditAction.DELETE_LICENSURE,
+        before=before,
+        after=None,
+    )
+    await repo.delete_licensure(licensure)
+    await repo.session.commit()
+
+
+# --- Education handlers --------------------------------------------------
+
+
+async def handle_create_education(
+    profile_id: UUID,
+    payload: ProviderEducationCreate,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> ProviderEducation:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    created = await repo.add_education(profile, **payload.model_dump())
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_education",
+        resource_id=created.id,
+        action=AuditAction.CREATE_EDUCATION,
+        before=None,
+        after=_snapshot_education(created),
+    )
+    await repo.session.commit()
+    return created
+
+
+async def handle_update_education(
+    profile_id: UUID,
+    education_id: UUID,
+    payload: ProviderEducationUpdate,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> ProviderEducation:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    education = await repo.get_education_by_id(education_id)
+    if education is None or education.profile_id != profile.id:
+        raise NotFoundError(detail="Education entry not found")
+
+    before = _snapshot_education(education)
+    updated = await repo.update_education(
+        education, **payload.model_dump(exclude_unset=True)
+    )
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_education",
+        resource_id=updated.id,
+        action=AuditAction.UPDATE_EDUCATION,
+        before=before,
+        after=_snapshot_education(updated),
+    )
+    await repo.session.commit()
+    return updated
+
+
+async def handle_delete_education(
+    profile_id: UUID,
+    education_id: UUID,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> None:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    education = await repo.get_education_by_id(education_id)
+    if education is None or education.profile_id != profile.id:
+        raise NotFoundError(detail="Education entry not found")
+
+    before = _snapshot_education(education)
+    target_id = education.id
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_education",
+        resource_id=target_id,
+        action=AuditAction.DELETE_EDUCATION,
+        before=before,
+        after=None,
+    )
+    await repo.delete_education(education)
+    await repo.session.commit()
+
+
+# --- Certification handlers ----------------------------------------------
+
+
+async def handle_create_certification(
+    profile_id: UUID,
+    payload: ProviderCertificationCreate,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> ProviderCertification:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    created = await repo.add_certification(profile, **payload.model_dump())
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_certification",
+        resource_id=created.id,
+        action=AuditAction.CREATE_CERTIFICATION,
+        before=None,
+        after=_snapshot_certification(created),
+    )
+    await repo.session.commit()
+    return created
+
+
+async def handle_update_certification(
+    profile_id: UUID,
+    certification_id: UUID,
+    payload: ProviderCertificationUpdate,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> ProviderCertification:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    certification = await repo.get_certification_by_id(certification_id)
+    if certification is None or certification.profile_id != profile.id:
+        raise NotFoundError(detail="Certification not found")
+
+    before = _snapshot_certification(certification)
+    updated = await repo.update_certification(
+        certification, **payload.model_dump(exclude_unset=True)
+    )
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_certification",
+        resource_id=updated.id,
+        action=AuditAction.UPDATE_CERTIFICATION,
+        before=before,
+        after=_snapshot_certification(updated),
+    )
+    await repo.session.commit()
+    return updated
+
+
+async def handle_delete_certification(
+    profile_id: UUID,
+    certification_id: UUID,
+    repo: ProviderProfileRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> None:
+    profile = await _load_profile_or_404(profile_id, repo)
+    _assert_can_mutate(profile, requesting_user)
+
+    certification = await repo.get_certification_by_id(certification_id)
+    if certification is None or certification.profile_id != profile.id:
+        raise NotFoundError(detail="Certification not found")
+
+    before = _snapshot_certification(certification)
+    target_id = certification.id
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type="provider_certification",
+        resource_id=target_id,
+        action=AuditAction.DELETE_CERTIFICATION,
+        before=before,
+        after=None,
+    )
+    await repo.delete_certification(certification)
+    await repo.session.commit()

--- a/src/logic/test_provider_profile_processing.py
+++ b/src/logic/test_provider_profile_processing.py
@@ -1,0 +1,790 @@
+"""Tests for provider-profile orchestration handlers.
+
+Exercises happy-path + ownership / not-found / bad-request error cases for
+each handler. Audit-row assertions verify that mutation handlers honor the
+discipline (`test_audit_discipline.py` enforces it statically; these tests
+verify the rows actually land with the expected `action` and snapshots).
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.api.common.exceptions import BadRequestError, ForbiddenError, NotFoundError
+from src.logic.audit import AuditAction
+from src.logic.provider_profile_processing import (
+    handle_create_certification,
+    handle_create_education,
+    handle_create_licensure,
+    handle_create_profile,
+    handle_delete_certification,
+    handle_delete_education,
+    handle_delete_licensure,
+    handle_delete_profile,
+    handle_get_my_profile,
+    handle_get_profile,
+    handle_list_profiles,
+    handle_update_certification,
+    handle_update_education,
+    handle_update_licensure,
+    handle_update_profile,
+)
+from src.models import (
+    AuditLog,
+    ProviderCertification,
+    ProviderEducation,
+    ProviderLicensure,
+    ProviderProfile,
+    User,
+)
+from src.repositories.audit_repository import AuditRepository
+from src.repositories.provider_profile_repository import ProviderProfileRepository
+from src.schemas.provider_profile import (
+    ProviderCertificationCreate,
+    ProviderCertificationUpdate,
+    ProviderEducationCreate,
+    ProviderEducationUpdate,
+    ProviderLicensureCreate,
+    ProviderLicensureUpdate,
+    ProviderProfileCreate,
+    ProviderProfileUpdate,
+)
+from tests.helpers import (
+    create_test_user,
+    make_provider_certification,
+    make_provider_education,
+    make_provider_licensure,
+    make_provider_profile,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- Seeding helpers -----------------------------------------------------
+
+
+async def _seed_user(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    is_superuser: bool = False,
+) -> User:
+    user = create_test_user(username=f"u-{uuid.uuid4()}", is_superuser=is_superuser)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+    return user
+
+
+async def _seed_profile(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    user_id: uuid.UUID,
+    with_licensure: bool = False,
+    with_education: bool = False,
+    with_certification: bool = False,
+) -> tuple[uuid.UUID, uuid.UUID | None, uuid.UUID | None, uuid.UUID | None]:
+    profile = make_provider_profile(user_id=user_id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(profile)
+        await session.refresh(profile)
+        profile_id = profile.id
+
+    licensure_id: uuid.UUID | None = None
+    education_id: uuid.UUID | None = None
+    certification_id: uuid.UUID | None = None
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            if with_licensure:
+                lic = make_provider_licensure(profile_id=profile_id)
+                session.add(lic)
+            if with_education:
+                edu = make_provider_education(profile_id=profile_id)
+                session.add(edu)
+            if with_certification:
+                cert = make_provider_certification(profile_id=profile_id)
+                session.add(cert)
+        if with_licensure:
+            await session.refresh(lic)
+            licensure_id = lic.id
+        if with_education:
+            await session.refresh(edu)
+            education_id = edu.id
+        if with_certification:
+            await session.refresh(cert)
+            certification_id = cert.id
+
+    return profile_id, licensure_id, education_id, certification_id
+
+
+def _profile_create_payload(**overrides) -> ProviderProfileCreate:
+    base = dict(
+        practice_name="Acme Health",
+        location_city="Springfield",
+        location_state="IL",
+        location_zip="62701",
+        in_person_sessions="yes",
+        virtual_sessions="no",
+    )
+    base.update(overrides)
+    return ProviderProfileCreate(**base)
+
+
+async def _audit_rows_for(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    resource_type: str,
+    resource_id: uuid.UUID,
+) -> list[AuditLog]:
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        rows = await repo.list_for_resource(
+            resource_type=resource_type, resource_id=resource_id
+        )
+        return list(rows)
+
+
+# --- Profile reads -------------------------------------------------------
+
+
+async def test_list_profiles_returns_persisted_profiles(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user_a = await _seed_user(db_test_session_manager)
+    user_b = await _seed_user(db_test_session_manager)
+    await _seed_profile(db_test_session_manager, user_id=user_a.id)
+    await _seed_profile(db_test_session_manager, user_id=user_b.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        result = await handle_list_profiles(repo)
+        assert len(result) == 2
+
+
+async def test_list_profiles_filters_by_license_type(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user_a = await _seed_user(db_test_session_manager)
+    user_b = await _seed_user(db_test_session_manager)
+    profile_a, *_ = await _seed_profile(
+        db_test_session_manager, user_id=user_a.id, with_licensure=True
+    )
+    profile_b, *_ = await _seed_profile(db_test_session_manager, user_id=user_b.id)
+    # Add a non-matching licensure to profile_b
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                make_provider_licensure(profile_id=profile_b, license_type="lpc")
+            )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        result = await handle_list_profiles(repo, license_type="lcsw")
+        assert [p.id for p in result] == [profile_a]
+
+
+async def test_get_profile_returns_profile(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=user.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        profile = await handle_get_profile(profile_id, repo, user)
+        assert profile.id == profile_id
+
+
+async def test_get_profile_404_for_unknown_id(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        with pytest.raises(NotFoundError):
+            await handle_get_profile(uuid.uuid4(), repo, user)
+
+
+async def test_get_my_profile_returns_users_profile(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=user.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        profile = await handle_get_my_profile(repo, user)
+        assert profile.id == profile_id
+
+
+async def test_get_my_profile_404_when_user_has_no_profile(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        with pytest.raises(NotFoundError):
+            await handle_get_my_profile(repo, user)
+
+
+# --- handle_create_profile ----------------------------------------------
+
+
+async def test_create_profile_persists_row_and_writes_audit(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    payload = _profile_create_payload()
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        created = await handle_create_profile(payload, repo, audit_repo, user)
+
+    assert created.user_id == user.id
+    assert created.practice_name == "Acme Health"
+
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_profile",
+        resource_id=created.id,
+    )
+    assert len(rows) == 1
+    assert rows[0].action == AuditAction.CREATE_PROVIDER_PROFILE
+    assert rows[0].actor_id == user.id
+    assert rows[0].before is None
+    assert rows[0].after["practice_name"] == "Acme Health"
+
+
+async def test_create_profile_with_inline_children_captures_them_in_audit(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    payload = _profile_create_payload(
+        licensures=[
+            ProviderLicensureCreate(
+                license_type="lcsw", license_number="L-1", issuing_state="IL"
+            )
+        ],
+        educations=[
+            ProviderEducationCreate(education_type="msw", institution="State U")
+        ],
+        certifications=[
+            ProviderCertificationCreate(
+                certification_type="emdr", certifying_body="EMDRIA"
+            )
+        ],
+    )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        created = await handle_create_profile(payload, repo, audit_repo, user)
+
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_profile",
+        resource_id=created.id,
+    )
+    assert len(rows) == 1
+    after = rows[0].after
+    assert len(after["licensures"]) == 1
+    assert after["licensures"][0]["license_number"] == "L-1"
+    assert len(after["educations"]) == 1
+    assert len(after["certifications"]) == 1
+
+    # Sub-rows actually persisted, too.
+    async with db_test_session_manager() as session:
+        licensures = (
+            (
+                await session.execute(
+                    select(ProviderLicensure).filter(
+                        ProviderLicensure.profile_id == created.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(licensures) == 1
+
+
+async def test_create_profile_400_when_user_already_has_one(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    await _seed_profile(db_test_session_manager, user_id=user.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        with pytest.raises(BadRequestError):
+            await handle_create_profile(
+                _profile_create_payload(), repo, audit_repo, user
+            )
+
+
+# --- handle_update_profile ----------------------------------------------
+
+
+async def test_update_profile_updates_fields_and_writes_audit(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=user.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        updated = await handle_update_profile(
+            profile_id,
+            ProviderProfileUpdate(practice_name="New Name"),
+            repo,
+            audit_repo,
+            user,
+        )
+
+    assert updated.practice_name == "New Name"
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_profile",
+        resource_id=profile_id,
+    )
+    assert len(rows) == 1
+    assert rows[0].action == AuditAction.UPDATE_PROVIDER_PROFILE
+    assert rows[0].before["practice_name"] == "Acme Health"
+    assert rows[0].after["practice_name"] == "New Name"
+
+
+async def test_update_profile_403_for_non_owner(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    owner = await _seed_user(db_test_session_manager)
+    intruder = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=owner.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        with pytest.raises(ForbiddenError):
+            await handle_update_profile(
+                profile_id,
+                ProviderProfileUpdate(practice_name="Hijacked"),
+                repo,
+                audit_repo,
+                intruder,
+            )
+
+
+async def test_update_profile_succeeds_for_superuser(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    owner = await _seed_user(db_test_session_manager)
+    admin = await _seed_user(db_test_session_manager, is_superuser=True)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=owner.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        updated = await handle_update_profile(
+            profile_id,
+            ProviderProfileUpdate(practice_name="By Admin"),
+            repo,
+            audit_repo,
+            admin,
+        )
+
+    assert updated.practice_name == "By Admin"
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_profile",
+        resource_id=profile_id,
+    )
+    assert rows[0].actor_id == admin.id
+
+
+async def test_update_profile_404_for_unknown_id(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        with pytest.raises(NotFoundError):
+            await handle_update_profile(
+                uuid.uuid4(),
+                ProviderProfileUpdate(practice_name="x"),
+                repo,
+                audit_repo,
+                user,
+            )
+
+
+# --- handle_delete_profile ----------------------------------------------
+
+
+async def test_delete_profile_removes_row_and_writes_audit(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, licensure_id, *_ = await _seed_profile(
+        db_test_session_manager, user_id=user.id, with_licensure=True
+    )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        await handle_delete_profile(profile_id, repo, audit_repo, user)
+
+    # Profile and cascaded sub-row both gone.
+    async with db_test_session_manager() as session:
+        assert (
+            await session.execute(
+                select(ProviderProfile).filter(ProviderProfile.id == profile_id)
+            )
+        ).scalars().first() is None
+        assert (
+            await session.execute(
+                select(ProviderLicensure).filter(ProviderLicensure.id == licensure_id)
+            )
+        ).scalars().first() is None
+
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_profile",
+        resource_id=profile_id,
+    )
+    assert len(rows) == 1
+    assert rows[0].action == AuditAction.DELETE_PROVIDER_PROFILE
+    assert rows[0].after is None
+    assert len(rows[0].before["licensures"]) == 1
+
+
+async def test_delete_profile_403_for_non_owner(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    owner = await _seed_user(db_test_session_manager)
+    intruder = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=owner.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        with pytest.raises(ForbiddenError):
+            await handle_delete_profile(profile_id, repo, audit_repo, intruder)
+
+
+# --- Licensure handlers -------------------------------------------------
+
+
+async def test_create_licensure_attaches_to_profile_and_audits(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=user.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        created = await handle_create_licensure(
+            profile_id,
+            ProviderLicensureCreate(
+                license_type="lcsw", license_number="L-99", issuing_state="IL"
+            ),
+            repo,
+            audit_repo,
+            user,
+        )
+
+    assert created.profile_id == profile_id
+    assert created.license_number == "L-99"
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_licensure",
+        resource_id=created.id,
+    )
+    assert len(rows) == 1
+    assert rows[0].action == AuditAction.CREATE_LICENSURE
+
+
+async def test_create_licensure_403_for_non_owner(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    owner = await _seed_user(db_test_session_manager)
+    intruder = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=owner.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        with pytest.raises(ForbiddenError):
+            await handle_create_licensure(
+                profile_id,
+                ProviderLicensureCreate(
+                    license_type="lcsw", license_number="L-99", issuing_state="IL"
+                ),
+                repo,
+                audit_repo,
+                intruder,
+            )
+
+
+async def test_update_licensure_audits_before_after(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, licensure_id, *_ = await _seed_profile(
+        db_test_session_manager, user_id=user.id, with_licensure=True
+    )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        updated = await handle_update_licensure(
+            profile_id,
+            licensure_id,
+            ProviderLicensureUpdate(license_number="L-NEW"),
+            repo,
+            audit_repo,
+            user,
+        )
+
+    assert updated.license_number == "L-NEW"
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_licensure",
+        resource_id=licensure_id,
+    )
+    assert rows[0].action == AuditAction.UPDATE_LICENSURE
+    assert rows[0].before["license_number"] == "L-12345"
+    assert rows[0].after["license_number"] == "L-NEW"
+
+
+async def test_update_licensure_404_when_sub_row_belongs_to_other_profile(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user_a = await _seed_user(db_test_session_manager)
+    user_b = await _seed_user(db_test_session_manager)
+    profile_a, *_ = await _seed_profile(db_test_session_manager, user_id=user_a.id)
+    profile_b, lic_b, *_ = await _seed_profile(
+        db_test_session_manager, user_id=user_b.id, with_licensure=True
+    )
+
+    # user_a tries to update lic_b via profile_a — should 404, not 403, since
+    # the URL claims a sub-row that doesn't belong to the named parent.
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        with pytest.raises(NotFoundError):
+            await handle_update_licensure(
+                profile_a,
+                lic_b,
+                ProviderLicensureUpdate(license_number="L-X"),
+                repo,
+                audit_repo,
+                user_a,
+            )
+
+
+async def test_delete_licensure_removes_row_and_audits(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, licensure_id, *_ = await _seed_profile(
+        db_test_session_manager, user_id=user.id, with_licensure=True
+    )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        await handle_delete_licensure(profile_id, licensure_id, repo, audit_repo, user)
+
+    async with db_test_session_manager() as session:
+        assert (
+            await session.execute(
+                select(ProviderLicensure).filter(ProviderLicensure.id == licensure_id)
+            )
+        ).scalars().first() is None
+
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_licensure",
+        resource_id=licensure_id,
+    )
+    assert rows[0].action == AuditAction.DELETE_LICENSURE
+    assert rows[0].after is None
+
+
+# --- Education + certification smoke tests ------------------------------
+
+
+async def test_create_education_attaches_and_audits(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=user.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        created = await handle_create_education(
+            profile_id,
+            ProviderEducationCreate(education_type="phd", institution="Some U"),
+            repo,
+            audit_repo,
+            user,
+        )
+
+    assert created.profile_id == profile_id
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_education",
+        resource_id=created.id,
+    )
+    assert rows[0].action == AuditAction.CREATE_EDUCATION
+
+
+async def test_update_education_audits(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, _, education_id, _ = await _seed_profile(
+        db_test_session_manager, user_id=user.id, with_education=True
+    )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        updated = await handle_update_education(
+            profile_id,
+            education_id,
+            ProviderEducationUpdate(institution="New U"),
+            repo,
+            audit_repo,
+            user,
+        )
+
+    assert updated.institution == "New U"
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_education",
+        resource_id=education_id,
+    )
+    assert rows[0].action == AuditAction.UPDATE_EDUCATION
+
+
+async def test_delete_education_removes_and_audits(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, _, education_id, _ = await _seed_profile(
+        db_test_session_manager, user_id=user.id, with_education=True
+    )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        await handle_delete_education(profile_id, education_id, repo, audit_repo, user)
+
+    async with db_test_session_manager() as session:
+        assert (
+            await session.execute(
+                select(ProviderEducation).filter(ProviderEducation.id == education_id)
+            )
+        ).scalars().first() is None
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_education",
+        resource_id=education_id,
+    )
+    assert rows[0].action == AuditAction.DELETE_EDUCATION
+
+
+async def test_create_certification_attaches_and_audits(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, *_ = await _seed_profile(db_test_session_manager, user_id=user.id)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        created = await handle_create_certification(
+            profile_id,
+            ProviderCertificationCreate(
+                certification_type="emdr", certifying_body="EMDRIA"
+            ),
+            repo,
+            audit_repo,
+            user,
+        )
+
+    assert created.profile_id == profile_id
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_certification",
+        resource_id=created.id,
+    )
+    assert rows[0].action == AuditAction.CREATE_CERTIFICATION
+
+
+async def test_update_certification_audits(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, _, _, certification_id = await _seed_profile(
+        db_test_session_manager, user_id=user.id, with_certification=True
+    )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        updated = await handle_update_certification(
+            profile_id,
+            certification_id,
+            ProviderCertificationUpdate(certifying_body="New Body"),
+            repo,
+            audit_repo,
+            user,
+        )
+
+    assert updated.certifying_body == "New Body"
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_certification",
+        resource_id=certification_id,
+    )
+    assert rows[0].action == AuditAction.UPDATE_CERTIFICATION
+
+
+async def test_delete_certification_removes_and_audits(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = await _seed_user(db_test_session_manager)
+    profile_id, _, _, certification_id = await _seed_profile(
+        db_test_session_manager, user_id=user.id, with_certification=True
+    )
+
+    async with db_test_session_manager() as session:
+        repo = ProviderProfileRepository(session)
+        audit_repo = AuditRepository(session)
+        await handle_delete_certification(
+            profile_id, certification_id, repo, audit_repo, user
+        )
+
+    async with db_test_session_manager() as session:
+        assert (
+            await session.execute(
+                select(ProviderCertification).filter(
+                    ProviderCertification.id == certification_id
+                )
+            )
+        ).scalars().first() is None
+    rows = await _audit_rows_for(
+        db_test_session_manager,
+        resource_type="provider_certification",
+        resource_id=certification_id,
+    )
+    assert rows[0].action == AuditAction.DELETE_CERTIFICATION

--- a/src/repositories/provider_profile_repository.py
+++ b/src/repositories/provider_profile_repository.py
@@ -105,9 +105,12 @@ class ProviderProfileRepository(BaseRepository):
         self, profile: ProviderProfile, **fields: Any
     ) -> ProviderLicensure:
         """Creates a new licensure attached to the profile; the caller
-        commits."""
-        licensure = ProviderLicensure(profile_id=profile.id, **fields)
-        self.session.add(licensure)
+        commits. Appends through `profile.licensures` so the parent's
+        in-memory collection stays consistent — callers that snapshot
+        the parent right after see the new child without an extra
+        `session.refresh(parent, attribute_names=[...])`."""
+        licensure = ProviderLicensure(**fields)
+        profile.licensures.append(licensure)
         await self.session.flush()
         await self.session.refresh(licensure)
         return licensure
@@ -143,9 +146,11 @@ class ProviderProfileRepository(BaseRepository):
         self, profile: ProviderProfile, **fields: Any
     ) -> ProviderEducation:
         """Creates a new education entry attached to the profile; the
-        caller commits."""
-        education = ProviderEducation(profile_id=profile.id, **fields)
-        self.session.add(education)
+        caller commits. Appends through `profile.educations` so the
+        parent's in-memory collection stays consistent — see
+        `add_licensure` for the rationale."""
+        education = ProviderEducation(**fields)
+        profile.educations.append(education)
         await self.session.flush()
         await self.session.refresh(education)
         return education
@@ -185,9 +190,11 @@ class ProviderProfileRepository(BaseRepository):
         self, profile: ProviderProfile, **fields: Any
     ) -> ProviderCertification:
         """Creates a new certification attached to the profile; the caller
-        commits."""
-        certification = ProviderCertification(profile_id=profile.id, **fields)
-        self.session.add(certification)
+        commits. Appends through `profile.certifications` so the parent's
+        in-memory collection stays consistent — see `add_licensure` for
+        the rationale."""
+        certification = ProviderCertification(**fields)
+        profile.certifications.append(certification)
         await self.session.flush()
         await self.session.refresh(certification)
         return certification


### PR DESCRIPTION
## Summary

- Adds 12 new `AuditAction` values and 15 `handle_*` functions in `src/logic/provider_profile_processing.py` covering the provider profile and its three credential sub-tables (licensure, education, certification). Each mutation follows the established fetch → 404 → 403 → snapshot → mutate → `record_audit` → commit pattern.
- Tightens `ProviderProfileRepository.add_licensure / add_education / add_certification` to append through the parent's relationship collection so the parent's in-memory collection stays consistent. Without this, callers that snapshot the parent right after adding children see stale empty collections from SQLAlchemy's identity map. The repository owns this invariant so future callers don't have to know.
- 26 colocated tests in `src/logic/test_provider_profile_processing.py` cover happy paths, 404 / 403 / 400, superuser bypass, URL ↔ sub-row consistency (a sub-row id under the wrong parent 404s), cascade-delete behavior, and audit-row contents. The static AST guard in `test_audit_discipline.py` auto-discovered all 12 new mutation handlers and confirmed each commit is paired with a `record_audit` call.

Closes #147.

## Open question to flag

Audit granularity on `handle_create_profile` with inline sub-rows: this PR emits **one** `CREATE_PROVIDER_PROFILE` row whose `after` snapshot includes the nested children, matching how `handle_create_post` captures the post + its detail row. Alternative would be one row per sub-row (`CREATE_LICENSURE` × N) plus the parent. Picked one-row because (a) the snapshot schema already embeds the nested lists by design and (b) audit volume should be proportional to user actions, not row count. Worth a gut check.

## Test plan

- [x] `dev test` — 399 passed, 1 skipped
- [x] `dev lint` — clean
- [x] `dev test src/logic/test_audit_discipline.py` — all 12 new handlers discovered and pass the discipline check

🤖 Generated with [Claude Code](https://claude.com/claude-code)