### PR TITLE
title_case_check: fail loudly when selectolax is missing

### DIFF
--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -613,15 +613,12 @@ class TitleCaseChecker:
         values. Inline ``style="..."`` is invisible here because ``style``
         isn't in ``LINTABLE_ATTR_NAMES``; ``<script>``/``<style>`` subtrees
         are skipped by ``NEVER_DESCEND_TAGS``.
-        """
-        if HTMLParser is None:
-            print(
-                f"Warning: selectolax is not installed; cannot parse {file_path}. "
-                "Install with: pip install selectolax",
-                file=sys.stderr,
-            )
-            return []
 
+        Callers must ensure ``selectolax`` is importable before invoking
+        this — the CLI guards in ``main()``. Per-file warn-and-skip used
+        to live here and silently masked missing-dep environments
+        (regression #198).
+        """
         stripped_content = self._strip_jinja(content)
 
         try:
@@ -994,6 +991,19 @@ Exception handling:
     )
 
     args = parser.parse_args()
+
+    if HTMLParser is None:
+        # Hard-fail rather than warn-and-skip per file: a missing parser
+        # used to cause every HTML/Jinja template to be silently skipped,
+        # so a real violation could pass `dev lint` locally and only
+        # surface in CI (#198).
+        print(
+            "Error: selectolax is not installed in this interpreter "
+            f"({sys.executable}). HTML/Jinja templates cannot be checked. "
+            "Install with: pip install selectolax",
+            file=sys.stderr,
+        )
+        return 1
 
     # --check-only overrides --fix
     fix_mode = args.fix and not args.check_only

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -254,7 +254,7 @@ class QualityCommands:
             ),
             (
                 "🏷️ Checking title case...",
-                ["python3", "scripts/dev/title_case_check.py", "--check-only"],
+                [sys.executable, "scripts/dev/title_case_check.py", "--check-only"],
             ),
         ]
 

--- a/tests/test_title_case_check.py
+++ b/tests/test_title_case_check.py
@@ -454,3 +454,20 @@ def test_genuinely_miscased_acronym_neighbour_still_flags(tmp_path):
     )
     originals = {v["original"] for v in _check(file)}
     assert "ZIP Code Lookup" in originals
+
+
+def test_main_exits_with_error_when_selectolax_missing(monkeypatch, capsys):
+    """If selectolax isn't importable, the CLI must hard-fail rather than
+    silently skip every HTML/Jinja file. Regression for #198 — the old
+    warn-and-skip behavior let `dev lint` pass locally with the wrong
+    interpreter while CI (with deps installed) caught real violations."""
+    from scripts.dev import title_case_check
+
+    monkeypatch.setattr(title_case_check, "HTMLParser", None)
+    monkeypatch.setattr("sys.argv", ["title_case_check.py", "--check-only"])
+
+    rc = title_case_check.main()
+
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "selectolax" in err


### PR DESCRIPTION
## Summary

- `dev lint` invoked the title-case checker via a literal `python3`, which resolves against PATH rather than the project's venv. When the resolved interpreter lacked `selectolax`, every HTML/Jinja template was silently skipped (`_check_html_parsed` warned and returned `[]`), so `dev lint` passed locally while CI caught real violations.
- Two complementary fixes: `scripts/dev_cli.py` now routes through `sys.executable`; `scripts/dev/title_case_check.py` hard-fails up-front in `main()` if `selectolax` is unimportable, instead of warn-and-skipping per file.
- Adds a regression test asserting the CLI exits non-zero with a clear error when the parser is unavailable.

Closes #198.

## Test plan

- [x] `dev test tests/test_title_case_check.py` — new regression test passes (25 total).
- [x] `dev test` — full suite green (467 passed, 1 skipped).
- [x] `dev lint` — passes; output now shows the venv interpreter being used (`/opt/homebrew/opt/python@3.11/bin/python3.11 scripts/dev/title_case_check.py`).
- [ ] Manual repro: in a shell with the venv inactive and a system `python3` lacking selectolax, `python3 scripts/dev/title_case_check.py --check-only` exits 1 with the new error rather than printing per-file warnings and exiting 0.

## Per-PR retrospective

### Issue body did most of the planning
**Friction:** none — having #198 lay out symptom, scope audit (which `dev` subcommands are affected), both fix options, and effort estimate compressed plan-mode to a sanity check.
**Fix:** keep writing issues this way. The issue → plan → diff path is cheapest when the issue already classifies the contract surface and considers alternatives.
**Why didn't existing patterns prevent this?** N/A — this is a "what worked" entry, not friction.
**Could this class recur elsewhere?** No, one-off.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)