### PR TITLE
Pin isort and black in lint extra (#218)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,10 @@ repos:
         language_version: python3.11
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    # Keep in sync with the isort version installed via pyproject.toml so
+    # pre-commit and `dev lint`/CI agree on import ordering. Same hazard
+    # as black above (PR #73 flap).
+    rev: 6.0.1
     hooks:
       - id: isort
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ test = [
 
 # Code quality and formatting
 lint = [
-    "black",
-    "isort",
+    "black==26.3.1",
+    "isort==6.0.1",
     "autoflake",
     "pre-commit",
     "pathspec",


### PR DESCRIPTION
## Summary
- Pin `isort` to `6.0.1` in both `.pre-commit-config.yaml` and `pyproject.toml`'s `lint` extra so pre-commit and `dev lint`/CI agree on import ordering.
- Pin `black==26.3.1` in `pyproject.toml`'s `lint` extra so the existing pre-commit sync comment is actually enforced (pre-commit pinned, pyproject didn't).
- Mirrors the pattern that closed the PR #73 black flap.

`autoflake` is also unpinned (pre-commit pins `v2.0.1`, pyproject doesn't pin at all). Out of scope here — flagged for a follow-on issue if desired.

Closes #218.

## Test plan
- [x] `pre-commit clean && pre-commit run isort --all-files` passes with the bumped version.
- [x] `dev lint` passes.
- [x] `dev test` passes (488 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)