### PR TITLE
Move provider TypeAdapters from routes to schemas (#224)

### DIFF
--- a/src/api/routes/auth_routes.py
+++ b/src/api/routes/auth_routes.py
@@ -8,7 +8,7 @@ from fastapi_users.router.common import ErrorCode, ErrorModel
 from src.api.common import BaseRouter
 from src.auth_config import get_user_manager
 from src.logic.auth.auth_processing import handle_registration
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository
 from src.schemas.users.user import UserCreate, UserRead
 

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -22,7 +22,7 @@ from src.logic.posts.post_processing import (
     handle_update_post,
 )
 from src.models import KIND_NAMES, REGISTERED_KINDS, User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository, get_post_repository
 from src.repositories.posts.post_repository import PostRepository
 from src.schemas.posts.post import post_create_adapter, post_update_adapter

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -3,7 +3,6 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Request, Response, status
 from fastapi.responses import JSONResponse
-from pydantic import TypeAdapter
 
 from src.api.common import (
     APIResponse,
@@ -35,37 +34,23 @@ from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository, get_provider_repository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.schemas.providers.provider import (
-    ProviderCertificationCreate,
     ProviderCertificationRead,
-    ProviderCertificationUpdate,
-    ProviderCreate,
-    ProviderEducationCreate,
     ProviderEducationRead,
-    ProviderEducationUpdate,
-    ProviderLicensureCreate,
     ProviderLicensureRead,
-    ProviderLicensureUpdate,
     ProviderRead,
-    ProviderUpdate,
+    certification_create_adapter,
+    certification_update_adapter,
+    education_create_adapter,
+    education_update_adapter,
+    licensure_create_adapter,
+    licensure_update_adapter,
+    provider_create_adapter,
+    provider_update_adapter,
 )
 
 providers_api_router = APIRouter(prefix="/providers")
 router = BaseRouter(router=providers_api_router, default_tags=["providers"])
 logger = logging.getLogger(__name__)
-
-
-# Module-level TypeAdapters mirror the `post_create_adapter` / `post_update_adapter`
-# pattern in `src/schemas/post.py` — pre-built adapters keep validation in one place
-# per schema. Defined here (not in the schema module) because the provider schemas
-# don't currently expose discriminated unions that would need an adapter anywhere else.
-_provider_create_adapter: TypeAdapter = TypeAdapter(ProviderCreate)
-_provider_update_adapter: TypeAdapter = TypeAdapter(ProviderUpdate)
-_licensure_create_adapter: TypeAdapter = TypeAdapter(ProviderLicensureCreate)
-_licensure_update_adapter: TypeAdapter = TypeAdapter(ProviderLicensureUpdate)
-_education_create_adapter: TypeAdapter = TypeAdapter(ProviderEducationCreate)
-_education_update_adapter: TypeAdapter = TypeAdapter(ProviderEducationUpdate)
-_certification_create_adapter: TypeAdapter = TypeAdapter(ProviderCertificationCreate)
-_certification_update_adapter: TypeAdapter = TypeAdapter(ProviderCertificationUpdate)
 
 
 def _provider_read_dict(profile) -> dict:
@@ -120,7 +105,7 @@ async def create_provider(
     """Creates a provider owned by the requesting user. Form-encoded
     body. A user may own multiple profiles."""
     payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(_provider_create_adapter, payload_dict)
+    payload = validate_or_422(provider_create_adapter, payload_dict)
     created = await handle_create_provider(
         payload=payload,
         repo=repo,
@@ -212,7 +197,7 @@ async def patch_profile(
     """Partially updates the practice/availability fields. Owner-only; admins
     may edit any profile. Sub-entity lists are managed via their own routes."""
     payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(_provider_update_adapter, payload_dict)
+    payload = validate_or_422(provider_update_adapter, payload_dict)
     updated = await handle_update_provider(
         provider_id=provider_id,
         payload=payload,
@@ -260,7 +245,7 @@ async def create_licensure(
     user: User = Depends(current_active_user),
 ):
     payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(_licensure_create_adapter, payload_dict)
+    payload = validate_or_422(licensure_create_adapter, payload_dict)
     created = await handle_create_licensure(
         provider_id=provider_id,
         payload=payload,
@@ -287,7 +272,7 @@ async def patch_licensure(
     user: User = Depends(current_active_user),
 ):
     payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(_licensure_update_adapter, payload_dict)
+    payload = validate_or_422(licensure_update_adapter, payload_dict)
     updated = await handle_update_licensure(
         provider_id=provider_id,
         licensure_id=licensure_id,
@@ -339,7 +324,7 @@ async def create_education(
     user: User = Depends(current_active_user),
 ):
     payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(_education_create_adapter, payload_dict)
+    payload = validate_or_422(education_create_adapter, payload_dict)
     created = await handle_create_education(
         provider_id=provider_id,
         payload=payload,
@@ -366,7 +351,7 @@ async def patch_education(
     user: User = Depends(current_active_user),
 ):
     payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(_education_update_adapter, payload_dict)
+    payload = validate_or_422(education_update_adapter, payload_dict)
     updated = await handle_update_education(
         provider_id=provider_id,
         education_id=education_id,
@@ -418,7 +403,7 @@ async def create_certification(
     user: User = Depends(current_active_user),
 ):
     payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(_certification_create_adapter, payload_dict)
+    payload = validate_or_422(certification_create_adapter, payload_dict)
     created = await handle_create_certification(
         provider_id=provider_id,
         payload=payload,
@@ -445,7 +430,7 @@ async def patch_certification(
     user: User = Depends(current_active_user),
 ):
     payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(_certification_update_adapter, payload_dict)
+    payload = validate_or_422(certification_update_adapter, payload_dict)
     updated = await handle_update_certification(
         provider_id=provider_id,
         certification_id=certification_id,

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -31,7 +31,7 @@ from src.logic.providers.provider_processing import (
     handle_update_provider,
 )
 from src.models import User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository, get_provider_repository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.schemas.providers.provider import (

--- a/src/api/routes/test_auth_routes.py
+++ b/src/api/routes/test_auth_routes.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import AuditLog, User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 
 # Mark all tests in this module as async
 pytestmark = pytest.mark.asyncio

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -13,7 +13,7 @@ from src.models import (
     ProviderAvailabilityDetail,
     User,
 )
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from tests.helpers import (
     client_referral_payload,
     create_test_user,

--- a/src/api/routes/test_providers.py
+++ b/src/api/routes/test_providers.py
@@ -13,7 +13,7 @@ from src.models import (
     ProviderLicensure,
     User,
 )
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from tests.helpers import (
     certification_payload,
     create_test_user,

--- a/src/api/routes/test_users.py
+++ b/src/api/routes/test_users.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import AuditLog, User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from tests.helpers import create_test_user, make_provider, promote_to_admin
 
 # Mark all tests in this module as async

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -14,7 +14,7 @@ from src.logic.users.user_processing import (
     handle_set_user_activation,
 )
 from src.models import User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import (
     get_audit_repository,
     get_provider_repository,

--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -38,7 +38,7 @@ from typing import Any, Callable, Literal
 from uuid import UUID
 
 from src.models import AuditLog, User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 
 logger = logging.getLogger(__name__)
 

--- a/src/logic/auth/auth_processing.py
+++ b/src/logic/auth/auth_processing.py
@@ -7,7 +7,7 @@ from fastapi_users.manager import BaseUserManager, UserManagerDependency
 
 from src.auth_config import get_user_manager
 from src.logic.audit import AuditAction, record_audit
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository
 from src.schemas.users.user import UserAuditSnapshot, UserCreate, UserRead
 

--- a/src/logic/posts/post_processing.py
+++ b/src/logic/posts/post_processing.py
@@ -6,7 +6,7 @@ from fastapi import Request
 from src.api.common.exceptions import BadRequestError, ForbiddenError, NotFoundError
 from src.logic.audit import AuditAction, AuditedResource, mutate
 from src.models import REGISTERED_KINDS, Post, User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.posts.post_repository import PostRepository
 from src.schemas.posts.post import (
     ClientReferralCreate,

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -31,7 +31,7 @@ from src.models import (
     ProviderLicensure,
     User,
 )
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.repositories.users.user_repository import UserRepository
 from src.schemas.providers.provider import (

--- a/src/logic/providers/test_provider_processing.py
+++ b/src/logic/providers/test_provider_processing.py
@@ -40,7 +40,7 @@ from src.models import (
     ProviderLicensure,
     User,
 )
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.repositories.users.user_repository import UserRepository
 from src.schemas.providers.provider import (

--- a/src/logic/test_audit.py
+++ b/src/logic/test_audit.py
@@ -10,7 +10,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.logic.audit import AuditAction, AuditedResource, mutate, record_audit
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.posts.post_repository import PostRepository
 from tests.helpers import create_test_user
 

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -6,7 +6,7 @@ from fastapi import Request
 from src.api.common.exceptions import ForbiddenError, NotFoundError
 from src.logic.audit import AuditAction, record_audit
 from src.models import User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.repositories.users.user_repository import UserRepository
 from src.schemas.users.user import (

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -92,7 +92,6 @@ Models follow the [cluster pattern](../README.md#domain-entities-and-the-cluster
   - `base.py` — `BaseModel` with common fields (id, timestamps, soft deletion). Every model inherits from it.
   - `enums.py` — Controlled-vocabulary tuples + `*_LABELS` dicts + a `check_in_tuple_sql` helper that renders DB-level `CHECK` fragments from a tuple. The single source of truth that schemas (`Literal[*TUPLE]`), form macros (Jinja globals), and DB constraints all derive from. Lives at the parent level because 2+ clusters depend on it — and is a *leaf* (no internal imports), so any cluster can import from it without cycling back through cluster code.
   - `audit_log.py` — Append-only mutation record. See [`api/routes/RESOURCE_GRAMMAR.md`](../api/routes/RESOURCE_GRAMMAR.md).
-  - `user.py` — User authentication and profile (extends FastAPI Users). Lives at the parent today because it predates clustering and has no internal complexity that would justify a `users/` cluster yet; this is the same exception path that any single-file entity follows until the cluster pulls its weight.
   - `__init__.py` — Re-exports model classes and constants. External code should always import from `src.models` (e.g. `from src.models import Post, REGISTERED_KINDS`); the `__init__.py` keeps that surface stable across cluster moves.
 
 A model in cluster A does not import from cluster B; if two clusters need a shared primitive, hoist it to the parent level (the path `enums.py` took).

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -20,7 +20,7 @@ from .providers.provider import Provider
 from .providers.provider_certification import ProviderCertification
 from .providers.provider_education import ProviderEducation
 from .providers.provider_licensure import ProviderLicensure
-from .user import User
+from .users.user import User
 
 __all__ = [
     "AuditLog",

--- a/src/models/users/user.py
+++ b/src/models/users/user.py
@@ -3,7 +3,7 @@ import uuid
 from fastapi_users.db import SQLAlchemyBaseUserTable
 from sqlalchemy import Column, Text
 
-from .base import BaseModel
+from ..base import BaseModel
 
 
 class User(SQLAlchemyBaseUserTable[uuid.UUID], BaseModel):

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -65,6 +65,7 @@ Repositories follow the [cluster pattern](../README.md#domain-entities-and-the-c
 - Parent-level shared tier:
   - `base.py` — `BaseRepository` generic with common session management. Every repository inherits from it.
   - `dependencies.py` — FastAPI `Depends()` providers that wire each repository to the request-scoped session. Adding a new repository means appending one provider here.
+  - `audit_repository.py` (+ its `test_audit_repository.py`) — append-only audit log, cross-cutting infrastructure consumed by every entity's logic handlers. Lives flat at the layer's shared tier (matching `src/logic/audit.py` and `src/models/audit_log.py`) rather than in a cluster, because audit isn't a domain entity in its own right.
 
 A repository does not import from a peer cluster's repository; if logic needs to coordinate two entities, that orchestration belongs in the [logic layer](../logic/README.md), not in repositories.
 

--- a/src/repositories/audit_repository.py
+++ b/src/repositories/audit_repository.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import AuditLog
 
-from ..base import BaseRepository
+from .base import BaseRepository
 
 
 class AuditRepository(BaseRepository):

--- a/src/repositories/dependencies.py
+++ b/src/repositories/dependencies.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.db import get_db_session
 
-from .audit.audit_repository import AuditRepository
+from .audit_repository import AuditRepository
 from .posts.post_repository import PostRepository
 from .providers.provider_repository import ProviderRepository
 from .users.user_repository import UserRepository

--- a/src/repositories/test_audit_repository.py
+++ b/src/repositories/test_audit_repository.py
@@ -12,7 +12,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.models import User
-from src.repositories.audit.audit_repository import AuditRepository
+from src.repositories.audit_repository import AuditRepository
 from tests.helpers import create_test_user
 
 pytestmark = pytest.mark.asyncio

--- a/src/schemas/providers/provider.py
+++ b/src/schemas/providers/provider.py
@@ -30,7 +30,7 @@ import uuid
 from datetime import date, datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, TypeAdapter, model_validator
 
 from src.models.enums import (
     CERTIFICATION_TYPES,
@@ -66,6 +66,9 @@ class ProviderLicensureCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+licensure_create_adapter: TypeAdapter = TypeAdapter(ProviderLicensureCreate)
+
+
 class ProviderLicensureUpdate(BaseModel):
     license_type: Literal[*LICENSE_TYPES] | None = None
     license_number: StrippedText | None = None
@@ -78,6 +81,9 @@ class ProviderLicensureUpdate(BaseModel):
     def _at_least_one_field(self) -> "ProviderLicensureUpdate":
         assert_any_field_set(self)
         return self
+
+
+licensure_update_adapter: TypeAdapter = TypeAdapter(ProviderLicensureUpdate)
 
 
 class ProviderLicensureAuditSnapshot(BaseModel):
@@ -119,6 +125,9 @@ class ProviderEducationCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+education_create_adapter: TypeAdapter = TypeAdapter(ProviderEducationCreate)
+
+
 class ProviderEducationUpdate(BaseModel):
     education_type: Literal[*EDUCATION_TYPES] | None = None
     institution: StrippedText | None = None
@@ -130,6 +139,9 @@ class ProviderEducationUpdate(BaseModel):
     def _at_least_one_field(self) -> "ProviderEducationUpdate":
         assert_any_field_set(self)
         return self
+
+
+education_update_adapter: TypeAdapter = TypeAdapter(ProviderEducationUpdate)
 
 
 class ProviderEducationAuditSnapshot(BaseModel):
@@ -167,6 +179,9 @@ class ProviderCertificationCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+certification_create_adapter: TypeAdapter = TypeAdapter(ProviderCertificationCreate)
+
+
 class ProviderCertificationUpdate(BaseModel):
     certification_type: Literal[*CERTIFICATION_TYPES] | None = None
     certifying_body: StrippedText | None = None
@@ -178,6 +193,9 @@ class ProviderCertificationUpdate(BaseModel):
     def _at_least_one_field(self) -> "ProviderCertificationUpdate":
         assert_any_field_set(self)
         return self
+
+
+certification_update_adapter: TypeAdapter = TypeAdapter(ProviderCertificationUpdate)
 
 
 class ProviderCertificationAuditSnapshot(BaseModel):
@@ -231,6 +249,9 @@ class ProviderCreate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+provider_create_adapter: TypeAdapter = TypeAdapter(ProviderCreate)
+
+
 class ProviderUpdate(BaseModel):
     """Partial update of practice/availability fields only. Sub-entity
     lists (licensures, educations, certifications) are managed via
@@ -249,6 +270,9 @@ class ProviderUpdate(BaseModel):
     def _at_least_one_field(self) -> "ProviderUpdate":
         assert_any_field_set(self)
         return self
+
+
+provider_update_adapter: TypeAdapter = TypeAdapter(ProviderUpdate)
 
 
 class ProviderAuditSnapshot(BaseModel):


### PR DESCRIPTION
## Summary
- Move the eight provider `TypeAdapter` declarations out of `src/api/routes/providers.py` and place each next to its schema class in `src/schemas/providers/provider.py`, matching the `post_create_adapter` / `post_update_adapter` pattern.
- Drop the leading-underscore prefix (they're now public cluster exports, not private to `providers.py`).
- Drop the apology comment about why they lived in the route module.

Closes #224. Stacked on `fix-221-flatten-audit-repo` (which contains #221 + #222).

## Test plan
- [x] `dev test` passes (488 passed, 1 skipped).
- [x] `dev lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)