### PR TITLE
Scope template-test list selectors to stable ids

### DIFF
--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -88,7 +88,7 @@ async def test_list_posts_one_post(
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    items = tree.css("ul:not(#primary-nav) > li")
+    items = tree.css("#post-list > li")
     assert len(items) == 1
     item_text = items[0].text()
     assert description in item_text
@@ -124,7 +124,7 @@ async def test_list_posts_orders_newest_first(
     assert response.status_code == 200
 
     tree = HTMLParser(response.text)
-    items = tree.css("ul:not(#primary-nav) > li")
+    items = tree.css("#post-list > li")
     assert len(items) == 2
     assert newer.client_referral_detail.description in items[0].text()
     assert older.client_referral_detail.description in items[1].text()

--- a/src/api/routes/test_users.py
+++ b/src/api/routes/test_users.py
@@ -71,7 +71,7 @@ async def test_list_users_one_user(
     assert "text/html" in response.headers["content-type"]
 
     tree = HTMLParser(response.text)
-    user_list_items = tree.css("ul:not(#primary-nav) > li")
+    user_list_items = tree.css("#user-list > li")
     assert len(user_list_items) == 1, "Expected one user in the list"
     assert (
         test_username in user_list_items[0].text()
@@ -101,7 +101,7 @@ async def test_list_users_multiple_users(
     assert "text/html" in response.headers["content-type"]
 
     tree = HTMLParser(response.text)
-    user_list_items = tree.css("ul:not(#primary-nav) > li")
+    user_list_items = tree.css("#user-list > li")
     assert len(user_list_items) == 2, "Expected two users in the list"
 
     usernames_found = {item.text() for item in user_list_items}

--- a/src/templates/posts/list.html
+++ b/src/templates/posts/list.html
@@ -11,7 +11,7 @@
 </p>
 
 {% if posts %}
-<ul>
+<ul id="post-list">
   {% for post in posts %}
   <li>
     {% if post.kind == "client_referral" %}

--- a/src/templates/users/list.html
+++ b/src/templates/users/list.html
@@ -4,7 +4,7 @@
 <h1>Users</h1>
 
 {% if users %}
-<ul>
+<ul id="user-list">
   {% for user in users %}
   <li{% if not user.is_active %} class="deactivated"{% endif %}>
     <a href="/users/{{ user.id }}">{{ user.username }}</a>

--- a/tests/README.md
+++ b/tests/README.md
@@ -104,6 +104,12 @@ async def test_my_endpoint(authenticated_client, logged_in_user):
     assert response.json()["id"] == str(logged_in_user.id)
 ```
 
+### Template-test selectors
+
+Template-test selectors must be scoped to a stable handle on the region under test. Give the element you're asserting on an `id`, `class`, or `data-testid`, and select through it (e.g. `#user-list > li`). Do **not** rely on a page having only one `<ul>` / `<form>` / `<table>` — that property is incidental and breaks the first time anything list-shaped lands in a shared template.
+
+Corollary: when adding markup to `base.html` or another shared template, give the new element a stable handle too (e.g. `id="primary-nav"`) so tests can scope around it independently. Exclusion selectors like `ul:not(#primary-nav) > li` are a smell — prefer inclusion (`#user-list > li`) over exclusion.
+
 ### Creating extra users in a test
 
 ```python


### PR DESCRIPTION
## Summary
- Add `id="user-list"` / `id="post-list"` handles to the content `<ul>`s in `templates/users/list.html` and `templates/posts/list.html`, and switch the four `ul:not(#primary-nav) > li` selectors in `test_users.py` / `test_posts.py` to inclusion-scoped `#user-list > li` / `#post-list > li`.
- Document the convention in `tests/README.md`: template-test selectors must be scoped to a stable handle (`id`, `class`, or `data-testid`); exclusion selectors are a smell.

Closes #178. Lifts the `ul:not(#primary-nav)` workaround that #174 introduced when it added the primary nav to `base.html`.

Audit: I ran `grep -rn 'tree.css(' src/api/routes/test_*.py` and confirmed the four exclusion-scoped selectors were the only offenders; every other call already scopes via `id`, class, or attribute selector.

## Test plan
- [x] `dev test src/api/routes/test_users.py src/api/routes/test_posts.py src/api/routes/test_provider_profiles.py` — 138 passed
- [x] `dev test` — 446 passed, 1 skipped
- [x] `dev lint` — clean
- [x] `dev test contract` — 16 passed (templates changed, so contract suite was run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)