### PR TITLE
Add form-encoded route response helpers (#227)

### DIFF
--- a/src/api/common/__init__.py
+++ b/src/api/common/__init__.py
@@ -9,8 +9,14 @@ from .exceptions import (
     NotFoundError,
     handle_fastapi_users_error,
 )
-from .forms import parse_form_to_payload, validate_or_422
-from .responses import APIResponse
+from .forms import parse_and_validate_form, parse_form_to_payload, validate_or_422
+from .responses import (
+    APIResponse,
+    created_response,
+    deleted_response,
+    refreshed_response,
+    updated_response,
+)
 
 __all__ = [
     "APIResponse",
@@ -21,6 +27,11 @@ __all__ = [
     "ForbiddenError",
     "handle_fastapi_users_error",
     "BaseRouter",
+    "created_response",
+    "deleted_response",
+    "parse_and_validate_form",
     "parse_form_to_payload",
+    "refreshed_response",
+    "updated_response",
     "validate_or_422",
 ]

--- a/src/api/common/forms.py
+++ b/src/api/common/forms.py
@@ -44,3 +44,15 @@ def validate_or_422(adapter: TypeAdapter, payload_dict: dict):
             for err in e.errors()
         ]
         raise HTTPException(status_code=422, detail=errors)
+
+
+async def parse_and_validate_form(request: Request, adapter: TypeAdapter):
+    """Parse a form-encoded request and validate it through `adapter`.
+
+    Combines the `parse_form_to_payload` and `validate_or_422` pair that
+    every form-encoded mutating route runs back-to-back. The underlying
+    primitives stay public for routes that need to inspect or transform
+    the parsed dict between the two steps.
+    """
+    payload_dict = await parse_form_to_payload(request)
+    return validate_or_422(adapter, payload_dict)

--- a/src/api/common/responses.py
+++ b/src/api/common/responses.py
@@ -1,5 +1,8 @@
 from typing import Any
 
+from fastapi import Response, status
+from fastapi.responses import JSONResponse
+
 
 class APIResponse:
     @staticmethod
@@ -15,3 +18,50 @@ class APIResponse:
         merged_context = {**global_context, **context}
 
         return templates.TemplateResponse(request, template_name, merged_context)
+
+
+def created_response(
+    *, id: Any, location: str, hx_redirect: str | None = None
+) -> JSONResponse:
+    """201 Created with `{"id": str(id)}` body, `Location: <location>`, and
+    `HX-Redirect: <hx_redirect or location>`.
+
+    The split lets a route point `Location` at the canonical resource URL
+    (per RFC 7231) while sending HTMX clients to a different page (e.g.
+    the edit form for the just-created resource).
+    """
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={"id": str(id)},
+        headers={"Location": location, "HX-Redirect": hx_redirect or location},
+    )
+
+
+def updated_response(*, body: dict | None = None, hx_redirect: str) -> JSONResponse:
+    """200 OK with optional body and `HX-Redirect: <hx_redirect>`."""
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content=body or {},
+        headers={"HX-Redirect": hx_redirect},
+    )
+
+
+def deleted_response(*, hx_redirect: str) -> Response:
+    """204 No Content with `HX-Redirect: <hx_redirect>`. Used when the
+    deleted resource's parent or list page is the post-delete landing
+    spot."""
+    return Response(
+        status_code=status.HTTP_204_NO_CONTENT,
+        headers={"HX-Redirect": hx_redirect},
+    )
+
+
+def refreshed_response() -> JSONResponse:
+    """200 OK with empty body and `HX-Refresh: true`. Tells HTMX to reload
+    the current page in place (used for actions that affect the current
+    view, e.g. user activation flips)."""
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={},
+        headers={"HX-Refresh": "true"},
+    )

