### PR TITLE
Extend mount_list and mount_form with query_params=

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -166,6 +166,34 @@ The mount derives the kwarg name from the dep callable: `get_provider_repository
 
 `extra_repo_deps` is per-mount, not per-spec, because different mounts on the same resource often need different extras (the list view doesn't need provider_repo even though the detail view does).
 
+### Query-param mounts
+
+`mount_list` and `mount_form` accept a per-mount `query_params=` kwarg — a tuple of `QueryParam(name, annotation, default)` declarations. Each becomes a FastAPI `Query(...)` parameter on the route signature (so OpenAPI docs and 422-on-invalid validation work like a hand-written route would), and the parsed value reaches the handler under its declared name.
+
+```python
+# Filtered list — providers' license_type / issuing_state filters.
+mount_list(
+    router, PROVIDER_SPEC, handler=handle_list_providers,
+    public=True,                                          # see below
+    query_params=(
+        QueryParam("license_type", str | None, None),
+        QueryParam("issuing_state", str | None, None),
+    ),
+)
+
+# Polymorphic-by-query form — posts' ?kind=client_referral picks the template.
+mount_form(
+    router, POST_SPEC, handler=handle_get_post_form,
+    query_params=(QueryParam("kind", Literal[*KIND_NAMES], KIND_NAMES[0]),),
+)
+```
+
+For the kind-picks-template case, the handler returns `template_name=...` in its context dict and the existing three-source resolution (handler-context > kwarg > spec) renders it.
+
+`mount_list` also accepts `public=True` to override the spec's `read_user_dep` for that mount only — used when a resource's list is public but its detail/form pages are authenticated (providers). The handler still receives `requesting_user=None` for kwarg uniformity.
+
+### Per-mount references
+
 Per-mount docstrings in `resource_routes.py` are the canonical reference for required spec fields and exact handler kwargs.
 
 ### What's *not* meant for this grammar
@@ -173,7 +201,7 @@ Per-mount docstrings in `resource_routes.py` are the canonical reference for req
 The grammar fits resource-shaped routes. It's deliberately **not** a home for:
 
 - **Auth flows** — register/login/verify/reset-password live in `auth_routes.py` / `auth_pages.py`. State-machine semantics, not CRUD.
-- **`/me/*` singletons** — no parent id, session-sourced. Stays bespoke (slice 9 decision: 3 routes total in `me.py`; widening the grammar to fit them would add a `singleton_alias` knob to every spec for one cluster's benefit).
+- **`/me/*` singletons** — no parent id, session-sourced. Stays bespoke: 3 routes total in `me.py`; widening the grammar to fit them would add a `singleton_alias` knob to every spec for one cluster's benefit.
 - **State-mutation actions like `PUT /users/{id}/activation`** — idempotent set with `HX-Refresh`, not partial edit with `HX-Redirect`. Doesn't match `mount_update` semantics.
 - **Utility endpoints** — `/`, `/health`.
 

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 from uuid import UUID
 
-from fastapi import Depends, Request, status
+from fastapi import Depends, Query, Request, status
 from pydantic import TypeAdapter
 
 from src.api.common.forms import parse_and_validate_form
@@ -50,6 +50,40 @@ from src.api.common.responses import (
     updated_response,
 )
 from src.logic.audit import AuditedResource
+
+_UNSET = object()
+
+
+@dataclass(frozen=True)
+class QueryParam:
+    """Declarative query-param description for ``mount_list`` / ``mount_form``.
+
+    The mount adds it to the route's ``__signature__`` as a FastAPI
+    ``Query(...)`` parameter so OpenAPI docs and 422-on-invalid validation
+    work the same way they would on a hand-written route.
+
+    Fields:
+      name: kwarg name the mount passes to the handler.
+      annotation: type annotation FastAPI uses for parsing/validation
+        (``str | None``, ``Literal["a","b"]``, ``int``, etc.).
+      default: default value if the param is omitted from the URL.
+        Use ``QueryParam.required()`` to mark a param required.
+      description: optional OpenAPI description.
+    """
+
+    name: str
+    annotation: Any
+    default: Any = None
+    description: str = ""
+
+    @classmethod
+    def required(
+        cls, name: str, annotation: Any, *, description: str = ""
+    ) -> "QueryParam":
+        """Mark a query param as required (no default)."""
+        return cls(
+            name=name, annotation=annotation, default=_UNSET, description=description
+        )
 
 
 @dataclass(frozen=True)
@@ -203,27 +237,36 @@ def mount_list(
     handler: Callable[..., Awaitable[dict]],
     *,
     extra_repo_deps: tuple[Callable[..., Any], ...] = (),
+    query_params: tuple[QueryParam, ...] = (),
+    public: bool = False,
 ) -> None:
     """Mount ``GET /<collection>`` rendering ``spec.list_template``.
 
     The handler is invoked with ``request``, ``repo`` (from
     ``spec.repo_dep``), ``requesting_user`` (from ``spec.read_user_dep``,
-    or ``None`` if no auth gate is set), and any ``extra_repo_deps`` under
-    their dep callable's name (``get_<entity>_repository`` →
-    ``<entity>_repo``). The handler returns a context dict; the mount
-    renders ``spec.list_template`` with it.
+    or ``None`` if no auth gate is set), each ``query_params`` entry
+    under its declared name, and any ``extra_repo_deps`` under their dep
+    callable's name (``get_<entity>_repository`` → ``<entity>_repo``).
+    The handler returns a context dict; the mount renders
+    ``spec.list_template`` with it.
 
-    ``extra_repo_deps`` is per-mount, not per-spec, because different
-    mounts on the same resource often need different extra repos (e.g.
-    list doesn't need provider_repo but detail does).
+    ``query_params`` is per-mount because filter shapes are usually
+    list-specific (e.g. provider list takes ``license_type`` and
+    ``issuing_state``; users list takes none today). Each ``QueryParam``
+    becomes a FastAPI ``Query(...)`` parameter on the route, with full
+    OpenAPI doc support and 422-on-invalid validation.
+
+    ``extra_repo_deps`` is per-mount for the same reason — different
+    mounts on the same resource often need different extras.
 
     Polymorphic resources can override the template by returning
-    ``template_name`` in the context — slice 5 (#250) wires that through
-    for ``mount_form``; for now ``mount_list`` always uses
-    ``spec.list_template``.
+    ``template_name`` in the context (the same precedence
+    ``mount_form`` uses).
 
-    Until slice 8 (#253), ``spec.parent`` must be ``None`` here; nested
-    list routes use ``mount_related_list`` (slice 9 / #254).
+    ``public=True`` overrides ``spec.read_user_dep`` for this mount only —
+    used when a resource's list is public but its detail/form pages are
+    authenticated (e.g. providers). The handler still receives
+    ``requesting_user=None`` so it can branch if needed.
     """
     if spec.parent is not None:
         raise NotImplementedError(
@@ -236,6 +279,7 @@ def mount_list(
         )
     list_template = spec.list_template
     extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
+    query_param_names = tuple(qp.name for qp in query_params)
 
     async def _list(**kwargs: Any) -> Any:
         request: Request = kwargs["request"]
@@ -244,15 +288,27 @@ def mount_list(
             repo=kwargs["repo"],
             requesting_user=kwargs.get("requesting_user"),
             **{name: kwargs[name] for name, _ in extra_deps_named},
+            **{name: kwargs[name] for name in query_param_names},
         )
+        # Honor handler-context override for polymorphic templates.
+        resolved_template = context.pop("template_name", None) or list_template
         return APIResponse.html_response(
-            template_name=list_template, context=context, request=request
+            template_name=resolved_template, context=context, request=request
         )
 
+    if public:
+        # Build deps without the spec's read_user_dep — handler receives
+        # `requesting_user=None`.
+        deps: list[tuple[str, Callable[..., Any]]] = [("repo", spec.repo_dep)]
+        deps.extend(extra_deps_named)
+        list_deps = tuple(deps)
+    else:
+        list_deps = _read_route_deps(spec, extra_deps_named)
     _set_route_signature(
         _list,
         path_params=(("request", Request),),
-        deps=_read_route_deps(spec, extra_deps_named),
+        query_params=query_params,
+        deps=list_deps,
     )
     router.get("")(_list)
 
@@ -317,6 +373,7 @@ def mount_form(
     template: str | None = None,
     on_existing: bool = False,
     extra_repo_deps: tuple[Callable[..., Any], ...] = (),
+    query_params: tuple[QueryParam, ...] = (),
 ) -> None:
     """Mount a form-rendering route.
 
@@ -328,16 +385,17 @@ def mount_form(
     Template precedence (highest to lowest):
       1. ``template_name`` returned in the handler's context dict (for
          polymorphic resources whose template varies at request time —
-         e.g. posts kind-dispatch).
+         e.g. posts kind-dispatch where ``?kind=`` picks the template).
       2. ``template`` kwarg on this call (the simple two-form case where
          create and edit render different static templates).
       3. ``spec.form_template`` (the spec's default).
 
     Handler kwargs: ``request``, ``repo``, ``requesting_user``, the
     resource id under ``spec.id_param`` (only when ``on_existing=True``),
-    and any ``extra_repo_deps``. Pure create-form handlers that don't
-    use the repo still have to accept ``repo=`` (just ignore it) —
-    uniform mount-handler contract beats a special case.
+    each ``query_params`` entry under its declared name, and any
+    ``extra_repo_deps``. Pure create-form handlers that don't use the
+    repo still have to accept ``repo=`` (just ignore it) — uniform
+    mount-handler contract beats a special case.
     """
     if spec.parent is not None:
         raise NotImplementedError(
@@ -346,6 +404,7 @@ def mount_form(
     id_param = spec.id_param
     extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
     spec_template = spec.form_template
+    query_param_names = tuple(qp.name for qp in query_params)
 
     if on_existing:
         path = f"/{{{id_param}}}/form"
@@ -361,6 +420,7 @@ def mount_form(
             "repo": kwargs["repo"],
             "requesting_user": kwargs.get("requesting_user"),
             **{name: kwargs[name] for name, _ in extra_deps_named},
+            **{name: kwargs[name] for name in query_param_names},
         }
         if on_existing:
             handler_kwargs[id_param] = kwargs[id_param]
@@ -385,6 +445,7 @@ def mount_form(
     _set_route_signature(
         _form,
         path_params=path_params,
+        query_params=query_params,
         deps=_read_route_deps(spec, extra_deps_named),
     )
     router.get(path)(_form)
@@ -751,6 +812,7 @@ def _set_route_signature(
     *,
     path_params: tuple[tuple[str, type], ...],
     deps: tuple[tuple[str, Callable[..., Any]], ...],
+    query_params: tuple[QueryParam, ...] = (),
 ) -> None:
     """Advertise an explicit signature on a `**kwargs`-based route handler.
 
@@ -761,6 +823,9 @@ def _set_route_signature(
 
     `path_params` are positional-or-keyword params with a type annotation
     and no default — FastAPI binds them from the URL.
+    `query_params` (optional) are positional-or-keyword params whose
+    default is `Query(...)` — FastAPI parses them from the query string,
+    validates against the annotation, and 422s on invalid input.
     `deps` are positional-or-keyword params whose default is `Depends(...)`
     — FastAPI resolves them via the injection system.
     """
@@ -773,6 +838,19 @@ def _set_route_signature(
                 name=name,
                 kind=Parameter.POSITIONAL_OR_KEYWORD,
                 annotation=ann,
+            )
+        )
+    for qp in query_params:
+        if qp.default is _UNSET:
+            default = Query(..., description=qp.description or None)
+        else:
+            default = Query(qp.default, description=qp.description or None)
+        params.append(
+            Parameter(
+                name=qp.name,
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                default=default,
+                annotation=qp.annotation,
             )
         )
     for name, dep in deps:

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 from src.api.common.resource_routes import (
+    QueryParam,
     ResourceSpec,
     mount_delete,
     mount_detail,
@@ -445,6 +446,105 @@ def test_mount_form_no_template_anywhere_raises():
 
     with pytest.raises(RuntimeError, match="could not resolve a template"):
         TestClient(app).get("/widgets/form")
+
+
+def test_mount_list_passes_query_params_to_handler(monkeypatch):
+    """Each `QueryParam` reaches the handler under its declared name."""
+    captured = {}
+
+    async def list_handler(**kwargs):
+        captured.update(kwargs)
+        return {"items": []}
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+        list_template="widgets/list.html",
+    )
+    _stub_html_response(monkeypatch)
+
+    app = FastAPI()
+    router = APIRouter(prefix="/widgets")
+    mount_list(
+        router,
+        spec,
+        handler=list_handler,
+        query_params=(
+            QueryParam("kind", str | None, None),
+            QueryParam("active", bool, True),
+        ),
+    )
+    app.include_router(router)
+
+    resp = TestClient(app).get("/widgets?kind=foo&active=false")
+    assert resp.status_code == 200
+    assert captured["kind"] == "foo"
+    assert captured["active"] is False
+
+
+def test_mount_list_public_skips_auth_dep(monkeypatch):
+    """`public=True` overrides the spec's read_user_dep; handler still
+    receives `requesting_user=None` for kwarg uniformity."""
+    captured = {}
+
+    async def list_handler(**kwargs):
+        captured.update(kwargs)
+        return {"items": []}
+
+    def required_user():
+        raise RuntimeError("auth dep should not be called when public=True")
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        read_user_dep=required_user,
+        list_template="widgets/list.html",
+    )
+    _stub_html_response(monkeypatch)
+
+    app = FastAPI()
+    router = APIRouter(prefix="/widgets")
+    mount_list(router, spec, handler=list_handler, public=True)
+    app.include_router(router)
+
+    resp = TestClient(app).get("/widgets")
+    assert resp.status_code == 200
+    assert captured["requesting_user"] is None
+
+
+def test_mount_form_query_param_drives_handler_template_choice(monkeypatch):
+    """A query param (e.g. `?kind=`) reaches the handler, and the handler's
+    `template_name` in context picks the rendered template — the existing
+    precedence chain handles polymorphic-by-query forms."""
+
+    async def form_handler(**kwargs):
+        kind = kwargs["kind"]
+        return {"template_name": f"widgets/{kind}.html"}
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        read_user_dep=lambda: SimpleNamespace(id=uuid4()),
+    )
+    rendered = _stub_html_response(monkeypatch)
+
+    app = FastAPI()
+    router = APIRouter(prefix="/widgets")
+    mount_form(
+        router,
+        spec,
+        handler=form_handler,
+        query_params=(QueryParam("kind", str, "default"),),
+    )
+    app.include_router(router)
+
+    resp = TestClient(app).get("/widgets/form?kind=variant_b")
+    assert resp.status_code == 200
+    assert rendered["template_name"] == "widgets/variant_b.html"
 
 
 def test_mount_related_list_path_under_parent_id(monkeypatch):

--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -99,8 +99,6 @@ The unified grammar fits resource-shaped CRUD. Several existing routes intention
 | `GET /auth/{register,login,forgot-password,reset-password/{token}}` | `auth_pages.py` | Pure form rendering, no resource. Could fit a hypothetical `mount_static_form` but not worth it for 4 routes. |
 | `GET /users/me`, `GET /users/me/profile`, `GET /users/me/providers` | `me.py` | Singleton aliases — no parent id, session-sourced. Adding a `singleton_alias` knob to every spec for 3 routes would be a bad trade. |
 | `PUT /users/{user_id}/activation` | `users.py` | Idempotent state set with `HX-Refresh` (not `HX-Redirect`); admin-only verb. Doesn't match `mount_update` semantics. |
-| `GET /providers` (with `?license_type=`/`?issuing_state=` filters) | `providers.py` | Public listing with query-param filters. `mount_list` doesn't accept query params; widening it for one resource would push the asymmetry onto every spec. |
-| `GET /posts/form?kind=X` | `posts.py` | Polymorphic-by-query-param: the kind picks the create template at request time. `mount_form`'s contract doesn't carry query params. |
 | `GET /`, `GET /health` | `main.py` | Utility endpoints. Not resource-shaped. |
 
 If a future case suggests the grammar should grow to fit one of these, that's the moment to reshape `ResourceSpec` — not to escape-hatch around it.

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -1,10 +1,11 @@
 import logging
 from typing import Literal
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter
 
-from src.api.common import APIResponse, BaseRouter
+from src.api.common import BaseRouter
 from src.api.common.resource_routes import (
+    QueryParam,
     ResourceSpec,
     mount_create,
     mount_delete,
@@ -25,7 +26,7 @@ from src.logic.posts.post_processing import (
     handle_list_posts,
     handle_update_post,
 )
-from src.models import KIND_NAMES, REGISTERED_KINDS, User
+from src.models import KIND_NAMES, REGISTERED_KINDS
 from src.repositories.dependencies import get_audit_repository, get_post_repository
 from src.schemas.posts.post import post_create_adapter, post_update_adapter
 
@@ -76,25 +77,22 @@ POST_SPEC = ResourceSpec(
 mount_list(router, POST_SPEC, handler=handle_list_posts)
 
 
-# GET /posts/form?kind=<X> — stays bespoke. The kind query param picks
-# the per-kind create template at request time. mount_form's contract
-# doesn't accept additional query params; widening the spec for this
-# single polymorphic-by-query case would bloat the grammar for everyone.
-# Slice 10 (#255) revisits whether the grammar should grow to fit it.
-@router.get("/form")
-async def get_post_form(
-    request: Request,
-    kind: Literal[*KIND_NAMES] = Query(KIND_NAMES[0]),
-    user: User = Depends(current_active_user),
-):
-    """Provides the create-post form for `kind` (defaults to the first
-    registered kind). Unsupported kinds 422 via FastAPI's Literal."""
-    context = await handle_get_post_form(request=request, requesting_user=user)
-    return APIResponse.html_response(
-        template_name=REGISTERED_KINDS[kind].create_template,
-        context=context,
-        request=request,
-    )
+# GET /posts/form?kind=<X> — `kind` query param picks the per-kind create
+# template at request time. The handler returns `template_name` in the
+# context dict; mount_form's three-source resolution picks it up.
+mount_form(
+    router,
+    POST_SPEC,
+    handler=handle_get_post_form,
+    query_params=(
+        QueryParam(
+            "kind",
+            Literal[*KIND_NAMES],
+            KIND_NAMES[0],
+            description="Which post kind's create form to render.",
+        ),
+    ),
+)
 
 
 # GET /posts/{post_id}/form — handler returns `template_name` in context

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -1,14 +1,16 @@
 import logging
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter
 
-from src.api.common import APIResponse, BaseRouter
+from src.api.common import BaseRouter
 from src.api.common.resource_routes import (
+    QueryParam,
     ResourceSpec,
     mount_create,
     mount_delete,
     mount_detail,
     mount_form,
+    mount_list,
     mount_update,
 )
 from src.auth_config import current_active_user
@@ -35,7 +37,6 @@ from src.logic.providers.provider_processing import (
     handle_update_provider,
 )
 from src.repositories.dependencies import get_audit_repository, get_provider_repository
-from src.repositories.providers.provider_repository import ProviderRepository
 from src.schemas.providers.provider import (
     ProviderCertificationRead,
     ProviderEducationRead,
@@ -68,6 +69,7 @@ PROVIDER_SPEC = ResourceSpec(
     read_to_dict=lambda profile: ProviderRead.model_validate(profile).model_dump(
         mode="json"
     ),
+    list_template="providers/list.html",
     detail_template="providers/detail.html",
     # After create, redirect to the edit form so the user can flesh out
     # sub-rows (licensures, educations, certifications). After update,
@@ -91,29 +93,19 @@ def _certification_read_dict(row) -> dict:
 
 # --- Profile collection routes ------------------------------------------
 
-
-@router.get("")
-async def list_providers(
-    request: Request,
-    license_type: str | None = Query(None),
-    issuing_state: str | None = Query(None),
-    repo: ProviderRepository = Depends(get_provider_repository),
-):
-    """Public HTML listing of providers. Optional `license_type` and
-    `issuing_state` filters narrow the results to profiles that hold a
-    licensure matching both filters."""
-    context = await handle_list_providers(
-        request=request,
-        repo=repo,
-        license_type=license_type,
-        issuing_state=issuing_state,
-    )
-    return APIResponse.html_response(
-        template_name="providers/list.html",
-        context=context,
-        request=request,
-    )
-
+# GET /providers — public listing with optional license_type / issuing_state
+# filters. `public=True` overrides the spec's `read_user_dep` for this
+# mount only (detail/form/mutations on the same spec stay authenticated).
+mount_list(
+    router,
+    PROVIDER_SPEC,
+    handler=handle_list_providers,
+    public=True,
+    query_params=(
+        QueryParam("license_type", str | None, None),
+        QueryParam("issuing_state", str | None, None),
+    ),
+)
 
 # POST /providers — owner inferred from session.
 mount_create(

--- a/src/logic/posts/post_processing.py
+++ b/src/logic/posts/post_processing.py
@@ -68,9 +68,25 @@ async def handle_get_post_detail(
 async def handle_get_post_form(
     request: Request,
     requesting_user: User,
+    repo: PostRepository | None = None,
+    kind: str = "",
 ):
-    """Builds the template context for the create-post form."""
-    return {"request": request, "current_user": requesting_user}
+    """Builds the template context for the create-post form.
+
+    `kind` picks the per-kind create template; the handler returns
+    `template_name` in the context so `mount_form` renders the
+    kind-specific template. Empty `kind` defaults to the first
+    registered kind, matching the previous bespoke route's
+    `Query(KIND_NAMES[0])` default. `repo` is accepted for uniformity
+    with the mount_form contract but unused here.
+    """
+    del repo  # explicitly unused
+    chosen_kind = kind or next(iter(REGISTERED_KINDS))
+    return {
+        "request": request,
+        "current_user": requesting_user,
+        "template_name": REGISTERED_KINDS[chosen_kind].create_template,
+    }
 
 
 async def handle_get_post_edit_form(

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -113,13 +113,19 @@ async def _load_subrow_or_404(getter, sub_id: UUID, parent_id: UUID, *, name: st
 async def handle_list_providers(
     request: Request,
     repo: ProviderRepository,
-    *,
+    requesting_user: User | None = None,
     license_type: str | None = None,
     issuing_state: str | None = None,
 ) -> dict[str, Any]:
     """Public listing — no auth gate, no audit, no commit. Returns the
     template context for the HTML list page; the active filter values are
-    forwarded so the template can preselect them in its filter form."""
+    forwarded so the template can preselect them in its filter form.
+
+    `requesting_user` is `None` for this handler — `mount_list(...,
+    public=True)` skips the auth dep — but the kwarg is accepted for
+    uniformity with the mount contract.
+    """
+    del requesting_user  # explicitly unused — public route
     profiles = await repo.list_providers(
         license_type=license_type, issuing_state=issuing_state
     )

--- a/src/models/posts/test_post_kinds.py
+++ b/src/models/posts/test_post_kinds.py
@@ -9,7 +9,7 @@ fails.
 
 from typing import get_args
 
-from src.api.routes.posts import get_post_form
+from src.api.routes import posts as posts_routes
 from src.models import KIND_BY_DETAIL_MODEL, KIND_NAMES, REGISTERED_KINDS, Post
 from src.models.posts.post_kinds import kind_check_sql
 
@@ -49,9 +49,17 @@ def test_kind_by_detail_model_inverse_matches_registry():
 
 def test_form_route_literal_matches_registry():
     """The `?kind=` Query parameter on `GET /posts/form` is typed as
-    `Literal[*KIND_NAMES]`; the FastAPI signature must reflect that."""
-    annotations = get_post_form.__annotations__
-    literal_args = get_args(annotations["kind"])
+    `Literal[*KIND_NAMES]`. The QueryParam published on the mount's
+    route signature must reflect that — guards against `KIND_NAMES`
+    drifting from the route's accepted-kinds list."""
+    import inspect
+
+    routes = [
+        r for r in posts_routes.posts_api_router.routes if r.path == "/posts/form"
+    ]
+    assert len(routes) == 1, "expected exactly one /posts/form route"
+    params = inspect.signature(routes[0].endpoint).parameters
+    literal_args = get_args(params["kind"].annotation)
     assert set(literal_args) == set(KIND_NAMES)
 
 


### PR DESCRIPTION
Closes #265.

## Summary
- New `QueryParam` dataclass + `_set_route_signature` extended to emit FastAPI `Query(...)` parameters per declaration.
- `mount_list` and `mount_form` accept `query_params=(QueryParam(...), ...)`. Each parsed value reaches the handler under its declared name; OpenAPI + 422 validation work like a hand-written route.
- `mount_list` also gains `public=True` to override the spec's `read_user_dep` for that mount only — needed where the list is public but detail/form pages are authenticated.
- Migrates `GET /providers?license_type=...&issuing_state=...` and `GET /posts/form?kind=X` onto the mounts. Two of the seven bespoke routes are absorbed.

## Why
Follow-on to the 10-slice unified-resource-spec refactor. Two of the documented bespoke routes were the same shape (CRUD-shaped with a small query payload); one extension absorbs both and unblocks future filtered lists.

## Notable design choices
- **Per-mount `query_params`**, not on the spec. Filter shapes are usually list-specific; sub-resources or sibling mounts don't share them.
- **`public=True` discovery.** Slice 1 of this work surfaced that `GET /providers` is public while `GET /providers/{id}` is authenticated. Rather than adding a `public_read: bool` field to the spec (which would force every spec to think about this), the public override is a per-mount kwarg with the same shape as the existing `extra_repo_deps`.
- **Polymorphic forms via handler-context override.** No new mechanism here — the `template_name` precedence chain already existed; query params just give the handler the input it needs to choose.

## Test plan
- [x] `dev test` (520 — was 517, +3 new mount tests)
- [x] `dev lint`
- [x] `dev test contract` (16)
- [x] `dev routes` shows `/providers` and `/posts/form` mounted via mount_list / mount_form

🤖 Generated with [Claude Code](https://claude.com/claude-code)