### PR TITLE
Promote src/models/user.py to users/ cluster (#222)

### DIFF
--- a/src/models/README.md
+++ b/src/models/README.md
@@ -92,7 +92,6 @@ Models follow the [cluster pattern](../README.md#domain-entities-and-the-cluster
   - `base.py` — `BaseModel` with common fields (id, timestamps, soft deletion). Every model inherits from it.
   - `enums.py` — Controlled-vocabulary tuples + `*_LABELS` dicts + a `check_in_tuple_sql` helper that renders DB-level `CHECK` fragments from a tuple. The single source of truth that schemas (`Literal[*TUPLE]`), form macros (Jinja globals), and DB constraints all derive from. Lives at the parent level because 2+ clusters depend on it — and is a *leaf* (no internal imports), so any cluster can import from it without cycling back through cluster code.
   - `audit_log.py` — Append-only mutation record. See [`api/routes/RESOURCE_GRAMMAR.md`](../api/routes/RESOURCE_GRAMMAR.md).
-  - `user.py` — User authentication and profile (extends FastAPI Users). Lives at the parent today because it predates clustering and has no internal complexity that would justify a `users/` cluster yet; this is the same exception path that any single-file entity follows until the cluster pulls its weight.
   - `__init__.py` — Re-exports model classes and constants. External code should always import from `src.models` (e.g. `from src.models import Post, REGISTERED_KINDS`); the `__init__.py` keeps that surface stable across cluster moves.
 
 A model in cluster A does not import from cluster B; if two clusters need a shared primitive, hoist it to the parent level (the path `enums.py` took).

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -20,7 +20,7 @@ from .providers.provider import Provider
 from .providers.provider_certification import ProviderCertification
 from .providers.provider_education import ProviderEducation
 from .providers.provider_licensure import ProviderLicensure
-from .user import User
+from .users.user import User
 
 __all__ = [
     "AuditLog",

--- a/src/models/users/user.py
+++ b/src/models/users/user.py
@@ -3,7 +3,7 @@ import uuid
 from fastapi_users.db import SQLAlchemyBaseUserTable
 from sqlalchemy import Column, Text
 
-from .base import BaseModel
+from ..base import BaseModel
 
 
 class User(SQLAlchemyBaseUserTable[uuid.UUID], BaseModel):


### PR DESCRIPTION
## Summary
- Close the asymmetry where users had cluster presence at every layer except `models/`. Move `src/models/user.py` → `src/models/users/user.py` with an empty `__init__.py`, matching `models/posts/` and `models/providers/`.
- The `from src.models import User` re-export keeps every caller transparent — no importer rewrites.
- Drop the now-stale exception note from `src/models/README.md`.

Closes #222.

Based on `fix-221-flatten-audit-repo` so this stacks on top of #236.

## Test plan
- [x] `dev test` passes (488 passed, 1 skipped — same as before).
- [x] `dev lint` passes, including the cluster-imports check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)