### PR TITLE
Add mount_form; migrate providers' form routes

### DIFF
--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -307,6 +307,87 @@ def mount_detail(
     router.get(f"/{{{id_param}}}")(_detail)
 
 
+def mount_form(
+    router: Any,
+    spec: ResourceSpec,
+    handler: Callable[..., Awaitable[dict]],
+    *,
+    template: str | None = None,
+    on_existing: bool = False,
+    extra_repo_deps: tuple[Callable[..., Any], ...] = (),
+) -> None:
+    """Mount a form-rendering route.
+
+    ``on_existing=False`` mounts ``GET /<collection>/form`` (create-form,
+    no entity loaded).
+    ``on_existing=True`` mounts ``GET /<collection>/{<id_param>}/form``
+    (edit-form, entity loaded by the handler).
+
+    Template precedence (highest to lowest):
+      1. ``template_name`` returned in the handler's context dict (for
+         polymorphic resources whose template varies at request time —
+         e.g. posts kind-dispatch).
+      2. ``template`` kwarg on this call (the simple two-form case where
+         create and edit render different static templates).
+      3. ``spec.form_template`` (the spec's default).
+
+    Handler kwargs: ``request``, ``repo``, ``requesting_user``, the
+    resource id under ``spec.id_param`` (only when ``on_existing=True``),
+    and any ``extra_repo_deps``. Pure create-form handlers that don't
+    use the repo still have to accept ``repo=`` (just ignore it) —
+    uniform mount-handler contract beats a special case.
+    """
+    if spec.parent is not None:
+        raise NotImplementedError(
+            "mount_form with spec.parent is not supported yet (slice 8 / #253)."
+        )
+    id_param = spec.id_param
+    extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
+    spec_template = spec.form_template
+
+    if on_existing:
+        path = f"/{{{id_param}}}/form"
+        path_params = (("request", Request), (id_param, UUID))
+    else:
+        path = "/form"
+        path_params = (("request", Request),)
+
+    async def _form(**kwargs: Any) -> Any:
+        request: Request = kwargs["request"]
+        handler_kwargs: dict[str, Any] = {
+            "request": request,
+            "repo": kwargs["repo"],
+            "requesting_user": kwargs.get("requesting_user"),
+            **{name: kwargs[name] for name, _ in extra_deps_named},
+        }
+        if on_existing:
+            handler_kwargs[id_param] = kwargs[id_param]
+
+        context = await handler(**handler_kwargs)
+        # Resolve template: handler context > per-mount kwarg > spec field.
+        # `pop` so the template name doesn't leak into the rendered context.
+        resolved_template = (
+            context.pop("template_name", None) or template or spec_template
+        )
+        if resolved_template is None:
+            raise RuntimeError(
+                f"mount_form for {spec.collection!r} (on_existing={on_existing}) "
+                "could not resolve a template — set spec.form_template, "
+                "the per-mount `template=` kwarg, or have the handler return "
+                "`template_name` in its context."
+            )
+        return APIResponse.html_response(
+            template_name=resolved_template, context=context, request=request
+        )
+
+    _set_route_signature(
+        _form,
+        path_params=path_params,
+        deps=_read_route_deps(spec, extra_deps_named),
+    )
+    router.get(path)(_form)
+
+
 def _name_extra_repo_deps(
     deps: tuple[Callable[..., Any], ...],
 ) -> tuple[tuple[str, Callable[..., Any]], ...]:

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -22,6 +22,7 @@ from src.api.common.resource_routes import (
     ResourceSpec,
     mount_delete,
     mount_detail,
+    mount_form,
     mount_list,
 )
 
@@ -289,6 +290,140 @@ def test_extra_repo_deps_must_be_named_get_x_repository():
         mount_detail(
             router, spec, handler=lambda **_: {}, extra_repo_deps=(badly_named,)
         )
+
+
+def _stub_html_response(monkeypatch):
+    """Patch APIResponse.html_response to return a simple JSONResponse so
+    tests don't need real templates. Returns the captured dict the patch
+    writes into."""
+    captured = {}
+
+    def fake(*, template_name, context, request):
+        captured["template_name"] = template_name
+        captured["context"] = context
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse({"ok": True})
+
+    monkeypatch.setattr(
+        "src.api.common.resource_routes.APIResponse.html_response",
+        staticmethod(fake),
+    )
+    return captured
+
+
+def test_mount_form_create_route_at_form_path(monkeypatch):
+    """on_existing=False mounts GET /<collection>/form (no id in URL)."""
+    captured_handler: dict = {}
+
+    async def form_handler(**kwargs):
+        captured_handler.update(kwargs)
+        return {"current_user": kwargs.get("requesting_user")}
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+    )
+    rendered = _stub_html_response(monkeypatch)
+
+    app = FastAPI()
+    router = APIRouter(prefix="/widgets")
+    mount_form(router, spec, handler=form_handler, template="widgets/new.html")
+    app.include_router(router)
+
+    resp = TestClient(app).get("/widgets/form")
+    assert resp.status_code == 200
+    assert rendered["template_name"] == "widgets/new.html"
+    assert "widget_id" not in captured_handler
+
+
+def test_mount_form_edit_route_at_id_form_path(monkeypatch):
+    """on_existing=True mounts GET /<collection>/{id}/form, passes id to handler."""
+    captured_handler: dict = {}
+
+    async def form_handler(**kwargs):
+        captured_handler.update(kwargs)
+        return {}
+
+    spec = ResourceSpec(
+        collection="gadgets",
+        id_param="gadget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+    )
+    _stub_html_response(monkeypatch)
+
+    app = FastAPI()
+    router = APIRouter(prefix="/gadgets")
+    mount_form(
+        router,
+        spec,
+        handler=form_handler,
+        template="gadgets/edit.html",
+        on_existing=True,
+    )
+    app.include_router(router)
+
+    gadget_id = uuid4()
+    resp = TestClient(app).get(f"/gadgets/{gadget_id}/form")
+    assert resp.status_code == 200
+    assert str(captured_handler["gadget_id"]) == str(gadget_id)
+
+
+def test_mount_form_handler_template_name_overrides_kwarg(monkeypatch):
+    """Handler returning template_name in context wins over the per-mount kwarg.
+    This is what posts kind-dispatch will use in slice 7 (#252). The template_name
+    key is popped so it doesn't appear in the rendered context dict."""
+
+    async def form_handler(**kwargs):
+        return {"template_name": "widgets/from-handler.html", "x": 1}
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+    )
+    rendered = _stub_html_response(monkeypatch)
+
+    app = FastAPI()
+    router = APIRouter(prefix="/widgets")
+    mount_form(router, spec, handler=form_handler, template="widgets/from-kwarg.html")
+    app.include_router(router)
+
+    resp = TestClient(app).get("/widgets/form")
+    assert resp.status_code == 200
+    assert rendered["template_name"] == "widgets/from-handler.html"
+    assert "template_name" not in rendered["context"]
+    assert rendered["context"] == {"x": 1}
+
+
+def test_mount_form_no_template_anywhere_raises():
+    """No template on spec, no template kwarg, handler doesn't return one
+    → RuntimeError at request time. The mount catches the misconfiguration
+    in the request path; the route's BaseRouter wrapping in production
+    surfaces this as 500. Here we use a bare APIRouter so the exception
+    propagates directly through TestClient."""
+
+    async def form_handler(**kwargs):
+        return {}
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+    )
+
+    app = FastAPI()
+    router = APIRouter(prefix="/widgets")
+    mount_form(router, spec, handler=form_handler)
+    app.include_router(router)
+
+    with pytest.raises(RuntimeError, match="could not resolve a template"):
+        TestClient(app).get("/widgets/form")
 
 
 def test_mount_delete_404_propagates_from_handler():

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -11,6 +11,7 @@ from src.api.common import (
     parse_and_validate_form,
     updated_response,
 )
