### PR TITLE
Hoist make_snapshotter into src/logic/audit.py (#226)

### DIFF
--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -37,10 +37,30 @@ from enum import Enum
 from typing import Any, Callable, Literal
 from uuid import UUID
 
+from pydantic import BaseModel
+
 from src.models import AuditLog, User
 from src.repositories.audit_repository import AuditRepository
 
 logger = logging.getLogger(__name__)
+
+
+def make_snapshotter(
+    schema_cls: type[BaseModel],
+) -> Callable[[Any], dict[str, Any]]:
+    """Build a snapshotter that validates an ORM row through `schema_cls`
+    and returns a JSON-mode dict.
+
+    Used by `AuditedResource.snapshot` and by handlers calling
+    `record_audit(before=..., after=...)` directly. Centralizes the
+    `SchemaCls.model_validate(obj).model_dump(mode="json")` chain so
+    audit-row snapshots have one shape across the codebase.
+    """
+
+    def _snapshot(obj: Any) -> dict[str, Any]:
+        return schema_cls.model_validate(obj).model_dump(mode="json")
+
+    return _snapshot
 
 
 class AuditAction(str, Enum):

--- a/src/logic/auth/auth_processing.py
+++ b/src/logic/auth/auth_processing.py
@@ -6,7 +6,7 @@ from fastapi_users import models
 from fastapi_users.manager import BaseUserManager, UserManagerDependency
 
 from src.auth_config import get_user_manager
-from src.logic.audit import AuditAction, record_audit
+from src.logic.audit import AuditAction, make_snapshotter, record_audit
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository
 from src.schemas.users.user import UserAuditSnapshot, UserCreate, UserRead
@@ -14,6 +14,8 @@ from src.schemas.users.user import UserAuditSnapshot, UserCreate, UserRead
 logger = logging.getLogger(__name__)
 
 AppUserManager = UserManagerDependency[models.UP, models.ID]
+
+_snapshot_user = make_snapshotter(UserAuditSnapshot)
 
 
 async def handle_registration(
@@ -41,7 +43,7 @@ async def handle_registration(
         resource_id=created_user.id,
         action=AuditAction.REGISTER,
         before=None,
-        after=UserAuditSnapshot.model_validate(created_user).model_dump(mode="json"),
+        after=_snapshot_user(created_user),
     )
     await audit_repo.session.commit()
     return created_user

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -20,11 +20,10 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import Request
-from pydantic import BaseModel
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
 from src.logic._authz import assert_owner_or_admin
-from src.logic.audit import AuditAction, AuditedResource, mutate
+from src.logic.audit import AuditAction, AuditedResource, make_snapshotter, mutate
 from src.models import (
     Provider,
     ProviderCertification,
@@ -56,40 +55,30 @@ logger = logging.getLogger(__name__)
 # --- Audited-resource declarations ---------------------------------------
 
 
-def _snap(schema_cls: type[BaseModel]):
-    """Build a snapshotter that validates an ORM row through the given
-    `*AuditSnapshot` schema and returns a JSON-mode dump."""
-
-    def _snapshot(obj: Any) -> dict[str, Any]:
-        return schema_cls.model_validate(obj).model_dump(mode="json")
-
-    return _snapshot
-
-
 PROFILE = AuditedResource(
     type="provider_profile",
-    snapshot=_snap(ProviderAuditSnapshot),
+    snapshot=make_snapshotter(ProviderAuditSnapshot),
     create=AuditAction.CREATE_PROVIDER,
     update=AuditAction.UPDATE_PROVIDER,
     delete=AuditAction.DELETE_PROVIDER,
 )
 LICENSURE = AuditedResource(
     type="provider_licensure",
-    snapshot=_snap(ProviderLicensureAuditSnapshot),
+    snapshot=make_snapshotter(ProviderLicensureAuditSnapshot),
     create=AuditAction.CREATE_LICENSURE,
     update=AuditAction.UPDATE_LICENSURE,
     delete=AuditAction.DELETE_LICENSURE,
 )
 EDUCATION = AuditedResource(
     type="provider_education",
-    snapshot=_snap(ProviderEducationAuditSnapshot),
+    snapshot=make_snapshotter(ProviderEducationAuditSnapshot),
     create=AuditAction.CREATE_EDUCATION,
     update=AuditAction.UPDATE_EDUCATION,
     delete=AuditAction.DELETE_EDUCATION,
 )
 CERTIFICATION = AuditedResource(
     type="provider_certification",
-    snapshot=_snap(ProviderCertificationAuditSnapshot),
+    snapshot=make_snapshotter(ProviderCertificationAuditSnapshot),
     create=AuditAction.CREATE_CERTIFICATION,
     update=AuditAction.UPDATE_CERTIFICATION,
     delete=AuditAction.DELETE_CERTIFICATION,

--- a/src/logic/test_audit.py
+++ b/src/logic/test_audit.py
@@ -5,16 +5,52 @@ contract is the kwargs they pass, not the internals of the repo.
 """
 
 import uuid
+from datetime import datetime
 
 import pytest
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.logic.audit import AuditAction, AuditedResource, mutate, record_audit
+from src.logic.audit import (
+    AuditAction,
+    AuditedResource,
+    make_snapshotter,
+    mutate,
+    record_audit,
+)
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.posts.post_repository import PostRepository
 from tests.helpers import create_test_user
 
 pytestmark = pytest.mark.asyncio
+
+
+class _ExampleSnapshot(BaseModel):
+    id: uuid.UUID
+    name: str
+    when: datetime
+
+    model_config = {"from_attributes": True}
+
+
+def test_make_snapshotter_returns_json_mode_dict():
+    """The snapshotter validates an ORM-shaped object and returns a dict
+    whose datetime/uuid values are serialized as strings (JSON mode)."""
+
+    class _Row:
+        def __init__(self):
+            self.id = uuid.uuid4()
+            self.name = "foo"
+            self.when = datetime(2026, 1, 1, 12, 0, 0)
+
+    row = _Row()
+    snap = make_snapshotter(_ExampleSnapshot)(row)
+
+    assert snap == {
+        "id": str(row.id),
+        "name": "foo",
+        "when": "2026-01-01T12:00:00",
+    }
 
 
 async def test_record_audit_round_trips_through_repo(

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
-from src.logic.audit import AuditAction, record_audit
+from src.logic.audit import AuditAction, make_snapshotter, record_audit
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
@@ -17,21 +17,8 @@ from src.schemas.users.user import (
 
 logger = logging.getLogger(__name__)
 
-
-def _snapshot_user_activation(user: User) -> dict:
-    """Capture just the activation axis for audit before/after.
-
-    Field set is defined by `UserActivationAuditSnapshot`.
-    """
-    return UserActivationAuditSnapshot.model_validate(user).model_dump(mode="json")
-
-
-def _snapshot_user(user: User) -> dict:
-    """Capture user-meaningful fields for `delete_user` audit `before`.
-
-    Field set is defined by `UserAuditSnapshot`.
-    """
-    return UserAuditSnapshot.model_validate(user).model_dump(mode="json")
+_snapshot_user_activation = make_snapshotter(UserActivationAuditSnapshot)
+_snapshot_user = make_snapshotter(UserAuditSnapshot)
 
 
 async def handle_list_users(


### PR DESCRIPTION
## Summary
- Promote the cluster-local `_snap` factory in `provider_processing.py` to a public `make_snapshotter` helper at the audit-layer shared tier (`src/logic/audit.py`).
- Route every audit-snapshot construction through it:
  - `provider_processing.py`: `PROFILE`/`LICENSURE`/`EDUCATION`/`CERTIFICATION` use `make_snapshotter`; drops the now-unused local `_snap` and `BaseModel` import.
  - `user_processing.py`: `_snapshot_user_activation` / `_snapshot_user` become module-level aliases.
  - `auth_processing.py`: inline `UserAuditSnapshot.model_validate(...).model_dump(...)` becomes `_snapshot_user(...)`.
- New colocated test `test_make_snapshotter_returns_json_mode_dict` in `src/logic/test_audit.py`.

`post_audit_snapshot` stays as-is — it uses `TypeAdapter` on a discriminated union, which is structurally different from the single-class snapshotter shape this helper captures.

Closes #226.

## Test plan
- [x] `dev test` passes (494 passed, 1 skipped — one new test).
- [x] `dev lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)