### PR TITLE
Standardize logic-handler primary repo kwarg to `repo`

### DIFF
--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -58,7 +58,7 @@ async def list_posts(
     """
     context = await handle_list_posts(
         request=request,
-        post_repo=post_repo,
+        repo=post_repo,
         requesting_user=user,
     )
     return APIResponse.html_response(
@@ -102,7 +102,7 @@ async def get_post_edit_form(
     context = await handle_get_post_edit_form(
         request=request,
         post_id=post_id,
-        post_repo=post_repo,
+        repo=post_repo,
         requesting_user=user,
     )
     post_kind = context["post"].kind
@@ -125,7 +125,7 @@ async def get_post(
     context = await handle_get_post_detail(
         request=request,
         post_id=post_id,
-        post_repo=post_repo,
+        repo=post_repo,
         requesting_user=user,
     )
     return APIResponse.html_response(
@@ -150,7 +150,7 @@ async def create_post(
     payload = await parse_and_validate_form(request, post_create_adapter)
     created = await handle_create_post(
         payload=payload,
-        post_repo=post_repo,
+        repo=post_repo,
         audit_repo=audit_repo,
         requesting_user=user,
     )
@@ -177,7 +177,7 @@ async def patch_post(
     updated = await handle_update_post(
         post_id=post_id,
         payload=payload,
-        post_repo=post_repo,
+        repo=post_repo,
         audit_repo=audit_repo,
         requesting_user=user,
     )
@@ -199,7 +199,7 @@ async def delete_post(
     """
     await handle_delete_post(
         post_id=post_id,
-        post_repo=post_repo,
+        repo=post_repo,
         audit_repo=audit_repo,
         requesting_user=user,
     )

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -41,7 +41,7 @@ async def list_users(
     """
     context = await handle_list_users(
         request=request,
-        user_repo=user_repo,
+        repo=user_repo,
         requesting_user=user,
     )
     return APIResponse.html_response(
@@ -62,7 +62,7 @@ async def get_user(
     context = await handle_get_user_detail(
         request=request,
         user_id=user_id,
-        user_repo=user_repo,
+        repo=user_repo,
         profile_repo=profile_repo,
         requesting_user=user,
     )
@@ -106,7 +106,7 @@ async def set_user_activation(
     updated = await handle_set_user_activation(
         user_id=user_id,
         payload=payload,
-        user_repo=user_repo,
+        repo=user_repo,
         audit_repo=audit_repo,
         requesting_user=admin,
     )
@@ -130,7 +130,7 @@ async def delete_user(
     """Admin-only: hard-delete a user."""
     await handle_delete_user(
         user_id=user_id,
-        user_repo=user_repo,
+        repo=user_repo,
         audit_repo=audit_repo,
         requesting_user=admin,
     )

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -19,11 +19,11 @@ Logic modules handle **complex business workflows** that need to coordinate repo
 
 ```python
 async def handle_list_users(
-    user_repo: UserRepository,
+    repo: UserRepository,
     requesting_user: User,
 ) -> dict:
     """Orchestrate user listing."""
-    users_list = await user_repo.list_users(exclude_user=requesting_user)
+    users_list = await repo.list_users(exclude_user=requesting_user)
     return {"users": users_list, "current_user": requesting_user}
 ```
 
@@ -42,17 +42,17 @@ async def handle_list_users(session: AsyncSession, user_id: UUID):
     return users.scalars().all()
 
 # Bad - HTTP response creation in logic
-async def handle_get_post(post_id: UUID, post_repo: PostRepository) -> JSONResponse:
-    post = await post_repo.get_post_by_id(post_id)
+async def handle_get_post(post_id: UUID, repo: PostRepository) -> JSONResponse:
+    post = await repo.get_post_by_id(post_id)
     return JSONResponse({"post": post})
 
 # Good - orchestration with proper separation
 async def handle_list_users(
-    user_repo: UserRepository,
+    repo: UserRepository,
     requesting_user: User,
 ):
     """Orchestrate user listing with filtering logic"""
-    users_list = await user_repo.list_users(exclude_user=requesting_user)
+    users_list = await repo.list_users(exclude_user=requesting_user)
     return {"users": users_list, "current_user": requesting_user}
 ```
 
@@ -69,11 +69,11 @@ There is no separate service layer — see [`../README.md`](../README.md) for th
 `logic/` owns the transaction commit:
 
 ```python
-async def handle_set_user_activation(user_id, payload, user_repo, requesting_user):
-    target = await user_repo.get_user_by_id(user_id)
+async def handle_set_user_activation(user_id, payload, repo, requesting_user):
+    target = await repo.get_user_by_id(user_id)
     ...
-    updated = await user_repo.set_user_activation(target, is_active=...)
-    await user_repo.session.commit()   # logic owns the commit
+    updated = await repo.set_user_activation(target, is_active=...)
+    await repo.session.commit()   # logic owns the commit
     return updated
 ```
 
@@ -89,6 +89,25 @@ Logic follows the [cluster pattern](../README.md#domain-entities-and-the-cluster
 A processing module does not import from a peer cluster's processing module; if a workflow needs to coordinate two entities, the parent-level orchestrator is the right home (or a single handler in one cluster that uses the other cluster's repositories, when the dependency direction is clear).
 
 ## Implementation patterns
+
+### Handler kwarg naming
+
+The repository for the resource the handler acts on is named `repo`. Additional repositories the handler needs are named by their type (`user_repo`, `audit_repo`, etc.). This keeps generic mount infrastructure able to inject `repo=` uniformly while leaving multi-repo cases legible.
+
+```python
+# Single-repo handler — primary repo is `repo`:
+async def handle_get_post_detail(post_id: UUID, repo: PostRepository, ...): ...
+
+# Multi-repo handler — primary stays `repo`, secondaries keep their typed name:
+async def handle_list_user_providers(
+    target_user_id: UUID,
+    repo: ProviderRepository,    # primary: providers are what we list
+    user_repo: UserRepository,   # secondary: needed only to verify the target user exists
+    requesting_user: User,
+): ...
+```
+
+The `audit_repo: AuditRepository` injected into mutation handlers is a secondary repo and follows the same rule (named by type, not collapsed to `repo`).
 
 ### Standard processing function structure
 
@@ -135,8 +154,8 @@ async def handle_some_operation(
 Logic handlers raise the API exception classes from `src.api.common.exceptions` directly — there is no separate domain-error hierarchy. The `@handle_route_errors` decorator (applied automatically by `BaseRouter`) lets `HTTPException` subclasses pass through, translates fastapi-users exceptions, and converts anything else into a generic 500.
 
 ```python
-async def handle_get_post_detail(post_id: UUID, post_repo: PostRepository):
-    post = await post_repo.get_post_with_detail(post_id)
+async def handle_get_post_detail(post_id: UUID, repo: PostRepository):
+    post = await repo.get_post_with_detail(post_id)
     if post is None:
         raise NotFoundError(detail="Post not found")  # → 404
     return post
@@ -193,12 +212,12 @@ async def handle_template_rendering_operation(
 ```python
 # Bad - HTTP concerns in logic
 async def handle_get_users(request: Request) -> JSONResponse:
-    users = await user_repo.list_users()
+    users = await repo.list_users()
     return JSONResponse({"users": [user.dict() for user in users]})
 
 # Good - return data for route to handle
-async def handle_get_users(user_repo: UserRepository, requesting_user: User):
-    users = await user_repo.list_users(exclude_user=requesting_user)
+async def handle_get_users(repo: UserRepository, requesting_user: User):
+    users = await repo.list_users(exclude_user=requesting_user)
     return {"users": users, "current_user": requesting_user}
 ```
 

--- a/src/logic/posts/post_processing.py
+++ b/src/logic/posts/post_processing.py
@@ -34,7 +34,7 @@ POST = AuditedResource(
 
 async def handle_list_posts(
     request: Request,
-    post_repo: PostRepository,
+    repo: PostRepository,
     requesting_user: User,
 ):
     """Loads all posts (newest first) and returns the template context.
@@ -42,7 +42,7 @@ async def handle_list_posts(
     Includes the registered post kinds in the context so the list page
     can render its per-kind "New X" links from a single source of truth.
     """
-    posts = await post_repo.list_posts()
+    posts = await repo.list_posts()
     return {
         "request": request,
         "posts": posts,
@@ -54,11 +54,11 @@ async def handle_list_posts(
 async def handle_get_post_detail(
     request: Request,
     post_id: UUID,
-    post_repo: PostRepository,
+    repo: PostRepository,
     requesting_user: User,
 ):
     """Loads a single post for the detail page; 404s if missing."""
-    post = await post_repo.get_post_by_id(post_id)
+    post = await repo.get_post_by_id(post_id)
     if post is None:
         raise NotFoundError(detail="Post not found")
 
@@ -76,12 +76,12 @@ async def handle_get_post_form(
 async def handle_get_post_edit_form(
     request: Request,
     post_id: UUID,
-    post_repo: PostRepository,
+    repo: PostRepository,
     requesting_user: User,
 ):
     """Loads a post for the edit-form page. 404 if missing, 403 if the
     requester is neither owner nor admin (mirrors `handle_update_post`)."""
-    post = await post_repo.get_post_by_id(post_id)
+    post = await repo.get_post_by_id(post_id)
     if post is None:
         raise NotFoundError(detail="Post not found")
 
@@ -92,7 +92,7 @@ async def handle_get_post_edit_form(
 
 async def handle_create_post(
     payload: PostCreatePayload,
-    post_repo: PostRepository,
+    repo: PostRepository,
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> Post:
@@ -108,9 +108,9 @@ async def handle_create_post(
     post = Post(kind=payload.kind, owner_id=requesting_user.id)
     detail = spec.detail_model(**{f: getattr(payload, f) for f in spec.detail_fields})
 
-    created = await post_repo.create_post(post, detail)
+    created = await repo.create_post(post, detail)
     async with mutate(
-        post_repo,
+        repo,
         audit_repo,
         actor=requesting_user,
         target=created,
@@ -124,7 +124,7 @@ async def handle_create_post(
 async def handle_update_post(
     post_id: UUID,
     payload: PostUpdatePayload,
-    post_repo: PostRepository,
+    repo: PostRepository,
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> Post:
@@ -137,7 +137,7 @@ async def handle_update_post(
     via PATCH. 404 if missing, 403 if not authorized, 400 on kind
     mismatch. Per-kind field set comes from `REGISTERED_KINDS`.
     """
-    post = await post_repo.get_post_by_id(post_id)
+    post = await repo.get_post_by_id(post_id)
     if post is None:
         raise NotFoundError(detail="Post not found")
 
@@ -153,14 +153,14 @@ async def handle_update_post(
 
     spec = REGISTERED_KINDS[payload.kind]
     async with mutate(
-        post_repo,
+        repo,
         audit_repo,
         actor=requesting_user,
         target=post,
         resource=POST,
         verb="update",
     ):
-        await post_repo.update_post(
+        await repo.update_post(
             post,
             **{f: getattr(payload, f) for f in spec.detail_fields},
         )
@@ -169,7 +169,7 @@ async def handle_update_post(
 
 async def handle_delete_post(
     post_id: UUID,
-    post_repo: PostRepository,
+    repo: PostRepository,
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> None:
@@ -180,18 +180,18 @@ async def handle_delete_post(
 
     404 if missing, 403 if not authorized.
     """
-    post = await post_repo.get_post_by_id(post_id)
+    post = await repo.get_post_by_id(post_id)
     if post is None:
         raise NotFoundError(detail="Post not found")
 
     assert_owner_or_admin(post, requesting_user, action="delete this post")
 
     async with mutate(
-        post_repo,
+        repo,
         audit_repo,
         actor=requesting_user,
         target=post,
         resource=POST,
         verb="delete",
     ):
-        await post_repo.delete_post(post)
+        await repo.delete_post(post)

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -23,7 +23,7 @@ _snapshot_user = make_snapshotter(UserAuditSnapshot)
 
 async def handle_list_users(
     request: Request,
-    user_repo: UserRepository,
+    repo: UserRepository,
     requesting_user: User,
 ):
     """
@@ -31,7 +31,7 @@ async def handle_list_users(
 
     Args:
         request: The FastAPI request object.
-        user_repo: The user repository dependency.
+        repo: The user repository dependency.
         requesting_user: The currently authenticated user.
 
     Returns:
@@ -43,7 +43,7 @@ async def handle_list_users(
     logger.debug(f"Handler: Listing users for user {requesting_user.id}.")
 
     try:
-        users_list = await user_repo.list_users(
+        users_list = await repo.list_users(
             exclude_user=requesting_user,
         )
     except Exception as e:
@@ -62,7 +62,7 @@ async def handle_list_users(
 async def handle_get_user_detail(
     request: Request,
     user_id: UUID,
-    user_repo: UserRepository,
+    repo: UserRepository,
     profile_repo: ProviderRepository,
     requesting_user: User,
 ):
@@ -70,7 +70,7 @@ async def handle_get_user_detail(
     they own; 404s if the user is missing. Provider data is already
     publicly available via `GET /providers`, so the embedded list is gated
     only by the existing user-detail auth (any active user)."""
-    target = await user_repo.get_user_by_id(user_id)
+    target = await repo.get_user_by_id(user_id)
     if target is None:
         raise NotFoundError(detail="User not found")
 
@@ -87,7 +87,7 @@ async def handle_get_user_detail(
 async def handle_set_user_activation(
     user_id: UUID,
     payload: UserActivationUpdate,
-    user_repo: UserRepository,
+    repo: UserRepository,
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> User:
@@ -97,7 +97,7 @@ async def handle_set_user_activation(
     Self-guard lives here so direct API calls can't bypass the template's
     `{% if %}` hide. The route's `current_admin_user` dep blocks non-admins.
     """
-    target = await user_repo.get_user_by_id(user_id)
+    target = await repo.get_user_by_id(user_id)
     if target is None:
         raise NotFoundError(detail="User not found")
     if target.id == requesting_user.id:
@@ -110,7 +110,7 @@ async def handle_set_user_activation(
         f"Handler: admin {requesting_user.id} setting activation={payload.state} on user {target.id}"
     )
     before = _snapshot_user_activation(target)
-    updated = await user_repo.set_user_activation(target, is_active=is_active)
+    updated = await repo.set_user_activation(target, is_active=is_active)
     await record_audit(
         audit_repo,
         actor_id=requesting_user.id,
@@ -120,13 +120,13 @@ async def handle_set_user_activation(
         before=before,
         after=_snapshot_user_activation(updated),
     )
-    await user_repo.session.commit()
+    await repo.session.commit()
     return updated
 
 
 async def handle_delete_user(
     user_id: UUID,
-    user_repo: UserRepository,
+    repo: UserRepository,
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> None:
@@ -136,7 +136,7 @@ async def handle_delete_user(
 
     Self-guard mirrors `handle_set_user_activation`; the route dep blocks non-admins.
     """
-    target = await user_repo.get_user_by_id(user_id)
+    target = await repo.get_user_by_id(user_id)
     if target is None:
         raise NotFoundError(detail="User not found")
     if target.id == requesting_user.id:
@@ -154,5 +154,5 @@ async def handle_delete_user(
         before=before,
         after=None,
     )
-    await user_repo.delete_user(target)
-    await user_repo.session.commit()
+    await repo.delete_user(target)
+    await repo.session.commit()


### PR DESCRIPTION
Closes #245.

## Summary
- Rename `user_repo` → `repo` in `src/logic/users/user_processing.py` (4 handlers)
- Rename `post_repo` → `repo` in `src/logic/posts/post_processing.py` (7 handlers)
- Update call sites in `src/api/routes/users.py` and `src/api/routes/posts.py` to pass `repo=`
- Document the convention in `src/logic/README.md` and refresh inline examples

`handle_list_user_providers` keeps `repo: ProviderRepository` (already correct, primary) + secondary `user_repo: UserRepository`. `me.py` was already calling correctly. No behavior change.

## Why
Slice 1 of ~10 in a sequenced refactor toward a unified `ResourceSpec` + opt-in `mount_*` grammar. Generic mount infrastructure needs to inject `repo=` uniformly into handlers; today's drift between `user_repo` / `post_repo` / `repo` blocks that.

## Test plan
- [x] `dev test` passes (504 passed, 1 skipped)
- [x] `dev lint` passes
- [x] `dev test contract` passes (16 passed)
- [x] No wire-format change — pure rename + call-site update

🤖 Generated with [Claude Code](https://claude.com/claude-code)