### PR TITLE
Introduce ResourceSpec + mount_delete; migrate DELETE /users/{id}

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -70,6 +70,8 @@ Common utilities handle concerns that span multiple routes and domains.
 | **Decorators**  | Cross-cutting concerns | Error handling, logging                                         | BaseRouter (automatic)   |
 | **Exceptions**  | Error vocabulary       | API exception classes raised by logic; fastapi-users translator | Logic handlers, decorator |
 | **Forms**       | Form-encoded request glue | `parse_form_to_payload` and `validate_or_422`                | Route handlers that accept form-encoded bodies |
+| **resource_routes** | Unified `ResourceSpec` grammar | Declare a resource once, opt into the operations to expose via `mount_*` | Route files for any CRUD-shaped resource |
+| **subresource_routes** | Sub-resource CRUD shorthand (legacy) | `SubresourceSpec` + `register_subresource_routes`. Folds into `resource_routes` in slice 8. | `providers.py` (until slice 8 / #253) |
 
 ## Directory structure
 
@@ -80,10 +82,87 @@ Common utilities handle concerns that span multiple routes and domains.
 - `decorators.py` - Error handling and logging decorators applied to all routes
 - `exceptions.py` - `APIException` subclasses (`NotFoundError`, `ForbiddenError`, ...) raised by logic, plus the fastapi-users → HTTP translator
 - `forms.py` - HTTP-adapter primitives for form-encoded route bodies: `parse_form_to_payload(request)` (form → dict, lists for repeated keys) and `validate_or_422(adapter, payload_dict)` (run a `TypeAdapter`, translate `ValidationError` to 422 with `[{"loc","msg","type"}]`). Home for any HTTP-adapter primitive that two or more route modules would otherwise import from each other.
+- `resource_routes.py` - Unified `ResourceSpec` + opt-in `mount_*` grammar. See [Unified resource grammar](#unified-resource-grammar) below.
+- `subresource_routes.py` - Earlier `SubresourceSpec` + `register_subresource_routes` helper that handles provider sub-resource CRUD. Slice 8 (#253) folds it into `resource_routes` via the `parent` field on `ResourceSpec`; until then both coexist.
 
 **Package infrastructure:**
 
 - `__init__.py` - Exports all common utilities for easy import
+
+## Unified resource grammar
+
+`resource_routes.py` is the in-progress home for a unified `ResourceSpec` + opt-in `mount_*` grammar that covers every CRUD-shaped route. It's being built incrementally in 10 slices (see issues with the `refactor` label whose titles start with "Slice"); today only `mount_delete` is wired up and exercised by `users.py`.
+
+### The shape
+
+A resource declares a single `ResourceSpec` describing its **identity** — collection name, id param, primary repo, audit bundle, auth deps, schemas, templates, redirect targets. The route file then **opts in** to the operations it wants to expose by calling the corresponding mount function:
+
+```python
+from src.api.common.resource_routes import ResourceSpec, mount_delete
+from src.logic.users.user_processing import USER, handle_delete_user
+
+users_api_router = APIRouter(prefix="/users")
+router = BaseRouter(router=users_api_router, default_tags=["users"])
+
+USER_SPEC = ResourceSpec(
+    collection="users",
+    id_param="user_id",
+    repo_dep=get_user_repository,
+    audit_resource=USER,                  # AuditedResource bundle from logic
+    read_user_dep=current_active_user,
+    write_user_dep=current_admin_user,
+)
+
+mount_delete(
+    router,
+    USER_SPEC,
+    handler=handle_delete_user,
+    audit_repo_dep=get_audit_repository,
+)
+```
+
+### Why this shape
+
+- **Opt-in mounts.** A read-only resource simply doesn't call `mount_create`/`mount_update`/`mount_delete` — there's no `read_only=True` flag because *not calling the mount* is the cleanest way to express "don't expose this verb." A backend-only resource (e.g. an async verification record written by a worker) still declares `audit_resource` so the worker can call `mutate(...)`, but the route file mounts only `mount_list` / `mount_detail`.
+- **Spec is identity, mounts are operations.** Adding a new mount function (`mount_list`, `mount_create`, ...) doesn't change `ResourceSpec`'s shape for resources that don't use it — defaults are `None`. The dataclass grows fields incrementally as new mounts land.
+- **Sub-resources nest via `parent`.** A child `ResourceSpec` carrying `parent=parent_spec` produces paths like `/providers/{provider_id}/licensures/{licensure_id}` — same mount functions, no separate registration helper. (Slice 8 / #253 lifts the current restriction that `mount_delete` rejects parent-bearing specs.)
+- **Polymorphic resources via handler-driven knobs.** Posts dispatch templates by `kind`; the route doesn't need to. The handler returns a `template_name` in its context dict and the mount honors it. This keeps the spec's shape stable even when the resource's behavior is polymorphic. (Lands in slice 5 / #250 for `mount_form`.)
+
+### Handler signatures
+
+Mount functions invoke handlers with a fixed shape so the spec can plumb args generically. Every handler the mounts call expects:
+
+- **`<id_param>=<UUID>`** for routes with an id in the path (detail/update/delete), under the per-resource kwarg name declared in the spec (`user_id`, `post_id`, ...).
+- **`repo=<primary repo>`** for the resource's primary repository, sourced from `spec.repo_dep`.
+- **`audit_repo=<AuditRepository>`** for mutation handlers, sourced from `audit_repo_dep` passed to the mount call (it's a layer-wide concern, not a per-resource knob).
+- **`requesting_user=<User>`** for any handler that gates on auth, sourced from `spec.read_user_dep` or `spec.write_user_dep`.
+- **`payload=<validated body>`** for create/update handlers (slices 6–7).
+
+Secondary repos (e.g. `user_repo: UserRepository` in the multi-repo `handle_list_user_providers`) keep their typed name per the [logic-layer convention](../../logic/README.md#handler-kwarg-naming) and arrive via `spec.extra_repo_deps`.
+
+### What's mounted today
+
+| Mount | Status | Resources using it |
+| --- | --- | --- |
+| `mount_delete` | Landed (slice 3 / #248) | `users` (DELETE) |
+| `mount_list` / `mount_detail` | Slice 4 / #249 | — |
+| `mount_form` | Slice 5 / #250 | — |
+| `mount_create` / `mount_update` | Slice 6 / #251 | — |
+| `mount_related_list` | Slice 9 / #254 | — |
+| Sub-resource via `parent=` | Slice 8 / #253 | — |
+
+Per-mount docstrings in `resource_routes.py` are the canonical reference for required spec fields and exact handler kwargs.
+
+### What's *not* meant for this grammar
+
+The grammar fits resource-shaped routes. It's deliberately **not** a home for:
+
+- **Auth flows** — register/login/verify/reset-password live in `auth_routes.py` / `auth_pages.py`. State-machine semantics, not CRUD.
+- **`/me/*` singletons** — no parent id, session-sourced. Stays bespoke (slice 9 decision).
+- **State-mutation actions like `PUT /users/{id}/activation`** — idempotent set with `HX-Refresh`, not partial edit with `HX-Redirect`. Doesn't match `mount_update` semantics.
+- **Utility endpoints** — `/`, `/health`.
+
+Slice 10 (#255) documents these explicitly. If a future case suggests the grammar should grow to fit them, that's the moment to reshape `ResourceSpec`, not to escape-hatch around it.
 
 ## Implementation patterns
 
@@ -305,7 +384,13 @@ handle_fastapi_users_error(fastapi_users_exception) -> APIException
 
 ## Tests
 
-**TODO** — no colocated tests yet. Add `test_*.py` here when modifying utilities in this directory (e.g. response helpers, error mapping). The route-level tests under `../routes/` exercise some of this behavior indirectly but should not be relied on as the only coverage.
+Colocated tests cover the helpers in this directory:
+
+- `test_responses.py` — `APIResponse`, `created_response`, `updated_response`, `deleted_response`, `refreshed_response`.
+- `test_subresource_routes.py` — `SubresourceSpec` + `register_subresource_routes` (slice 8 / #253 folds this into `resource_routes`).
+- `test_resource_routes.py` — `ResourceSpec` + per-mount tests. Add a test here whenever a new mount function lands or an existing one grows a knob.
+
+Route-level tests under `../routes/` exercise the mounts indirectly via the resources that use them; the unit tests here cover spec validation, error handling at mount time, and the path-param wiring that the route-level tests can't easily isolate.
 
 ## Related documentation
 

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -1,0 +1,239 @@
+"""Unified resource-route infrastructure: `ResourceSpec` + opt-in `mount_*`.
+
+A new resource declares a single `ResourceSpec` describing its identity
+(collection name, id param, repo, audit bundle, auth deps, schemas,
+templates, redirect targets). It then opts into the operations it wants
+exposed by calling the corresponding mount function:
+
+    USER_SPEC = ResourceSpec(
+        collection="users",
+        id_param="user_id",
+        repo_dep=get_user_repository,
+        audit_resource=USER,
+        write_user_dep=current_admin_user,
+    )
+    mount_delete(router, USER_SPEC, handler=handle_delete_user)
+
+The grammar is **opt-in**: only the mount calls you make produce routes.
+A read-only resource simply doesn't call `mount_create`/`mount_update`/
+`mount_delete`. A backend-mutated resource (e.g. an async verification
+record) still declares an `audit_resource` so backend code can call
+`mutate(...)`, but never mounts the mutation routes — HTTP exposure and
+backend write capability are independent.
+
+Sub-resources nest under a parent by setting `parent=parent_spec`. The
+mount functions walk the chain to build paths like
+`/providers/{provider_id}/licensures/{licensure_id}`. Parent-chain
+support lands incrementally; until slice 8 (#253) only `mount_delete`
+exists, and it asserts `parent is None` so callers don't silently fall
+into an unsupported case.
+
+Adding a new mount function (e.g. `mount_list`, `mount_create`) follows
+the same pattern: read knobs from the spec, build the route, delegate to
+the handler. Each mount is independent — adding one doesn't change the
+others. See the per-mount docstrings for the exact handler kwargs each
+expects.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+from uuid import UUID
+
+from fastapi import Depends, status
+from pydantic import TypeAdapter
+
+from src.api.common.responses import deleted_response
+from src.logic.audit import AuditedResource
+
+
+@dataclass(frozen=True)
+class ResourceSpec:
+    """Declarative identity of a resource.
+
+    The mount functions read knobs from here. Most fields default to
+    `None` so a spec only declares what its mounted operations actually
+    need; e.g. a read-only resource leaves `create_adapter` /
+    `update_adapter` / `read_to_dict` unset.
+
+    Fields:
+      collection: URL segment (e.g. ``"users"``).
+      id_param: name of the path param + handler kwarg for the resource
+        id (e.g. ``"user_id"``).
+      repo_dep: FastAPI ``Depends`` provider for the resource's primary
+        repository. Mount functions inject this and pass it to handlers
+        as ``repo=``.
+      audit_resource: the ``AuditedResource`` bundle for ``mutate(...)``
+        calls. Optional for read-only resources; required if the
+        handler does any audited mutation.
+      read_user_dep / write_user_dep: ``Depends`` providers for the
+        authenticated user on read vs. write routes. ``None`` means
+        public (no auth gate). Defaults to ``None`` so callers must
+        opt in deliberately — silently public reads would be a bug.
+      write_authz: optional callable invoked inside mutation handlers
+        to enforce per-resource auth (e.g. ``assert_owner_or_admin``).
+        Today the handler calls this itself; reserved on the spec for
+        future centralization.
+      create_adapter / update_adapter: ``TypeAdapter`` for form-encoded
+        request bodies on POST/PATCH. Mount functions parse with
+        ``parse_and_validate_form``.
+      read_to_dict: callable that turns a persisted object into the
+        response body for PATCH (and possibly other mounts later).
+      list_template / detail_template / form_template: Jinja paths for
+        read mounts. Polymorphic resources (e.g. posts kind-dispatch)
+        may return ``template_name`` in the handler's context dict to
+        override these per-request.
+      extra_repo_deps: ``Depends`` providers for any *additional*
+        repositories the handler needs beyond the primary ``repo_dep``.
+        Mount functions inject these by their dep callable's name
+        (minus the ``get_`` prefix). Used by handlers like
+        ``handle_get_user_detail`` that take both a user repo and a
+        provider repo. Empty for the common single-repo case.
+      create_redirect / update_redirect / delete_redirect: callables
+        receiving the path params + (for create/update) the resource id,
+        returning the ``HX-Redirect`` URL. ``None`` means use a sensible
+        default per mount.
+      parent: another ``ResourceSpec`` for sub-resources. Slice 8 (#253)
+        wires this through; until then ``mount_delete`` asserts
+        ``parent is None``.
+    """
+
+    collection: str
+    id_param: str
+    repo_dep: Callable[..., Any]
+    audit_resource: AuditedResource | None = None
+
+    read_user_dep: Callable[..., Any] | None = None
+    write_user_dep: Callable[..., Any] | None = None
+    write_authz: Callable[..., None] | None = None
+
+    create_adapter: TypeAdapter | None = None
+    update_adapter: TypeAdapter | None = None
+    read_to_dict: Callable[[Any], dict] | None = None
+
+    list_template: str | None = None
+    detail_template: str | None = None
+    form_template: str | None = None
+
+    extra_repo_deps: tuple[Callable[..., Any], ...] = ()
+
+    create_redirect: Callable[..., str] | None = None
+    update_redirect: Callable[..., str] | None = None
+    delete_redirect: Callable[..., str] | None = None
+
+    parent: "ResourceSpec | None" = None
+
+
+def mount_delete(
+    router: Any,
+    spec: ResourceSpec,
+    handler: Callable[..., Awaitable[None]],
+    *,
+    audit_repo_dep: Callable[..., Any],
+) -> None:
+    """Mount ``DELETE /<collection>/{<id_param>}`` on ``router``.
+
+    The handler is invoked with the resource id (under ``spec.id_param``),
+    ``repo`` (from ``spec.repo_dep``), ``audit_repo`` (from
+    ``audit_repo_dep``), and ``requesting_user`` (from
+    ``spec.write_user_dep``). The handler is expected to use
+    ``mutate(verb="delete")`` so the audit row is written and the
+    transaction commits inside the same scope.
+
+    Response is ``204 No Content`` with ``HX-Redirect`` set by
+    ``spec.delete_redirect(**path_params)`` if provided, else
+    ``f"/{spec.collection}"``.
+
+    `audit_repo_dep` is passed in rather than read from the spec because
+    the audit repo dependency is a layer-wide concern, not a per-resource
+    knob — every mounted mutation uses the same one. Callers import it
+    once and reuse it across all `mount_*` calls.
+
+    Until slice 8 (#253) sub-resource support lands, this asserts
+    ``spec.parent is None``. The path is just ``/{<id_param>}`` —
+    callers register the router with the resource's collection prefix
+    (e.g. ``APIRouter(prefix="/users")``).
+    """
+    if spec.parent is not None:
+        raise NotImplementedError(
+            "mount_delete with spec.parent is not supported yet "
+            "(slice 8 / issue #253). Use register_subresource_routes for now."
+        )
+    if spec.write_user_dep is None:
+        raise ValueError(
+            f"mount_delete requires {spec.collection!r} to set "
+            "write_user_dep — silent public deletes would be a bug."
+        )
+
+    path = f"/{{{spec.id_param}}}"
+    id_param = spec.id_param
+    delete_redirect = spec.delete_redirect
+    default_redirect = f"/{spec.collection}"
+
+    async def _delete(**kwargs: Any) -> Any:
+        # FastAPI binds the path param under `id_param`, the deps under
+        # the names declared in `__signature__` below.
+        resource_id = kwargs[id_param]
+        await handler(
+            **{id_param: resource_id},
+            repo=kwargs["repo"],
+            audit_repo=kwargs["audit_repo"],
+            requesting_user=kwargs["requesting_user"],
+        )
+        if delete_redirect is not None:
+            hx_redirect = delete_redirect(**{id_param: resource_id})
+        else:
+            hx_redirect = default_redirect
+        return deleted_response(hx_redirect=hx_redirect)
+
+    _set_route_signature(
+        _delete,
+        path_params=((id_param, UUID),),
+        deps=(
+            ("repo", spec.repo_dep),
+            ("audit_repo", audit_repo_dep),
+            ("requesting_user", spec.write_user_dep),
+        ),
+    )
+
+    router.delete(path, status_code=status.HTTP_204_NO_CONTENT)(_delete)
+
+
+def _set_route_signature(
+    fn: Callable[..., Any],
+    *,
+    path_params: tuple[tuple[str, type], ...],
+    deps: tuple[tuple[str, Callable[..., Any]], ...],
+) -> None:
+    """Advertise an explicit signature on a `**kwargs`-based route handler.
+
+    FastAPI introspects `inspect.signature(fn)` to figure out path params
+    and dependencies. The mount helpers define the actual handler with
+    `**kwargs` (so the parameter names can be data-driven from the
+    `ResourceSpec`) and call this to publish the signature FastAPI sees.
+
+    `path_params` are positional-or-keyword params with a type annotation
+    and no default — FastAPI binds them from the URL.
+    `deps` are positional-or-keyword params whose default is `Depends(...)`
+    — FastAPI resolves them via the injection system.
+    """
+    from inspect import Parameter, Signature
+
+    params: list[Parameter] = []
+    for name, ann in path_params:
+        params.append(
+            Parameter(
+                name=name,
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=ann,
+            )
+        )
+    for name, dep in deps:
+        params.append(
+            Parameter(
+                name=name,
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                default=Depends(dep),
+                annotation=Any,
+            )
+        )
+    fn.__signature__ = Signature(parameters=params)  # type: ignore[attr-defined]

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -1,0 +1,170 @@
+"""Tests for `src/api/common/resource_routes.py`.
+
+Mounts a tiny stub resource against a FastAPI app and exercises the
+mount functions end-to-end. Validates that:
+  - Path params use the per-resource `id_param` name from the spec.
+  - Handlers receive `repo`, `audit_repo`, `requesting_user`, and the
+    resource id under its declared kwarg name.
+  - Response shape (status, HX-Redirect) matches the hand-written
+    equivalents.
+  - Misconfigurations (missing `write_user_dep`, sub-resource specs
+    until slice 8) raise at mount time, not at request time.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.common.resource_routes import ResourceSpec, mount_delete
+
+
+def _build_app(spec: ResourceSpec, captured: dict) -> FastAPI:
+    """Mount `mount_delete` for `spec` and capture every handler call into
+    `captured`. Stub deps return predictable sentinels so kwargs are
+    inspectable in assertions."""
+
+    async def delete_handler(**kwargs):
+        captured.update(kwargs)
+
+    app = FastAPI()
+    router = APIRouter(prefix=f"/{spec.collection}")
+    mount_delete(
+        router,
+        spec,
+        handler=delete_handler,
+        audit_repo_dep=lambda: SimpleNamespace(name="audit_repo"),
+    )
+    app.include_router(router)
+    return app
+
+
+def test_mount_delete_returns_204_with_hx_redirect_default():
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+    captured: dict = {}
+    client = TestClient(_build_app(spec, captured))
+
+    widget_id = uuid4()
+    resp = client.delete(f"/widgets/{widget_id}")
+
+    assert resp.status_code == 204
+    assert resp.headers["HX-Redirect"] == "/widgets"
+
+
+def test_mount_delete_passes_id_under_spec_kwarg_name():
+    spec = ResourceSpec(
+        collection="gadgets",
+        id_param="gadget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+    captured: dict = {}
+    client = TestClient(_build_app(spec, captured))
+
+    gadget_id = uuid4()
+    resp = client.delete(f"/gadgets/{gadget_id}")
+
+    assert resp.status_code == 204
+    assert "gadget_id" in captured
+    assert str(captured["gadget_id"]) == str(gadget_id)
+    assert captured["repo"].name == "repo"
+    assert captured["audit_repo"].name == "audit_repo"
+
+
+def test_mount_delete_uses_custom_redirect_callable():
+    def custom_redirect(*, sprocket_id):
+        return f"/sprockets-overview?last={sprocket_id}"
+
+    spec = ResourceSpec(
+        collection="sprockets",
+        id_param="sprocket_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+        delete_redirect=custom_redirect,
+    )
+    captured: dict = {}
+    client = TestClient(_build_app(spec, captured))
+
+    sprocket_id = uuid4()
+    resp = client.delete(f"/sprockets/{sprocket_id}")
+
+    assert resp.status_code == 204
+    assert resp.headers["HX-Redirect"] == f"/sprockets-overview?last={sprocket_id}"
+
+
+def test_mount_delete_rejects_subresource_spec_until_slice_8():
+    parent = ResourceSpec(
+        collection="parents",
+        id_param="parent_id",
+        repo_dep=lambda: None,
+        write_user_dep=lambda: None,
+    )
+    child = ResourceSpec(
+        collection="children",
+        id_param="child_id",
+        repo_dep=lambda: None,
+        write_user_dep=lambda: None,
+        parent=parent,
+    )
+    router = APIRouter()
+    with pytest.raises(NotImplementedError, match="parent"):
+        mount_delete(
+            router,
+            child,
+            handler=lambda **_: None,
+            audit_repo_dep=lambda: None,
+        )
+
+
+def test_mount_delete_requires_write_user_dep():
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: None,
+        # write_user_dep intentionally omitted
+    )
+    router = APIRouter()
+    with pytest.raises(ValueError, match="write_user_dep"):
+        mount_delete(
+            router,
+            spec,
+            handler=lambda **_: None,
+            audit_repo_dep=lambda: None,
+        )
+
+
+def test_mount_delete_404_propagates_from_handler():
+    """If the handler raises NotFoundError, the route surfaces it as 404
+    (decorator translation). Confirms the mount doesn't swallow exceptions."""
+
+    from src.api.common.exceptions import NotFoundError
+
+    async def raising_handler(**kwargs):
+        raise NotFoundError(detail="missing")
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+    app = FastAPI()
+    router = APIRouter(prefix=f"/{spec.collection}")
+    mount_delete(
+        router,
+        spec,
+        handler=raising_handler,
+        audit_repo_dep=lambda: SimpleNamespace(name="audit_repo"),
+    )
+    app.include_router(router)
+    client = TestClient(app)
+
+    resp = client.delete(f"/widgets/{uuid4()}")
+    assert resp.status_code == 404

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -1,13 +1,15 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
-from src.api.common import APIResponse, BaseRouter, deleted_response
+from src.api.common import APIResponse, BaseRouter
+from src.api.common.resource_routes import ResourceSpec, mount_delete
 from src.auth_config import current_active_user, current_admin_user
 from src.logic.providers.provider_processing import handle_list_user_providers
 from src.logic.users.user_processing import (
+    USER,
     handle_delete_user,
     handle_get_user_detail,
     handle_list_users,
@@ -27,6 +29,16 @@ from src.schemas.users.user import UserActivationUpdate
 users_api_router = APIRouter(prefix="/users")
 router = BaseRouter(router=users_api_router, default_tags=["users"])
 logger = logging.getLogger(__name__)
+
+
+USER_SPEC = ResourceSpec(
+    collection="users",
+    id_param="user_id",
+    repo_dep=get_user_repository,
+    audit_resource=USER,
+    read_user_dep=current_active_user,
+    write_user_dep=current_admin_user,
+)
 
 
 @router.get("")
@@ -120,18 +132,12 @@ async def set_user_activation(
     )
 
 
-@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_user(
-    user_id: UUID,
-    user_repo: UserRepository = Depends(get_user_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    admin: User = Depends(current_admin_user),
-):
-    """Admin-only: hard-delete a user."""
-    await handle_delete_user(
-        user_id=user_id,
-        repo=user_repo,
-        audit_repo=audit_repo,
-        requesting_user=admin,
-    )
-    return deleted_response(hx_redirect="/users")
+# DELETE /users/{user_id} is mounted via the unified ResourceSpec grammar.
+# Admin-only: hard-delete a user. The handler uses `mutate(verb="delete")`
+# so the audit row + commit are owned by the context manager.
+mount_delete(
+    router,
+    USER_SPEC,
+    handler=handle_delete_user,
+    audit_repo_dep=get_audit_repository,
+)

--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -75,6 +75,8 @@ class AuditAction(str, Enum):
     UPDATE_POST = "update_post"
     DELETE_POST = "delete_post"
     SET_USER_ACTIVATION = "set_user_activation"
+    CREATE_USER = "create_user"
+    UPDATE_USER = "update_user"
     DELETE_USER = "delete_user"
     REGISTER = "register"
     CREATE_PROVIDER = "create_provider_profile"

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -4,7 +4,13 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
-from src.logic.audit import AuditAction, make_snapshotter, record_audit
+from src.logic.audit import (
+    AuditAction,
+    AuditedResource,
+    make_snapshotter,
+    mutate,
+    record_audit,
+)
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
@@ -18,7 +24,15 @@ from src.schemas.users.user import (
 logger = logging.getLogger(__name__)
 
 _snapshot_user_activation = make_snapshotter(UserActivationAuditSnapshot)
-_snapshot_user = make_snapshotter(UserAuditSnapshot)
+
+
+USER = AuditedResource(
+    type="user",
+    snapshot=make_snapshotter(UserAuditSnapshot),
+    create=AuditAction.CREATE_USER,
+    update=AuditAction.UPDATE_USER,
+    delete=AuditAction.DELETE_USER,
+)
 
 
 async def handle_list_users(
@@ -131,10 +145,11 @@ async def handle_delete_user(
     requesting_user: User,
 ) -> None:
     """Admin-only: hard-delete a user row. Writes an audit row in the same
-    transaction (recorded before the delete fires so the actor FK is still
-    valid; the row's `before` captures the soon-to-be-gone state).
+    transaction; `before` captures the soon-to-be-gone state, `after` is None.
 
-    Self-guard mirrors `handle_set_user_activation`; the route dep blocks non-admins.
+    Self-delete is forbidden (the actor is never the target), so writing the
+    audit row after the delete fires is safe — the actor row stays around
+    for the FK and `mutate()` captures `target.id` up front.
     """
     target = await repo.get_user_by_id(user_id)
     if target is None:
@@ -143,16 +158,12 @@ async def handle_delete_user(
         raise ForbiddenError(detail="Admins cannot delete their own account here")
 
     logger.info(f"Handler: admin {requesting_user.id} hard-deleting user {target.id}")
-    before = _snapshot_user(target)
-    target_id = target.id
-    await record_audit(
+    async with mutate(
+        repo,
         audit_repo,
-        actor_id=requesting_user.id,
-        resource_type="user",
-        resource_id=target_id,
-        action=AuditAction.DELETE_USER,
-        before=before,
-        after=None,
-    )
-    await repo.delete_user(target)
-    await repo.session.commit()
+        actor=requesting_user,
+        target=target,
+        resource=USER,
+        verb="delete",
+    ):
+        await repo.delete_user(target)


### PR DESCRIPTION
Closes #248.

## Summary
- New `src/api/common/resource_routes.py` with `ResourceSpec` dataclass + `mount_delete` (smallest of the planned `mount_*` primitives).
- `users.py` declares `USER_SPEC` and migrates `DELETE /users/{user_id}` to `mount_delete`. The 33 existing user-route tests pass unchanged.
- 6 new unit tests in `src/api/common/test_resource_routes.py`: 204 status, default HX-Redirect, custom redirect callable, per-resource kwarg name routing, mount-time validation errors, 404 propagation.
- `src/api/common/README.md` documents the unified grammar, opt-in philosophy, handler signature contract, and what stays bespoke.

## Why
Slice 3 of 10 in the unified `ResourceSpec` refactor — the slice that lets the vocabulary either earn its keep or get reshaped. `mount_delete` is the simplest mount (no body, no template), so it's the cleanest place to find out.

## Implementation note
Path-param wiring uses a `**kwargs` handler with `__signature__` overridden via `_set_route_signature()` — FastAPI sees explicit named params (the id under its per-resource kwarg name, deps as injection-resolved). Sub-resource support (`parent=` field) lands in slice 8 (#253); until then `mount_delete` asserts `parent is None`.

## Test plan
- [x] `dev test` passes (510 — was 504, 6 new)
- [x] `dev lint` passes
- [x] `dev test contract` passes (16)
- [x] `dev routes /users` shows `DELETE /users/{user_id}` mounted via `mount_delete` (path/name unchanged)
- [x] Existing audit-row test (`test_delete_user_writes_audit_row`) passes — same shape via the new mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)