### PR TITLE
Align dev env template with Settings (#217)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,5 +4,4 @@
 SECRET=test-secret-key-for-local-testing-only
 DATABASE_URL=sqlite+aiosqlite:///./test.db
 ACCESS_TOKEN_EXPIRE_MINUTES=60
-ALGORITHM=HS256
 ENVIRONMENT=development

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,6 @@ services:
       - SECRET=${SECRET}
       - DATABASE_URL=${DATABASE_URL:-sqlite+aiosqlite:///./data/bedlam-connect.db}
       - ACCESS_TOKEN_EXPIRE_MINUTES=${ACCESS_TOKEN_EXPIRE_MINUTES:-60}
-      - ALGORITHM=${ALGORITHM:-HS256}
       - ENVIRONMENT=development # Enable template auto-reload
     volumes:
       - ./data:/app/data

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -20,12 +20,12 @@ ENV_TEMPLATE = """# Development environment variables
 DATABASE_URL=sqlite+aiosqlite:///./data/app.db
 
 # Application
-DEBUG=true
 # 32+ bytes required so JWT HMAC keys meet the SHA256 minimum
 SECRET=dev-only-do-not-use-in-prod-aaaaaaaa
+ACCESS_TOKEN_EXPIRE_MINUTES=60
 
-# Development
-DEVELOPMENT=true
+# Development — enables template auto-reload
+ENVIRONMENT=development
 """
 
 


### PR DESCRIPTION
## Summary
- Drop `DEBUG` and `DEVELOPMENT` from the `dev setup` env template — neither field exists on `Settings`.
- Add `ENVIRONMENT=development` and `ACCESS_TOKEN_EXPIRE_MINUTES=60` so the template matches `Settings`'s declared fields exactly.
- Drop unused `ALGORITHM` from `.env.test` and `docker-compose.dev.yml`.

Closes #217.

## Test plan
- [x] `dev lint` passes.
- [x] `dev test` passes (488 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)