### PR TITLE
Sync three drifted docs to current code reality (#215)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,9 +6,9 @@ This directory contains scripts organized by purpose for better maintainability.
 
 ```
 scripts/
-├── dev/                     # Development utilities
-│   ├── title_case_check.py # Code quality enforcement
-│   └── template_imports_check.py # Forbid cross-resource template imports
+├── dev/                     # One file per `dev <command>` implementation,
+│                            #   each with its colocated `test_*.py`.
+│                            #   `ls scripts/dev/*.py` is the source of truth.
 ├── runtime/                 # Application runtime scripts
 │   ├── start.sh            # Production startup script
 │   └── start-dev.sh        # Development startup script with hot reloading

--- a/src/README.md
+++ b/src/README.md
@@ -65,10 +65,14 @@ async def create_entity(data: dict, session: AsyncSession = Depends(get_db_sessi
     # ... more business logic
     return new_entity
 
-# Good - delegate to service layer
+# Good - delegate to a logic handler that owns the commit
 @router.post("/[entities]")
-async def create_entity(data: EntityCreate, service: EntityService = Depends()):
-    return await service.create_entity(data)
+async def create_entity(
+    data: EntityCreate,
+    user: User = Depends(current_active_user),
+    repo: EntityRepository = Depends(get_entity_repository),
+):
+    return await handle_create_entity(data, user, repo)
 ```
 
 ## Architecture: Simple layered design
@@ -92,7 +96,7 @@ Everything else (schemas, models, templates) supports these main layers. There i
 | **Logic**        | active   | Business logic, orchestration, transaction commit           | `logic/*.py`        | Repositories, Schemas, Models, API common exceptions |
 | **Repositories** | active   | Data access, queries                                        | `repositories/*.py` | Models, Database                      |
 | **Models**       | active   | Database schema, relationships                              | `models/*.py`       | SQLAlchemy                            |
-| **Schemas**      | active   | Request/response validation                                 | `schemas/*.py`      | Pydantic                              |
+| **Schemas**      | active   | Request/response validation                                 | `schemas/*.py`      | Pydantic, Models (enums + registries only) |
 | **Middleware**   | empty    | Cross-cutting concerns                                      | `middleware/*.py`   | FastAPI                               |
 | **Core**         | active   | Configuration, utilities                                    | `core/*.py`         | None                                  |
 

--- a/src/api/routes/RESOURCE_GRAMMAR.md
+++ b/src/api/routes/RESOURCE_GRAMMAR.md
@@ -2,7 +2,7 @@
 
 The **prescriptive contract** for how every CRUD-shaped resource is exposed over HTTP. It governs URL shape, subresources, the optional publication lifecycle, and when each pattern applies. Read this **before** adding or modifying a resource type.
 
-The grammar carries zero domain knowledge — domain meaning lives in the service layer. That split is what makes the surface scale: adding `/posts` or `/widgets` is following the rulebook, not redesigning the URL space.
+The grammar carries zero domain knowledge — domain meaning lives in the logic layer. That split is what makes the surface scale: adding `/posts` or `/widgets` is following the rulebook, not redesigning the URL space.
 
 The publication lifecycle (`draft | published | archived`) is **not** universal. Resources opt in when it has real domain meaning. Forcing it on sessions, API keys, audit rows, or webhooks creates ceremony without honest semantics.
 
@@ -48,7 +48,7 @@ PUT  /<resource>/{id}/<axis>         set the axis value
 POST /<resource>/{id}/<event>        event-shaped transition (e.g. /publication, /archival)
 ```
 
-The service layer enforces legal transitions and authorization. A resource may have zero, one, or several state-axis subresources — adopt only those with real domain meaning. Examples:
+The logic layer enforces legal transitions and authorization. A resource may have zero, one, or several state-axis subresources — adopt only those with real domain meaning. Examples:
 
 ```
 PUT /posts/{id}/status                draft | published | archived (publication lifecycle)

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -1,18 +1,19 @@
-# Logic: Processing layer between routes and services
+# Logic: business logic, orchestration, and transaction commit
 
-The `logic/` directory contains **processing functions** that handle the orchestration of business operations, serving as the coordination layer between API routes and services while managing error handling, validation, and data transformation for specific use cases.
+The `logic/` directory contains the layer that owns business logic and the transaction commit. There is no separate services layer: see [`../README.md`](../README.md) — `logic/` sits directly between routes and repositories. Logic modules orchestrate repository calls, raise API exceptions directly, and commit (or roll back) the transaction.
 
-## Core philosophy: Business operation orchestration
+## Core philosophy: business logic owns the commit
 
-Logic modules handle **complex business workflows** that require coordination between multiple services, proper error handling, and data transformation, providing a clean separation between HTTP concerns (routes) and pure business logic (services).
+Logic modules handle **complex business workflows** that need to coordinate repositories, enforce auth and business rules, and commit atomically with a matching audit row. They keep HTTP concerns out (routes own those) and database-statement details out (repositories own those).
 
 ### What we do
 
-- **Operation orchestration**: Coordinate complex workflows involving multiple services
-- **Error translation**: Convert service exceptions into appropriate route-level responses
-- **Data transformation**: Transform route input into service method parameters
-- **Business rule validation**: Apply operation-specific business rules and constraints
-- **Logging and monitoring**: Provide detailed logging for business operations
+- **Operation orchestration**: coordinate workflows that touch one or more repositories
+- **Error raising**: raise the API exception classes from [`src/api/common/exceptions.py`](../api/common/exceptions.py) directly — `NotFoundError`, `ForbiddenError`, `BadRequestError` — and let the `@handle_route_errors` decorator translate them into HTTP responses
+- **Data transformation**: turn route input (validated Pydantic models) into repository calls
+- **Business rule enforcement**: apply operation-specific rules and authorization checks
+- **Transaction control**: own the `session.commit()` for every mutation, paired with an audit row via `record_audit(...)` / `mutate(...)`
+- **Logging and monitoring**: detailed logging at the operation boundary
 
 **Example**: User listing orchestration with error handling:
 
@@ -28,12 +29,11 @@ async def handle_list_users(
 
 ### What we don't do
 
-- **Direct database access**: Database operations stay in repositories/services
-- **HTTP response creation**: Routes handle HTTP-specific response formatting
-- **Business rule enforcement**: Core business rules stay in services
-- **Authentication/authorization**: Auth logic stays in auth layer
+- **Direct database access**: database operations stay in repositories
+- **HTTP response creation**: routes handle HTTP-specific response formatting
+- **Authentication/authorization scaffolding**: the auth layer issues the user; logic handlers enforce per-operation rules using that user
 
-**Example**: Don't put repository or HTTP logic in processing functions:
+**Example**: don't put repository or HTTP logic in processing functions:
 
 ```python
 # Bad - direct database access in logic
@@ -42,9 +42,9 @@ async def handle_list_users(session: AsyncSession, user_id: UUID):
     return users.scalars().all()
 
 # Bad - HTTP response creation in logic
-async def handle_get_entity(slug: str) -> JSONResponse:
-    entity = await service.get_entity(slug)
-    return JSONResponse({"entity": entity})
+async def handle_get_post(post_id: UUID, post_repo: PostRepository) -> JSONResponse:
+    post = await post_repo.get_post_by_id(post_id)
+    return JSONResponse({"post": post})
 
 # Good - orchestration with proper separation
 async def handle_list_users(
@@ -56,17 +56,17 @@ async def handle_list_users(
     return {"users": users_list, "current_user": requesting_user}
 ```
 
-## Architecture: Orchestration layer between routes and services
+## Architecture: routes → logic → repositories
 
-**Routes -> Logic -> Services -> Repositories -> Database**
+**Routes -> Logic -> Repositories -> Database**
 
-Logic functions coordinate business operations without handling HTTP or database concerns.
+There is no separate service layer — see [`../README.md`](../README.md) for the canonical layer matrix. Logic functions coordinate business operations without handling HTTP or database statement details.
 
 ### Transactions: logic owns the commit
 
 `get_db_session` (in [`src/db.py`](../db.py)) yields a session and does **not** auto-commit. Repositories deliberately don't commit either — they `flush()` so the result is visible inside the open transaction, but they leave commit/rollback to the caller (see [`../repositories/README.md`](../repositories/README.md)).
 
-There is no separate service layer — `logic/` owns the transaction commit:
+`logic/` owns the transaction commit:
 
 ```python
 async def handle_set_user_activation(user_id, payload, user_repo, requesting_user):

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -4,13 +4,13 @@ The `repositories/` directory contains the **data access layer** of the applicat
 
 ## Core philosophy: Clean data access abstraction
 
-Repositories provide **focused, domain-specific data access** methods that encapsulate complex SQLAlchemy queries while maintaining transaction boundaries and providing type-safe interfaces for the service layer.
+Repositories provide **focused, domain-specific data access** methods that encapsulate complex SQLAlchemy queries while maintaining transaction boundaries and providing type-safe interfaces for the [`logic/`](../logic/README.md) layer (which owns the commit).
 
 ### What we do
 
 - **Query encapsulation**: Complex SQLAlchemy queries wrapped in meaningful method names
 - **Relationship loading**: Explicit control over eager/lazy loading using `selectinload` and `joinedload`
-- **Transaction management**: Coordinate database operations within service-controlled transactions
+- **Transaction management**: coordinate database operations within logic-controlled transactions (repositories `flush()` but never `commit()` — the calling logic handler owns the commit)
 - **Type safety**: Return proper domain models with full type annotations
 - **Domain-specific methods**: Business-relevant query methods like `list_users()`
 

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -53,7 +53,7 @@ class UserCreateRequest(BaseModel):
 
 ## Architecture: Request/response boundary layer
 
-**API Routes -> Schema Validation -> Service Layer -> Schema Serialization -> Response**
+**API Routes -> Schema Validation -> Logic / Repositories -> Schema Serialization -> Response**
 
 Schemas act as the data contract layer between HTTP and business logic.
 


### PR DESCRIPTION
Closes #215.

## Summary

- **\`src/logic/README.md\`**: rewrite around the actual logic layer. Title, opening paragraph, "what we do / don't do", architecture diagram, and transactions section no longer assert a services layer.
- **\`src/README.md\`**: Schemas dependency row reflects the actual \`Models (enums + registries only)\` dependency that schema files have (verified via \`grep\` on \`src/schemas/\`). Also fixes a stale "Good - delegate to service layer" code example.
- **\`scripts/README.md\`**: \`dev/\` block expresses grammar ("one file per \`dev\` command, plus its colocated \`test_*.py\`") instead of enumerating two of the six actually-present scripts.

## Sweep follow-ons

Per the issue's "scan for orphan service references" instruction, also fixed:

- \`src/repositories/README.md\` — "type-safe interfaces for the service layer" → "for the logic layer (which owns the commit)"; also clarified the transaction-management bullet
- \`src/schemas/README.md\` — flow diagram \`Service Layer\` → \`Logic / Repositories\`
- \`src/api/routes/RESOURCE_GRAMMAR.md\` — two "the service layer" references → "the logic layer"

## Test plan

- [x] \`dev test\` (488 passed, 1 skipped)
- [x] \`dev lint\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)