### PR TITLE
Add primary nav bar to base template

### DIFF
--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -88,7 +88,7 @@ async def test_list_posts_one_post(
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    items = tree.css("ul > li")
+    items = tree.css("ul:not(#primary-nav) > li")
     assert len(items) == 1
     item_text = items[0].text()
     assert description in item_text
@@ -124,7 +124,7 @@ async def test_list_posts_orders_newest_first(
     assert response.status_code == 200
 
     tree = HTMLParser(response.text)
-    items = tree.css("ul > li")
+    items = tree.css("ul:not(#primary-nav) > li")
     assert len(items) == 2
     assert newer.client_referral_detail.description in items[0].text()
     assert older.client_referral_detail.description in items[1].text()

--- a/src/api/routes/test_users.py
+++ b/src/api/routes/test_users.py
@@ -16,6 +16,23 @@ from tests.helpers import create_test_user, promote_to_admin
 pytestmark = pytest.mark.asyncio
 
 
+# --- Base template nav ---------------------------------------------------
+
+
+async def test_base_template_renders_primary_nav(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """Pages rendered from base.html include nav links to the main sections."""
+    response = await authenticated_client.get("/users")
+
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    nav_items = tree.css("#primary-nav > li > a")
+    hrefs = {a.attributes.get("href") for a in nav_items}
+    assert {"/posts", "/users", "/provider-profiles"} <= hrefs
+
+
 # --- Listing -------------------------------------------------------------
 
 
@@ -54,7 +71,7 @@ async def test_list_users_one_user(
     assert "text/html" in response.headers["content-type"]
 
     tree = HTMLParser(response.text)
-    user_list_items = tree.css("ul > li")
+    user_list_items = tree.css("ul:not(#primary-nav) > li")
     assert len(user_list_items) == 1, "Expected one user in the list"
     assert (
         test_username in user_list_items[0].text()
@@ -84,7 +101,7 @@ async def test_list_users_multiple_users(
     assert "text/html" in response.headers["content-type"]
 
     tree = HTMLParser(response.text)
-    user_list_items = tree.css("ul > li")
+    user_list_items = tree.css("ul:not(#primary-nav) > li")
     assert len(user_list_items) == 2, "Expected two users in the list"
 
     usernames_found = {item.text() for item in user_list_items}

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -63,7 +63,7 @@ Templates use inheritance for consistent layout and feature-specific customizati
 
 | Directory  | Purpose                | Templates                                                              |
 | ---------- | ---------------------- | ---------------------------------------------------------------------- |
-| **/**      | Base layout and shared | `base.html` - Foundation template                                      |
+| **/**      | Base layout and shared | `base.html` - Foundation template (includes site-wide `<nav>` linking to `/posts`, `/users`, `/provider-profiles`) |
 | **auth/**  | Authentication pages   | login, register, forgot/reset password                                 |
 | **users/** | User management        | list, detail, `_admin_actions.html` partial (shared by list & detail)  |
 | **posts/** | Posts                  | list, detail, per-kind `new_<kind>.html` + `edit_<kind>.html` thin wrappers around `_<kind>_form.html` partials, `_form_macros.html` (shared field macros), `_owner_actions.html` partial (shared by detail) |

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -8,6 +8,10 @@
       crossorigin="anonymous"></script>
     <script src="https://unpkg.com/htmx.org@2.0.4/dist/ext/json-enc.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      #primary-nav { list-style: none; padding: 0; display: flex; }
+      #primary-nav li { margin-right: 1rem; }
+    </style>
     {% block head %}{% endblock %} {% if is_development %}
     <!-- LiveReload script for development hot reloading -->
     <script>
@@ -22,6 +26,13 @@
     {% endif %}
   </head>
   <body>
+    <nav aria-label="Primary">
+      <ul id="primary-nav">
+        <li><a href="/posts">Posts</a></li>
+        <li><a href="/users">Users</a></li>
+        <li><a href="/provider-profiles">Provider profiles</a></li>
+      </ul>
+    </nav>
     {% block content %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds a site-wide `<nav id=\"primary-nav\">` to `base.html` with links to `/posts`, `/users`, `/provider-profiles`. Renders on every page that extends `base.html`.
- Scopes existing `ul > li` test selectors in `test_users.py` and `test_posts.py` to `ul:not(#primary-nav) > li` so content-list item counts ignore nav items.
- Adds `test_base_template_renders_primary_nav` in `test_users.py` covering the three expected hrefs.
- Updates `src/templates/README.md` matrix to mention the nav.

## Test plan
- [x] `dev test` (434 passed, 1 skipped)
- [x] `dev lint` clean
- [ ] Spot-check `/posts`, `/users`, `/provider-profiles` render the nav and links work

## Notes
- Nav styling lives in a `<style>` block in `<head>` rather than inline `style=\"...\"` because `scripts/dev/title_case_check.py` runs its `[A-Z]+:` regex with `re.IGNORECASE` and only allowlists a hardcoded subset of CSS properties — `gap` (and the attribute name `style` itself) get flagged as missing-title-case \"labels.\" The linter correctly skips `<style>` blocks, so that's the path of least resistance. Improving the linter to skip inline `style=\"...\"` attributes is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)