### PR TITLE
Ignore Claude Code runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Per-developer Claude Code settings (project settings.json is committed)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
## Summary
- Adds `.claude/scheduled_tasks.lock` and `.claude/worktrees/` to `.gitignore` so local Claude Code runtime artifacts stop polluting `git status`.

## Test plan
- [x] `git status` is clean after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)