### PR TITLE
Prototype field_for: schema-driven form-field rendering

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -96,7 +96,7 @@ Everything else (schemas, models, templates) supports these main layers. There i
 | **Logic**        | active   | Business logic, orchestration, transaction commit           | `logic/*.py`        | Repositories, Schemas, Models, API common exceptions |
 | **Repositories** | active   | Data access, queries                                        | `repositories/*.py` | Models, Database                      |
 | **Models**       | active   | Database schema, relationships                              | `models/*.py`       | SQLAlchemy                            |
-| **Schemas**      | active   | Request/response validation                                 | `schemas/*.py`      | Pydantic, Models (enums + registries only) |
+| **Schemas**      | active   | Request/response validation                                 | `schemas/*.py`      | Pydantic, Models (enums + registries only), Core (`form_fields.HtmlPattern` marker only) |
 | **Middleware**   | empty    | Cross-cutting concerns                                      | `middleware/*.py`   | FastAPI                               |
 | **Core**         | active   | Configuration, utilities                                    | `core/*.py`         | None                                  |
 

--- a/src/api/routes/test_providers.py
+++ b/src/api/routes/test_providers.py
@@ -596,10 +596,19 @@ async def test_get_provider_form_renders(
     form = tree.css_first("form")
     assert form is not None
     assert form.attributes.get("hx-post") == "/providers"
-    # Required practice fields are present.
-    assert tree.css_first('input[name="practice_name"]') is not None
-    assert tree.css_first('input[name="location_city"]') is not None
-    assert tree.css_first('input[name="location_zip"]') is not None
+    # Required practice fields are present, with `maxlength` /
+    # `pattern` attributes derived from the `ProviderCreate` schema's
+    # `HtmlPattern` markers via `field_for` → `field_spec`.
+    practice = tree.css_first('input[name="practice_name"]')
+    assert practice is not None
+    assert practice.attributes.get("maxlength") == "200"
+    city = tree.css_first('input[name="location_city"]')
+    assert city is not None
+    assert city.attributes.get("maxlength") == "120"
+    zip_input = tree.css_first('input[name="location_zip"]')
+    assert zip_input is not None
+    assert zip_input.attributes.get("pattern") == r"\d{5}"
+    assert zip_input.attributes.get("maxlength") == "5"
     # State select with all 51 entries (50 states + DC) plus a placeholder.
     state_select = tree.css_first('select[name="location_state"]')
     assert state_select is not None

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -81,6 +81,7 @@ Core modules are imported and used throughout the application stack.
 | ----------------- | ----------------------------------- | ------------------------------------------------- |
 | **config.py**     | Application settings and validation | Environment variables, validation, error handling |
 | **templating.py** | Template system configuration       | Jinja2 setup, global context, auto-reload, post-enum tuples + label dicts exposed as Jinja globals |
+| **form_fields.py**| Schema-driven form-field rendering  | `field_spec(schema_cls, name)` introspects a Pydantic field and returns the spec the `field_for` Jinja macro dispatches on; `HtmlPattern` marker for `Annotated[...]` aliases that need a form-side `pattern`/`maxlength` |
 
 ## Directory structure
 
@@ -92,6 +93,17 @@ core/
 │                   #   from `src/models/enums.py` as Jinja globals
 │                   #   so per-kind form templates can iterate over them
 │                   #   directly (single source of truth for option lists).
+│                   #   Also exposes `field_spec` (from `form_fields.py`)
+│                   #   as a Jinja global and registers the choice-tuple →
+│                   #   labels-dict mapping it uses for `Literal[*TUPLE]`
+│                   #   fields.
+├── form_fields.py  # Schema-driven form rendering. `field_spec(schema_cls,
+│                   #   name)` introspects a Pydantic field and produces
+│                   #   the spec that `field_for` (in
+│                   #   `src/templates/_shared/form_fields.html`)
+│                   #   dispatches on. `HtmlPattern` is the marker an
+│                   #   `Annotated[...]` schema alias attaches to expose
+│                   #   client-side `pattern`/`maxlength` to the form.
 └── __init__.py     # Package exports
 ```
 
@@ -375,6 +387,7 @@ Each module has a colocated `test_<module>.py` covering its behavior:
 
 - `test_config.py` — environment variable defaults, particularly that production is the safe default.
 - `test_templating.py` — template context generation, including livereload only loading in development.
+- `test_form_fields.py` — `field_spec` derivation: required-vs-optional from `T | None`, `Literal[*TUPLE]` → select with labels resolved by tuple-value lookup, `HtmlPattern` marker propagation, and an end-to-end check that `ZipText` carries its pattern through the real `ProviderCreate` schema.
 
 ## Related documentation
 

--- a/src/core/form_fields.py
+++ b/src/core/form_fields.py
@@ -1,0 +1,131 @@
+"""Schema-driven form-field rendering.
+
+`field_spec(schema_cls, name)` introspects a Pydantic schema's
+`FieldInfo` and returns a normalized dict the `field_for` Jinja macro
+(in `src/templates/_shared/form_fields.html`) dispatches on. The point
+is to derive the form's HTML attributes from the same Pydantic field
+that validates the request — adding a `Literal[*US_STATES]` to the
+schema flows automatically to the form's `<select>`; tightening
+`ZipText`'s pattern updates the form's `pattern` attribute.
+
+What's derived today:
+
+  - `required` — from whether the field's annotation is `T | None`.
+  - `kind="select"` + `choices` + (optional) `labels` — for
+    `Literal[*TUPLE]` fields. Labels are resolved by tuple-value
+    lookup against `register_choice_labels()` calls (see
+    `src/core/templating.py`).
+  - `pattern` / `maxlength` — from any `HtmlPattern` marker attached to
+    an `Annotated[...]` alias in `src/schemas/_validators.py`. The
+    schema's regex validator stays the source of truth; the marker
+    just exposes a *form* rendering of the same constraint.
+  - Default `kind="text"` for everything else.
+
+What's deliberately NOT derived (yet):
+
+  - Field labels — the human label ("Practice name") is passed at the
+    call site. Keeps copy under template-author control.
+  - Multi-select / checkbox-grid / radio-bool — these have form-level
+    grouping (fieldset/legend) that the existing macros own; they
+    should be added once their schema-side shape (e.g. `list[Literal]`
+    + a discriminator metadata marker) is settled.
+  - `select_field` placeholder behavior — `field_for` always passes
+    `placeholder=true`, which suits create forms. Edit forms with
+    pre-filled `current` already suppress the placeholder inside
+    `select_field`.
+"""
+
+from dataclasses import dataclass
+from types import UnionType
+from typing import Any, Literal, Union, get_args, get_origin
+
+from pydantic import BaseModel
+
+
+@dataclass(frozen=True)
+class HtmlPattern:
+    """Annotation marker carrying HTML pattern/maxlength hints for an
+    `Annotated[...]` alias in `src/schemas/_validators.py`.
+
+    The schema's validator is the authoritative constraint; this marker
+    exposes a form-side rendering of the same constraint so the
+    `<input>` rejects bad values client-side too. Define the regex once
+    on the alias and reuse it via `Annotated[..., HtmlPattern(pattern,
+    maxlength)]` — the alias is the one place both surfaces look.
+    """
+
+    pattern: str | None = None
+    maxlength: int | None = None
+
+
+# Choice-tuple → label-dict registry, populated at startup by
+# `register_choice_labels()` from `src/core/templating.py`. Lookup is
+# by tuple value (not identity) because `Literal[*TUPLE]` unpacks the
+# source tuple into a fresh tuple inside `typing.Literal`'s args.
+_CHOICE_LABELS: dict[tuple, dict[str, str] | None] = {}
+
+
+def register_choice_labels(
+    choices: tuple[str, ...], labels: dict[str, str] | None
+) -> None:
+    """Register the labels dict (or `None`) for a controlled-vocabulary
+    tuple, so `field_spec` can resolve labels for any
+    `Literal[*tuple]` it sees. Idempotent — re-registering the same
+    tuple with the same labels is a no-op."""
+    _CHOICE_LABELS[tuple(choices)] = labels
+
+
+def _is_optional(annotation: Any) -> bool:
+    """`True` if `annotation` is `T | None` (either the PEP 604 union
+    or `typing.Union[T, None]`)."""
+    origin = get_origin(annotation)
+    if origin is Union or origin is UnionType:
+        return type(None) in get_args(annotation)
+    return False
+
+
+def _strip_optional(annotation: Any) -> Any:
+    """Return the non-None arm of a `T | None` annotation. If
+    `annotation` is a multi-arm union (`A | B | None`), returns the
+    union of the non-None arms."""
+    args = tuple(a for a in get_args(annotation) if a is not type(None))
+    if len(args) == 1:
+        return args[0]
+    return Union[args]  # type: ignore[return-value]
+
+
+def field_spec(schema_cls: type[BaseModel], name: str) -> dict[str, Any]:
+    """Return the rendering spec for `schema_cls.<name>`. See module
+    docstring for what's derived."""
+    field = schema_cls.model_fields[name]
+    annotation = field.annotation
+    optional = _is_optional(annotation)
+    inner = _strip_optional(annotation) if optional else annotation
+
+    if get_origin(inner) is Literal:
+        choices = list(get_args(inner))
+        labels = _CHOICE_LABELS.get(tuple(choices))
+        return {
+            "kind": "select",
+            "name": name,
+            "required": not optional,
+            "choices": choices,
+            "labels": labels,
+        }
+
+    pattern: str | None = None
+    maxlength: int | None = None
+    for marker in field.metadata:
+        if isinstance(marker, HtmlPattern):
+            if marker.pattern is not None:
+                pattern = marker.pattern
+            if marker.maxlength is not None:
+                maxlength = marker.maxlength
+
+    return {
+        "kind": "text",
+        "name": name,
+        "required": not optional,
+        "pattern": pattern,
+        "maxlength": maxlength,
+    }

--- a/src/core/templating.py
+++ b/src/core/templating.py
@@ -2,6 +2,7 @@ from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from src.core.config import settings
+from src.core.form_fields import field_spec, register_choice_labels
 from src.models import enums
 
 auto_reload = settings.ENVIRONMENT == "development"
@@ -48,7 +49,37 @@ _env.globals.update(
     EDUCATION_TYPES_LABELS=enums.EDUCATION_TYPES_LABELS,
     CERTIFICATION_TYPES=enums.CERTIFICATION_TYPES,
     CERTIFICATION_TYPES_LABELS=enums.CERTIFICATION_TYPES_LABELS,
+    # Pydantic-driven field rendering: `field_for(schema, name, label)`
+    # in `_shared/form_fields.html` calls `field_spec(schema, name)` to
+    # derive the form's HTML attributes (required, choices, pattern,
+    # maxlength) from the schema. The schema class itself is passed
+    # into the template context by the route handler — keeps the
+    # core → schemas import direction clean (see layer matrix in
+    # `src/README.md`).
+    field_spec=field_spec,
 )
+
+# Register the choice-tuple → labels-dict mapping that `field_spec`
+# uses to resolve labels for `Literal[*TUPLE]` fields. Lookup is by
+# tuple value, so the mapping needs to be populated before any
+# template render. Tuples without a labels dict (USPS state codes are
+# self-describing) register `None` so misses are explicit.
+register_choice_labels(enums.US_STATES, None)
+register_choice_labels(
+    enums.LOCATION_AVAILABILITY_OPTIONS, enums.LOCATION_AVAILABILITY_LABELS
+)
+register_choice_labels(enums.CLIENT_AGE_GROUPS, enums.CLIENT_AGE_GROUP_LABELS)
+register_choice_labels(
+    enums.LANGUAGE_PREFERRED_OPTIONS, enums.LANGUAGE_PREFERRED_LABELS
+)
+register_choice_labels(enums.INSURANCE_OPTIONS, enums.INSURANCE_LABELS)
+register_choice_labels(
+    enums.CLIENT_REFERRAL_SERVICES, enums.CLIENT_REFERRAL_SERVICE_LABELS
+)
+register_choice_labels(enums.TREATMENT_SETTINGS, enums.TREATMENT_SETTINGS_LABELS)
+register_choice_labels(enums.LICENSE_TYPES, enums.LICENSE_TYPES_LABELS)
+register_choice_labels(enums.EDUCATION_TYPES, enums.EDUCATION_TYPES_LABELS)
+register_choice_labels(enums.CERTIFICATION_TYPES, enums.CERTIFICATION_TYPES_LABELS)
 
 templates = Jinja2Templates(env=_env)
 

--- a/src/core/test_form_fields.py
+++ b/src/core/test_form_fields.py
@@ -1,0 +1,96 @@
+"""Tests for `src/core/form_fields.py`.
+
+Covers what `field_spec` derives from a Pydantic field — required-ness,
+Literal → select, Annotated `HtmlPattern` markers — using a small
+in-test schema. The provider/new.html → `field_for` integration is
+exercised by the route test in `src/api/routes/test_providers.py`.
+"""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel
+
+from src.core.form_fields import (
+    HtmlPattern,
+    field_spec,
+    register_choice_labels,
+)
+
+
+_COLORS = ("red", "green", "blue")
+_COLOR_LABELS = {"red": "Red", "green": "Green", "blue": "Blue"}
+register_choice_labels(_COLORS, _COLOR_LABELS)
+
+_SIZES = ("s", "m", "l")
+register_choice_labels(_SIZES, None)
+
+_PatternedString = Annotated[str, HtmlPattern(pattern=r"\d{5}", maxlength=5)]
+
+
+class _Sample(BaseModel):
+    required_text: str
+    optional_text: str | None = None
+    required_choice: Literal[*_COLORS]
+    optional_choice: Literal[*_COLORS] | None = None
+    unlabeled_choice: Literal[*_SIZES]
+    patterned: _PatternedString
+
+
+def test_required_text_field():
+    spec = field_spec(_Sample, "required_text")
+    assert spec == {
+        "kind": "text",
+        "name": "required_text",
+        "required": True,
+        "pattern": None,
+        "maxlength": None,
+    }
+
+
+def test_optional_text_field_drops_required():
+    spec = field_spec(_Sample, "optional_text")
+    assert spec["kind"] == "text"
+    assert spec["required"] is False
+
+
+def test_literal_field_renders_as_select_with_labels():
+    spec = field_spec(_Sample, "required_choice")
+    assert spec["kind"] == "select"
+    assert spec["choices"] == list(_COLORS)
+    assert spec["labels"] == _COLOR_LABELS
+    assert spec["required"] is True
+
+
+def test_optional_literal_field_is_select_not_required():
+    spec = field_spec(_Sample, "optional_choice")
+    assert spec["kind"] == "select"
+    assert spec["required"] is False
+    assert spec["choices"] == list(_COLORS)
+
+
+def test_unlabeled_choice_returns_none_labels():
+    """Tuples registered without a labels dict (e.g. USPS state codes)
+    surface `labels=None` so the macro falls back to using the value
+    itself as the option text."""
+    spec = field_spec(_Sample, "unlabeled_choice")
+    assert spec["kind"] == "select"
+    assert spec["labels"] is None
+
+
+def test_html_pattern_marker_propagates():
+    spec = field_spec(_Sample, "patterned")
+    assert spec["kind"] == "text"
+    assert spec["pattern"] == r"\d{5}"
+    assert spec["maxlength"] == 5
+
+
+def test_zip_text_alias_carries_pattern_in_real_schema():
+    """End-to-end: the `ZipText` alias in `src/schemas/_validators.py`
+    is the production wiring this prototype targets. If someone removes
+    the `HtmlPattern` marker on `ZipText`, the form's client-side
+    validation silently drops — catch it here."""
+    from src.schemas.providers.provider import ProviderCreate
+
+    spec = field_spec(ProviderCreate, "location_zip")
+    assert spec["pattern"] == r"\d{5}"
+    assert spec["maxlength"] == 5

--- a/src/core/test_form_fields.py
+++ b/src/core/test_form_fields.py
@@ -16,7 +16,6 @@ from src.core.form_fields import (
     register_choice_labels,
 )
 
-
 _COLORS = ("red", "green", "blue")
 _COLOR_LABELS = {"red": "Red", "green": "Green", "blue": "Blue"}
 register_choice_labels(_COLORS, _COLOR_LABELS)

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -194,7 +194,15 @@ async def handle_get_provider_form(
     creating a profile doesn't need to load anything from the db.
     """
     del repo  # explicitly unused
-    return {"request": request, "current_user": requesting_user}
+    return {
+        "request": request,
+        "current_user": requesting_user,
+        # `providers/new.html` calls `field_for(schema, ...)` against
+        # this Pydantic class; pass it explicitly rather than via a
+        # core-level Jinja global so schemas stay opt-in per template
+        # (and core doesn't need to import schemas).
+        "schema": ProviderCreate,
+    }
 
 
 async def handle_get_provider_edit_form(

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -62,7 +62,7 @@ Schemas act as the data contract layer between HTTP and business logic.
 Schemas follow the [cluster pattern](../README.md#domain-entities-and-the-cluster-pattern):
 
 - One cluster directory per domain entity (`<entity>/`). Each holds the Pydantic Create/Update/Read/AuditSnapshot variants for that entity (and its sub-entities, if any), plus the colocated test file. Per-entity specifics — discriminator unions, controlled-vocabulary fields, embedded sub-entities — live inside the cluster, with a `<entity>/README.md` if anything is non-obvious.
-- Parent-level shared tier (`_validators.py`) — `Annotated[T, AfterValidator(fn)]` aliases and helpers used by 2+ clusters. Add to it when a primitive is used by 2+ schema modules, or when two modules are about to define near-duplicates of the same helper.
+- Parent-level shared tier (`_validators.py`) — `Annotated[T, AfterValidator(fn)]` aliases and helpers used by 2+ clusters. Add to it when a primitive is used by 2+ schema modules, or when two modules are about to define near-duplicates of the same helper. An alias may also attach an `HtmlPattern(pattern=..., maxlength=...)` marker (from [`src/core/form_fields.py`](../core/form_fields.py)) when the alias's regex/length constraint should also be exposed as the form's client-side `pattern`/`maxlength` — keeps both surfaces aligned at the alias's definition site rather than duplicated per template.
 
 A schema cluster does not import from a peer cluster; cross-cluster reuse happens via the shared tier ([lint-enforced](../README.md#domain-entities-and-the-cluster-pattern)).
 

--- a/src/schemas/_validators.py
+++ b/src/schemas/_validators.py
@@ -20,6 +20,8 @@ from typing import Annotated
 
 from pydantic import AfterValidator, BaseModel
 
+from src.core.form_fields import HtmlPattern
+
 # --- Field-cleaning helpers ---------------------------------------------
 #
 # Each runs AFTER Pydantic's type validation, so for required fields
@@ -66,7 +68,13 @@ def _strip_optional(v: str | None) -> str | None:
 # the right alias; the validator definition lives once.
 
 StrippedText = Annotated[str, AfterValidator(_strip_required)]
-ZipText = Annotated[str, AfterValidator(_validate_zip)]
+# `HtmlPattern` mirrors the regex enforced by `_validate_zip` so the
+# form's `<input pattern>` rejects bad ZIPs client-side. The validator
+# stays the source of truth — keep the two regexes aligned at this
+# definition site.
+ZipText = Annotated[
+    str, AfterValidator(_validate_zip), HtmlPattern(pattern=r"\d{5}", maxlength=5)
+]
 StrippedOptionalText = Annotated[str | None, AfterValidator(_strip_optional)]
 
 

--- a/src/schemas/providers/provider.py
+++ b/src/schemas/providers/provider.py
@@ -28,10 +28,11 @@ universes aligned with the source tuples.
 
 import uuid
 from datetime import date, datetime
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, TypeAdapter, model_validator
 
+from src.core.form_fields import HtmlPattern
 from src.models.enums import (
     CERTIFICATION_TYPES,
     EDUCATION_TYPES,
@@ -220,8 +221,14 @@ class ProviderCreate(BaseModel):
     set by the route from the authenticated user, not accepted on the
     wire."""
 
-    practice_name: StrippedText
-    location_city: StrippedText
+    # `HtmlPattern(maxlength=...)` is a form-side hint only — does not
+    # affect server-side validation. It exists so the rendered
+    # `<input maxlength=...>` matches the previous hand-rolled form
+    # without restating the number per template. Adding a true server-
+    # side length cap (`pydantic.StringConstraints` etc.) is a separate
+    # concern.
+    practice_name: Annotated[StrippedText, HtmlPattern(maxlength=200)]
+    location_city: Annotated[StrippedText, HtmlPattern(maxlength=120)]
     location_state: Literal[*US_STATES]
     location_zip: ZipText
     in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -81,12 +81,24 @@ CRUD templates pull from a single `_shared/` directory rather than duplicating t
 
 A template under `<resource>/` may only `{% extends %}` / `{% include %}` / `{% from %}` / `{% import %}` from: the project root (`base.html`), its own directory, or `_shared/`. Anything else is a layering smell — the partial is *de facto* shared and belongs in `_shared/`. The rule is enforced by `scripts/dev/template_imports_check.py`, which runs as part of `dev lint` and as a pre-commit hook.
 
-1. **`_shared/form_fields.html`** — field-render macros: `text_field`, `textarea_field`, `select_field`, `filter_select_field`, `radio_bool_field`, `multi_select_field`, `time_grid_field`. Each emits a label + control + line-breaks. The `<select>` and checkbox macros iterate over a controlled-vocabulary tuple from [`src/models/enums.py`](../models/enums.py) and look display labels up in the matching `*_LABELS` dict — both registered as Jinja globals in [`src/core/templating.py`](../core/templating.py). Adding a value to a tuple flows automatically to every form using these macros. `select_field` is for create/edit forms (required by default; optional disabled-placeholder); `filter_select_field` is for filter forms on list pages (never required; leading "Any" option is selectable so users can clear filters).
+1. **`_shared/form_fields.html`** — field-render macros: `text_field`, `textarea_field`, `select_field`, `filter_select_field`, `radio_bool_field`, `multi_select_field`, `time_grid_field`, plus the schema-driven `field_for` (see below). Each emits a label + control + line-breaks. The `<select>` and checkbox macros iterate over a controlled-vocabulary tuple from [`src/models/enums.py`](../models/enums.py) and look display labels up in the matching `*_LABELS` dict — both registered as Jinja globals in [`src/core/templating.py`](../core/templating.py). Adding a value to a tuple flows automatically to every form using these macros. `select_field` is for create/edit forms (required by default; optional disabled-placeholder); `filter_select_field` is for filter forms on list pages (never required; leading "Any" option is selectable so users can clear filters).
 2. **`_shared/forms.html`** — `inline_add_form(action, legend, submit_label, method="post")`: single-fieldset form skeleton for sub-resource add forms. Forms with multiple fieldsets stay hand-rolled.
 3. **`_shared/sections.html`** — `list_or_empty(items, list_class, empty_message)`: `<ul>`-of-items or empty-state `<p>`. Caller passes the per-row `<li>` body via `{% call(item) %}…{% endcall %}`. The `<section>`/`<h2>` wrapper is left to the caller (varies too little to be worth abstracting).
 4. **`_shared/actions.html`** — `confirm_delete_button(url, confirm_message, label="Delete")`: HTMX `hx-delete` button with confirm dialog.
 
 The labels-vs-tuple guardrail (`test_labels_cover_their_tuples`) lives alongside the schema that depends on it; if a value lands in a tuple without a matching label, the form's `<select>` would render a `KeyError` at request time, so the test catches it at CI time instead.
+
+### Schema-driven `field_for`
+
+`field_for(schema, name, label, current=None, required=None)` (in `_shared/form_fields.html`) renders one labelled control by introspecting the Pydantic schema rather than restating the schema's constraints in HTML. The route handler passes the Pydantic class through the template context (e.g. `"schema": ProviderCreate`); the macro calls the `field_spec` Jinja global (which points at [`src/core/form_fields.py`](../core/form_fields.py)) to derive:
+
+- `required` — from whether the field annotation is `T | None`.
+- `<select>` + choices — from `Literal[*TUPLE]`. Labels are resolved against the choice-tuple registry populated in [`src/core/templating.py`](../core/templating.py).
+- `pattern` / `maxlength` — from any `HtmlPattern` marker attached to an `Annotated[...]` alias in [`src/schemas/_validators.py`](../schemas/_validators.py). The schema's regex validator stays the source of truth; the marker exposes the same constraint to the `<input>`.
+
+Use it instead of hand-restating the schema in HTML. Hand-rolled `text_field` / `select_field` calls are still appropriate when the form intentionally diverges from the schema (e.g. a filter `<select>` whose choices are the schema's `Literal` minus an "all" sentinel).
+
+`field_for` does not handle multi-select, checkbox grids, or radio-bool today — those have form-level grouping (fieldset/legend) that the existing macros own and the schema-side shape (e.g. `list[Literal]`) is not yet a stable signal for which control to render.
 
 ### Per-kind form partials
 

--- a/src/templates/_shared/form_fields.html
+++ b/src/templates/_shared/form_fields.html
@@ -11,6 +11,13 @@ every form using these macros, no per-template edits.
 `current` is the prefilled value (None on the create form, the persisted
 value on edit). For the bool-radio `current` should be `True` / `False`
 / `None` — neither radio is checked when `None`.
+
+`field_for(schema, name, label, current=None, required=None)` is the
+schema-driven counterpart: it calls `field_spec(schema, name)` (a
+Jinja global pointing at `src/core/form_fields.field_spec`) and
+dispatches to the right control. The schema class is passed in by the
+route handler's template context — see `providers/new.html` for the
+canonical use.
 #}
 
 {% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None) -%}
@@ -87,6 +94,21 @@ tokens. `current` is an iterable of currently-selected tokens (`[]` on
 create, the persisted list on edit). The form using this macro must
 also declare `data-array-fields="<name> ..."` so a 0-checked grid still
 posts an empty array. #}
+{# Schema-driven dispatch macro. Reads `field_spec(schema, name)` and
+   delegates to `text_field` / `select_field` based on the spec's
+   `kind`. `current` and `required` pass through; pass `required=false`
+   to override the schema-derived default (e.g. an optional filter on a
+   field that's required for create). #}
+{% macro field_for(schema, name, label, current=None, required=None) -%}
+{%- set spec = field_spec(schema, name) -%}
+{%- set is_required = spec.required if required is none else required -%}
+{%- if spec.kind == "select" -%}
+{{ select_field(name, label, spec.choices, labels=spec.labels, current=current, required=is_required, placeholder=true) }}
+{%- elif spec.kind == "text" -%}
+{{ text_field(name, label, current=current, required=is_required, pattern=spec.pattern, maxlength=spec.maxlength) }}
+{%- endif -%}
+{%- endmacro %}
+
 {% macro time_grid_field(name, label, current=None) -%}
 {%- set selected = current or [] -%}
 <fieldset>

--- a/src/templates/providers/new.html
+++ b/src/templates/providers/new.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{%- from "_shared/form_fields.html" import text_field, select_field -%}
+{%- from "_shared/form_fields.html" import field_for -%}
 {% block title %}Create provider{% endblock %}
 {% block content %}
 <h1>Create provider</h1>
@@ -8,16 +8,16 @@
 <form hx-post="/providers">
   <fieldset>
     <legend>Practice</legend>
-    {{ text_field("practice_name", "Practice name", maxlength=200) }}
-    {{ text_field("location_city", "City", maxlength=120) }}
-    {{ select_field("location_state", "State", US_STATES, placeholder=true) }}
-    {{ text_field("location_zip", "ZIP", pattern="\\d{5}", maxlength=5) }}
+    {{ field_for(schema, "practice_name", "Practice name") }}
+    {{ field_for(schema, "location_city", "City") }}
+    {{ field_for(schema, "location_state", "State") }}
+    {{ field_for(schema, "location_zip", "ZIP") }}
   </fieldset>
 
   <fieldset>
     <legend>Session availability</legend>
-    {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, placeholder=true) }}
-    {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, placeholder=true) }}
+    {{ field_for(schema, "in_person_sessions", "In-person sessions") }}
+    {{ field_for(schema, "virtual_sessions", "Virtual sessions") }}
   </fieldset>
 
   <input type="submit" value="Create profile" />

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI, Request
 from src.api.common import APIResponse
 from src.api.routes import auth_pages
 from src.auth_config import current_active_user, current_admin_user
+from src.schemas.providers.provider import ProviderCreate
 
 from ..utilities.mocks import MockAuthManager, create_mock_user
 from .base import ServerManager, setup_health_check_route
@@ -156,7 +157,10 @@ def _setup_provider_create_form_stub(app: FastAPI) -> None:
         )
         return APIResponse.html_response(
             template_name="providers/new.html",
-            context={"current_user": current_user},
+            # `schema` is what the template's `field_for` macro
+            # introspects to derive each control — same key the
+            # production `handle_get_provider_form` puts in context.
+            context={"current_user": current_user, "schema": ProviderCreate},
             request=request,
         )
 


### PR DESCRIPTION
Adds `field_spec(schema_cls, name)` in src/core/form_fields.py that
introspects a Pydantic field and returns the spec a new `field_for`
Jinja macro dispatches on. Derives required-vs-optional from `T | None`,
`<select>` choices from `Literal[*TUPLE]` (with labels resolved via a
choice-tuple registry populated in templating.py), and `pattern` /
`maxlength` from an `HtmlPattern` marker that schema aliases can attach
inside `Annotated[...]`. Removes per-template restatement of constraints
that already live on the schema.

Demonstrated on providers/new.html: ZipText carries its pattern/maxlength
once at the alias definition site, and ProviderCreate's practice_name /
location_city use Annotated to keep the form's prior `maxlength` caps
without copying them into HTML. The route handler passes the schema
class through the template context so core never needs to import schemas.

Layer matrix updated to sanction the schemas → core import for the
HtmlPattern marker.

https://claude.ai/code/session_01CbECBfBkwR2CUDgJjgs7EZ