### PR TITLE
Add boolean authz predicates (is_admin, is_owner)

### DIFF
--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -83,6 +83,7 @@ Logic follows the [cluster pattern](../README.md#domain-entities-and-the-cluster
 
 - One cluster directory per domain entity (`<entity>/`). Each holds `<entity>_processing.py` with the `handle_*` functions that orchestrate that entity's operations, plus `test_<entity>_processing.py`. Per-entity workflow specifics — auth gates, audit-snapshot shapes, transaction boundaries — live inside the cluster, with a `<entity>/README.md` if anything is non-obvious.
 - Parent-level shared tier:
+  - `_authz.py` — `is_admin(user)`, `is_owner(obj, user, owner_attr=...)`, and `assert_owner_or_admin(...)`. The booleans are the rule; handlers compose them to compute template-context flags (`can_edit = is_owner(post, user) or is_admin(user)`). The asserting wrapper is the same composition for use as a single-callable in `ResourceSpec.write_authz`. New authorization rules belong here, not inlined into handlers or templates.
   - `audit.py` — `record_audit(...)`, `record_audit_for(...)`, and the `mutate(...)` async context manager. Every mutation handler imports from here. The `mutate` ritual snapshots before, performs the mutation in the `async with` body, audits, and commits on clean exit; on exception the audit row and the commit are both skipped so the transaction rolls back atomically (load-bearing — an audit row must never be durable without its mutation). Non-CRUD audits (register, set-activation, etc.) use `record_audit(...)` directly.
   - `test_audit_discipline.py` — static AST check across every `*_processing.py` (recursively, so cluster directories are covered) that fails if a `handle_*` function calls `.commit()` without a `record_audit(...)`, `record_audit_for(...)`, or `mutate(...)` call. Enforces [`RESOURCE_GRAMMAR.md`'s audit rule](../api/routes/RESOURCE_GRAMMAR.md). Opt out per-handler with `audit-discipline-ignore: <reason>` in the docstring.
 
@@ -119,6 +120,7 @@ from typing import Any, Dict
 from uuid import UUID
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
+from src.logic._authz import assert_owner_or_admin
 from src.models import User
 from src.repositories.[domain]_repository import [Domain]Repository
 
@@ -141,8 +143,7 @@ async def handle_some_operation(
     target = await repo.get_by_id(target_id)
     if target is None:
         raise NotFoundError(detail="[Entity] not found")
-    if target.owner_id != user.id and not user.is_admin:
-        raise ForbiddenError(detail="Only the owner or an admin can do this")
+    assert_owner_or_admin(target, user, action="do this")
 
     result = await repo.do_the_thing(target)
     await repo.session.commit()

--- a/src/logic/_authz.py
+++ b/src/logic/_authz.py
@@ -2,10 +2,32 @@
 
 The leading-underscore filename matches `src/schemas/_validators.py` —
 shared infra at the layer's parent level, importable from every cluster.
+
+The boolean predicates (`is_admin`, `is_owner`) are the source of truth
+for the authorization rules. Handlers compose them to compute
+template-context flags (`can_edit = is_owner(post, user) or is_admin(user)`),
+and the asserting form (`assert_owner_or_admin`) wraps the same
+composition for use as a single-callable in `ResourceSpec.write_authz`.
 """
 
 from src.api.common.exceptions import ForbiddenError
 from src.models import User
+
+
+def is_admin(user: User | None) -> bool:
+    """True iff `user` is authenticated and is a superuser."""
+    return user is not None and user.is_superuser
+
+
+def is_owner(obj, user: User | None, *, owner_attr: str = "owner_id") -> bool:
+    """True iff `user` is authenticated and `obj`'s owner-FK matches.
+
+    `owner_attr` names the foreign-key column on `obj` that points at
+    the owning user (`Post.owner_id` vs `Provider.user_id`).
+    """
+    if user is None:
+        return False
+    return getattr(obj, owner_attr) == user.id
 
 
 def assert_owner_or_admin(
@@ -17,11 +39,8 @@ def assert_owner_or_admin(
 ) -> None:
     """Raise `ForbiddenError` unless `user` owns `obj` or is a superuser.
 
-    `owner_attr` names the foreign-key column on `obj` that points at the
-    owning user (`Post.owner_id` vs `Provider.user_id`). `action` is
-    interpolated into the error message: ``"Only the owner or an admin
-    can {action}"``.
+    `action` is interpolated into the error message: ``"Only the owner
+    or an admin can {action}"``.
     """
-    owner_id = getattr(obj, owner_attr)
-    if owner_id != user.id and not user.is_superuser:
+    if not (is_owner(obj, user, owner_attr=owner_attr) or is_admin(user)):
         raise ForbiddenError(detail=f"Only the owner or an admin can {action}")

--- a/src/logic/test__authz.py
+++ b/src/logic/test__authz.py
@@ -6,11 +6,63 @@ from types import SimpleNamespace
 import pytest
 
 from src.api.common.exceptions import ForbiddenError
-from src.logic._authz import assert_owner_or_admin
+from src.logic._authz import assert_owner_or_admin, is_admin, is_owner
 
 
 def _user(*, is_superuser: bool = False, id_=None):
     return SimpleNamespace(id=id_ or uuid.uuid4(), is_superuser=is_superuser)
+
+
+# --- is_admin --------------------------------------------------------------
+
+
+def test_is_admin_none_user():
+    assert is_admin(None) is False
+
+
+def test_is_admin_regular_user():
+    assert is_admin(_user()) is False
+
+
+def test_is_admin_superuser():
+    assert is_admin(_user(is_superuser=True)) is True
+
+
+# --- is_owner --------------------------------------------------------------
+
+
+def test_is_owner_none_user():
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner(obj, None) is False
+
+
+def test_is_owner_matches_owner_id():
+    u = _user()
+    obj = SimpleNamespace(owner_id=u.id)
+    assert is_owner(obj, u) is True
+
+
+def test_is_owner_non_matching_id():
+    u = _user()
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner(obj, u) is False
+
+
+def test_is_owner_admin_is_not_automatic_owner():
+    """`is_owner` checks ownership only; admin-override is the caller's
+    job to compose (`is_owner(...) or is_admin(...)`)."""
+    u = _user(is_superuser=True)
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner(obj, u) is False
+
+
+def test_is_owner_custom_owner_attr():
+    u = _user()
+    obj = SimpleNamespace(user_id=u.id)
+    assert is_owner(obj, u, owner_attr="user_id") is True
+
+
+# --- assert_owner_or_admin (composes is_owner + is_admin) ------------------
 
 
 def test_owner_passes():


### PR DESCRIPTION
## Summary
- Adds \`is_admin(user)\` and \`is_owner(obj, user, owner_attr=)\` to \`src/logic/_authz.py\`.
- Refactors \`assert_owner_or_admin\` to compose them (behavior unchanged).
- Updates \`src/logic/README.md\` shared-tier section to describe \`_authz.py\`.

First of a four-PR stack implementing the authz-mirror plan: handlers compose these predicates into template-context \`can_<verb>\` flags so templates stop hand-rolling \`current_user.id == X.owner_id or current_user.is_superuser\` (currently duplicated in three template sites and the asserting wrapper).

Closes #277. Stacks below: #278, #279, #280.

## Test plan
- [x] \`dev test\` — 502 passed, 1 skipped
- [x] \`dev lint\` — clean
- [x] New tests in \`src/logic/test__authz.py\` cover None / regular / admin / owner / non-owner / custom-attr cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)