### PR TITLE
Add mount_related_list; migrate /users/{user_id}/providers

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -146,7 +146,7 @@ Secondary repos (e.g. `user_repo: UserRepository` in the multi-repo `handle_list
 | `mount_list` / `mount_detail` | Landed (slice 4 / #249) | `users` (GET / and GET /{id}) |
 | `mount_form` | Landed (slice 5 / #250) | `providers` (GET /form, GET /{id}/form); `posts` (edit form via handler-returned template_name) |
 | `mount_create` / `mount_update` | Landed (slice 6 / #251) | `providers`, `posts`, `licensures`, `educations`, `certifications` |
-| `mount_related_list` | Slice 9 / #254 | — |
+| `mount_related_list` | Landed (slice 9 / #254) | `users` (GET /{id}/providers) |
 | Sub-resource via `parent=` | Landed (slice 8 / #253) | `licensures`, `educations`, `certifications` (under providers) |
 
 ### Multi-repo handlers: `extra_repo_deps`
@@ -173,7 +173,7 @@ Per-mount docstrings in `resource_routes.py` are the canonical reference for req
 The grammar fits resource-shaped routes. It's deliberately **not** a home for:
 
 - **Auth flows** — register/login/verify/reset-password live in `auth_routes.py` / `auth_pages.py`. State-machine semantics, not CRUD.
-- **`/me/*` singletons** — no parent id, session-sourced. Stays bespoke (slice 9 decision).
+- **`/me/*` singletons** — no parent id, session-sourced. Stays bespoke (slice 9 decision: 3 routes total in `me.py`; widening the grammar to fit them would add a `singleton_alias` knob to every spec for one cluster's benefit).
 - **State-mutation actions like `PUT /users/{id}/activation`** — idempotent set with `HX-Refresh`, not partial edit with `HX-Redirect`. Doesn't match `mount_update` semantics.
 - **Utility endpoints** — `/`, `/health`.
 

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -545,6 +545,72 @@ def mount_update(
     router.patch(path)(_update)
 
 
+def mount_related_list(
+    router: Any,
+    parent_spec: ResourceSpec,
+    child_spec: ResourceSpec,
+    handler: Callable[..., Awaitable[dict]],
+    *,
+    template: str,
+    extra_repo_deps: tuple[Callable[..., Any], ...] = (),
+) -> None:
+    """Mount ``GET /<parent.collection>/{<parent.id_param>}/<child.collection>``.
+
+    A scoped read of children belonging to a parent — e.g.
+    ``GET /users/{user_id}/providers`` lists the providers owned by a user.
+
+    Handler kwargs: ``request``, the parent id under
+    ``parent_spec.id_param`` (e.g. ``user_id=...``), ``repo`` (the *child's*
+    repo, since the handler returns children), ``requesting_user``, and any
+    ``extra_repo_deps`` under their derived kwarg name. Returns a context
+    dict; the mount renders ``template``.
+
+    ``template`` is a per-mount kwarg (not on the spec) because related-list
+    templates often live in the parent's namespace
+    (``users/providers_list.html``, not ``providers/list.html``) — making
+    it a per-mount knob keeps both the parent and child specs reusable.
+
+    Auth follows the parent's ``read_user_dep`` (the URL is rooted at the
+    parent so its read-auth governs). If the parent is public
+    (``read_user_dep=None``), the route is public too.
+    """
+    if not template:
+        raise ValueError(
+            "mount_related_list requires `template=` — related-list "
+            "templates aren't on the spec because they typically live in "
+            "the parent's namespace."
+        )
+    parent_id_param = parent_spec.id_param
+    extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
+    path = f"/{{{parent_id_param}}}/{child_spec.collection}"
+
+    async def _related_list(**kwargs: Any) -> Any:
+        request: Request = kwargs["request"]
+        parent_id: UUID = kwargs[parent_id_param]
+        context = await _resolve_handler(handler)(
+            request=request,
+            **{parent_id_param: parent_id},
+            repo=kwargs["repo"],
+            requesting_user=kwargs.get("requesting_user"),
+            **{name: kwargs[name] for name, _ in extra_deps_named},
+        )
+        return APIResponse.html_response(
+            template_name=template, context=context, request=request
+        )
+
+    deps: list[tuple[str, Callable[..., Any]]] = [("repo", child_spec.repo_dep)]
+    if parent_spec.read_user_dep is not None:
+        deps.append(("requesting_user", parent_spec.read_user_dep))
+    deps.extend(extra_deps_named)
+
+    _set_route_signature(
+        _related_list,
+        path_params=(("request", Request), (parent_id_param, UUID)),
+        deps=tuple(deps),
+    )
+    router.get(path)(_related_list)
+
+
 def _walk_parent_chain(spec: ResourceSpec) -> list[ResourceSpec]:
     """Return ancestors top-to-bottom including ``spec`` itself.
 

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -24,6 +24,7 @@ from src.api.common.resource_routes import (
     mount_detail,
     mount_form,
     mount_list,
+    mount_related_list,
 )
 
 
@@ -444,6 +445,70 @@ def test_mount_form_no_template_anywhere_raises():
 
     with pytest.raises(RuntimeError, match="could not resolve a template"):
         TestClient(app).get("/widgets/form")
+
+
+def test_mount_related_list_path_under_parent_id(monkeypatch):
+    """`mount_related_list` mounts GET /<parent>/{parent_id}/<child>. The
+    handler is invoked with the parent id under parent_spec.id_param,
+    `repo` from the *child* spec, and any extra_repo_deps."""
+    captured = {}
+
+    async def list_handler(**kwargs):
+        captured.update(kwargs)
+        return {"profiles": []}
+
+    parent = ResourceSpec(
+        collection="parents",
+        id_param="parent_id",
+        repo_dep=lambda: SimpleNamespace(name="parent_repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+    )
+    child = ResourceSpec(
+        collection="children",
+        id_param="child_id",
+        repo_dep=lambda: SimpleNamespace(name="child_repo"),
+    )
+
+    rendered = _stub_html_response(monkeypatch)
+
+    app = FastAPI()
+    router = APIRouter(prefix="/parents")
+    mount_related_list(
+        router,
+        parent_spec=parent,
+        child_spec=child,
+        handler=list_handler,
+        template="parents/children_list.html",
+    )
+    app.include_router(router)
+
+    parent_id = uuid4()
+    resp = TestClient(app).get(f"/parents/{parent_id}/children")
+
+    assert resp.status_code == 200
+    assert rendered["template_name"] == "parents/children_list.html"
+    assert "parent_id" in captured
+    assert str(captured["parent_id"]) == str(parent_id)
+    # Handler's `repo` is the CHILD's repo (the handler returns children)
+    assert captured["repo"].name == "child_repo"
+
+
+def test_mount_related_list_requires_template():
+    parent = ResourceSpec(
+        collection="parents", id_param="parent_id", repo_dep=lambda: None
+    )
+    child = ResourceSpec(
+        collection="children", id_param="child_id", repo_dep=lambda: None
+    )
+    router = APIRouter()
+    with pytest.raises(ValueError, match="template"):
+        mount_related_list(
+            router,
+            parent_spec=parent,
+            child_spec=child,
+            handler=lambda **_: {},
+            template="",
+        )
 
 
 def test_mount_delete_404_propagates_from_handler():

--- a/src/api/routes/me.py
+++ b/src/api/routes/me.py
@@ -53,7 +53,7 @@ async def list_my_providers(
     for `GET /users/{requesting_user.id}/providers`."""
     context = await handle_list_user_providers(
         request=request,
-        target_user_id=user.id,
+        user_id=user.id,
         repo=repo,
         user_repo=user_repo,
         requesting_user=user,

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -1,16 +1,18 @@
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
-from src.api.common import APIResponse, BaseRouter
+from src.api.common import BaseRouter
 from src.api.common.resource_routes import (
     ResourceSpec,
     mount_delete,
     mount_detail,
     mount_list,
+    mount_related_list,
 )
+from src.api.routes.providers import PROVIDER_SPEC
 from src.auth_config import current_active_user, current_admin_user
 from src.logic.providers.provider_processing import handle_list_user_providers
 from src.logic.users.user_processing import (
@@ -27,7 +29,6 @@ from src.repositories.dependencies import (
     get_provider_repository,
     get_user_repository,
 )
-from src.repositories.providers.provider_repository import ProviderRepository
 from src.repositories.users.user_repository import UserRepository
 from src.schemas.users.user import UserActivationUpdate
 
@@ -61,27 +62,18 @@ mount_detail(
 )
 
 
-@router.get("/{user_id}/providers")
-async def list_user_providers(
-    user_id: UUID,
-    request: Request,
-    profile_repo: ProviderRepository = Depends(get_provider_repository),
-    user_repo: UserRepository = Depends(get_user_repository),
-    user: User = Depends(current_active_user),
-):
-    """Renders the provider list for a user. Self or admin only."""
-    context = await handle_list_user_providers(
-        request=request,
-        target_user_id=user_id,
-        repo=profile_repo,
-        user_repo=user_repo,
-        requesting_user=user,
-    )
-    return APIResponse.html_response(
-        template_name="users/providers_list.html",
-        context=context,
-        request=request,
-    )
+# GET /users/{user_id}/providers — related-list, scoped to the parent user.
+# Self-or-admin auth lives inside the handler. Template lives in the parent's
+# namespace (users/providers_list.html), not the child's, since the page is
+# *about a user*, not a generic provider list.
+mount_related_list(
+    router,
+    parent_spec=USER_SPEC,
+    child_spec=PROVIDER_SPEC,
+    handler=handle_list_user_providers,
+    template="users/providers_list.html",
+    extra_repo_deps=(get_user_repository,),
+)
 
 
 @router.put("/{user_id}/activation")

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -149,7 +149,7 @@ async def handle_get_provider_detail(
 
 async def handle_list_user_providers(
     request: Request,
-    target_user_id: UUID,
+    user_id: UUID,
     repo: ProviderRepository,
     user_repo: UserRepository,
     requesting_user: User,
@@ -159,19 +159,19 @@ async def handle_list_user_providers(
     404 if the target user does not exist; 403 if a non-admin requests
     another user's list.
     """
-    if target_user_id != requesting_user.id and not requesting_user.is_superuser:
+    if user_id != requesting_user.id and not requesting_user.is_superuser:
         raise ForbiddenError(
             detail="Only the target user or an admin may view their providers"
         )
-    target_user = await user_repo.get_user_by_id(target_user_id)
+    target_user = await user_repo.get_user_by_id(user_id)
     if target_user is None:
-        raise NotFoundError(detail=f"User {target_user_id} not found")
-    profiles = await repo.list_for_user(target_user_id)
+        raise NotFoundError(detail=f"User {user_id} not found")
+    profiles = await repo.list_for_user(user_id)
     return {
         "request": request,
         "target_user": target_user,
         "profiles": profiles,
-        "is_self": target_user_id == requesting_user.id,
+        "is_self": user_id == requesting_user.id,
         "current_user": requesting_user,
     }
 

--- a/src/logic/providers/test_provider_processing.py
+++ b/src/logic/providers/test_provider_processing.py
@@ -248,7 +248,7 @@ async def test_list_user_providers_self_returns_owned(
         user_repo = UserRepository(session)
         context = await handle_list_user_providers(
             request=_fake_request(),
-            target_user_id=user.id,
+            user_id=user.id,
             repo=profile_repo,
             user_repo=user_repo,
             requesting_user=user,
@@ -269,7 +269,7 @@ async def test_list_user_providers_self_returns_empty_when_none(
         user_repo = UserRepository(session)
         context = await handle_list_user_providers(
             request=_fake_request(),
-            target_user_id=user.id,
+            user_id=user.id,
             repo=profile_repo,
             user_repo=user_repo,
             requesting_user=user,
@@ -291,7 +291,7 @@ async def test_list_user_providers_admin_can_view_anyone(
         user_repo = UserRepository(session)
         context = await handle_list_user_providers(
             request=_fake_request(),
-            target_user_id=target.id,
+            user_id=target.id,
             repo=profile_repo,
             user_repo=user_repo,
             requesting_user=admin,
@@ -314,7 +314,7 @@ async def test_list_user_providers_non_admin_cannot_view_other(
         with pytest.raises(ForbiddenError):
             await handle_list_user_providers(
                 request=_fake_request(),
-                target_user_id=target.id,
+                user_id=target.id,
                 repo=profile_repo,
                 user_repo=user_repo,
                 requesting_user=other,
@@ -332,7 +332,7 @@ async def test_list_user_providers_404_when_target_user_missing(
         with pytest.raises(NotFoundError):
             await handle_list_user_providers(
                 request=_fake_request(),
-                target_user_id=uuid.uuid4(),
+                user_id=uuid.uuid4(),
                 repo=profile_repo,
                 user_repo=user_repo,
                 requesting_user=admin,


### PR DESCRIPTION
Closes #254.

## Summary
- `mount_related_list(router, parent_spec, child_spec, handler, *, template, extra_repo_deps)` mounts `GET /<parent.collection>/{<parent.id_param>}/<child.collection>`.
- Migrates `GET /users/{user_id}/providers` to use it.
- Renames `handle_list_user_providers`'s `target_user_id` kwarg to `user_id` so it matches `USER_SPEC.id_param` (the mount injects the parent id under that name). All callers updated.
- `/users/me/*` stays bespoke (Option B per the issue): 3 routes total in `me.py`; widening the grammar with a `singleton_alias` knob on every spec to fit them would be a bad trade.

## Why
Slice 9 of 10. Related-lists are structurally distinct from sub-resource CRUD (no mutation, single GET, parent-namespaced template). The mount cleanly handles the case without growing the spec — the per-mount `template=` kwarg avoids forcing the spec to enumerate cross-resource templates.

## Test plan
- [x] `dev test` (517, +2 mount_related_list tests)
- [x] `dev lint`
- [x] `dev test contract` (16)
- [x] `dev routes /users` shows GET /{user_id}/providers via mount_related_list

🤖 Generated with [Claude Code](https://claude.com/claude-code)