+from src.api.common.resource_routes import ResourceSpec, mount_form
 from src.api.common.subresource_routes import (
     SubresourceDeps,
     SubresourceSpec,
@@ -57,6 +58,18 @@ from src.schemas.providers.provider import (
 providers_api_router = APIRouter(prefix="/providers")
 router = BaseRouter(router=providers_api_router, default_tags=["providers"])
 logger = logging.getLogger(__name__)
+
+
+# Spec is incrementally fleshed out as each slice migrates more operations
+# onto the mounts. Slice 5 (#250) fills in just enough to mount the two
+# form routes; slice 6 (#251) adds adapters/redirects for create/update.
+PROVIDER_SPEC = ResourceSpec(
+    collection="providers",
+    id_param="provider_id",
+    repo_dep=get_provider_repository,
+    read_user_dep=current_active_user,
+    write_user_dep=current_active_user,
+)
 
 
 def _provider_read_dict(profile) -> dict:
@@ -125,21 +138,22 @@ async def create_provider(
 
 
 # --- Form routes --------------------------------------------------------
-# Registered before `/{provider_id}` so the literal `form` is not parsed as a UUID.
-
-
-@router.get("/form")
-async def get_provider_form(
-    request: Request,
-    user: User = Depends(current_active_user),
-):
-    """Renders the create-profile HTML form."""
-    context = await handle_get_provider_form(request=request, requesting_user=user)
-    return APIResponse.html_response(
-        template_name="providers/new.html",
-        context=context,
-        request=request,
-    )
+# Mounted before `/{provider_id}` so the literal `form` segment is not
+# parsed as a UUID. Two form templates: `new.html` (create) and
+# `edit.html` (edit, identifies the profile from the URL id).
+mount_form(
+    router,
+    PROVIDER_SPEC,
+    handler=handle_get_provider_form,
+    template="providers/new.html",
+)
+mount_form(
+    router,
+    PROVIDER_SPEC,
+    handler=handle_get_provider_edit_form,
+    template="providers/edit.html",
+    on_existing=True,
+)
 
 
 # --- Profile item routes ------------------------------------------------
@@ -161,29 +175,6 @@ async def get_profile(
     )
     return APIResponse.html_response(
         template_name="providers/detail.html",
-        context=context,
-        request=request,
-    )
-
-
-@router.get("/{provider_id}/form")
-async def get_provider_edit_form(
-    provider_id: UUID,
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    user: User = Depends(current_active_user),
-):
-    """Renders the edit-profile HTML page. Owner-only; admins may edit any
-    profile. 404 if missing, 403 if not authorized.
-    """
-    context = await handle_get_provider_edit_form(
-        request=request,
-        provider_id=provider_id,
-        repo=repo,
-        requesting_user=user,
-    )
-    return APIResponse.html_response(
-        template_name="providers/edit.html",
         context=context,
         request=request,
     )

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -179,8 +179,15 @@ async def handle_list_user_providers(
 async def handle_get_provider_form(
     request: Request,
     requesting_user: User,
+    repo: ProviderRepository | None = None,
 ) -> dict[str, Any]:
-    """Builds the template context for the create-provider form."""
+    """Builds the template context for the create-provider form.
+
+    `repo` is accepted for uniformity with the mount_form contract (every
+    form handler gets the resource's primary repo) but not used here —
+    creating a profile doesn't need to load anything from the db.
+    """
+    del repo  # explicitly unused
     return {"request": request, "current_user": requesting_user}
 
 


### PR DESCRIPTION
Closes #250.

## Summary
- `mount_form(router, spec, handler, *, template, on_existing, extra_repo_deps)` — `GET /<collection>/form` or `GET /<collection>/{id}/form`.
- Three-source template precedence: handler-returned `template_name` > per-mount `template=` kwarg > `spec.form_template`. The first wires polymorphic resources (posts kind-dispatch in slice 7); the second covers the simple two-form case (providers); the third is the static default.
- Migrates `GET /providers/form` and `GET /providers/{provider_id}/form` to `mount_form`.
- Adds incremental `PROVIDER_SPEC` (slice 6 will extend with mutation knobs).
- `handle_get_provider_form` now accepts optional `repo=` to match the standard mount-handler contract.

## Why
Slice 5 of 10. Form rendering is the read-but-with-templating shape — a useful intermediate between pure list/detail (slice 4) and mutations (slice 6).

## Test plan
- [x] `dev test` (519, +4 mount_form tests)
- [x] `dev lint`
- [x] `dev test contract`
- [x] `dev routes /providers` shows the two form routes mounted via mount_form, no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)