### PR TITLE
title_case_check: teach vocabulary, retire most ignore markers

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -110,7 +110,7 @@ Without `pip install -e .`, the CLI is also runnable directly: `python3 scripts/
 
 The `dev` CLI auto-detects the current project root by walking up from the caller's cwd looking for a `pyproject.toml`, so it operates on the worktree you're sitting in rather than the install-time checkout.
 
-#### Tests <!-- title-case-ignore -->
+#### Tests
 
 Tests for `scripts/dev/*` live colocated as `scripts/dev/test_*.py`, matching the `src/<layer>/test_*.py` pattern in [`../CLAUDE.md`](../CLAUDE.md). Tests for `scripts/dev_cli.py` itself live as `scripts/test_dev_cli.py`. Pytest discovers them via the `scripts` entry in `pyproject.toml`'s `testpaths`. Run only the dev CLI tests with `dev test scripts/`.
 

--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -111,8 +111,12 @@ class TitleCaseChecker:
         ".sqlite3",
     }
 
-    # Words that should remain capitalized (proper nouns, acronyms, etc.)
+    # Words that should remain capitalized (proper nouns, acronyms, etc.).
+    # Add domain acronyms and language names here rather than asking authors
+    # to scatter ``title-case-ignore`` markers — the marker is the escape
+    # hatch for one-offs, not a vocabulary problem.
     ALWAYS_CAPITALIZE = {
+        # Web/protocol acronyms
         "API",
         "APIs",
         "URL",
@@ -127,21 +131,16 @@ class TitleCaseChecker:
         "SQL",
         "REST",
         "RESTful",
+        "OAuth",
+        "JWT",
+        "UUID",
+        "UUIDs",
+        # Tech / framework names
         "FastAPI",
         "SQLAlchemy",
         "Jinja2",
         "pytest",
         "GitHub",
-        "OAuth",
-        "JWT",
-        "UUID",
-        "UUIDs",
-        "CRUD",
-        "TDD",
-        "LLM",
-        "LLMs",
-        "AI",
-        "MVP",
         "PostgreSQL",
         "SQLite",
         "Docker",
@@ -149,6 +148,36 @@ class TitleCaseChecker:
         "JavaScript",
         "TypeScript",
         "Pact",  # Contract testing framework
+        # General-domain acronyms
+        "CRUD",
+        "TDD",
+        "LLM",
+        "LLMs",
+        "AI",
+        "MVP",
+        # App-domain acronyms (intake forms, public-facing copy)
+        "ZIP",  # Postal code field
+        "PII",  # Personally identifiable information
+        "DBT",  # Dialectical behavior therapy
+        "EMDR",  # Eye movement desensitization and reprocessing
+        # Language names — surface in form labels ("non-English", "Spanish")
+        # and standard sentence-case rules would lowercase them.
+        "English",
+        "Spanish",
+        "Mandarin",
+        "Cantonese",
+        "French",
+        "German",
+        "Japanese",
+        "Korean",
+        "Vietnamese",
+        "Tagalog",
+        "Arabic",
+        "Hebrew",
+        "Hindi",
+        "Russian",
+        "Italian",
+        "Portuguese",
     }
 
     # HTTP methods are ambiguous: they overlap with common English words
@@ -398,6 +427,15 @@ class TitleCaseChecker:
 
         result_words = []
         for i, word in enumerate(words):
+            # Backtick-wrapped code spans (`.env`, `BaseRepository`) are
+            # identifiers, not prose. Preserve verbatim and don't let any
+            # case rule touch them — including the "first word" rule,
+            # which would otherwise mangle a header opening with a span
+            # like ``` `.env` vs `.env.test` ```.
+            if "`" in word:
+                result_words.append(word)
+                continue
+
             # Remove punctuation for checking
             clean_word = re.sub(r"[^\w]", "", word)
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
             raise
 ```
 
-### `.env` vs `.env.test` <!-- title-case-ignore -->
+### `.env` vs `.env.test`
 
 Two distinct files, two distinct purposes:
 

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -189,7 +189,7 @@ async def handle_create_entity(data, user, repo: [Entity]Repository):
     return entity
 ```
 
-### CRUD primitives on `BaseRepository` <!-- title-case-ignore -->
+### CRUD primitives on `BaseRepository`
 
 `BaseRepository` carries four protected primitives that capture the exact shapes every resource repo writes by hand. They own only the flush/refresh ritual; they never call `commit()`. Use them when your method body is one of these shapes plus *zero* other operations; otherwise write the body explicitly.
 

--- a/src/templates/posts/_client_referral_form.html
+++ b/src/templates/posts/_client_referral_form.html
@@ -27,8 +27,8 @@ which FastAPI/Pydantic parses as a list.
     <legend>Client location</legend>
     {{ text_field("location_city", "City", current=d.location_city if d else None) }}
     {{ select_field("location_state", "State", US_STATES, current=d.location_state if d else None, placeholder=true) }}
-    {{ text_field("location_zip", "ZIP", current=d.location_zip if d else None, pattern="\\d{5}", maxlength=5, title_case_ignore=true) }}
-    {{ select_field("location_in_person", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.location_in_person if d else None, placeholder=true, title_case_ignore=true) }}
+    {{ text_field("location_zip", "ZIP", current=d.location_zip if d else None, pattern="\\d{5}", maxlength=5) }}
+    {{ select_field("location_in_person", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.location_in_person if d else None, placeholder=true) }}
     {{ select_field("location_virtual", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.location_virtual if d else None, placeholder=true) }}
     {{ time_grid_field("desired_times", "Desired times (optional)", current=d.desired_times if d else None) }}
   </fieldset>
@@ -36,18 +36,18 @@ which FastAPI/Pydantic parses as a list.
   <fieldset>
     <legend>Demographics</legend>
     {{ select_field("client_dem_ages", "Age group", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.client_dem_ages if d else None, placeholder=true) }}
-    {{ select_field("language_preferred", "Services preferred in language other than English?", LANGUAGE_PREFERRED_OPTIONS, labels=LANGUAGE_PREFERRED_LABELS, current=(d.language_preferred if d else "no"), title_case_ignore=true) }}
+    {{ select_field("language_preferred", "Services preferred in language other than English?", LANGUAGE_PREFERRED_OPTIONS, labels=LANGUAGE_PREFERRED_LABELS, current=(d.language_preferred if d else "no")) }}
   </fieldset>
 
   <fieldset>
     <legend>Description</legend>
-    {{ textarea_field("description", "Description (no PII)", current=d.description if d else None, title_case_ignore=true) }}
+    {{ textarea_field("description", "Description (no PII)", current=d.description if d else None) }}
   </fieldset>
 
   <fieldset>
     <legend>Services</legend>
     {{ multi_select_field("services", "Services (optional)", CLIENT_REFERRAL_SERVICES, labels=CLIENT_REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
-    {{ text_field("services_psychotherapy_modality", "Psychotherapy modality (optional, e.g. DBT, EMDR)", current=d.services_psychotherapy_modality if d else None, required=false, title_case_ignore=true) }}
+    {{ text_field("services_psychotherapy_modality", "Psychotherapy modality (optional, e.g. DBT, EMDR)", current=d.services_psychotherapy_modality if d else None, required=false) }}
   </fieldset>
 
   <fieldset>

--- a/src/templates/posts/_form_macros.html
+++ b/src/templates/posts/_form_macros.html
@@ -11,27 +11,20 @@ every form using these macros, no per-template edits.
 `current` is the prefilled value (None on the create form, the persisted
 value on edit). For the bool-radio `current` should be `True` / `False`
 / `None` — neither radio is checked when `None`.
-
-`title_case_ignore` lets a caller suppress the project's title-case
-linter (`scripts/dev/title_case_check.py`, run by `dev lint`) for a
-label whose human spelling intentionally diverges from sentence case
-(acronyms like ZIP/PII, hyphenated openers like "In-person"). The
-flag emits the inline `<!-- title-case-ignore -->` HTML comment that
-the linter looks for on the label line.
 #}
 
-{% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None, title_case_ignore=False) -%}
-<label for="{{ name }}">{{ label }}:</label>{% if title_case_ignore %}<!-- title-case-ignore -->{% endif %}<br />
+{% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None) -%}
+<label for="{{ name }}">{{ label }}:</label><br />
 <input type="text" id="{{ name }}" name="{{ name }}"{% if current is not none %} value="{{ current }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}{% if maxlength %} maxlength="{{ maxlength }}"{% endif %}{% if required %} required{% endif %} /><br /><br />
 {%- endmacro %}
 
-{% macro textarea_field(name, label, current=None, required=True, title_case_ignore=False) -%}
-<label for="{{ name }}">{{ label }}:</label>{% if title_case_ignore %}<!-- title-case-ignore -->{% endif %}<br />
+{% macro textarea_field(name, label, current=None, required=True) -%}
+<label for="{{ name }}">{{ label }}:</label><br />
 <textarea id="{{ name }}" name="{{ name }}"{% if required %} required{% endif %}>{{ current or "" }}</textarea><br /><br />
 {%- endmacro %}
 
-{% macro select_field(name, label, options, labels=None, current=None, required=True, placeholder=False, title_case_ignore=False) -%}
-<label for="{{ name }}">{{ label }}:</label>{% if title_case_ignore %}<!-- title-case-ignore -->{% endif %}<br />
+{% macro select_field(name, label, options, labels=None, current=None, required=True, placeholder=False) -%}
+<label for="{{ name }}">{{ label }}:</label><br />
 <select id="{{ name }}" name="{{ name }}"{% if required %} required{% endif %}>
   {%- if placeholder and not current %}
   <option value="" disabled selected>--</option>

--- a/src/templates/posts/_provider_availability_form.html
+++ b/src/templates/posts/_provider_availability_form.html
@@ -31,12 +31,12 @@ which FastAPI/Pydantic parses as a list.
     <legend>Location</legend>
     {{ text_field("location_city", "City", current=d.location_city if d else None) }}
     {{ select_field("location_state", "State", US_STATES, current=d.location_state if d else None, placeholder=true) }}
-    {{ text_field("location_zip", "ZIP", current=d.location_zip if d else None, pattern="\\d{5}", maxlength=5, title_case_ignore=true) }}
+    {{ text_field("location_zip", "ZIP", current=d.location_zip if d else None, pattern="\\d{5}", maxlength=5) }}
   </fieldset>
 
   <fieldset>
     <legend>Availability</legend>
-    {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.in_person_sessions if d else None, placeholder=true, title_case_ignore=true) }}
+    {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.in_person_sessions if d else None, placeholder=true) }}
     {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.virtual_sessions if d else None, placeholder=true) }}
     {{ time_grid_field("desired_times", "Desired times (optional)", current=d.desired_times if d else None) }}
   </fieldset>
@@ -45,10 +45,10 @@ which FastAPI/Pydantic parses as a list.
     <legend>Featured services</legend>
     {{ multi_select_field("services", "Services (select at least one)", CLIENT_REFERRAL_SERVICES, labels=CLIENT_REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
     {{ multi_select_field("settings", "Treatment settings (select at least one)", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
-    {{ text_field("treatment_modality", "Treatment modality (optional, e.g. DBT, EMDR)", current=d.treatment_modality if d else None, required=false, title_case_ignore=true) }}
-    {{ textarea_field("client_focus", "Client focus (no PII)", current=d.client_focus if d else None, title_case_ignore=true) }}
+    {{ text_field("treatment_modality", "Treatment modality (optional, e.g. DBT, EMDR)", current=d.treatment_modality if d else None, required=false) }}
+    {{ textarea_field("client_focus", "Client focus (no PII)", current=d.client_focus if d else None) }}
     {{ select_field("age_group", "Age group", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.age_group if d else None, placeholder=true) }}
-    {{ select_field("non_english_services", "Services offered in non-English language?", LANGUAGE_PREFERRED_OPTIONS, labels=LANGUAGE_PREFERRED_LABELS, current=(d.non_english_services if d else "no"), required=false, title_case_ignore=true) }}
+    {{ select_field("non_english_services", "Services offered in non-English language?", LANGUAGE_PREFERRED_OPTIONS, labels=LANGUAGE_PREFERRED_LABELS, current=(d.non_english_services if d else "no"), required=false) }}
   </fieldset>
 
   <fieldset>

--- a/src/templates/posts/new_client_referral.html
+++ b/src/templates/posts/new_client_referral.html
@@ -3,7 +3,7 @@
 {% block title %}New client referral{% endblock %}
 {% block content %}
 <h1>New client referral</h1>
-<p>Per <code>notes/forms_spec.md</code>. No PII.</p>{# title-case-ignore — "PII" acronym #}
+<p>Per <code>notes/forms_spec.md</code>. No PII.</p>
 {{ client_referral_form("post", "/posts", "Create client referral") }}
 
 <hr />

--- a/src/templates/posts/new_provider_availability.html
+++ b/src/templates/posts/new_provider_availability.html
@@ -3,7 +3,7 @@
 {% block title %}New provider availability{% endblock %}
 {% block content %}
 <h1>New provider availability</h1>
-<p>Per <code>notes/forms_spec.md</code>. No PII.</p>{# title-case-ignore — "PII" acronym #}
+<p>Per <code>notes/forms_spec.md</code>. No PII.</p>
 {{ provider_availability_form("post", "/posts", "Create provider availability") }}
 
 <hr />

--- a/src/templates/provider_profiles/detail.html
+++ b/src/templates/provider_profiles/detail.html
@@ -11,7 +11,7 @@
     <dt>Practice name</dt><dd>{{ profile.practice_name }}</dd>
     <dt>City</dt><dd>{{ profile.location_city }}</dd>
     <dt>State</dt><dd>{{ profile.location_state }}</dd>
-    <dt>ZIP</dt><dd>{{ profile.location_zip }}</dd>{# title-case-ignore — "ZIP" acronym #}
+    <dt>ZIP</dt><dd>{{ profile.location_zip }}</dd>
     <dt>In-person sessions</dt><dd>{{ LOCATION_AVAILABILITY_LABELS[profile.in_person_sessions] }}</dd>
     <dt>Virtual sessions</dt><dd>{{ LOCATION_AVAILABILITY_LABELS[profile.virtual_sessions] }}</dd>
   </dl>

--- a/src/templates/provider_profiles/edit.html
+++ b/src/templates/provider_profiles/edit.html
@@ -12,11 +12,11 @@
       {{ text_field("practice_name", "Practice name", current=profile.practice_name, maxlength=200) }}
       {{ text_field("location_city", "City", current=profile.location_city, maxlength=120) }}
       {{ select_field("location_state", "State", US_STATES, current=profile.location_state) }}
-      {{ text_field("location_zip", "ZIP", current=profile.location_zip, pattern="\\d{5}", maxlength=5, title_case_ignore=true) }}
+      {{ text_field("location_zip", "ZIP", current=profile.location_zip, pattern="\\d{5}", maxlength=5) }}
     </fieldset>
     <fieldset>
       <legend>Session availability</legend>
-      {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=profile.in_person_sessions, title_case_ignore=true) }}
+      {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=profile.in_person_sessions) }}
       {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=profile.virtual_sessions) }}
     </fieldset>
     <input type="submit" value="Save practice details" />

--- a/src/templates/provider_profiles/new.html
+++ b/src/templates/provider_profiles/new.html
@@ -11,12 +11,12 @@
     {{ text_field("practice_name", "Practice name", maxlength=200) }}
     {{ text_field("location_city", "City", maxlength=120) }}
     {{ select_field("location_state", "State", US_STATES, placeholder=true) }}
-    {{ text_field("location_zip", "ZIP", pattern="\\d{5}", maxlength=5, title_case_ignore=true) }}
+    {{ text_field("location_zip", "ZIP", pattern="\\d{5}", maxlength=5) }}
   </fieldset>
 
   <fieldset>
     <legend>Session availability</legend>
-    {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, placeholder=true, title_case_ignore=true) }}
+    {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, placeholder=true) }}
     {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, placeholder=true) }}
   </fieldset>
 

--- a/tests/test_title_case_check.py
+++ b/tests/test_title_case_check.py
@@ -362,7 +362,7 @@ def test_inline_title_case_ignore_marker_suppresses(tmp_path):
         tmp_path,
         """
         <html><body>
-        <dt>ZIP</dt>{# title-case-ignore #}
+        <h1>Some Bad Heading</h1>{# title-case-ignore #}
         </body></html>
         """,
     )
@@ -386,3 +386,71 @@ def test_fix_mode_replaces_text_in_html(tmp_path):
     assert "Bad heading" in file.read_text(encoding="utf-8")
     # Running again on the fixed file produces no violations.
     assert TitleCaseChecker(respect_gitignore=False).check_file(file) == []
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary and code-span handling
+#
+# These are the rules that displaced the bulk of the project's
+# ``title-case-ignore`` markers: the linter recognises domain acronyms and
+# language names directly, and treats backtick-wrapped tokens in Markdown
+# headers as code rather than prose. Each test pins a class of false
+# positive that previously required a hand-placed ignore.
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_header_starting_with_backtick_code_span(tmp_path):
+    """A code span at the start of a header must not be lower-cased into
+    prose (``\\`.env\\` vs \\`.env.test\\``` → ``.Env vs ...``).
+    """
+    file = _write_md(tmp_path, "### `.env` vs `.env.test`\n")
+    assert _check(file) == []
+
+
+def test_markdown_header_with_camelcase_in_backticks(tmp_path):
+    """CamelCase identifiers wrapped in backticks must survive verbatim,
+    not be lower-cased to ``baserepository``."""
+    file = _write_md(tmp_path, "### CRUD primitives on `BaseRepository`\n")
+    assert _check(file) == []
+
+
+def test_acronyms_in_form_labels_pass(tmp_path):
+    """Domain acronyms (ZIP/PII/DBT/EMDR) are part of the allowlist; form
+    labels using them must not require per-line ignore markers."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <label>ZIP:</label>
+        <label>Description (no PII):</label>
+        <label>Treatment modality (optional, e.g. DBT, EMDR):</label>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_language_names_in_prose_pass(tmp_path):
+    """Language names (English, Spanish, ...) are part of the allowlist
+    so labels like "Services in English?" don't need per-line ignores."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <label>Services preferred in language other than English?</label>
+        <p>Available in Spanish and Mandarin.</p>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_genuinely_miscased_acronym_neighbour_still_flags(tmp_path):
+    """Adding ZIP to the allowlist must not let an adjacent miscased word
+    slip through — only ZIP is preserved, the rest is sentence-cased."""
+    file = _write_html(
+        tmp_path,
+        "<html><body><h1>ZIP Code Lookup</h1></body></html>",
+    )
+    originals = {v["original"] for v in _check(file)}
+    assert "ZIP Code Lookup" in originals


### PR DESCRIPTION
## Summary

- Add domain acronyms (`ZIP`, `PII`, `DBT`, `EMDR`) and a set of common language names (`English`, `Spanish`, `Mandarin`, …) to `ALWAYS_CAPITALIZE`, so form labels and docs using them stop tripping the linter.
- Preserve backtick-wrapped tokens verbatim in `_convert_single_sentence`, so Markdown headers like `` `.env` vs `.env.test` `` and `` CRUD primitives on `BaseRepository` `` no longer require ignore markers.
- Remove all 6 now-dead `title-case-ignore` comments (3 READMEs, 3 templates), plus the `title_case_ignore` macro parameter in `_form_macros.html` and its 14 callers.

The inline `{# title-case-ignore #}` escape hatch is preserved for genuine one-offs; the macro parameter only ever existed as a cushion for the missing vocabulary.

Closes #193.

## Test plan

- [x] `dev test` — 466 passed, 1 skipped
- [x] `dev lint` — clean
- [x] `python scripts/dev/title_case_check.py` on full repo — zero violations
- [x] New test cases pin: backtick at header start, CamelCase in backticks, acronyms in `<label>`, language names in prose, and acronym allowlist not bleeding into adjacent words

🤖 Generated with [Claude Code](https://claude.com/claude-code)