--- a/src/api/common/test_responses.py
+++ b/src/api/common/test_responses.py
@@ -1,0 +1,56 @@
+"""Tests for `src/api/common/responses.py` helpers."""
+
+import json
+import uuid
+
+from .responses import (
+    created_response,
+    deleted_response,
+    refreshed_response,
+    updated_response,
+)
+
+
+def test_created_response_defaults_hx_redirect_to_location():
+    obj_id = uuid.uuid4()
+    resp = created_response(id=obj_id, location=f"/posts/{obj_id}")
+    assert resp.status_code == 201
+    assert json.loads(resp.body) == {"id": str(obj_id)}
+    assert resp.headers["Location"] == f"/posts/{obj_id}"
+    assert resp.headers["HX-Redirect"] == f"/posts/{obj_id}"
+
+
+def test_created_response_separate_location_and_hx_redirect():
+    obj_id = uuid.uuid4()
+    resp = created_response(
+        id=obj_id,
+        location=f"/providers/{obj_id}",
+        hx_redirect=f"/providers/{obj_id}/form",
+    )
+    assert resp.headers["Location"] == f"/providers/{obj_id}"
+    assert resp.headers["HX-Redirect"] == f"/providers/{obj_id}/form"
+
+
+def test_updated_response_with_body():
+    resp = updated_response(body={"id": "abc", "name": "x"}, hx_redirect="/x")
+    assert resp.status_code == 200
+    assert json.loads(resp.body) == {"id": "abc", "name": "x"}
+    assert resp.headers["HX-Redirect"] == "/x"
+
+
+def test_updated_response_empty_body_default():
+    resp = updated_response(hx_redirect="/x")
+    assert resp.status_code == 200
+    assert json.loads(resp.body) == {}
+
+
+def test_deleted_response_204_with_hx_redirect():
+    resp = deleted_response(hx_redirect="/posts")
+    assert resp.status_code == 204
+    assert resp.headers["HX-Redirect"] == "/posts"
+
+
+def test_refreshed_response_204_with_hx_refresh():
+    resp = refreshed_response()
+    assert resp.status_code == 200
+    assert resp.headers["HX-Refresh"] == "true"

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -2,14 +2,15 @@ import logging
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, Request, Response, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, Query, Request, status
 
 from src.api.common import (
     APIResponse,
     BaseRouter,
-    parse_form_to_payload,
-    validate_or_422,
+    created_response,
+    deleted_response,
+    parse_and_validate_form,
+    updated_response,
 )
 from src.auth_config import current_active_user
 from src.logic.posts.post_processing import (
@@ -146,20 +147,14 @@ async def create_post(
     the session; clients sending it (or any other unknown field) are
     rejected with 422 by the schema.
     """
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(post_create_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, post_create_adapter)
     created = await handle_create_post(
         payload=payload,
         post_repo=post_repo,
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    location = f"/posts/{created.id}"
-    return JSONResponse(
-        status_code=status.HTTP_201_CREATED,
-        content={"id": str(created.id)},
-        headers={"Location": location, "HX-Redirect": location},
-    )
+    return created_response(id=created.id, location=f"/posts/{created.id}")
 
 
 @router.patch("/{post_id}")
@@ -178,8 +173,7 @@ async def patch_post(
     changed via PATCH; mismatches are rejected with 400.
     The body must be form-encoded.
     """
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(post_update_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, post_update_adapter)
     updated = await handle_update_post(
         post_id=post_id,
         payload=payload,
@@ -187,10 +181,9 @@ async def patch_post(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    location = f"/posts/{updated.id}"
-    return JSONResponse(
-        content=_patch_response_body(updated),
-        headers={"HX-Redirect": location},
+    return updated_response(
+        body=_patch_response_body(updated),
+        hx_redirect=f"/posts/{updated.id}",
     )
 
 
@@ -210,7 +203,4 @@ async def delete_post(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    return Response(
-        status_code=status.HTTP_204_NO_CONTENT,
-        headers={"HX-Redirect": "/posts"},
-    )
+    return deleted_response(hx_redirect="/posts")

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -1,14 +1,15 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, Request, Response, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, Query, Request, status
 
 from src.api.common import (
     APIResponse,
     BaseRouter,
-    parse_form_to_payload,
-    validate_or_422,
+    created_response,
+    deleted_response,
+    parse_and_validate_form,
+    updated_response,
 )
 from src.auth_config import current_active_user
 from src.logic.providers.provider_processing import (
@@ -104,20 +105,17 @@ async def create_provider(
 ):
     """Creates a provider owned by the requesting user. Form-encoded
     body. A user may own multiple profiles."""
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(provider_create_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, provider_create_adapter)
     created = await handle_create_provider(
         payload=payload,
         repo=repo,
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    detail_location = f"/providers/{created.id}"
-    edit_location = f"/providers/{created.id}/form"
-    return JSONResponse(
-        status_code=status.HTTP_201_CREATED,
-        content={"id": str(created.id)},
-        headers={"Location": detail_location, "HX-Redirect": edit_location},
+    return created_response(
+        id=created.id,
+        location=f"/providers/{created.id}",
+        hx_redirect=f"/providers/{created.id}/form",
     )
 
 
@@ -196,8 +194,7 @@ async def patch_profile(
 ):
     """Partially updates the practice/availability fields. Owner-only; admins
     may edit any profile. Sub-entity lists are managed via their own routes."""
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(provider_update_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, provider_update_adapter)
     updated = await handle_update_provider(
         provider_id=provider_id,
         payload=payload,
@@ -205,10 +202,9 @@ async def patch_profile(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    location = f"/providers/{updated.id}/form"
-    return JSONResponse(
-        content=_provider_read_dict(updated),
-        headers={"HX-Redirect": location},
+    return updated_response(
+        body=_provider_read_dict(updated),
+        hx_redirect=f"/providers/{updated.id}/form",
     )
 
 
@@ -227,10 +223,7 @@ async def delete_provider(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    return Response(
-        status_code=status.HTTP_204_NO_CONTENT,
-        headers={"HX-Redirect": "/providers"},
-    )
+    return deleted_response(hx_redirect="/providers")
 
 
 # --- Licensure sub-resource ---------------------------------------------
@@ -244,8 +237,7 @@ async def create_licensure(
     audit_repo: AuditRepository = Depends(get_audit_repository),
     user: User = Depends(current_active_user),
 ):
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(licensure_create_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, licensure_create_adapter)
     created = await handle_create_licensure(
         provider_id=provider_id,
         payload=payload,
@@ -253,12 +245,10 @@ async def create_licensure(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    parent_location = f"/providers/{provider_id}"
-    edit_location = f"/providers/{provider_id}/form"
-    return JSONResponse(
-        status_code=status.HTTP_201_CREATED,
-        content={"id": str(created.id)},
-        headers={"Location": parent_location, "HX-Redirect": edit_location},
+    return created_response(
+        id=created.id,
+        location=f"/providers/{provider_id}",
+        hx_redirect=f"/providers/{provider_id}/form",
     )
 
 
@@ -271,8 +261,7 @@ async def patch_licensure(
     audit_repo: AuditRepository = Depends(get_audit_repository),
     user: User = Depends(current_active_user),
 ):
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(licensure_update_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, licensure_update_adapter)
     updated = await handle_update_licensure(
         provider_id=provider_id,
         licensure_id=licensure_id,
@@ -281,10 +270,9 @@ async def patch_licensure(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    location = f"/providers/{provider_id}/form"
-    return JSONResponse(
-        content=_licensure_read_dict(updated),
-        headers={"HX-Redirect": location},
+    return updated_response(
+        body=_licensure_read_dict(updated),
+        hx_redirect=f"/providers/{provider_id}/form",
     )
 
 
@@ -306,10 +294,7 @@ async def delete_licensure(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    return Response(
-        status_code=status.HTTP_204_NO_CONTENT,
-        headers={"HX-Redirect": f"/providers/{provider_id}/form"},
-    )
+    return deleted_response(hx_redirect=f"/providers/{provider_id}/form")
 
 
 # --- Education sub-resource ---------------------------------------------
@@ -323,8 +308,7 @@ async def create_education(
     audit_repo: AuditRepository = Depends(get_audit_repository),
     user: User = Depends(current_active_user),
 ):
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(education_create_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, education_create_adapter)
     created = await handle_create_education(
         provider_id=provider_id,
         payload=payload,
@@ -332,12 +316,10 @@ async def create_education(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    parent_location = f"/providers/{provider_id}"
-    edit_location = f"/providers/{provider_id}/form"
-    return JSONResponse(
-        status_code=status.HTTP_201_CREATED,
-        content={"id": str(created.id)},
-        headers={"Location": parent_location, "HX-Redirect": edit_location},
+    return created_response(
+        id=created.id,
+        location=f"/providers/{provider_id}",
+        hx_redirect=f"/providers/{provider_id}/form",
     )
 
 
@@ -350,8 +332,7 @@ async def patch_education(
     audit_repo: AuditRepository = Depends(get_audit_repository),
     user: User = Depends(current_active_user),
 ):
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(education_update_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, education_update_adapter)
     updated = await handle_update_education(
         provider_id=provider_id,
         education_id=education_id,
@@ -360,10 +341,9 @@ async def patch_education(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    location = f"/providers/{provider_id}/form"
-    return JSONResponse(
-        content=_education_read_dict(updated),
-        headers={"HX-Redirect": location},
+    return updated_response(
+        body=_education_read_dict(updated),
+        hx_redirect=f"/providers/{provider_id}/form",
     )
 
 
@@ -385,10 +365,7 @@ async def delete_education(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    return Response(
-        status_code=status.HTTP_204_NO_CONTENT,
-        headers={"HX-Redirect": f"/providers/{provider_id}/form"},
-    )
+    return deleted_response(hx_redirect=f"/providers/{provider_id}/form")
 
 
 # --- Certification sub-resource -----------------------------------------
@@ -402,8 +379,7 @@ async def create_certification(
     audit_repo: AuditRepository = Depends(get_audit_repository),
     user: User = Depends(current_active_user),
 ):
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(certification_create_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, certification_create_adapter)
     created = await handle_create_certification(
         provider_id=provider_id,
         payload=payload,
@@ -411,12 +387,10 @@ async def create_certification(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    parent_location = f"/providers/{provider_id}"
-    edit_location = f"/providers/{provider_id}/form"
-    return JSONResponse(
-        status_code=status.HTTP_201_CREATED,
-        content={"id": str(created.id)},
-        headers={"Location": parent_location, "HX-Redirect": edit_location},
+    return created_response(
+        id=created.id,
+        location=f"/providers/{provider_id}",
+        hx_redirect=f"/providers/{provider_id}/form",
     )
 
 
@@ -429,8 +403,7 @@ async def patch_certification(
     audit_repo: AuditRepository = Depends(get_audit_repository),
     user: User = Depends(current_active_user),
 ):
-    payload_dict = await parse_form_to_payload(request)
-    payload = validate_or_422(certification_update_adapter, payload_dict)
+    payload = await parse_and_validate_form(request, certification_update_adapter)
     updated = await handle_update_certification(
         provider_id=provider_id,
         certification_id=certification_id,
@@ -439,10 +412,9 @@ async def patch_certification(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    location = f"/providers/{provider_id}/form"
-    return JSONResponse(
-        content=_certification_read_dict(updated),
-        headers={"HX-Redirect": location},
+    return updated_response(
+        body=_certification_read_dict(updated),
+        hx_redirect=f"/providers/{provider_id}/form",
     )
 
 
@@ -464,7 +436,4 @@ async def delete_certification(
         audit_repo=audit_repo,
         requesting_user=user,
     )
-    return Response(
-        status_code=status.HTTP_204_NO_CONTENT,
-        headers={"HX-Redirect": f"/providers/{provider_id}/form"},
-    )
+    return deleted_response(hx_redirect=f"/providers/{provider_id}/form")

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -1,10 +1,10 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request, Response, status
+from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import JSONResponse
 
-from src.api.common import APIResponse, BaseRouter
+from src.api.common import APIResponse, BaseRouter, deleted_response
 from src.auth_config import current_active_user, current_admin_user
 from src.logic.providers.provider_processing import handle_list_user_providers
 from src.logic.users.user_processing import (
@@ -134,7 +134,4 @@ async def delete_user(
         audit_repo=audit_repo,
         requesting_user=admin,
     )
-    return Response(
-        status_code=status.HTTP_204_NO_CONTENT,
-        headers={"HX-Redirect": "/users"},
-    )
+    return deleted_response(hx_redirect="/users")

--- a/src/schemas/providers/provider.py
+++ b/src/schemas/providers/provider.py
@@ -41,20 +41,34 @@ from src.models.enums import (
 )
 from src.schemas._validators import StrippedText, ZipText, assert_any_field_set
 
-# --- ProviderLicensure --------------------------------------------------
 
+class _ProviderSubrowBase(BaseModel):
+    """Common fields for every provider sub-row Read and AuditSnapshot
+    schema (licensure / education / certification). Subclasses add
+    entity-specific fields.
 
-class ProviderLicensureRead(BaseModel):
+    The two surfaces are structurally identical here (same FK column,
+    same timestamps, same `from_attributes` config), so they share one
+    base — unlike `_PostReadBase` / `_PostAuditSnapshotBase` in the post
+    cluster, which differ because Read carries a flattening validator.
+    """
+
     id: uuid.UUID
     provider_id: uuid.UUID
     created_at: datetime
     updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# --- ProviderLicensure --------------------------------------------------
+
+
+class ProviderLicensureRead(_ProviderSubrowBase):
     license_type: str
     license_number: str
     issuing_state: str
     expiration_date: date | None = None
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 class ProviderLicensureCreate(BaseModel):
@@ -86,32 +100,20 @@ class ProviderLicensureUpdate(BaseModel):
 licensure_update_adapter: TypeAdapter = TypeAdapter(ProviderLicensureUpdate)
 
 
-class ProviderLicensureAuditSnapshot(BaseModel):
-    id: uuid.UUID
-    provider_id: uuid.UUID
-    created_at: datetime
-    updated_at: datetime
+class ProviderLicensureAuditSnapshot(_ProviderSubrowBase):
     license_type: str
     license_number: str
     issuing_state: str
     expiration_date: date | None = None
 
-    model_config = ConfigDict(from_attributes=True)
-
 
 # --- ProviderEducation --------------------------------------------------
 
 
-class ProviderEducationRead(BaseModel):
-    id: uuid.UUID
-    provider_id: uuid.UUID
-    created_at: datetime
-    updated_at: datetime
+class ProviderEducationRead(_ProviderSubrowBase):
     education_type: str
     institution: str
     month_completed: str | None = None
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 class ProviderEducationCreate(BaseModel):
@@ -144,31 +146,19 @@ class ProviderEducationUpdate(BaseModel):
 education_update_adapter: TypeAdapter = TypeAdapter(ProviderEducationUpdate)
 
 
-class ProviderEducationAuditSnapshot(BaseModel):
-    id: uuid.UUID
-    provider_id: uuid.UUID
-    created_at: datetime
-    updated_at: datetime
+class ProviderEducationAuditSnapshot(_ProviderSubrowBase):
     education_type: str
     institution: str
     month_completed: str | None = None
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 # --- ProviderCertification ----------------------------------------------
 
 
-class ProviderCertificationRead(BaseModel):
-    id: uuid.UUID
-    provider_id: uuid.UUID
-    created_at: datetime
-    updated_at: datetime
+class ProviderCertificationRead(_ProviderSubrowBase):
     certification_type: str
     certifying_body: str
     expiration_date: date | None = None
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 class ProviderCertificationCreate(BaseModel):
@@ -198,16 +188,10 @@ class ProviderCertificationUpdate(BaseModel):
 certification_update_adapter: TypeAdapter = TypeAdapter(ProviderCertificationUpdate)
 
 
-class ProviderCertificationAuditSnapshot(BaseModel):
-    id: uuid.UUID
-    provider_id: uuid.UUID
-    created_at: datetime
-    updated_at: datetime
+class ProviderCertificationAuditSnapshot(_ProviderSubrowBase):
     certification_type: str
     certifying_body: str
     expiration_date: date | None = None
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 # --- Provider ----------------------------------------------------


### PR DESCRIPTION
## Summary
- `parse_and_validate_form` in `src/api/common/forms.py` collapses the parse+validate pair every form-encoded mutating route runs.
- Four response shorthands in `src/api/common/responses.py`: `created_response` (201 + Location/HX-Redirect), `updated_response` (200 + body + HX-Redirect), `deleted_response` (204 + HX-Redirect), `refreshed_response` (200 + HX-Refresh: true).
- Rewrite every form-encoded mutating route in `posts.py`, `providers.py`, and `users.py`. The Location vs HX-Redirect distinction (per RFC 7231 vs HTMX hint) is preserved.
- Add colocated `test_responses.py` covering all four helpers.

**Holdout:** `users.py:113` (`set_user_activation`) still emits `JSONResponse + HX-Refresh` because the response carries a body — `refreshed_response` is body-less by design. Surfacing rather than forcing an awkward fit.

Closes #227.

## Test plan
- [x] `dev test` passes (499 passed — 6 new from `test_responses.py`).
- [x] `dev lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)