### PR TITLE
Add mount_create + mount_update; migrate providers

### DIFF
--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -42,7 +42,13 @@ from uuid import UUID
 from fastapi import Depends, Request, status
 from pydantic import TypeAdapter
 
-from src.api.common.responses import APIResponse, deleted_response
+from src.api.common.forms import parse_and_validate_form
+from src.api.common.responses import (
+    APIResponse,
+    created_response,
+    deleted_response,
+    updated_response,
+)
 from src.logic.audit import AuditedResource
 
 
@@ -170,7 +176,7 @@ def mount_delete(
         # FastAPI binds the path param under `id_param`, the deps under
         # the names declared in `__signature__` below.
         resource_id = kwargs[id_param]
-        await handler(
+        await _resolve_handler(handler)(
             **{id_param: resource_id},
             repo=kwargs["repo"],
             audit_repo=kwargs["audit_repo"],
@@ -237,7 +243,7 @@ def mount_list(
 
     async def _list(**kwargs: Any) -> Any:
         request: Request = kwargs["request"]
-        context = await handler(
+        context = await _resolve_handler(handler)(
             request=request,
             repo=kwargs["repo"],
             requesting_user=kwargs.get("requesting_user"),
@@ -288,7 +294,7 @@ def mount_detail(
     async def _detail(**kwargs: Any) -> Any:
         request: Request = kwargs["request"]
         resource_id: UUID = kwargs[id_param]
-        context = await handler(
+        context = await _resolve_handler(handler)(
             request=request,
             repo=kwargs["repo"],
             requesting_user=kwargs.get("requesting_user"),
@@ -363,7 +369,7 @@ def mount_form(
         if on_existing:
             handler_kwargs[id_param] = kwargs[id_param]
 
-        context = await handler(**handler_kwargs)
+        context = await _resolve_handler(handler)(**handler_kwargs)
         # Resolve template: handler context > per-mount kwarg > spec field.
         # `pop` so the template name doesn't leak into the rendered context.
         resolved_template = (
@@ -386,6 +392,168 @@ def mount_form(
         deps=_read_route_deps(spec, extra_deps_named),
     )
     router.get(path)(_form)
+
+
+def mount_create(
+    router: Any,
+    spec: ResourceSpec,
+    handler: Callable[..., Awaitable[Any]],
+    *,
+    audit_repo_dep: Callable[..., Any],
+) -> None:
+    """Mount ``POST /<collection>``.
+
+    Parses a form-encoded body via ``spec.create_adapter`` (a Pydantic
+    ``TypeAdapter``) and calls the handler with ``payload=``, ``repo=``,
+    ``audit_repo=``, ``requesting_user=``. The handler is expected to use
+    ``mutate(verb="create")`` so the audit row + commit are owned by the
+    context manager.
+
+    Response is ``201 Created`` with ``Location`` and ``HX-Redirect`` set.
+    Defaults: ``Location: /<collection>/<new_id>``, ``HX-Redirect`` =
+    ``spec.create_redirect(...)`` if set, else ``Location``. The
+    ``create_redirect`` callable receives the new id under ``spec.id_param``
+    so it can build a per-resource target (e.g. providers redirect to
+    ``/providers/{id}/form`` after create).
+
+    Requires: ``spec.write_user_dep``, ``spec.create_adapter``.
+    """
+    if spec.parent is not None:
+        raise NotImplementedError(
+            "mount_create with spec.parent is not supported yet (slice 8 / #253)."
+        )
+    if spec.write_user_dep is None:
+        raise ValueError(
+            f"mount_create requires {spec.collection!r} to set write_user_dep."
+        )
+    if spec.create_adapter is None:
+        raise ValueError(
+            f"mount_create requires {spec.collection!r} to set create_adapter."
+        )
+
+    collection = spec.collection
+    id_param = spec.id_param
+    create_adapter = spec.create_adapter
+    create_redirect = spec.create_redirect
+
+    async def _create(**kwargs: Any) -> Any:
+        request: Request = kwargs["request"]
+        payload = await parse_and_validate_form(request, create_adapter)
+        created = await _resolve_handler(handler)(
+            payload=payload,
+            repo=kwargs["repo"],
+            audit_repo=kwargs["audit_repo"],
+            requesting_user=kwargs["requesting_user"],
+        )
+        location = f"/{collection}/{created.id}"
+        if create_redirect is not None:
+            hx = create_redirect(**{id_param: created.id})
+        else:
+            hx = location
+        return created_response(id=created.id, location=location, hx_redirect=hx)
+
+    _set_route_signature(
+        _create,
+        path_params=(("request", Request),),
+        deps=(
+            ("repo", spec.repo_dep),
+            ("audit_repo", audit_repo_dep),
+            ("requesting_user", spec.write_user_dep),
+        ),
+    )
+    router.post("", status_code=status.HTTP_201_CREATED)(_create)
+
+
+def mount_update(
+    router: Any,
+    spec: ResourceSpec,
+    handler: Callable[..., Awaitable[Any]],
+    *,
+    audit_repo_dep: Callable[..., Any],
+) -> None:
+    """Mount ``PATCH /<collection>/{<id_param>}``.
+
+    Parses a form-encoded body via ``spec.update_adapter`` and calls the
+    handler with the resource id (under ``spec.id_param``), ``payload=``,
+    ``repo=``, ``audit_repo=``, ``requesting_user=``. Handler uses
+    ``mutate(verb="update")``.
+
+    Response is ``200 OK`` with body = ``spec.read_to_dict(updated)`` (if
+    set, else empty body) and ``HX-Redirect`` =
+    ``spec.update_redirect(...)`` (if set, else ``f"/<collection>/<id>"``).
+
+    Requires: ``spec.write_user_dep``, ``spec.update_adapter``.
+    ``read_to_dict`` is optional but conventional — clients often want
+    the new state without a follow-up GET.
+    """
+    if spec.parent is not None:
+        raise NotImplementedError(
+            "mount_update with spec.parent is not supported yet (slice 8 / #253)."
+        )
+    if spec.write_user_dep is None:
+        raise ValueError(
+            f"mount_update requires {spec.collection!r} to set write_user_dep."
+        )
+    if spec.update_adapter is None:
+        raise ValueError(
+            f"mount_update requires {spec.collection!r} to set update_adapter."
+        )
+
+    collection = spec.collection
+    id_param = spec.id_param
+    update_adapter = spec.update_adapter
+    update_redirect = spec.update_redirect
+    read_to_dict = spec.read_to_dict
+
+    async def _update(**kwargs: Any) -> Any:
+        request: Request = kwargs["request"]
+        resource_id: UUID = kwargs[id_param]
+        payload = await parse_and_validate_form(request, update_adapter)
+        updated = await _resolve_handler(handler)(
+            **{id_param: resource_id},
+            payload=payload,
+            repo=kwargs["repo"],
+            audit_repo=kwargs["audit_repo"],
+            requesting_user=kwargs["requesting_user"],
+        )
+        body = read_to_dict(updated) if read_to_dict else None
+        if update_redirect is not None:
+            hx = update_redirect(**{id_param: updated.id})
+        else:
+            hx = f"/{collection}/{updated.id}"
+        return updated_response(body=body, hx_redirect=hx)
+
+    _set_route_signature(
+        _update,
+        path_params=(("request", Request), (id_param, UUID)),
+        deps=(
+            ("repo", spec.repo_dep),
+            ("audit_repo", audit_repo_dep),
+            ("requesting_user", spec.write_user_dep),
+        ),
+    )
+    router.patch(f"/{{{id_param}}}")(_update)
+
+
+def _resolve_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Look up a handler in its home module at call time so test
+    monkey-patches applied via ``setattr(<module>, "<name>", mock)`` take
+    effect — closure-captured references can't be rebound, but a lookup
+    against ``sys.modules`` reads the current binding.
+
+    Falls back to the original reference if anything is missing (e.g. the
+    function is a lambda or its module isn't loaded).
+    """
+    import sys
+
+    mod_name = getattr(fn, "__module__", "")
+    fn_name = getattr(fn, "__name__", "")
+    if not mod_name or not fn_name:
+        return fn
+    mod = sys.modules.get(mod_name)
+    if mod is None:
+        return fn
+    return getattr(mod, fn_name, fn)
 
 
 def _name_extra_repo_deps(

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -1,23 +1,23 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi import APIRouter, Depends, Query, Request
 
-from src.api.common import (
-    APIResponse,
-    BaseRouter,
-    created_response,
-    deleted_response,
-    parse_and_validate_form,
-    updated_response,
+from src.api.common import APIResponse, BaseRouter
+from src.api.common.resource_routes import (
+    ResourceSpec,
+    mount_create,
+    mount_delete,
+    mount_form,
+    mount_update,
 )
-from src.api.common.resource_routes import ResourceSpec, mount_form
 from src.api.common.subresource_routes import (
     SubresourceDeps,
     SubresourceSpec,
     register_subresource_routes,
 )
 from src.auth_config import current_active_user
+from src.logic._authz import assert_owner_or_admin
 from src.logic.providers.provider_processing import (
     handle_create_certification,
     handle_create_education,
@@ -37,7 +37,6 @@ from src.logic.providers.provider_processing import (
     handle_update_provider,
 )
 from src.models import User
-from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import get_audit_repository, get_provider_repository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.schemas.providers.provider import (
@@ -60,20 +59,24 @@ router = BaseRouter(router=providers_api_router, default_tags=["providers"])
 logger = logging.getLogger(__name__)
 
 
-# Spec is incrementally fleshed out as each slice migrates more operations
-# onto the mounts. Slice 5 (#250) fills in just enough to mount the two
-# form routes; slice 6 (#251) adds adapters/redirects for create/update.
 PROVIDER_SPEC = ResourceSpec(
     collection="providers",
     id_param="provider_id",
     repo_dep=get_provider_repository,
     read_user_dep=current_active_user,
     write_user_dep=current_active_user,
+    write_authz=assert_owner_or_admin,
+    create_adapter=provider_create_adapter,
+    update_adapter=provider_update_adapter,
+    read_to_dict=lambda profile: ProviderRead.model_validate(profile).model_dump(
+        mode="json"
+    ),
+    # After create, redirect to the edit form so the user can flesh out
+    # sub-rows (licensures, educations, certifications). After update,
+    # send them back to the same edit form.
+    create_redirect=lambda *, provider_id: f"/providers/{provider_id}/form",
+    update_redirect=lambda *, provider_id: f"/providers/{provider_id}/form",
 )
-
-
-def _provider_read_dict(profile) -> dict:
-    return ProviderRead.model_validate(profile).model_dump(mode="json")
 
 
 def _licensure_read_dict(row) -> dict:
@@ -114,27 +117,13 @@ async def list_providers(
     )
 
 
-@router.post("", status_code=status.HTTP_201_CREATED)
-async def create_provider(
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    """Creates a provider owned by the requesting user. Form-encoded
-    body. A user may own multiple profiles."""
-    payload = await parse_and_validate_form(request, provider_create_adapter)
-    created = await handle_create_provider(
-        payload=payload,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return created_response(
-        id=created.id,
-        location=f"/providers/{created.id}",
-        hx_redirect=f"/providers/{created.id}/form",
-    )
+# POST /providers — owner inferred from session.
+mount_create(
+    router,
+    PROVIDER_SPEC,
+    handler=handle_create_provider,
+    audit_repo_dep=get_audit_repository,
+)
 
 
 # --- Form routes --------------------------------------------------------
@@ -180,46 +169,20 @@ async def get_profile(
     )
 
 
-@router.patch("/{provider_id}")
-async def patch_profile(
-    provider_id: UUID,
-    request: Request,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    """Partially updates the practice/availability fields. Owner-only; admins
-    may edit any profile. Sub-entity lists are managed via their own routes."""
-    payload = await parse_and_validate_form(request, provider_update_adapter)
-    updated = await handle_update_provider(
-        provider_id=provider_id,
-        payload=payload,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return updated_response(
-        body=_provider_read_dict(updated),
-        hx_redirect=f"/providers/{updated.id}/form",
-    )
-
-
-@router.delete("/{provider_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_provider(
-    provider_id: UUID,
-    repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    user: User = Depends(current_active_user),
-):
-    """Hard-deletes the profile (sub-rows cascade). Owner-only; admins may
-    delete any profile."""
-    await handle_delete_provider(
-        provider_id=provider_id,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return deleted_response(hx_redirect="/providers")
+# PATCH /providers/{provider_id} — partial update, owner-or-admin (handler enforces).
+mount_update(
+    router,
+    PROVIDER_SPEC,
+    handler=handle_update_provider,
+    audit_repo_dep=get_audit_repository,
+)
+# DELETE /providers/{provider_id} — hard delete, sub-rows cascade.
+mount_delete(
+    router,
+    PROVIDER_SPEC,
+    handler=handle_delete_provider,
+    audit_repo_dep=get_audit_repository,
+)
 
 
 # --- Sub-resource CRUD (licensure / education / certification) ----------

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -154,7 +154,7 @@ class MockDataFactory:
             id=UUID("33333333-3333-3333-3333-333333333333"),
         )
         return {
-            "src.api.routes.providers.handle_create_provider": {
+            "src.logic.providers.provider_processing.handle_create_provider": {
                 "return_value_config": stub_profile
             }
         }
@@ -187,7 +187,7 @@ class MockDataFactory:
             certifications=[],
         )
         return {
-            "src.api.routes.providers.handle_update_provider": {
+            "src.logic.providers.provider_processing.handle_update_provider": {
                 "return_value_config": stub_profile
             }
         }


### PR DESCRIPTION
Closes #251.

## Summary
- `mount_create(router, spec, handler, *, audit_repo_dep)` — POST /<collection>, form-encoded body via `spec.create_adapter`, audit via `mutate(verb="create")` in handler.
- `mount_update(router, spec, handler, *, audit_repo_dep)` — PATCH /<collection>/{id}, body via `spec.update_adapter`, response body via `spec.read_to_dict`, redirect via `spec.update_redirect`.
- Migrates providers' POST + PATCH + DELETE to mounts. The route file is now ~190 lines with one `PROVIDER_SPEC` and four mount calls (down from ~290 lines of hand-written CRUD).

## Why
Slice 6 of 10. First mutation primitives — confirms adapters, audit, redirects all fit cleanly on the spec without escape hatches.

## Test-time handler resolution
The mounts call handlers via `_resolve_handler(handler)`, which re-resolves through `sys.modules[fn.__module__]`. This makes `setattr(<module>, "<name>", mock)` apply at request time so contract-test mocks work. Mock factory patch targets updated to the source module (`src.logic.providers.provider_processing.handle_*`) — closure capture meant the prior route-module paths no longer intercepted the call.

## Test plan
- [x] `dev test` passes (519)
- [x] `dev lint` passes
- [x] `dev test contract` passes (16) — provider create/update pacts confirmed
- [x] `dev routes /providers` shows POST/PATCH/DELETE all on mount_*; sub-resources unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)