### PR TITLE
Extract assert_owner_or_admin to logic shared tier (#225)

### DIFF
--- a/src/logic/_authz.py
+++ b/src/logic/_authz.py
@@ -1,0 +1,27 @@
+"""Authorization helpers shared across logic-layer handlers.
+
+The leading-underscore filename matches `src/schemas/_validators.py` —
+shared infra at the layer's parent level, importable from every cluster.
+"""
+
+from src.api.common.exceptions import ForbiddenError
+from src.models import User
+
+
+def assert_owner_or_admin(
+    obj,
+    user: User,
+    *,
+    owner_attr: str = "owner_id",
+    action: str = "edit this resource",
+) -> None:
+    """Raise `ForbiddenError` unless `user` owns `obj` or is a superuser.
+
+    `owner_attr` names the foreign-key column on `obj` that points at the
+    owning user (`Post.owner_id` vs `Provider.user_id`). `action` is
+    interpolated into the error message: ``"Only the owner or an admin
+    can {action}"``.
+    """
+    owner_id = getattr(obj, owner_attr)
+    if owner_id != user.id and not user.is_superuser:
+        raise ForbiddenError(detail=f"Only the owner or an admin can {action}")

--- a/src/logic/posts/post_processing.py
+++ b/src/logic/posts/post_processing.py
@@ -3,7 +3,8 @@ from uuid import UUID
 
 from fastapi import Request
 
-from src.api.common.exceptions import BadRequestError, ForbiddenError, NotFoundError
+from src.api.common.exceptions import BadRequestError, NotFoundError
+from src.logic._authz import assert_owner_or_admin
 from src.logic.audit import AuditAction, AuditedResource, mutate
 from src.models import REGISTERED_KINDS, Post, User
 from src.repositories.audit_repository import AuditRepository
@@ -84,8 +85,7 @@ async def handle_get_post_edit_form(
     if post is None:
         raise NotFoundError(detail="Post not found")
 
-    if post.owner_id != requesting_user.id and not requesting_user.is_superuser:
-        raise ForbiddenError(detail="Only the owner or an admin can edit this post")
+    assert_owner_or_admin(post, requesting_user, action="edit this post")
 
     return {"request": request, "post": post, "current_user": requesting_user}
 
@@ -141,8 +141,7 @@ async def handle_update_post(
     if post is None:
         raise NotFoundError(detail="Post not found")
 
-    if post.owner_id != requesting_user.id and not requesting_user.is_superuser:
-        raise ForbiddenError(detail="Only the owner or an admin can edit this post")
+    assert_owner_or_admin(post, requesting_user, action="edit this post")
 
     if payload.kind != post.kind:
         raise BadRequestError(
@@ -185,8 +184,7 @@ async def handle_delete_post(
     if post is None:
         raise NotFoundError(detail="Post not found")
 
-    if post.owner_id != requesting_user.id and not requesting_user.is_superuser:
-        raise ForbiddenError(detail="Only the owner or an admin can delete this post")
+    assert_owner_or_admin(post, requesting_user, action="delete this post")
 
     async with mutate(
         post_repo,

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -23,6 +23,7 @@ from fastapi import Request
 from pydantic import BaseModel
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
+from src.logic._authz import assert_owner_or_admin
 from src.logic.audit import AuditAction, AuditedResource, mutate
 from src.models import (
     Provider,
@@ -93,16 +94,6 @@ CERTIFICATION = AuditedResource(
     update=AuditAction.UPDATE_CERTIFICATION,
     delete=AuditAction.DELETE_CERTIFICATION,
 )
-
-
-# --- Authorization helper ------------------------------------------------
-
-
-def _assert_can_mutate(profile: Provider, user: User) -> None:
-    if profile.user_id != user.id and not user.is_superuser:
-        raise ForbiddenError(
-            detail="Only the profile owner or an admin can perform this action"
-        )
 
 
 async def _load_provider_or_404(
@@ -209,14 +200,16 @@ async def handle_get_provider_edit_form(
     requesting_user: User,
 ) -> dict[str, Any]:
     """Loads a profile for the edit-form page. 404 if missing, 403 if the
-    requester is neither owner nor admin (mirrors `_assert_can_mutate`).
+    requester is neither owner nor admin (mirrors `assert_owner_or_admin`).
 
     The repo's `get_by_id` eager-loads `licensures`, `educations`, and
     `certifications` via `lazy="selectin"`, so the template can render
     each sub-section without further queries.
     """
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
     return {"request": request, "profile": profile, "current_user": requesting_user}
 
 
@@ -266,7 +259,9 @@ async def handle_update_provider(
 ) -> Provider:
     """Patches practice/availability fields on the profile. Owner-or-admin only."""
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     async with mutate(
         repo,
@@ -294,7 +289,9 @@ async def handle_delete_provider(
     durable record.
     """
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     async with mutate(
         repo,
@@ -318,7 +315,9 @@ async def handle_create_licensure(
     requesting_user: User,
 ) -> ProviderLicensure:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     created = await repo.add_licensure(profile, **payload.model_dump())
     async with mutate(
@@ -342,7 +341,9 @@ async def handle_update_licensure(
     requesting_user: User,
 ) -> ProviderLicensure:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     licensure = await _load_subrow_or_404(
         repo.get_licensure_by_id, licensure_id, profile.id, name="Licensure"
@@ -367,7 +368,9 @@ async def handle_delete_licensure(
     requesting_user: User,
 ) -> None:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     licensure = await _load_subrow_or_404(
         repo.get_licensure_by_id, licensure_id, profile.id, name="Licensure"
@@ -394,7 +397,9 @@ async def handle_create_education(
     requesting_user: User,
 ) -> ProviderEducation:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     created = await repo.add_education(profile, **payload.model_dump())
     async with mutate(
@@ -418,7 +423,9 @@ async def handle_update_education(
     requesting_user: User,
 ) -> ProviderEducation:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     education = await _load_subrow_or_404(
         repo.get_education_by_id, education_id, profile.id, name="Education entry"
@@ -443,7 +450,9 @@ async def handle_delete_education(
     requesting_user: User,
 ) -> None:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     education = await _load_subrow_or_404(
         repo.get_education_by_id, education_id, profile.id, name="Education entry"
@@ -470,7 +479,9 @@ async def handle_create_certification(
     requesting_user: User,
 ) -> ProviderCertification:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     created = await repo.add_certification(profile, **payload.model_dump())
     async with mutate(
@@ -494,7 +505,9 @@ async def handle_update_certification(
     requesting_user: User,
 ) -> ProviderCertification:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     certification = await _load_subrow_or_404(
         repo.get_certification_by_id,
@@ -524,7 +537,9 @@ async def handle_delete_certification(
     requesting_user: User,
 ) -> None:
     profile = await _load_provider_or_404(provider_id, repo)
-    _assert_can_mutate(profile, requesting_user)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
 
     certification = await _load_subrow_or_404(
         repo.get_certification_by_id,

--- a/src/logic/test__authz.py
+++ b/src/logic/test__authz.py
@@ -1,0 +1,49 @@
+"""Tests for `src/logic/_authz.py`."""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.common.exceptions import ForbiddenError
+from src.logic._authz import assert_owner_or_admin
+
+
+def _user(*, is_superuser: bool = False, id_=None):
+    return SimpleNamespace(id=id_ or uuid.uuid4(), is_superuser=is_superuser)
+
+
+def test_owner_passes():
+    u = _user()
+    obj = SimpleNamespace(owner_id=u.id)
+    assert_owner_or_admin(obj, u)
+
+
+def test_superuser_passes_even_if_not_owner():
+    u = _user(is_superuser=True)
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert_owner_or_admin(obj, u)
+
+
+def test_non_owner_non_admin_raises():
+    u = _user()
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    with pytest.raises(ForbiddenError) as excinfo:
+        assert_owner_or_admin(obj, u, action="edit this resource")
+    assert "Only the owner or an admin can edit this resource" in str(
+        excinfo.value.detail
+    )
+
+
+def test_custom_owner_attr():
+    u = _user()
+    obj = SimpleNamespace(user_id=u.id)
+    assert_owner_or_admin(obj, u, owner_attr="user_id")
+
+
+def test_custom_action_in_message():
+    u = _user()
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    with pytest.raises(ForbiddenError) as excinfo:
+        assert_owner_or_admin(obj, u, action="delete this widget")
+    assert "delete this widget" in str(excinfo.value.detail)


### PR DESCRIPTION
## Summary
- New `src/logic/_authz.py` with `assert_owner_or_admin(obj, user, owner_attr=..., action=...)`. One shape with tunable knobs replaces three inline copies in `post_processing.py` and a cluster-local `_assert_can_mutate` helper in `provider_processing.py`.
- Standardizes the error message across the codebase to "Only the owner or an admin can {action}".
- Adds colocated `src/logic/test__authz.py` covering owner pass, superuser bypass, custom `owner_attr`, custom `action`, and the raise path.

The "self-or-admin" shape (`provider_processing.py:171`) remains inline — it appears once, not twice as the issue described, so the second helper proposed there isn't justified yet.

Closes #225.

## Test plan
- [x] `dev test` passes (493 passed — 5 new from `test__authz.py`).
- [x] `dev lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)