### PR TITLE
Add CRUD primitives to BaseRepository (#166)

### DIFF
--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -189,6 +189,43 @@ async def handle_create_entity(data, user, repo: [Entity]Repository):
     return entity
 ```
 
+### CRUD primitives on `BaseRepository` <!-- title-case-ignore -->
+
+`BaseRepository` carries four protected primitives that capture the exact shapes every resource repo writes by hand. They own only the flush/refresh ritual; they never call `commit()`. Use them when your method body is one of these shapes plus *zero* other operations; otherwise write the body explicitly.
+
+| Primitive | Shape it captures |
+| --- | --- |
+| `_get_by_id(Model, id)` | `select(Model).filter(Model.id == id).scalars().first()` |
+| `_persist_new(obj)` | `session.add(obj); flush; refresh; return obj` |
+| `_add_child(parent, "collection", child)` | `getattr(parent, "collection").append(child); flush; refresh(child); return child` |
+| `_patch(obj, **fields)` | skip-`None` `setattr` loop, then `flush; refresh; return obj` |
+| `_delete(obj)` | `session.delete(obj); flush` |
+
+When *not* to delegate:
+
+- `list_X` queries (joins, filters, custom ordering) — write them out.
+- `get_X_by_<field>` lookups that are not by primary key — write them out.
+- `update_X` methods that need a richer skip predicate (e.g. `PostRepository.update_post`'s "skip fields not in this kind's spec") — write them out and document why.
+- Any flow that wires up multiple related rows in one flush — e.g. `PostRepository.create_post` calls `_attach_detail` before delegating to `_persist_new`, but the attachment itself stays explicit.
+
+```python
+# Typical resource repo using the primitives:
+async def get_by_id(self, profile_id: UUID) -> ProviderProfile | None:
+    return await self._get_by_id(ProviderProfile, profile_id)
+
+async def create_profile(self, user_id: UUID, **fields) -> ProviderProfile:
+    return await self._persist_new(ProviderProfile(user_id=user_id, **fields))
+
+async def add_licensure(self, profile, **fields) -> ProviderLicensure:
+    return await self._add_child(profile, "licensures", ProviderLicensure(**fields))
+
+async def update_profile(self, profile, **fields) -> ProviderProfile:
+    return await self._patch(profile, **fields)
+
+async def delete_profile(self, profile) -> None:
+    await self._delete(profile)
+```
+
 ## Common issues and solutions
 
 ### Issue: N+1 query problems

--- a/src/repositories/audit_repository.py
+++ b/src/repositories/audit_repository.py
@@ -34,24 +34,20 @@ class AuditRepository(BaseRepository):
         The row's `created_at` (inherited from BaseModel) doubles as the
         audit `at` field — see `src/models/audit_log.py`.
         """
-        row = AuditLog(
-            actor_id=actor_id,
-            resource_type=resource_type,
-            resource_id=resource_id,
-            action=action,
-            before=before,
-            after=after,
+        return await self._persist_new(
+            AuditLog(
+                actor_id=actor_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                action=action,
+                before=before,
+                after=after,
+            )
         )
-        self.session.add(row)
-        await self.session.flush()
-        await self.session.refresh(row)
-        return row
 
     async def get_by_id(self, audit_id: UUID) -> AuditLog | None:
         """Look up a single audit row. Primarily for tests."""
-        stmt = select(AuditLog).filter(AuditLog.id == audit_id)
-        result = await self.session.execute(stmt)
-        return result.scalars().first()
+        return await self._get_by_id(AuditLog, audit_id)
 
     async def list_for_resource(
         self, *, resource_type: str, resource_id: UUID

--- a/src/repositories/base.py
+++ b/src/repositories/base.py
@@ -1,6 +1,79 @@
+"""Common session management + CRUD primitives shared by every repository.
+
+The four protected primitives (`_get_by_id`, `_persist_new`, `_add_child`,
+`_patch`, `_delete`) capture the exact shapes that every resource repo was
+writing by hand. They own only the flush/refresh ritual; they never call
+`commit()` — the logic layer owns the transaction boundary.
+
+When to delegate vs. write the method out: if your repo method body is one
+of these shapes plus *zero* other operations (no joins, no filters, no
+custom ordering, no per-kind dispatch), delegate. Otherwise write the
+method body explicitly — that domain-specific shape is exactly what the
+named per-resource methods are for.
+"""
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
 class BaseRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
+
+    async def _get_by_id(self, model: type[Any], obj_id: UUID) -> Any | None:
+        """Fetch a single row by primary key. Returns `None` if missing."""
+        stmt = select(model).filter(model.id == obj_id)
+        result = await self.session.execute(stmt)
+        return result.scalars().first()
+
+    async def _persist_new(self, obj: Any) -> Any:
+        """Add a fresh ORM instance, flush, and refresh; return the row.
+
+        For rows that belong in a parent's loaded collection, use
+        `_add_child` instead so the parent's in-memory state stays
+        coherent for callers that snapshot the parent right after the
+        mutation.
+        """
+        self.session.add(obj)
+        await self.session.flush()
+        await self.session.refresh(obj)
+        return obj
+
+    async def _add_child(self, parent: Any, collection: str, child: Any) -> Any:
+        """Append `child` to `parent.<collection>`, flush, and refresh.
+
+        Going through the relationship attribute (rather than just
+        setting `child.<fk> = parent.id`) keeps the parent's loaded
+        collection consistent — callers snapshotting the parent see the
+        new child without a second `session.refresh(parent, ...)`.
+        """
+        getattr(parent, collection).append(child)
+        await self.session.flush()
+        await self.session.refresh(child)
+        return child
+
+    async def _patch(self, obj: Any, **fields: Any) -> Any:
+        """Apply non-`None` `fields` to `obj`, flush, and refresh.
+
+        `None` values are skipped so callers can pass
+        `payload.model_dump(exclude_unset=True)` directly. Use a custom
+        method body when you need a richer skip predicate (e.g. only
+        fields belonging to a particular kind).
+        """
+        for field_name, value in fields.items():
+            if value is None:
+                continue
+            setattr(obj, field_name, value)
+        self.session.add(obj)
+        await self.session.flush()
+        await self.session.refresh(obj)
+        return obj
+
+    async def _delete(self, obj: Any) -> None:
+        """Hard-delete the row; flush. Cascades fire per the model's
+        SQLAlchemy and FK configuration."""
+        await self.session.delete(obj)
+        await self.session.flush()

--- a/src/repositories/post_repository.py
+++ b/src/repositories/post_repository.py
@@ -35,9 +35,7 @@ class PostRepository(BaseRepository):
     async def get_post_by_id(self, post_id: UUID) -> Post | None:
         """Retrieves a post by its ID. Per-kind detail relationships are
         eager-loaded via `lazy="selectin"` on the model."""
-        stmt = select(Post).filter(Post.id == post_id)
-        result = await self.session.execute(stmt)
-        return result.scalars().first()
+        return await self._get_by_id(Post, post_id)
 
     async def list_posts(self) -> Sequence[Post]:
         """Lists all posts, newest first. Detail relationships are eager-loaded."""
@@ -54,10 +52,7 @@ class PostRepository(BaseRepository):
         detail's type). CASCADE on the FK keeps lifetimes locked together.
         """
         _attach_detail(post, detail)
-        self.session.add(post)
-        await self.session.flush()
-        await self.session.refresh(post)
-        return post
+        return await self._persist_new(post)
 
     async def update_post(self, post: Post, **detail_fields: Any) -> Post:
         """Mutates the per-kind detail fields that were provided and flushes;
@@ -87,5 +82,4 @@ class PostRepository(BaseRepository):
     async def delete_post(self, post: Post) -> None:
         """Deletes a post and flushes; the caller commits. The per-kind
         detail row is removed by `ON DELETE CASCADE` on the FK."""
-        await self.session.delete(post)
-        await self.session.flush()
+        await self._delete(post)

--- a/src/repositories/provider_profile_repository.py
+++ b/src/repositories/provider_profile_repository.py
@@ -21,15 +21,12 @@ class ProviderProfileRepository(BaseRepository):
     # --- ProviderProfile reads --------------------------------------------
 
     async def get_by_id(self, profile_id: UUID) -> ProviderProfile | None:
-        """Retrieves a provider profile by its ID. Sub-table relationships
-        (licensures, educations, certifications) are eager-loaded via
-        `lazy="selectin"` on the model."""
-        stmt = select(ProviderProfile).filter(ProviderProfile.id == profile_id)
-        result = await self.session.execute(stmt)
-        return result.scalars().first()
+        """Retrieves a profile by id. Sub-table relationships are
+        eager-loaded via `lazy="selectin"` on the model."""
+        return await self._get_by_id(ProviderProfile, profile_id)
 
     async def get_by_user_id(self, user_id: UUID) -> ProviderProfile | None:
-        """Retrieves a provider profile by its owning user ID. The
+        """Retrieves a profile by its owning user id. The
         `uq_provider_profiles_user_id` constraint guarantees at most one."""
         stmt = select(ProviderProfile).filter(ProviderProfile.user_id == user_id)
         result = await self.session.execute(stmt)
@@ -41,10 +38,9 @@ class ProviderProfileRepository(BaseRepository):
         license_type: str | None = None,
         issuing_state: str | None = None,
     ) -> Sequence[ProviderProfile]:
-        """Lists provider profiles, newest first. When `license_type` or
-        `issuing_state` is set, joins through `provider_licensures` and
-        filters; `.distinct()` prevents duplicate parents when multiple
-        licensures on the same profile match."""
+        """Lists profiles, newest first. When a filter is set, joins
+        through `provider_licensures` and `.distinct()`s the parents so
+        a profile with multiple matching licensures appears once."""
         stmt = select(ProviderProfile)
         if license_type is not None or issuing_state is not None:
             stmt = stmt.join(
@@ -63,157 +59,70 @@ class ProviderProfileRepository(BaseRepository):
     # --- ProviderProfile mutations ----------------------------------------
 
     async def create_profile(self, user_id: UUID, **fields: Any) -> ProviderProfile:
-        """Creates a new provider profile for the given user; the caller
-        commits."""
-        profile = ProviderProfile(user_id=user_id, **fields)
-        self.session.add(profile)
-        await self.session.flush()
-        await self.session.refresh(profile)
-        return profile
+        return await self._persist_new(ProviderProfile(user_id=user_id, **fields))
 
     async def update_profile(
         self, profile: ProviderProfile, **fields: Any
     ) -> ProviderProfile:
-        """Mutates the provided fields on the profile and flushes; the
-        caller commits. Fields whose value is `None` are skipped, mirroring
-        `PostRepository.update_post`."""
-        for field_name, value in fields.items():
-            if value is None:
-                continue
-            setattr(profile, field_name, value)
-        self.session.add(profile)
-        await self.session.flush()
-        await self.session.refresh(profile)
-        return profile
+        return await self._patch(profile, **fields)
 
     async def delete_profile(self, profile: ProviderProfile) -> None:
-        """Hard-deletes the profile; the caller commits. Sub-rows are
-        removed by ORM cascade (`all, delete-orphan`) and FK
-        `ON DELETE CASCADE`."""
-        await self.session.delete(profile)
-        await self.session.flush()
+        await self._delete(profile)
 
     # --- Licensure sub-table ----------------------------------------------
 
     async def get_licensure_by_id(self, licensure_id: UUID) -> ProviderLicensure | None:
-        """Retrieves a licensure by its ID."""
-        stmt = select(ProviderLicensure).filter(ProviderLicensure.id == licensure_id)
-        result = await self.session.execute(stmt)
-        return result.scalars().first()
+        return await self._get_by_id(ProviderLicensure, licensure_id)
 
     async def add_licensure(
         self, profile: ProviderProfile, **fields: Any
     ) -> ProviderLicensure:
-        """Creates a new licensure attached to the profile; the caller
-        commits. Appends through `profile.licensures` so the parent's
-        in-memory collection stays consistent — callers that snapshot
-        the parent right after see the new child without an extra
-        `session.refresh(parent, attribute_names=[...])`."""
-        licensure = ProviderLicensure(**fields)
-        profile.licensures.append(licensure)
-        await self.session.flush()
-        await self.session.refresh(licensure)
-        return licensure
+        return await self._add_child(profile, "licensures", ProviderLicensure(**fields))
 
     async def update_licensure(
         self, licensure: ProviderLicensure, **fields: Any
     ) -> ProviderLicensure:
-        """Mutates the provided fields on the licensure and flushes; the
-        caller commits. `None` values are skipped."""
-        for field_name, value in fields.items():
-            if value is None:
-                continue
-            setattr(licensure, field_name, value)
-        self.session.add(licensure)
-        await self.session.flush()
-        await self.session.refresh(licensure)
-        return licensure
+        return await self._patch(licensure, **fields)
 
     async def delete_licensure(self, licensure: ProviderLicensure) -> None:
-        """Hard-deletes the licensure; the caller commits."""
-        await self.session.delete(licensure)
-        await self.session.flush()
+        await self._delete(licensure)
 
     # --- Education sub-table ----------------------------------------------
 
     async def get_education_by_id(self, education_id: UUID) -> ProviderEducation | None:
-        """Retrieves an education entry by its ID."""
-        stmt = select(ProviderEducation).filter(ProviderEducation.id == education_id)
-        result = await self.session.execute(stmt)
-        return result.scalars().first()
+        return await self._get_by_id(ProviderEducation, education_id)
 
     async def add_education(
         self, profile: ProviderProfile, **fields: Any
     ) -> ProviderEducation:
-        """Creates a new education entry attached to the profile; the
-        caller commits. Appends through `profile.educations` so the
-        parent's in-memory collection stays consistent — see
-        `add_licensure` for the rationale."""
-        education = ProviderEducation(**fields)
-        profile.educations.append(education)
-        await self.session.flush()
-        await self.session.refresh(education)
-        return education
+        return await self._add_child(profile, "educations", ProviderEducation(**fields))
 
     async def update_education(
         self, education: ProviderEducation, **fields: Any
     ) -> ProviderEducation:
-        """Mutates the provided fields on the education entry and flushes;
-        the caller commits. `None` values are skipped."""
-        for field_name, value in fields.items():
-            if value is None:
-                continue
-            setattr(education, field_name, value)
-        self.session.add(education)
-        await self.session.flush()
-        await self.session.refresh(education)
-        return education
+        return await self._patch(education, **fields)
 
     async def delete_education(self, education: ProviderEducation) -> None:
-        """Hard-deletes the education entry; the caller commits."""
-        await self.session.delete(education)
-        await self.session.flush()
+        await self._delete(education)
 
     # --- Certification sub-table ------------------------------------------
 
     async def get_certification_by_id(
         self, certification_id: UUID
     ) -> ProviderCertification | None:
-        """Retrieves a certification by its ID."""
-        stmt = select(ProviderCertification).filter(
-            ProviderCertification.id == certification_id
-        )
-        result = await self.session.execute(stmt)
-        return result.scalars().first()
+        return await self._get_by_id(ProviderCertification, certification_id)
 
     async def add_certification(
         self, profile: ProviderProfile, **fields: Any
     ) -> ProviderCertification:
-        """Creates a new certification attached to the profile; the caller
-        commits. Appends through `profile.certifications` so the parent's
-        in-memory collection stays consistent — see `add_licensure` for
-        the rationale."""
-        certification = ProviderCertification(**fields)
-        profile.certifications.append(certification)
-        await self.session.flush()
-        await self.session.refresh(certification)
-        return certification
+        return await self._add_child(
+            profile, "certifications", ProviderCertification(**fields)
+        )
 
     async def update_certification(
         self, cert: ProviderCertification, **fields: Any
     ) -> ProviderCertification:
-        """Mutates the provided fields on the certification and flushes;
-        the caller commits. `None` values are skipped."""
-        for field_name, value in fields.items():
-            if value is None:
-                continue
-            setattr(cert, field_name, value)
-        self.session.add(cert)
-        await self.session.flush()
-        await self.session.refresh(cert)
-        return cert
+        return await self._patch(cert, **fields)
 
     async def delete_certification(self, cert: ProviderCertification) -> None:
-        """Hard-deletes the certification; the caller commits."""
-        await self.session.delete(cert)
-        await self.session.flush()
+        await self._delete(cert)

--- a/src/repositories/user_repository.py
+++ b/src/repositories/user_repository.py
@@ -15,9 +15,7 @@ class UserRepository(BaseRepository):
 
     async def get_user_by_id(self, user_id: UUID) -> User | None:
         """Retrieves a user by their ID."""
-        stmt = select(User).filter(User.id == user_id)
-        result = await self.session.execute(stmt)
-        return result.scalars().first()
+        return await self._get_by_id(User, user_id)
 
     async def get_user_by_username(self, username: str) -> User | None:
         """Retrieves a user by their username."""
@@ -56,5 +54,4 @@ class UserRepository(BaseRepository):
 
     async def delete_user(self, user: User) -> None:
         """Hard-deletes the user row; the caller commits."""
-        await self.session.delete(user)
-        await self.session.flush()
+        await self._delete(user)


### PR DESCRIPTION
## Summary

Closes #166. Stacked on #169.

`BaseRepository` was 7 lines (just `__init__`). Every resource repo was re-implementing the same four shapes by hand: `select(Model).filter(.id == ...)`, `parent.collection.append(child); flush; refresh`, the skip-`None` update loop, and `session.delete; flush`.

- Five protected primitives on `BaseRepository`: `_get_by_id`, `_persist_new`, `_add_child`, `_patch`, `_delete`. They own only the flush/refresh ritual; they never call `commit()` (the logic layer owns the transaction boundary).
- `ProviderProfileRepository` 219 → 128 LOC (~42%); every per-resource CRUD method is a one-line delegation. The genuinely-domain methods (`list_profiles` join through licensures, `get_by_user_id`) stay explicit.
- `PostRepository`, `UserRepository`, `AuditRepository` migrated to delegate where it fits. `PostRepository.update_post` keeps its custom body because it filters by `spec.detail_fields` — exactly the exception the issue called out as out-of-scope.
- `src/repositories/README.md` gains a section on the primitives and *when not to delegate* (rule of thumb: if it's a one-liner over `_get_by_id` / `_patch` / `_delete` / `_add_child`, delegate; otherwise write the method body).

Public method names unchanged; no callsite outside `src/repositories/` touched.

PR 2 of 4 in the runtime-refactor sequence (#165 → #166 → #167 → #168). Targeted at #169's branch — GitHub will retarget to `main` when #169 merges.

## Test plan

- [x] `dev test src/repositories/` — 30 passed.
- [x] `dev test src/` — 402 passed, 1 skipped.
- [x] `dev lint` — clean.
- [ ] CI

## Contract-surface classification

- Wire request/response shape — untouched.
- URL shape — untouched.
- Persisted JSON / DB schema — untouched.
- Repository public surface — method *names* unchanged; method *bodies* are simpler. No external caller affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuJupk7VRYHiKqoSqBu2jR)_