### PR TITLE
Add mount_list + mount_detail; migrate users' reads

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -145,11 +145,28 @@ Secondary repos (e.g. `user_repo: UserRepository` in the multi-repo `handle_list
 | Mount | Status | Resources using it |
 | --- | --- | --- |
 | `mount_delete` | Landed (slice 3 / #248) | `users` (DELETE) |
-| `mount_list` / `mount_detail` | Slice 4 / #249 | — |
+| `mount_list` / `mount_detail` | Landed (slice 4 / #249) | `users` (GET / and GET /{id}) |
 | `mount_form` | Slice 5 / #250 | — |
 | `mount_create` / `mount_update` | Slice 6 / #251 | — |
 | `mount_related_list` | Slice 9 / #254 | — |
 | Sub-resource via `parent=` | Slice 8 / #253 | — |
+
+### Multi-repo handlers: `extra_repo_deps`
+
+Some handlers need more than the resource's primary repo — e.g. `handle_get_user_detail` takes both the user repo (the primary) and the provider repo (to embed the owned-providers list on the user-detail page). The mount that needs them passes them via the `extra_repo_deps` kwarg:
+
+```python
+mount_detail(
+    router,
+    USER_SPEC,
+    handler=handle_get_user_detail,
+    extra_repo_deps=(get_provider_repository,),
+)
+```
+
+The mount derives the kwarg name from the dep callable: `get_provider_repository` → `provider_repo` (strip `get_` prefix, replace `_repository` suffix with `_repo`). The handler must take the same name. If the dep doesn't follow the `get_<entity>_repository` convention, the mount raises at registration time — silent name-mismatches would be a request-time bug.
+
+`extra_repo_deps` is per-mount, not per-spec, because different mounts on the same resource often need different extras (the list view doesn't need provider_repo even though the detail view does).
 
 Per-mount docstrings in `resource_routes.py` are the canonical reference for required spec fields and exact handler kwargs.
 

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -39,10 +39,10 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 from uuid import UUID
 
-from fastapi import Depends, status
+from fastapi import Depends, Request, status
 from pydantic import TypeAdapter
 
-from src.api.common.responses import deleted_response
+from src.api.common.responses import APIResponse, deleted_response
 from src.logic.audit import AuditedResource
 
 
@@ -82,12 +82,11 @@ class ResourceSpec:
         read mounts. Polymorphic resources (e.g. posts kind-dispatch)
         may return ``template_name`` in the handler's context dict to
         override these per-request.
-      extra_repo_deps: ``Depends`` providers for any *additional*
-        repositories the handler needs beyond the primary ``repo_dep``.
-        Mount functions inject these by their dep callable's name
-        (minus the ``get_`` prefix). Used by handlers like
-        ``handle_get_user_detail`` that take both a user repo and a
-        provider repo. Empty for the common single-repo case.
+      (Per-mount ``extra_repo_deps`` kwargs let an individual mount
+        inject additional repos beyond ``repo_dep`` for handlers that
+        need them — e.g. ``handle_get_user_detail`` takes the provider
+        repo. They're per-mount, not per-spec, because different mounts
+        on the same spec may need different extras.)
       create_redirect / update_redirect / delete_redirect: callables
         receiving the path params + (for create/update) the resource id,
         returning the ``HX-Redirect`` URL. ``None`` means use a sensible
@@ -113,8 +112,6 @@ class ResourceSpec:
     list_template: str | None = None
     detail_template: str | None = None
     form_template: str | None = None
-
-    extra_repo_deps: tuple[Callable[..., Any], ...] = ()
 
     create_redirect: Callable[..., str] | None = None
     update_redirect: Callable[..., str] | None = None
@@ -196,6 +193,162 @@ def mount_delete(
     )
 
     router.delete(path, status_code=status.HTTP_204_NO_CONTENT)(_delete)
+
+
+def mount_list(
+    router: Any,
+    spec: ResourceSpec,
+    handler: Callable[..., Awaitable[dict]],
+    *,
+    extra_repo_deps: tuple[Callable[..., Any], ...] = (),
+) -> None:
+    """Mount ``GET /<collection>`` rendering ``spec.list_template``.
+
+    The handler is invoked with ``request``, ``repo`` (from
+    ``spec.repo_dep``), ``requesting_user`` (from ``spec.read_user_dep``,
+    or ``None`` if no auth gate is set), and any ``extra_repo_deps`` under
+    their dep callable's name (``get_<entity>_repository`` →
+    ``<entity>_repo``). The handler returns a context dict; the mount
+    renders ``spec.list_template`` with it.
+
+    ``extra_repo_deps`` is per-mount, not per-spec, because different
+    mounts on the same resource often need different extra repos (e.g.
+    list doesn't need provider_repo but detail does).
+
+    Polymorphic resources can override the template by returning
+    ``template_name`` in the context — slice 5 (#250) wires that through
+    for ``mount_form``; for now ``mount_list`` always uses
+    ``spec.list_template``.
+
+    Until slice 8 (#253), ``spec.parent`` must be ``None`` here; nested
+    list routes use ``mount_related_list`` (slice 9 / #254).
+    """
+    if spec.parent is not None:
+        raise NotImplementedError(
+            "mount_list with spec.parent is not supported yet "
+            "(slice 8 / #253). Use mount_related_list for child collections."
+        )
+    if spec.list_template is None:
+        raise ValueError(
+            f"mount_list requires {spec.collection!r} to set list_template."
+        )
+    list_template = spec.list_template
+    extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
+
+    async def _list(**kwargs: Any) -> Any:
+        request: Request = kwargs["request"]
+        context = await handler(
+            request=request,
+            repo=kwargs["repo"],
+            requesting_user=kwargs.get("requesting_user"),
+            **{name: kwargs[name] for name, _ in extra_deps_named},
+        )
+        return APIResponse.html_response(
+            template_name=list_template, context=context, request=request
+        )
+
+    _set_route_signature(
+        _list,
+        path_params=(("request", Request),),
+        deps=_read_route_deps(spec, extra_deps_named),
+    )
+    router.get("")(_list)
+
+
+def mount_detail(
+    router: Any,
+    spec: ResourceSpec,
+    handler: Callable[..., Awaitable[dict]],
+    *,
+    extra_repo_deps: tuple[Callable[..., Any], ...] = (),
+) -> None:
+    """Mount ``GET /<collection>/{<id_param>}`` rendering ``spec.detail_template``.
+
+    The handler is invoked with ``request``, the resource id under
+    ``spec.id_param``, ``repo``, ``requesting_user``, and any
+    ``extra_repo_deps`` under their derived kwarg name. Returns a
+    context dict; the mount renders ``spec.detail_template`` with it.
+
+    The multi-repo case (e.g. ``handle_get_user_detail`` takes both a
+    user repo and a provider repo) is the canonical reason
+    ``extra_repo_deps`` exists.
+    """
+    if spec.parent is not None:
+        raise NotImplementedError(
+            "mount_detail with spec.parent is not supported yet " "(slice 8 / #253)."
+        )
+    if spec.detail_template is None:
+        raise ValueError(
+            f"mount_detail requires {spec.collection!r} to set detail_template."
+        )
+    id_param = spec.id_param
+    detail_template = spec.detail_template
+    extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
+
+    async def _detail(**kwargs: Any) -> Any:
+        request: Request = kwargs["request"]
+        resource_id: UUID = kwargs[id_param]
+        context = await handler(
+            request=request,
+            repo=kwargs["repo"],
+            requesting_user=kwargs.get("requesting_user"),
+            **{id_param: resource_id},
+            **{name: kwargs[name] for name, _ in extra_deps_named},
+        )
+        return APIResponse.html_response(
+            template_name=detail_template, context=context, request=request
+        )
+
+    _set_route_signature(
+        _detail,
+        path_params=(("request", Request), (id_param, UUID)),
+        deps=_read_route_deps(spec, extra_deps_named),
+    )
+    router.get(f"/{{{id_param}}}")(_detail)
+
+
+def _name_extra_repo_deps(
+    deps: tuple[Callable[..., Any], ...],
+) -> tuple[tuple[str, Callable[..., Any]], ...]:
+    """Derive the kwarg name each extra repo dep is passed under.
+
+    Convention: ``get_provider_repository`` → ``provider_repo``,
+    ``get_audit_repository`` → ``audit_repo``. Strips the ``get_`` prefix
+    and the ``ository`` suffix on ``_repository``. If a dep has a name
+    that doesn't match the convention, raise — silent name-mismatches
+    would be a bug at the kwarg-injection site.
+    """
+    out: list[tuple[str, Callable[..., Any]]] = []
+    for dep in deps:
+        name = getattr(dep, "__name__", None)
+        if not name or not name.startswith("get_"):
+            raise ValueError(
+                f"extra_repo_deps callable {dep!r} must be named "
+                "'get_<entity>_repository' so the kwarg can be derived."
+            )
+        bare = name[len("get_") :]
+        if bare.endswith("_repository"):
+            kwarg = bare[: -len("_repository")] + "_repo"
+        else:
+            kwarg = bare
+        out.append((kwarg, dep))
+    return tuple(out)
+
+
+def _read_route_deps(
+    spec: ResourceSpec,
+    extra_deps_named: tuple[tuple[str, Callable[..., Any]], ...],
+) -> tuple[tuple[str, Callable[..., Any]], ...]:
+    """Build the (kwarg, callable) pairs for the dep-injected params on a
+    read route. Includes the primary repo, optional read user dep, and
+    each extra repo. ``read_user_dep=None`` means public — the route is
+    mounted without a user dep, and the handler receives
+    ``requesting_user=None``."""
+    deps: list[tuple[str, Callable[..., Any]]] = [("repo", spec.repo_dep)]
+    if spec.read_user_dep is not None:
+        deps.append(("requesting_user", spec.read_user_dep))
+    deps.extend(extra_deps_named)
+    return tuple(deps)
 
 
 def _set_route_signature(

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -18,7 +18,12 @@ import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
-from src.api.common.resource_routes import ResourceSpec, mount_delete
+from src.api.common.resource_routes import (
+    ResourceSpec,
+    mount_delete,
+    mount_detail,
+    mount_list,
+)
 
 
 def _build_app(spec: ResourceSpec, captured: dict) -> FastAPI:
@@ -137,6 +142,152 @@ def test_mount_delete_requires_write_user_dep():
             spec,
             handler=lambda **_: None,
             audit_repo_dep=lambda: None,
+        )
+
+
+def _build_read_app(
+    spec: ResourceSpec, list_handler, detail_handler, *, detail_extra=()
+):
+    """Mount mount_list + mount_detail and return a TestClient. Handlers
+    return a context dict that the templating layer can render against
+    a stub template."""
+    app = FastAPI()
+    router = APIRouter(prefix=f"/{spec.collection}")
+    mount_list(router, spec, handler=list_handler)
+    mount_detail(router, spec, handler=detail_handler, extra_repo_deps=detail_extra)
+    app.include_router(router)
+    return app
+
+
+def test_mount_list_renders_template_with_handler_context(monkeypatch):
+    captured = {}
+
+    async def list_handler(**kwargs):
+        captured.update(kwargs)
+        return {"users": ["alice", "bob"]}
+
+    async def detail_handler(**kwargs):
+        return {}
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="widget_repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+        list_template="widgets/list.html",
+        detail_template="widgets/detail.html",
+    )
+
+    rendered = {}
+
+    def fake_html_response(*, template_name, context, request):
+        rendered["template_name"] = template_name
+        rendered["context"] = context
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse({"ok": True})
+
+    monkeypatch.setattr(
+        "src.api.common.resource_routes.APIResponse.html_response",
+        staticmethod(fake_html_response),
+    )
+
+    client = TestClient(_build_read_app(spec, list_handler, detail_handler))
+    resp = client.get("/widgets")
+
+    assert resp.status_code == 200
+    assert rendered["template_name"] == "widgets/list.html"
+    assert rendered["context"] == {"users": ["alice", "bob"]}
+    assert captured["repo"].name == "widget_repo"
+
+
+def test_mount_detail_injects_extra_repo_deps_under_derived_name(monkeypatch):
+    """`get_widget_repository` → `widget_repo` kwarg. Confirms the
+    derived-kwarg-name convention reaches the handler."""
+    captured = {}
+
+    async def list_handler(**kwargs):
+        return {}
+
+    async def detail_handler(**kwargs):
+        captured.update(kwargs)
+        return {"widget": kwargs.get("widget_id")}
+
+    def get_audit_repository():
+        return SimpleNamespace(name="audit_repo")
+
+    spec = ResourceSpec(
+        collection="gadgets",
+        id_param="gadget_id",
+        repo_dep=lambda: SimpleNamespace(name="gadget_repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+        list_template="gadgets/list.html",
+        detail_template="gadgets/detail.html",
+    )
+
+    monkeypatch.setattr(
+        "src.api.common.resource_routes.APIResponse.html_response",
+        staticmethod(
+            lambda *, template_name, context, request: __import__(
+                "fastapi"
+            ).responses.JSONResponse({})
+        ),
+    )
+
+    client = TestClient(
+        _build_read_app(
+            spec, list_handler, detail_handler, detail_extra=(get_audit_repository,)
+        )
+    )
+    gadget_id = uuid4()
+    resp = client.get(f"/gadgets/{gadget_id}")
+
+    assert resp.status_code == 200
+    assert "audit_repo" in captured  # derived from `get_audit_repository`
+    assert captured["audit_repo"].name == "audit_repo"
+    assert "gadget_id" in captured
+    assert str(captured["gadget_id"]) == str(gadget_id)
+
+
+def test_mount_list_requires_list_template():
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: None,
+        read_user_dep=lambda: None,
+        # list_template intentionally omitted
+    )
+    router = APIRouter()
+    with pytest.raises(ValueError, match="list_template"):
+        mount_list(router, spec, handler=lambda **_: {})
+
+
+def test_mount_detail_requires_detail_template():
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: None,
+        read_user_dep=lambda: None,
+    )
+    router = APIRouter()
+    with pytest.raises(ValueError, match="detail_template"):
+        mount_detail(router, spec, handler=lambda **_: {})
+
+
+def test_extra_repo_deps_must_be_named_get_x_repository():
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: None,
+        read_user_dep=lambda: None,
+        list_template="widgets/list.html",
+        detail_template="widgets/detail.html",
+    )
+    badly_named = lambda: None  # noqa: E731 — anonymous lambda has no usable __name__
+    router = APIRouter()
+    with pytest.raises(ValueError, match="get_<entity>_repository"):
+        mount_detail(
+            router, spec, handler=lambda **_: {}, extra_repo_deps=(badly_named,)
         )
 
 

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -5,7 +5,12 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
 from src.api.common import APIResponse, BaseRouter
-from src.api.common.resource_routes import ResourceSpec, mount_delete
+from src.api.common.resource_routes import (
+    ResourceSpec,
+    mount_delete,
+    mount_detail,
+    mount_list,
+)
 from src.auth_config import current_active_user, current_admin_user
 from src.logic.providers.provider_processing import handle_list_user_providers
 from src.logic.users.user_processing import (
@@ -38,49 +43,22 @@ USER_SPEC = ResourceSpec(
     audit_resource=USER,
     read_user_dep=current_active_user,
     write_user_dep=current_admin_user,
+    list_template="users/list.html",
+    detail_template="users/detail.html",
 )
 
 
-@router.get("")
-async def list_users(
-    request: Request,
-    user_repo: UserRepository = Depends(get_user_repository),
-    user: User = Depends(current_active_user),
-):
-    """Provides an HTML page listing registered users.
-    Requires authentication.
-    Uses a logic handler to fetch and prepare user data.
-    """
-    context = await handle_list_users(
-        request=request,
-        repo=user_repo,
-        requesting_user=user,
-    )
-    return APIResponse.html_response(
-        template_name="users/list.html", context=context, request=request
-    )
-
-
-@router.get("/{user_id}")
-async def get_user(
-    user_id: UUID,
-    request: Request,
-    user_repo: UserRepository = Depends(get_user_repository),
-    profile_repo: ProviderRepository = Depends(get_provider_repository),
-    user: User = Depends(current_active_user),
-):
-    """Provides an HTML detail page for a single user, including the list
-    of providers they own."""
-    context = await handle_get_user_detail(
-        request=request,
-        user_id=user_id,
-        repo=user_repo,
-        profile_repo=profile_repo,
-        requesting_user=user,
-    )
-    return APIResponse.html_response(
-        template_name="users/detail.html", context=context, request=request
-    )
+# GET /users
+mount_list(router, USER_SPEC, handler=handle_list_users)
+# GET /users/{user_id} — `handle_get_user_detail` also takes the provider
+# repo to embed the owned-providers list. The mount injects it under
+# `provider_repo` (derived from `get_provider_repository`).
+mount_detail(
+    router,
+    USER_SPEC,
+    handler=handle_get_user_detail,
+    extra_repo_deps=(get_provider_repository,),
+)
 
 
 @router.get("/{user_id}/providers")

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -77,7 +77,7 @@ async def handle_get_user_detail(
     request: Request,
     user_id: UUID,
     repo: UserRepository,
-    profile_repo: ProviderRepository,
+    provider_repo: ProviderRepository,
     requesting_user: User,
 ):
     """Loads a single user for the detail page along with the providers
@@ -88,7 +88,7 @@ async def handle_get_user_detail(
     if target is None:
         raise NotFoundError(detail="User not found")
 
-    providers = await profile_repo.list_for_user(user_id)
+    providers = await provider_repo.list_for_user(user_id)
 
     return {
         "request": request,


### PR DESCRIPTION
Closes #249.

## Summary
- `mount_list(router, spec, handler)` — `GET /<collection>` rendering `spec.list_template`.
- `mount_detail(router, spec, handler)` — `GET /<collection>/{id}` rendering `spec.detail_template`.
- Both accept per-mount `extra_repo_deps=(get_X_repository, ...)` for handlers needing more than the primary repo.
- `users.py`: `GET /users` and `GET /users/{user_id}` migrated to mounts.
- `handle_get_user_detail`'s legacy `profile_repo` kwarg renamed to `provider_repo` to match the `get_provider_repository` → `provider_repo` derivation convention.

## Why
Slice 4 of 10 in the unified `ResourceSpec` refactor. Both reads land cleanly on the spec without growing it; the multi-repo case (user-detail-with-providers) becomes the canonical reason `extra_repo_deps` exists.

## Multi-repo decision
`extra_repo_deps` is per-mount (not per-spec) because different mounts on the same resource often need different extras — `mount_list` for users doesn't need `provider_repo` but `mount_detail` does. Per-mount kwargs keep each declarative without the spec enumerating every operation's needs.

## Test plan
- [x] `dev test` passes (515 — was 510, 5 new tests for read mounts)
- [x] `dev lint` passes
- [x] `dev test contract` passes (16)
- [x] `dev routes /users` paths unchanged (`mount_list`/`mount_detail`/`mount_delete` mounted at the same paths as the prior hand-written routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)