### PR TITLE
Lint: forbid cross-cluster Python imports in clustered layers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,10 @@ repos:
         language: python
         files: ^src/templates/.*\.html$
         pass_filenames: true
+
+      - id: python-cluster-imports-check
+        name: Check Python cluster boundaries
+        entry: python scripts/dev/python_cluster_imports_check.py
+        language: python
+        files: ^src/(models|schemas|repositories|logic)/.*\.py$
+        pass_filenames: true

--- a/scripts/dev/python_cluster_imports_check.py
+++ b/scripts/dev/python_cluster_imports_check.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Forbid cross-cluster Python imports inside layered directories.
+
+Companion to ``template_imports_check.py``: same rule, different file
+type. A file under ``src/<layer>/<cluster>/`` may import from its own
+cluster or from any parent-level (shared) module in the same layer; it
+may NOT import from a sibling cluster directory in the same layer.
+
+Today this applies to ``src/models/``, ``src/schemas/``, ``src/repositories/``,
+and ``src/logic/`` — the layers that have been clustered. ``src/api/``
+and ``src/core/`` aren't clustered (single file or single directory per
+entity is the layer's natural shape there) and are skipped.
+
+Imports we recognize:
+  - absolute:  ``from src.<layer>.<cluster>.<file> import X``
+  - relative:  ``from .<cluster>.<file> import X`` (file at layer root)
+               ``from ..<cluster>.<file> import X`` (file at cluster level)
+  - bare-package: ``from src.<layer>.<cluster> import X``
+
+Cross-layer imports (e.g. ``from src.repositories.posts...`` inside
+``src/logic/providers/``) are out of scope for this check — the
+within-layer rule is what matches the templates rule. A separate rule
+about cross-layer cluster discipline (e.g. logic/posts may only depend
+on repositories/posts, not repositories/providers) could be added if
+it earns its keep; it's not enforced here today.
+
+Usage:
+    python scripts/dev/python_cluster_imports_check.py            # check all clustered layers
+    python scripts/dev/python_cluster_imports_check.py path/a ... # check specific files
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+# Layers whose direct subdirectories we treat as clusters. Each layer's
+# parent-level files (anything not inside a cluster directory) are the
+# shared tier. Add a layer here when it grows cluster directories.
+_CLUSTERED_LAYERS = ("models", "schemas", "repositories", "logic")
+
+
+@dataclass(frozen=True)
+class Violation:
+    file: Path
+    line: int
+    importer_layer: str
+    importer_cluster: str
+    target_cluster: str
+    raw_import: str
+
+    def message(self) -> str:
+        return (
+            f"{self.file}:{self.line}: `{self.raw_import.strip()}` "
+            f"crosses cluster boundary inside src/{self.importer_layer}/ "
+            f"({self.importer_cluster}/ → {self.target_cluster}/). "
+            f"Hoist the shared piece to src/{self.importer_layer}/ "
+            f"or fix the dependency direction."
+        )
+
+
+def _project_root() -> Path:
+    here = Path(__file__).resolve().parent
+    while here != here.parent:
+        if (here / "pyproject.toml").exists():
+            return here
+        here = here.parent
+    raise RuntimeError("Could not locate project root (no pyproject.toml found).")
+
+
+def _layer_clusters(layer_root: Path) -> set[str]:
+    """Direct subdirectories of layer_root that contain at least one .py file.
+
+    Anything else at the parent level (loose .py files, __pycache__) isn't a
+    cluster. We don't hardcode entity names — the directories *are* the
+    entity registry.
+    """
+    clusters: set[str] = set()
+    if not layer_root.is_dir():
+        return clusters
+    for entry in layer_root.iterdir():
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith("__") or entry.name.startswith("."):
+            continue
+        if any(entry.rglob("*.py")):
+            clusters.add(entry.name)
+    return clusters
+
+
+def _file_position(file: Path, src_root: Path) -> tuple[str, str | None]:
+    """Return (layer, cluster) for a file under src/, or (layer, None) if at parent.
+
+    Files outside any clustered layer return ("", None) and are skipped by callers.
+    """
+    try:
+        rel = file.resolve().relative_to(src_root.resolve())
+    except ValueError:
+        return ("", None)
+    parts = rel.parts
+    if len(parts) < 2:
+        return ("", None)
+    layer = parts[0]
+    if layer not in _CLUSTERED_LAYERS:
+        return ("", None)
+    if len(parts) == 2:
+        return (layer, None)  # File at layer root — parent-level shared.
+    return (layer, parts[1])
+
+
+# Patterns we recognize. Group 1 captures the layer-or-relative-marker;
+# group 2 captures what comes after.
+_ABS_RE = re.compile(
+    r"^\s*from\s+src\.(\w+)\.(\w+)(?:\.\w+)*\s+import\b",
+)
+_REL_RE = re.compile(
+    r"^\s*from\s+(\.+)(\w+)(?:\.\w+)*\s+import\b",
+)
+
+
+def _check_file(
+    file: Path,
+    layer: str,
+    cluster: str,
+    layer_clusters: set[str],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    for lineno, raw in enumerate(
+        file.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        m = _ABS_RE.match(raw)
+        if m:
+            target_layer, target_cluster = m.group(1), m.group(2)
+            if target_layer != layer:
+                continue  # Cross-layer — out of scope.
+            if target_cluster not in layer_clusters:
+                continue  # Target is a parent-level shared file, not a cluster.
+            if target_cluster == cluster:
+                continue  # Same cluster — fine.
+            violations.append(
+                Violation(file, lineno, layer, cluster, target_cluster, raw)
+            )
+            continue
+
+        m = _REL_RE.match(raw)
+        if m:
+            dots, target_cluster = m.group(1), m.group(2)
+            # `from .X import` from a file at <layer>/<cluster>/ resolves to
+            # <layer>/<cluster>/X — that's a same-cluster sibling, not cross-cluster.
+            # `from ..X import` from a file at <layer>/<cluster>/ resolves to
+            # <layer>/X — possibly another cluster.
+            if len(dots) == 1:
+                continue  # Same-cluster sibling — fine.
+            if len(dots) == 2:
+                if target_cluster not in layer_clusters:
+                    continue
+                if target_cluster == cluster:
+                    continue
+                violations.append(
+                    Violation(file, lineno, layer, cluster, target_cluster, raw)
+                )
+            # 3+ dots would walk above the layer — out of scope for the
+            # within-layer rule, and Python won't resolve it anyway in this
+            # tree (src is not a package).
+    return violations
+
+
+def find_violations(
+    files: Iterable[Path],
+    src_root: Path,
+) -> list[Violation]:
+    cluster_cache: dict[str, set[str]] = {}
+    violations: list[Violation] = []
+    for file in files:
+        layer, cluster = _file_position(file, src_root)
+        if not layer or cluster is None:
+            continue
+        if layer not in cluster_cache:
+            cluster_cache[layer] = _layer_clusters(src_root / layer)
+        violations.extend(_check_file(file, layer, cluster, cluster_cache[layer]))
+    return violations
+
+
+def _collect_files(paths: list[str], src_root: Path) -> list[Path]:
+    if not paths:
+        files: list[Path] = []
+        for layer in _CLUSTERED_LAYERS:
+            files.extend(sorted((src_root / layer).rglob("*.py")))
+        return files
+    out: list[Path] = []
+    for raw in paths:
+        p = Path(raw).resolve()
+        if p.is_dir():
+            out.extend(sorted(p.rglob("*.py")))
+        elif p.suffix == ".py":
+            out.append(p)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files or directories to check. Defaults to all clustered layers.",
+    )
+    args = parser.parse_args(argv)
+
+    src_root = _project_root() / "src"
+    files = _collect_files(args.paths, src_root)
+    violations = find_violations(files, src_root)
+
+    if violations:
+        print("❌ Cross-cluster Python imports found:", file=sys.stderr)
+        for v in violations:
+            print(f"  {v.message()}", file=sys.stderr)
+        print(
+            "\nA shared piece belongs at the layer's parent level "
+            "(e.g. src/logic/audit.py, src/models/enums.py). See "
+            "src/README.md → 'Domain entities and the cluster pattern'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✅ No cross-cluster Python imports ({len(files)} files checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/test_python_cluster_imports_check.py
+++ b/scripts/dev/test_python_cluster_imports_check.py
@@ -1,0 +1,179 @@
+"""Tests for scripts/dev/python_cluster_imports_check.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.dev.python_cluster_imports_check import find_violations
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _build_layer(
+    src_root: Path,
+    layer: str,
+    clusters: list[str],
+    parent_files: list[str] | None = None,
+) -> None:
+    """Create a fake layer with given cluster directories under src_root.
+
+    Each cluster gets a placeholder file so it counts as a real cluster
+    in the auto-discovery step.
+    """
+    layer_root = src_root / layer
+    layer_root.mkdir(parents=True, exist_ok=True)
+    for c in clusters:
+        _write(layer_root / c / "_placeholder.py", "")
+    for f in parent_files or []:
+        _write(layer_root / f, "")
+
+
+def test_same_cluster_absolute_import_is_allowed(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _build_layer(src, "logic", ["posts", "providers"], parent_files=["audit.py"])
+    f = _write(
+        src / "logic" / "posts" / "post_processing.py",
+        "from src.logic.posts._placeholder import x\n",
+    )
+
+    assert find_violations([f], src) == []
+
+
+def test_shared_parent_file_import_is_allowed(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _build_layer(src, "logic", ["posts", "providers"], parent_files=["audit.py"])
+    f = _write(
+        src / "logic" / "posts" / "post_processing.py",
+        "from src.logic.audit import record_audit\n",
+    )
+
+    assert find_violations([f], src) == []
+
+
+def test_cross_layer_import_is_out_of_scope(tmp_path: Path) -> None:
+    """Cross-layer imports are not enforced by this check (only within-layer)."""
+    src = tmp_path / "src"
+    _build_layer(src, "logic", ["posts"])
+    _build_layer(src, "repositories", ["providers"])
+    f = _write(
+        src / "logic" / "posts" / "post_processing.py",
+        "from src.repositories.providers.repo import X\n",
+    )
+
+    assert find_violations([f], src) == []
+
+
+def test_cross_cluster_absolute_import_is_flagged(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _build_layer(src, "logic", ["posts", "providers"], parent_files=["audit.py"])
+    f = _write(
+        src / "logic" / "posts" / "post_processing.py",
+        "from src.logic.providers.handler import x\n",
+    )
+
+    violations = find_violations([f], src)
+
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.importer_layer == "logic"
+    assert v.importer_cluster == "posts"
+    assert v.target_cluster == "providers"
+    assert "posts/ → providers/" in v.message()
+
+
+def test_relative_dot_import_is_same_cluster(tmp_path: Path) -> None:
+    """`from .x import y` from inside a cluster resolves within the same cluster."""
+    src = tmp_path / "src"
+    _build_layer(src, "logic", ["posts"])
+    f = _write(
+        src / "logic" / "posts" / "post_processing.py",
+        "from .helpers import h\n",
+    )
+
+    assert find_violations([f], src) == []
+
+
+def test_relative_double_dot_import_to_sibling_cluster_is_flagged(
+    tmp_path: Path,
+) -> None:
+    """`from ..providers.x import y` walks to a sibling cluster."""
+    src = tmp_path / "src"
+    _build_layer(src, "logic", ["posts", "providers"])
+    f = _write(
+        src / "logic" / "posts" / "post_processing.py",
+        "from ..providers.handler import x\n",
+    )
+
+    violations = find_violations([f], src)
+
+    assert len(violations) == 1
+    assert violations[0].target_cluster == "providers"
+
+
+def test_relative_double_dot_to_shared_is_allowed(tmp_path: Path) -> None:
+    """`from ..base import` from a clustered file walks to the layer's parent — fine."""
+    src = tmp_path / "src"
+    _build_layer(src, "repositories", ["posts"], parent_files=["base.py"])
+    f = _write(
+        src / "repositories" / "posts" / "post_repository.py",
+        "from ..base import BaseRepository\n",
+    )
+
+    assert find_violations([f], src) == []
+
+
+def test_parent_level_file_is_not_lint_subject(tmp_path: Path) -> None:
+    """Files at the layer's parent level have no cluster — they are the shared tier
+    and may import anywhere in the layer (audit.py orchestrates across clusters)."""
+    src = tmp_path / "src"
+    _build_layer(src, "logic", ["posts", "providers"], parent_files=["audit.py"])
+    f = _write(
+        src / "logic" / "audit.py",
+        "from src.logic.posts.handler import x\n"
+        "from src.logic.providers.handler import y\n",
+    )
+
+    assert find_violations([f], src) == []
+
+
+def test_unclustered_layer_is_skipped(tmp_path: Path) -> None:
+    """Layers not in _CLUSTERED_LAYERS (e.g. api/, core/) aren't checked."""
+    src = tmp_path / "src"
+    api = src / "api" / "routes"
+    api.mkdir(parents=True)
+    f = _write(api / "posts.py", "from src.api.routes.providers import x\n")
+
+    assert find_violations([f], src) == []
+
+
+def test_module_starting_with_underscore_is_not_a_cluster(tmp_path: Path) -> None:
+    """Auto-discovery skips dunder/underscore directories — `__pycache__` etc."""
+    src = tmp_path / "src"
+    layer_root = src / "schemas"
+    layer_root.mkdir(parents=True)
+    (layer_root / "__pycache__").mkdir()
+    _write(layer_root / "_validators.py", "")
+    _write(layer_root / "posts" / "_placeholder.py", "")
+
+    f = _write(
+        src / "schemas" / "posts" / "post.py",
+        "from src.schemas._validators import StrippedText\n",
+    )
+
+    assert find_violations([f], src) == []
+
+
+def test_multiple_violations_in_one_file(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _build_layer(src, "logic", ["posts", "providers", "users"])
+    body = "from src.logic.providers.x import a\n" "from src.logic.users.y import b\n"
+    f = _write(src / "logic" / "posts" / "post_processing.py", body)
+
+    violations = find_violations([f], src)
+
+    assert len(violations) == 2
+    assert {v.target_cluster for v in violations} == {"providers", "users"}

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -260,6 +260,10 @@ class QualityCommands:
                 "🔗 Checking template import boundaries...",
                 [sys.executable, "scripts/dev/template_imports_check.py"],
             ),
+            (
+                "🐍 Checking Python cluster boundaries...",
+                [sys.executable, "scripts/dev/python_cluster_imports_check.py"],
+            ),
         ]
 
         exit_code = 0

--- a/src/README.md
+++ b/src/README.md
@@ -106,24 +106,25 @@ There is no separate domain-error hierarchy (e.g. `ServiceError`, `BusinessRuleE
 
 The codebase has a small set of top-level domain entities — currently `posts`, `providers`, `users`, `auth`, `me`, `audit` — and the layer matrix above is only one axis of the architecture. The other axis is **the entity itself**: every entity should have a 1:1 directory presence at every layer that touches it, and every layer should have a *shared tier* at the parent level for genuinely cross-entity infrastructure.
 
-**The import rule.** A file in `<layer>/<entity>/` may import from its own cluster and from the layer's shared tier. Cross-cluster imports (e.g. `models/posts/foo.py` importing from `models/providers/`) are forbidden — fix the design or hoist the shared piece into the parent. Where the directory shape allows, this is lint-enforced (`scripts/dev/template_imports_check.py`, today scoped to `src/templates/`); other layers follow the rule by convention. Audit it with:
+**The import rule.** A file in `<layer>/<entity>/` may import from its own cluster and from the layer's shared tier. Cross-cluster imports (e.g. `models/posts/foo.py` importing from `models/providers/`) are forbidden — fix the design or hoist the shared piece into the parent. Two lint checks enforce this:
 
-```bash
-grep -rnE 'from \.\.(posts|providers|users)' src/models src/repositories src/logic src/schemas
-```
+- [`scripts/dev/template_imports_check.py`](../scripts/dev/template_imports_check.py) — Jinja `{% extends/include/from/import %}` directives across `src/templates/`.
+- [`scripts/dev/python_cluster_imports_check.py`](../scripts/dev/python_cluster_imports_check.py) — Python `from ...` imports across `src/models/`, `src/schemas/`, `src/repositories/`, `src/logic/`. Cluster directories are auto-discovered (any subdirectory with `.py` files) so a future cluster picks up the rule for free.
 
-**Current state of the convention across layers.** Some layers are fully clustered, some still flat:
+Both run as part of `dev lint` and as pre-commit hooks scoped to the relevant file globs.
+
+**Current state of the convention across layers.**
 
 | Layer | Cluster directories | Parent-level shared tier |
 | --- | --- | --- |
 | `templates/` | yes (all entities) | `_shared/`, `base.html` |
-| `models/` | partial — `posts/`, `providers/` ([extracted in #191](https://github.com/willthefirst/bedlam-connect/pull/191)); `user.py` not yet a cluster | `enums.py`, `base.py`, `audit_log.py` |
-| `repositories/` | not yet — flat `<entity>_repository.py` | `base.py`, `dependencies.py` |
-| `logic/` | not yet — flat `<entity>_processing.py` | `audit.py` |
-| `schemas/` | not yet — flat `<entity>.py` | `_validators.py` |
+| `models/` | partial — `posts/`, `providers/` ([#191](https://github.com/willthefirst/bedlam-connect/pull/191)); `user.py` not yet a cluster | `enums.py`, `base.py`, `audit_log.py` |
+| `schemas/` | yes — `posts/`, `providers/`, `users/` ([#209](https://github.com/willthefirst/bedlam-connect/pull/209)) | `_validators.py` |
+| `repositories/` | yes — `posts/`, `providers/`, `users/`, `audit/` ([#210](https://github.com/willthefirst/bedlam-connect/pull/210)) | `base.py`, `dependencies.py` |
+| `logic/` | yes — `posts/`, `providers/`, `users/`, `auth/` ([#211](https://github.com/willthefirst/bedlam-connect/pull/211)) | `audit.py` |
 | `api/routes/` | not applicable — single-file-per-entity is the layer's shape; URL grammar in [`api/routes/RESOURCE_GRAMMAR.md`](api/routes/RESOURCE_GRAMMAR.md) handles the per-entity contract | `common/` |
 
-The trajectory is toward full clustering as each entity's per-layer code grows. The argument that justified PR #191 for models — multiple files per entity made the cluster directory pull its weight — applies to the other layers when they cross the same threshold. Until a layer is clustered, treat the file-level naming convention (`<entity>_<role>.py`) as the implicit cluster boundary; cross-entity imports between sibling files are still smells.
+The remaining migration is `src/models/users/` (currently `models/user.py`) — small, optional, takes the rule from "convention everywhere it can apply" to "convention everywhere full stop."
 
 **Documentation locality.** The same shape applies to READMEs. A layer's parent README describes the layer's *contract* (what's a repository, what may it depend on) and the shared tier; entity-specific facts that are non-trivial enough to write down belong in the entity cluster's own README (`<layer>/<entity>/README.md`). When an entity has nothing surprising to say at a layer, no entity README is required — silence is fine. This avoids the "fact stated in two places" drift the [single-source-of-truth rule](../CLAUDE.md#one-source-of-truth--link-dont-copy) calls out: each fact has exactly one home.
 


### PR DESCRIPTION
## Summary

Step 3 of the cluster-pattern migration. New `scripts/dev/python_cluster_imports_check.py` enforces the same rule as `template_imports_check.py` but for Python files: a file in `src/<layer>/<cluster>/` may import from its own cluster + the layer's parent-level shared tier, but not from a sibling cluster.

Cluster directories are **auto-discovered** (any subdirectory of a clustered layer that contains `.py` files), so when `src/models/users/` lands or some future entity arrives, the rule covers it without a code change.

Out of scope (deliberate):
- Cross-layer cluster discipline (e.g. `logic/posts/` may only import from `repositories/posts/`, not `repositories/providers/`). That's a different and stricter rule; the within-layer rule is what matches the templates lint.
- Files at a layer's parent level (e.g. `src/logic/audit.py`) — they're the shared tier and may orchestrate across clusters.

```
$ python3 scripts/dev/python_cluster_imports_check.py
✅ No cross-cluster Python imports (42 files checked).
```

End-to-end smoke: synthetically introduced `from src.logic.providers.provider_processing import ...` into `src/logic/posts/post_processing.py` → check fired with the expected message and exited 1.

Wired into `dev lint` and as a pre-commit hook scoped to `^src/(models|schemas|repositories|logic)/.*\.py$`.

Branch was originally stacked on #209/#210/#211; those merged together via #211's rebase-and-merge, so this branch was rebased onto main and the three predecessor PRs were closed as superseded. The diff here is now just the lint script, its tests, and the wiring.

## Test plan
- [x] `dev test` (488 passed — 11 new for this check)
- [x] `dev lint` includes the new check
- [x] Synthetic-violation smoke verified

## Tests cover
- Same-cluster absolute import allowed
- Shared parent-file import allowed
- Cross-layer import out of scope
- Cross-cluster absolute import flagged
- Relative `.x` import → same cluster
- Relative `..providers.x` from `posts/` → flagged
- Relative `..base` to shared parent → allowed
- Parent-level file (`audit.py`) may import any cluster
- Unclustered layers (`api/`, `core/`) skipped
- `__pycache__` and underscore dirs excluded from cluster auto-discovery
- Multiple violations in one file all reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)