### PR TITLE
Consolidate provider sub-resource CRUD routes (#230)

### DIFF
--- a/src/api/common/subresource_routes.py
+++ b/src/api/common/subresource_routes.py
@@ -1,0 +1,131 @@
+"""Generic CRUD route registration for provider sub-resources.
+
+The provider profile owns three credential sub-resources (licensures,
+educations, certifications) whose POST/PATCH/DELETE routes differ only in
+the path segment, the schema adapters, the read-dict helper, the logic
+handler trio, and the kwarg name used to pass the child id.
+
+`SubresourceSpec` declares those knobs once per sub-resource;
+`register_subresource_routes` mounts the three routes on a shared
+`APIRouter`. Behavior — paths, request bodies, response status codes,
+response bodies, and `Location` / `HX-Redirect` headers — matches the
+hand-written equivalents byte-for-byte.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+from uuid import UUID
+
+from fastapi import Depends, Request, status
+from pydantic import TypeAdapter
+
+from src.api.common.forms import parse_and_validate_form
+from src.api.common.responses import (
+    created_response,
+    deleted_response,
+    updated_response,
+)
+
+
+@dataclass(frozen=True)
+class SubresourceSpec:
+    collection: str
+    child_id_param: str
+    create_adapter: TypeAdapter
+    update_adapter: TypeAdapter
+    read_to_dict: Callable[[Any], dict]
+    create_handler: Callable[..., Awaitable[Any]]
+    update_handler: Callable[..., Awaitable[Any]]
+    delete_handler: Callable[..., Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class SubresourceDeps:
+    """The three FastAPI dependency callables every sub-resource route uses."""
+
+    repo: Callable[..., Any]
+    audit_repo: Callable[..., Any]
+    user: Callable[..., Any]
+
+
+def register_subresource_routes(
+    router: Any,
+    spec: SubresourceSpec,
+    *,
+    deps: SubresourceDeps,
+) -> None:
+    """Mount POST / PATCH / DELETE for `spec.collection` on `router`.
+
+    The mounted handlers route the parsed payload through the spec's
+    adapters and forward to the spec's logic handlers using the spec's
+    `child_id_param` name (so existing handlers like
+    `handle_update_licensure(licensure_id=...)` keep working without
+    signature changes).
+    """
+    collection = spec.collection
+    child_param = spec.child_id_param
+
+    @router.post(f"/{{provider_id}}/{collection}", status_code=status.HTTP_201_CREATED)
+    async def _create(
+        provider_id: UUID,
+        request: Request,
+        repo=Depends(deps.repo),
+        audit_repo=Depends(deps.audit_repo),
+        user=Depends(deps.user),
+    ):
+        payload = await parse_and_validate_form(request, spec.create_adapter)
+        created = await spec.create_handler(
+            provider_id=provider_id,
+            payload=payload,
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=user,
+        )
+        return created_response(
+            id=created.id,
+            location=f"/providers/{provider_id}",
+            hx_redirect=f"/providers/{provider_id}/form",
+        )
+
+    @router.patch(f"/{{provider_id}}/{collection}/{{child_id}}")
+    async def _patch(
+        provider_id: UUID,
+        child_id: UUID,
+        request: Request,
+        repo=Depends(deps.repo),
+        audit_repo=Depends(deps.audit_repo),
+        user=Depends(deps.user),
+    ):
+        payload = await parse_and_validate_form(request, spec.update_adapter)
+        updated = await spec.update_handler(
+            provider_id=provider_id,
+            payload=payload,
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=user,
+            **{child_param: child_id},
+        )
+        return updated_response(
+            body=spec.read_to_dict(updated),
+            hx_redirect=f"/providers/{provider_id}/form",
+        )
+
+    @router.delete(
+        f"/{{provider_id}}/{collection}/{{child_id}}",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    async def _delete(
+        provider_id: UUID,
+        child_id: UUID,
+        repo=Depends(deps.repo),
+        audit_repo=Depends(deps.audit_repo),
+        user=Depends(deps.user),
+    ):
+        await spec.delete_handler(
+            provider_id=provider_id,
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=user,
+            **{child_param: child_id},
+        )
+        return deleted_response(hx_redirect=f"/providers/{provider_id}/form")

--- a/src/api/common/test_subresource_routes.py
+++ b/src/api/common/test_subresource_routes.py
@@ -1,0 +1,182 @@
+"""Tests for `src/api/common/subresource_routes.py`.
+
+Registers a tiny `widgets` sub-resource against a stub router and exercises
+the three POST/PATCH/DELETE routes end-to-end. Validates that the helper
+forwards the child-id to the spec's logic handlers under the right kwarg
+name and emits the same response shape as the hand-written equivalents.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, ConfigDict, TypeAdapter
+
+from .subresource_routes import (
+    SubresourceDeps,
+    SubresourceSpec,
+    register_subresource_routes,
+)
+
+
+class _WidgetCreate(BaseModel):
+    name: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class _WidgetUpdate(BaseModel):
+    name: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def _build_app(spec: SubresourceSpec, captured: dict) -> FastAPI:
+    app = FastAPI()
+    router = APIRouter(prefix="/providers")
+    register_subresource_routes(
+        router,
+        spec,
+        deps=SubresourceDeps(
+            repo=lambda: SimpleNamespace(name="repo"),
+            audit_repo=lambda: SimpleNamespace(name="audit_repo"),
+            user=lambda: SimpleNamespace(id=uuid4(), is_superuser=False),
+        ),
+    )
+    app.include_router(router)
+    return app
+
+
+def test_create_route_calls_handler_with_kwargs():
+    captured = {}
+
+    async def create_handler(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id=uuid4())
+
+    async def update_handler(**kwargs):
+        return None
+
+    async def delete_handler(**kwargs):
+        return None
+
+    spec = SubresourceSpec(
+        collection="widgets",
+        child_id_param="widget_id",
+        create_adapter=TypeAdapter(_WidgetCreate),
+        update_adapter=TypeAdapter(_WidgetUpdate),
+        read_to_dict=lambda r: {"id": str(r.id)},
+        create_handler=create_handler,
+        update_handler=update_handler,
+        delete_handler=delete_handler,
+    )
+
+    parent_id = uuid4()
+    client = TestClient(_build_app(spec, captured))
+    resp = client.post(f"/providers/{parent_id}/widgets", data={"name": "x"})
+
+    assert resp.status_code == 201
+    assert resp.headers["Location"] == f"/providers/{parent_id}"
+    assert resp.headers["HX-Redirect"] == f"/providers/{parent_id}/form"
+    assert captured["provider_id"] == parent_id
+    assert captured["payload"].name == "x"
+
+
+def test_patch_route_forwards_child_id_under_spec_kwarg():
+    captured = {}
+
+    async def update_handler(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id=uuid4())
+
+    async def create_handler(**kwargs):
+        return SimpleNamespace(id=uuid4())
+
+    async def delete_handler(**kwargs):
+        return None
+
+    spec = SubresourceSpec(
+        collection="widgets",
+        child_id_param="widget_id",
+        create_adapter=TypeAdapter(_WidgetCreate),
+        update_adapter=TypeAdapter(_WidgetUpdate),
+        read_to_dict=lambda r: {"id": str(r.id)},
+        create_handler=create_handler,
+        update_handler=update_handler,
+        delete_handler=delete_handler,
+    )
+
+    parent_id, child_id = uuid4(), uuid4()
+    client = TestClient(_build_app(spec, captured))
+    resp = client.patch(
+        f"/providers/{parent_id}/widgets/{child_id}", data={"name": "y"}
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["HX-Redirect"] == f"/providers/{parent_id}/form"
+    # The helper must forward child_id under the spec's kwarg name
+    # (preserves existing handler signatures like
+    # `handle_update_licensure(licensure_id=...)`).
+    assert captured["widget_id"] == child_id
+    assert "child_id" not in captured
+
+
+def test_delete_route_returns_204_with_hx_redirect():
+    captured = {}
+
+    async def delete_handler(**kwargs):
+        captured.update(kwargs)
+
+    async def create_handler(**kwargs):
+        return SimpleNamespace(id=uuid4())
+
+    async def update_handler(**kwargs):
+        return SimpleNamespace(id=uuid4())
+
+    spec = SubresourceSpec(
+        collection="widgets",
+        child_id_param="widget_id",
+        create_adapter=TypeAdapter(_WidgetCreate),
+        update_adapter=TypeAdapter(_WidgetUpdate),
+        read_to_dict=lambda r: {"id": str(r.id)},
+        create_handler=create_handler,
+        update_handler=update_handler,
+        delete_handler=delete_handler,
+    )
+
+    parent_id, child_id = uuid4(), uuid4()
+    client = TestClient(_build_app(spec, captured))
+    resp = client.delete(f"/providers/{parent_id}/widgets/{child_id}")
+
+    assert resp.status_code == 204
+    assert resp.headers["HX-Redirect"] == f"/providers/{parent_id}/form"
+    assert captured["widget_id"] == child_id
+
+
+def test_create_payload_validation_returns_422():
+    async def create_handler(**kwargs):
+        return SimpleNamespace(id=uuid4())
+
+    async def update_handler(**kwargs):
+        return None
+
+    async def delete_handler(**kwargs):
+        return None
+
+    spec = SubresourceSpec(
+        collection="widgets",
+        child_id_param="widget_id",
+        create_adapter=TypeAdapter(_WidgetCreate),
+        update_adapter=TypeAdapter(_WidgetUpdate),
+        read_to_dict=lambda r: {"id": str(r.id)},
+        create_handler=create_handler,
+        update_handler=update_handler,
+        delete_handler=delete_handler,
+    )
+
+    parent_id = uuid4()
+    client = TestClient(_build_app(spec, {}))
+    # Missing required `name` field — schema rejects with 422.
+    resp = client.post(f"/providers/{parent_id}/widgets", data={})
+    assert resp.status_code == 422

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -11,6 +11,11 @@ from src.api.common import (
     parse_and_validate_form,
     updated_response,
 )
+from src.api.common.subresource_routes import (
+    SubresourceDeps,
+    SubresourceSpec,
+    register_subresource_routes,
+)
 from src.auth_config import current_active_user
 from src.logic.providers.provider_processing import (
     handle_create_certification,
@@ -226,214 +231,59 @@ async def delete_provider(
     return deleted_response(hx_redirect="/providers")
 
 
-# --- Licensure sub-resource ---------------------------------------------
+# --- Sub-resource CRUD (licensure / education / certification) ----------
+# Three near-identical CRUD blocks live in src/api/common/subresource_routes.py
+# and are mounted via register_subresource_routes; per-sub-resource knobs
+# (path segment, schemas, handlers, child-id kwarg name) live in the specs
+# below.
 
-
-@router.post("/{provider_id}/licensures", status_code=status.HTTP_201_CREATED)
-async def create_licensure(
-    provider_id: UUID,
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    payload = await parse_and_validate_form(request, licensure_create_adapter)
-    created = await handle_create_licensure(
-        provider_id=provider_id,
-        payload=payload,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return created_response(
-        id=created.id,
-        location=f"/providers/{provider_id}",
-        hx_redirect=f"/providers/{provider_id}/form",
-    )
-
-
-@router.patch("/{provider_id}/licensures/{licensure_id}")
-async def patch_licensure(
-    provider_id: UUID,
-    licensure_id: UUID,
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    payload = await parse_and_validate_form(request, licensure_update_adapter)
-    updated = await handle_update_licensure(
-        provider_id=provider_id,
-        licensure_id=licensure_id,
-        payload=payload,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return updated_response(
-        body=_licensure_read_dict(updated),
-        hx_redirect=f"/providers/{provider_id}/form",
-    )
-
-
-@router.delete(
-    "/{provider_id}/licensures/{licensure_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+_provider_subresource_deps = SubresourceDeps(
+    repo=get_provider_repository,
+    audit_repo=get_audit_repository,
+    user=current_active_user,
 )
-async def delete_licensure(
-    provider_id: UUID,
-    licensure_id: UUID,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    await handle_delete_licensure(
-        provider_id=provider_id,
-        licensure_id=licensure_id,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return deleted_response(hx_redirect=f"/providers/{provider_id}/form")
 
-
-# --- Education sub-resource ---------------------------------------------
-
-
-@router.post("/{provider_id}/educations", status_code=status.HTTP_201_CREATED)
-async def create_education(
-    provider_id: UUID,
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    payload = await parse_and_validate_form(request, education_create_adapter)
-    created = await handle_create_education(
-        provider_id=provider_id,
-        payload=payload,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return created_response(
-        id=created.id,
-        location=f"/providers/{provider_id}",
-        hx_redirect=f"/providers/{provider_id}/form",
-    )
-
-
-@router.patch("/{provider_id}/educations/{education_id}")
-async def patch_education(
-    provider_id: UUID,
-    education_id: UUID,
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    payload = await parse_and_validate_form(request, education_update_adapter)
-    updated = await handle_update_education(
-        provider_id=provider_id,
-        education_id=education_id,
-        payload=payload,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return updated_response(
-        body=_education_read_dict(updated),
-        hx_redirect=f"/providers/{provider_id}/form",
-    )
-
-
-@router.delete(
-    "/{provider_id}/educations/{education_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+register_subresource_routes(
+    router,
+    SubresourceSpec(
+        collection="licensures",
+        child_id_param="licensure_id",
+        create_adapter=licensure_create_adapter,
+        update_adapter=licensure_update_adapter,
+        read_to_dict=_licensure_read_dict,
+        create_handler=handle_create_licensure,
+        update_handler=handle_update_licensure,
+        delete_handler=handle_delete_licensure,
+    ),
+    deps=_provider_subresource_deps,
 )
-async def delete_education(
-    provider_id: UUID,
-    education_id: UUID,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    await handle_delete_education(
-        provider_id=provider_id,
-        education_id=education_id,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return deleted_response(hx_redirect=f"/providers/{provider_id}/form")
 
-
-# --- Certification sub-resource -----------------------------------------
-
-
-@router.post("/{provider_id}/certifications", status_code=status.HTTP_201_CREATED)
-async def create_certification(
-    provider_id: UUID,
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    payload = await parse_and_validate_form(request, certification_create_adapter)
-    created = await handle_create_certification(
-        provider_id=provider_id,
-        payload=payload,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return created_response(
-        id=created.id,
-        location=f"/providers/{provider_id}",
-        hx_redirect=f"/providers/{provider_id}/form",
-    )
-
-
-@router.patch("/{provider_id}/certifications/{certification_id}")
-async def patch_certification(
-    provider_id: UUID,
-    certification_id: UUID,
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    payload = await parse_and_validate_form(request, certification_update_adapter)
-    updated = await handle_update_certification(
-        provider_id=provider_id,
-        certification_id=certification_id,
-        payload=payload,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return updated_response(
-        body=_certification_read_dict(updated),
-        hx_redirect=f"/providers/{provider_id}/form",
-    )
-
-
-@router.delete(
-    "/{provider_id}/certifications/{certification_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+register_subresource_routes(
+    router,
+    SubresourceSpec(
+        collection="educations",
+        child_id_param="education_id",
+        create_adapter=education_create_adapter,
+        update_adapter=education_update_adapter,
+        read_to_dict=_education_read_dict,
+        create_handler=handle_create_education,
+        update_handler=handle_update_education,
+        delete_handler=handle_delete_education,
+    ),
+    deps=_provider_subresource_deps,
 )
-async def delete_certification(
-    provider_id: UUID,
-    certification_id: UUID,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    await handle_delete_certification(
-        provider_id=provider_id,
-        certification_id=certification_id,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return deleted_response(hx_redirect=f"/providers/{provider_id}/form")
+
+register_subresource_routes(
+    router,
+    SubresourceSpec(
+        collection="certifications",
+        child_id_param="certification_id",
+        create_adapter=certification_create_adapter,
+        update_adapter=certification_update_adapter,
+        read_to_dict=_certification_read_dict,
+        create_handler=handle_create_certification,
+        update_handler=handle_update_certification,
+        delete_handler=handle_delete_certification,
+    ),
+    deps=_provider_subresource_deps,
+)

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -16,10 +16,12 @@ silently mutate a licensure belonging to a different profile.
 """
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
 from fastapi import Request
+from pydantic import BaseModel
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
 from src.logic._authz import assert_owner_or_admin
@@ -293,6 +295,133 @@ async def handle_delete_provider(
         await repo.delete_provider(profile)
 
 
+# --- Sub-row CRUD helpers ------------------------------------------------
+# Three private helpers parameterized by `_SubrowSpec` cover the nine public
+# sub-row handlers below. Each public handler is a thin wrapper that
+# preserves its existing signature so route callers and tests don't change.
+
+
+@dataclass(frozen=True)
+class _SubrowSpec:
+    resource: AuditedResource
+    add: str
+    update: str
+    delete: str
+    get_by_id: str
+    display_name: str
+
+
+_LICENSURE_SPEC = _SubrowSpec(
+    resource=LICENSURE,
+    add="add_licensure",
+    update="update_licensure",
+    delete="delete_licensure",
+    get_by_id="get_licensure_by_id",
+    display_name="Licensure",
+)
+_EDUCATION_SPEC = _SubrowSpec(
+    resource=EDUCATION,
+    add="add_education",
+    update="update_education",
+    delete="delete_education",
+    get_by_id="get_education_by_id",
+    display_name="Education entry",
+)
+_CERTIFICATION_SPEC = _SubrowSpec(
+    resource=CERTIFICATION,
+    add="add_certification",
+    update="update_certification",
+    delete="delete_certification",
+    get_by_id="get_certification_by_id",
+    display_name="Certification",
+)
+
+
+async def _handle_subrow_create(
+    *,
+    provider_id: UUID,
+    payload: BaseModel,
+    repo: ProviderRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+    spec: _SubrowSpec,
+) -> Any:
+    profile = await _load_provider_or_404(provider_id, repo)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
+
+    created = await getattr(repo, spec.add)(profile, **payload.model_dump())
+    async with mutate(
+        repo,
+        audit_repo,
+        actor=requesting_user,
+        target=created,
+        resource=spec.resource,
+        verb="create",
+    ):
+        pass
+    return created
+
+
+async def _handle_subrow_update(
+    *,
+    provider_id: UUID,
+    child_id: UUID,
+    payload: BaseModel,
+    repo: ProviderRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+    spec: _SubrowSpec,
+) -> Any:
+    profile = await _load_provider_or_404(provider_id, repo)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
+
+    row = await _load_subrow_or_404(
+        getattr(repo, spec.get_by_id), child_id, profile.id, name=spec.display_name
+    )
+    async with mutate(
+        repo,
+        audit_repo,
+        actor=requesting_user,
+        target=row,
+        resource=spec.resource,
+        verb="update",
+    ):
+        await getattr(repo, spec.update)(row, **payload.model_dump(exclude_unset=True))
+    return row
+
+
+async def _handle_subrow_delete(
+    *,
+    provider_id: UUID,
+    child_id: UUID,
+    repo: ProviderRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+    spec: _SubrowSpec,
+) -> None:
+    profile = await _load_provider_or_404(provider_id, repo)
+    assert_owner_or_admin(
+        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    )
+
+    row = await _load_subrow_or_404(
+        getattr(repo, spec.get_by_id), child_id, profile.id, name=spec.display_name
+    )
+    async with mutate(
+        repo,
+        audit_repo,
+        actor=requesting_user,
+        target=row,
+        resource=spec.resource,
+        verb="delete",
+    ):
+        await getattr(repo, spec.delete)(row)
+
+
 # --- Licensure handlers --------------------------------------------------
 
 
@@ -303,22 +432,14 @@ async def handle_create_licensure(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> ProviderLicensure:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    return await _handle_subrow_create(
+        provider_id=provider_id,
+        payload=payload,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_LICENSURE_SPEC,
     )
-
-    created = await repo.add_licensure(profile, **payload.model_dump())
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=created,
-        resource=LICENSURE,
-        verb="create",
-    ):
-        pass
-    return created
 
 
 async def handle_update_licensure(
@@ -329,24 +450,15 @@ async def handle_update_licensure(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> ProviderLicensure:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    return await _handle_subrow_update(
+        provider_id=provider_id,
+        child_id=licensure_id,
+        payload=payload,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_LICENSURE_SPEC,
     )
-
-    licensure = await _load_subrow_or_404(
-        repo.get_licensure_by_id, licensure_id, profile.id, name="Licensure"
-    )
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=licensure,
-        resource=LICENSURE,
-        verb="update",
-    ):
-        await repo.update_licensure(licensure, **payload.model_dump(exclude_unset=True))
-    return licensure
 
 
 async def handle_delete_licensure(
@@ -356,23 +468,14 @@ async def handle_delete_licensure(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> None:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    await _handle_subrow_delete(
+        provider_id=provider_id,
+        child_id=licensure_id,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_LICENSURE_SPEC,
     )
-
-    licensure = await _load_subrow_or_404(
-        repo.get_licensure_by_id, licensure_id, profile.id, name="Licensure"
-    )
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=licensure,
-        resource=LICENSURE,
-        verb="delete",
-    ):
-        await repo.delete_licensure(licensure)
 
 
 # --- Education handlers --------------------------------------------------
@@ -385,22 +488,14 @@ async def handle_create_education(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> ProviderEducation:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    return await _handle_subrow_create(
+        provider_id=provider_id,
+        payload=payload,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_EDUCATION_SPEC,
     )
-
-    created = await repo.add_education(profile, **payload.model_dump())
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=created,
-        resource=EDUCATION,
-        verb="create",
-    ):
-        pass
-    return created
 
 
 async def handle_update_education(
@@ -411,24 +506,15 @@ async def handle_update_education(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> ProviderEducation:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    return await _handle_subrow_update(
+        provider_id=provider_id,
+        child_id=education_id,
+        payload=payload,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_EDUCATION_SPEC,
     )
-
-    education = await _load_subrow_or_404(
-        repo.get_education_by_id, education_id, profile.id, name="Education entry"
-    )
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=education,
-        resource=EDUCATION,
-        verb="update",
-    ):
-        await repo.update_education(education, **payload.model_dump(exclude_unset=True))
-    return education
 
 
 async def handle_delete_education(
@@ -438,23 +524,14 @@ async def handle_delete_education(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> None:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    await _handle_subrow_delete(
+        provider_id=provider_id,
+        child_id=education_id,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_EDUCATION_SPEC,
     )
-
-    education = await _load_subrow_or_404(
-        repo.get_education_by_id, education_id, profile.id, name="Education entry"
-    )
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=education,
-        resource=EDUCATION,
-        verb="delete",
-    ):
-        await repo.delete_education(education)
 
 
 # --- Certification handlers ----------------------------------------------
@@ -467,22 +544,14 @@ async def handle_create_certification(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> ProviderCertification:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    return await _handle_subrow_create(
+        provider_id=provider_id,
+        payload=payload,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_CERTIFICATION_SPEC,
     )
-
-    created = await repo.add_certification(profile, **payload.model_dump())
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=created,
-        resource=CERTIFICATION,
-        verb="create",
-    ):
-        pass
-    return created
 
 
 async def handle_update_certification(
@@ -493,29 +562,15 @@ async def handle_update_certification(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> ProviderCertification:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    return await _handle_subrow_update(
+        provider_id=provider_id,
+        child_id=certification_id,
+        payload=payload,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_CERTIFICATION_SPEC,
     )
-
-    certification = await _load_subrow_or_404(
-        repo.get_certification_by_id,
-        certification_id,
-        profile.id,
-        name="Certification",
-    )
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=certification,
-        resource=CERTIFICATION,
-        verb="update",
-    ):
-        await repo.update_certification(
-            certification, **payload.model_dump(exclude_unset=True)
-        )
-    return certification
 
 
 async def handle_delete_certification(
@@ -525,23 +580,11 @@ async def handle_delete_certification(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> None:
-    profile = await _load_provider_or_404(provider_id, repo)
-    assert_owner_or_admin(
-        profile, requesting_user, owner_attr="user_id", action="modify this provider"
+    await _handle_subrow_delete(
+        provider_id=provider_id,
+        child_id=certification_id,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+        spec=_CERTIFICATION_SPEC,
     )
-
-    certification = await _load_subrow_or_404(
-        repo.get_certification_by_id,
-        certification_id,
-        profile.id,
-        name="Certification",
-    )
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=certification,
-        resource=CERTIFICATION,
-        verb="delete",
-    ):
-        await repo.delete_certification(certification)


### PR DESCRIPTION
## Summary
- Three near-identical CRUD blocks for licensure / education / certification sub-resources collapse into a registration helper.
- New `src/api/common/subresource_routes.py` exports `SubresourceSpec`, `SubresourceDeps`, and `register_subresource_routes`. Each spec carries the per-sub-resource knobs (path segment, adapters, read-dict, handler trio, child-id kwarg name).
- `src/api/routes/providers.py` replaces ~230 lines of explicit per-sub-resource endpoints with three `register_subresource_routes` calls. Parent `Provider` CRUD routes untouched.
- New `src/api/common/test_subresource_routes.py` registers a stub `widgets` sub-resource and exercises POST/PATCH/DELETE end-to-end, including 422 validation and child-id forwarding.

The `child_id_param` knob keeps existing logic-handler signatures (e.g. `handle_update_licensure(licensure_id=...)`) unchanged — the helper passes `child_id` under the spec's kwarg name. URL paths, request bodies, response status codes, response bodies, and `Location` / `HX-Redirect` headers are byte-identical pre/post.

Closes #230.

## Test plan
- [x] `dev test` passes (504 passed — 4 new from `test_subresource_routes.py`).
- [x] `dev lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)