### PR TITLE
Add USER AuditedResource and route handle_delete_user through mutate()

### DIFF
--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -75,6 +75,8 @@ class AuditAction(str, Enum):
     UPDATE_POST = "update_post"
     DELETE_POST = "delete_post"
     SET_USER_ACTIVATION = "set_user_activation"
+    CREATE_USER = "create_user"
+    UPDATE_USER = "update_user"
     DELETE_USER = "delete_user"
     REGISTER = "register"
     CREATE_PROVIDER = "create_provider_profile"

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -4,7 +4,13 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
-from src.logic.audit import AuditAction, make_snapshotter, record_audit
+from src.logic.audit import (
+    AuditAction,
+    AuditedResource,
+    make_snapshotter,
+    mutate,
+    record_audit,
+)
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
@@ -18,7 +24,15 @@ from src.schemas.users.user import (
 logger = logging.getLogger(__name__)
 
 _snapshot_user_activation = make_snapshotter(UserActivationAuditSnapshot)
-_snapshot_user = make_snapshotter(UserAuditSnapshot)
+
+
+USER = AuditedResource(
+    type="user",
+    snapshot=make_snapshotter(UserAuditSnapshot),
+    create=AuditAction.CREATE_USER,
+    update=AuditAction.UPDATE_USER,
+    delete=AuditAction.DELETE_USER,
+)
 
 
 async def handle_list_users(
@@ -131,10 +145,11 @@ async def handle_delete_user(
     requesting_user: User,
 ) -> None:
     """Admin-only: hard-delete a user row. Writes an audit row in the same
-    transaction (recorded before the delete fires so the actor FK is still
-    valid; the row's `before` captures the soon-to-be-gone state).
+    transaction; `before` captures the soon-to-be-gone state, `after` is None.
 
-    Self-guard mirrors `handle_set_user_activation`; the route dep blocks non-admins.
+    Self-delete is forbidden (the actor is never the target), so writing the
+    audit row after the delete fires is safe — the actor row stays around
+    for the FK and `mutate()` captures `target.id` up front.
     """
     target = await repo.get_user_by_id(user_id)
     if target is None:
@@ -143,16 +158,12 @@ async def handle_delete_user(
         raise ForbiddenError(detail="Admins cannot delete their own account here")
 
     logger.info(f"Handler: admin {requesting_user.id} hard-deleting user {target.id}")
-    before = _snapshot_user(target)
-    target_id = target.id
-    await record_audit(
+    async with mutate(
+        repo,
         audit_repo,
-        actor_id=requesting_user.id,
-        resource_type="user",
-        resource_id=target_id,
-        action=AuditAction.DELETE_USER,
-        before=before,
-        after=None,
-    )
-    await repo.delete_user(target)
-    await repo.session.commit()
+        actor=requesting_user,
+        target=target,
+        resource=USER,
+        verb="delete",
+    ):
+        await repo.delete_user(target)


### PR DESCRIPTION
Closes #247.

## Summary
- Add `USER = AuditedResource(...)` in `src/logic/users/user_processing.py` matching the pattern used by `POST`, `PROFILE`, `LICENSURE`, `EDUCATION`, `CERTIFICATION`.
- Refactor `handle_delete_user` to use `mutate()` instead of manual `record_audit` + `session.commit`.
- Add `CREATE_USER` and `UPDATE_USER` to the `AuditAction` enum (reserved for future use — `REGISTER` still covers user creation in the auth flow).
- `handle_set_user_activation` unchanged — non-CRUD audit stays on `record_audit(...)`.

Drop `_snapshot_user` (the `make_snapshotter(UserAuditSnapshot)` instance) since `USER.snapshot` covers the same shape.

## Why
Slice 2 of 10 in the unified `ResourceSpec` refactor. `mount_delete` (slice 3, #248) will mount `DELETE /users/{id}` generically and expects the handler to use `mutate()` so the bundle plumbs `audit_resource` through the spec.

## Test plan
- [x] `dev test` passes (504 passed)
- [x] `dev lint` passes
- [x] `dev test contract` passes (16 passed)
- [x] Existing `test_delete_user_writes_audit_row` passes unchanged — confirms the audit row written by `mutate()` matches the previous shape (action=`delete_user`, resource_type=`user`, before=full snapshot, after=None, actor_id=admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)