### PR TITLE
Add chrome context layer + hide nav from anon visitors

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -432,8 +432,10 @@ APIResponse.success(data, message="Success", status_code=200)
 APIResponse.error(message, status_code=400, code=None)
 
 # HTML responses
-APIResponse.html_response(template_name, context, request)
+APIResponse.html_response(template_name, context, request, current_user=None)
 ```
+
+`html_response` merges three context tiers (later overwrites earlier): caller `context` → dev/global context → chrome scalars from `base_context(current_user)` (`is_authenticated`, `is_admin`, `current_username`, `current_user_id`). Chrome scalars are computed from the authenticated user and overwrite caller-provided values — a handler can't accidentally pass `is_admin=True` for a non-admin viewer. Mount functions in `resource_routes.py` thread `requesting_user` to `current_user`; auth-page handlers (no auth dep) take the default `None`.
 
 ### Exception classes
 

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -293,7 +293,10 @@ def mount_list(
         # Honor handler-context override for polymorphic templates.
         resolved_template = context.pop("template_name", None) or list_template
         return APIResponse.html_response(
-            template_name=resolved_template, context=context, request=request
+            template_name=resolved_template,
+            context=context,
+            request=request,
+            current_user=kwargs.get("requesting_user"),
         )
 
     if public:
@@ -361,7 +364,10 @@ def mount_detail(
             **{name: kwargs[name] for name, _ in extra_deps_named},
         )
         return APIResponse.html_response(
-            template_name=detail_template, context=context, request=request
+            template_name=detail_template,
+            context=context,
+            request=request,
+            current_user=kwargs.get("requesting_user"),
         )
 
     _set_route_signature(
@@ -470,7 +476,10 @@ def mount_form(
                 "`template_name` in its context."
             )
         return APIResponse.html_response(
-            template_name=resolved_template, context=context, request=request
+            template_name=resolved_template,
+            context=context,
+            request=request,
+            current_user=kwargs.get("requesting_user"),
         )
 
     _set_route_signature(
@@ -695,7 +704,10 @@ def mount_related_list(
             **{name: kwargs[name] for name, _ in extra_deps_named},
         )
         return APIResponse.html_response(
-            template_name=template, context=context, request=request
+            template_name=template,
+            context=context,
+            request=request,
+            current_user=kwargs.get("requesting_user"),
         )
 
     deps: list[tuple[str, Callable[..., Any]]] = [("repo", child_spec.repo_dep)]

--- a/src/api/common/responses.py
+++ b/src/api/common/responses.py
@@ -3,19 +3,59 @@ from typing import Any
 from fastapi import Response, status
 from fastapi.responses import JSONResponse
 
+from src.logic._authz import is_admin
+from src.models import User
+
+
+def base_context(user: User | None) -> dict:
+    """Flat scalars the chrome layer (`base.html` + identity widgets) reads
+    on every render.
+
+    Returning primitives instead of the `User` object means templates
+    cannot accidentally introspect identity fields (`{{ user.email }}`)
+    and tests can render the chrome with literals rather than
+    constructing a User.
+
+    `is_admin` is computed via `src.logic._authz.is_admin` so the rule
+    has a single home; templates never re-derive it.
+    """
+    return {
+        "is_authenticated": user is not None,
+        "is_admin": is_admin(user),
+        "current_username": user.username if user is not None else None,
+        "current_user_id": user.id if user is not None else None,
+    }
+
 
 class APIResponse:
     @staticmethod
-    def html_response(template_name: str, context: dict, request: Any) -> Any:
+    def html_response(
+        template_name: str,
+        context: dict,
+        request: Any,
+        *,
+        current_user: User | None = None,
+    ) -> Any:
         """
         Helper for HTML responses using templates.
-        Includes global template context for development features.
+
+        Merges three context tiers (later tiers overwrite earlier ones):
+          1. caller-provided `context`
+          2. dev/global context (`is_development`, livereload port)
+          3. chrome scalars from `base_context(current_user)`
+
+        Chrome scalars overwrite the caller — they're computed from the
+        authenticated `current_user` and are not callable-overridable, so
+        a handler can't accidentally pass `is_admin=True` for a non-admin
+        viewer.
         """
         from src.core.templating import get_template_context, templates
 
-        # Merge the provided context with global template context
-        global_context = get_template_context()
-        merged_context = {**global_context, **context}
+        merged_context = {
+            **context,
+            **get_template_context(),
+            **base_context(current_user),
+        }
 
         return templates.TemplateResponse(request, template_name, merged_context)
 

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -203,9 +203,10 @@ def test_mount_list_renders_template_with_handler_context(monkeypatch):
 
     rendered = {}
 
-    def fake_html_response(*, template_name, context, request):
+    def fake_html_response(*, template_name, context, request, current_user=None):
         rendered["template_name"] = template_name
         rendered["context"] = context
+        rendered["current_user"] = current_user
         from fastapi.responses import JSONResponse
 
         return JSONResponse({"ok": True})
@@ -251,7 +252,7 @@ def test_mount_detail_injects_extra_repo_deps_under_derived_name(monkeypatch):
     monkeypatch.setattr(
         "src.api.common.resource_routes.APIResponse.html_response",
         staticmethod(
-            lambda *, template_name, context, request: __import__(
+            lambda *, template_name, context, request, current_user=None: __import__(
                 "fastapi"
             ).responses.JSONResponse({})
         ),
@@ -320,9 +321,10 @@ def _stub_html_response(monkeypatch):
     writes into."""
     captured = {}
 
-    def fake(*, template_name, context, request):
+    def fake(*, template_name, context, request, current_user=None):
         captured["template_name"] = template_name
         captured["context"] = context
+        captured["current_user"] = current_user
         from fastapi.responses import JSONResponse
 
         return JSONResponse({"ok": True})

--- a/src/api/common/test_responses.py
+++ b/src/api/common/test_responses.py
@@ -2,13 +2,48 @@
 
 import json
 import uuid
+from types import SimpleNamespace
 
 from .responses import (
+    base_context,
     created_response,
     deleted_response,
     refreshed_response,
     updated_response,
 )
+
+# --- base_context: chrome scalars ----------------------------------------
+
+
+def test_base_context_anonymous():
+    ctx = base_context(None)
+    assert ctx == {
+        "is_authenticated": False,
+        "is_admin": False,
+        "current_username": None,
+        "current_user_id": None,
+    }
+
+
+def test_base_context_regular_user():
+    user_id = uuid.uuid4()
+    user = SimpleNamespace(id=user_id, username="alice", is_superuser=False)
+    assert base_context(user) == {
+        "is_authenticated": True,
+        "is_admin": False,
+        "current_username": "alice",
+        "current_user_id": user_id,
+    }
+
+
+def test_base_context_admin():
+    user = SimpleNamespace(id=uuid.uuid4(), username="root", is_superuser=True)
+    ctx = base_context(user)
+    assert ctx["is_admin"] is True
+    assert ctx["is_authenticated"] is True
+
+
+# --- existing helpers ----------------------------------------------------
 
 
 def test_created_response_defaults_hx_redirect_to_location():

--- a/src/api/routes/test_users.py
+++ b/src/api/routes/test_users.py
@@ -19,18 +19,34 @@ pytestmark = pytest.mark.asyncio
 # --- Base template nav ---------------------------------------------------
 
 
-async def test_base_template_renders_primary_nav(
+async def test_base_template_renders_primary_nav_when_authenticated(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """Pages rendered from base.html include nav links to the main sections."""
+    """Authenticated pages include nav links to the main sections plus the
+    `/users/me` shortcut to the viewer's own profile."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     nav_items = tree.css("#primary-nav > li > a")
     hrefs = {a.attributes.get("href") for a in nav_items}
-    assert {"/posts", "/users", "/providers"} <= hrefs
+    assert {"/posts", "/users", "/providers", "/users/me"} <= hrefs
+
+
+async def test_base_template_hides_nav_for_anonymous_visitors(
+    test_client: AsyncClient,
+):
+    """Public pages (auth flow) must not link to auth-gated sections —
+    those links would 401 and clutter the page for users who can't use
+    them yet. The chrome `{% if is_authenticated %}` gate is what
+    enforces this; the four scalars from `base_context(None)` are what
+    let `base.html` make the call without per-handler boilerplate."""
+    response = await test_client.get("/auth/login")
+
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first("#primary-nav") is None
 
 
 # --- Listing -------------------------------------------------------------

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -83,6 +83,7 @@ Logic follows the [cluster pattern](../README.md#domain-entities-and-the-cluster
 
 - One cluster directory per domain entity (`<entity>/`). Each holds `<entity>_processing.py` with the `handle_*` functions that orchestrate that entity's operations, plus `test_<entity>_processing.py`. Per-entity workflow specifics — auth gates, audit-snapshot shapes, transaction boundaries — live inside the cluster, with a `<entity>/README.md` if anything is non-obvious.
 - Parent-level shared tier:
+  - `_authz.py` — `is_admin(user)`, `is_owner(obj, user, owner_attr=...)`, and `assert_owner_or_admin(...)`. The booleans are the rule; handlers compose them to compute template-context flags (`can_edit = is_owner(post, user) or is_admin(user)`). The asserting wrapper is the same composition for use as a single-callable in `ResourceSpec.write_authz`. New authorization rules belong here, not inlined into handlers or templates.
   - `audit.py` — `record_audit(...)`, `record_audit_for(...)`, and the `mutate(...)` async context manager. Every mutation handler imports from here. The `mutate` ritual snapshots before, performs the mutation in the `async with` body, audits, and commits on clean exit; on exception the audit row and the commit are both skipped so the transaction rolls back atomically (load-bearing — an audit row must never be durable without its mutation). Non-CRUD audits (register, set-activation, etc.) use `record_audit(...)` directly.
   - `test_audit_discipline.py` — static AST check across every `*_processing.py` (recursively, so cluster directories are covered) that fails if a `handle_*` function calls `.commit()` without a `record_audit(...)`, `record_audit_for(...)`, or `mutate(...)` call. Enforces [`RESOURCE_GRAMMAR.md`'s audit rule](../api/routes/RESOURCE_GRAMMAR.md). Opt out per-handler with `audit-discipline-ignore: <reason>` in the docstring.
 
@@ -119,6 +120,7 @@ from typing import Any, Dict
 from uuid import UUID
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
+from src.logic._authz import assert_owner_or_admin
 from src.models import User
 from src.repositories.[domain]_repository import [Domain]Repository
 
@@ -141,8 +143,7 @@ async def handle_some_operation(
     target = await repo.get_by_id(target_id)
     if target is None:
         raise NotFoundError(detail="[Entity] not found")
-    if target.owner_id != user.id and not user.is_admin:
-        raise ForbiddenError(detail="Only the owner or an admin can do this")
+    assert_owner_or_admin(target, user, action="do this")
 
     result = await repo.do_the_thing(target)
     await repo.session.commit()

--- a/src/logic/_authz.py
+++ b/src/logic/_authz.py
@@ -2,10 +2,32 @@
 
 The leading-underscore filename matches `src/schemas/_validators.py` —
 shared infra at the layer's parent level, importable from every cluster.
+
+The boolean predicates (`is_admin`, `is_owner`) are the source of truth
+for the authorization rules. Handlers compose them to compute
+template-context flags (`can_edit = is_owner(post, user) or is_admin(user)`),
+and the asserting form (`assert_owner_or_admin`) wraps the same
+composition for use as a single-callable in `ResourceSpec.write_authz`.
 """
 
 from src.api.common.exceptions import ForbiddenError
 from src.models import User
+
+
+def is_admin(user: User | None) -> bool:
+    """True iff `user` is authenticated and is a superuser."""
+    return user is not None and user.is_superuser
+
+
+def is_owner(obj, user: User | None, *, owner_attr: str = "owner_id") -> bool:
+    """True iff `user` is authenticated and `obj`'s owner-FK matches.
+
+    `owner_attr` names the foreign-key column on `obj` that points at
+    the owning user (`Post.owner_id` vs `Provider.user_id`).
+    """
+    if user is None:
+        return False
+    return getattr(obj, owner_attr) == user.id
 
 
 def assert_owner_or_admin(
@@ -17,11 +39,8 @@ def assert_owner_or_admin(
 ) -> None:
     """Raise `ForbiddenError` unless `user` owns `obj` or is a superuser.
 
-    `owner_attr` names the foreign-key column on `obj` that points at the
-    owning user (`Post.owner_id` vs `Provider.user_id`). `action` is
-    interpolated into the error message: ``"Only the owner or an admin
-    can {action}"``.
+    `action` is interpolated into the error message: ``"Only the owner
+    or an admin can {action}"``.
     """
-    owner_id = getattr(obj, owner_attr)
-    if owner_id != user.id and not user.is_superuser:
+    if not (is_owner(obj, user, owner_attr=owner_attr) or is_admin(user)):
         raise ForbiddenError(detail=f"Only the owner or an admin can {action}")

--- a/src/logic/test__authz.py
+++ b/src/logic/test__authz.py
@@ -6,11 +6,63 @@ from types import SimpleNamespace
 import pytest
 
 from src.api.common.exceptions import ForbiddenError
-from src.logic._authz import assert_owner_or_admin
+from src.logic._authz import assert_owner_or_admin, is_admin, is_owner
 
 
 def _user(*, is_superuser: bool = False, id_=None):
     return SimpleNamespace(id=id_ or uuid.uuid4(), is_superuser=is_superuser)
+
+
+# --- is_admin --------------------------------------------------------------
+
+
+def test_is_admin_none_user():
+    assert is_admin(None) is False
+
+
+def test_is_admin_regular_user():
+    assert is_admin(_user()) is False
+
+
+def test_is_admin_superuser():
+    assert is_admin(_user(is_superuser=True)) is True
+
+
+# --- is_owner --------------------------------------------------------------
+
+
+def test_is_owner_none_user():
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner(obj, None) is False
+
+
+def test_is_owner_matches_owner_id():
+    u = _user()
+    obj = SimpleNamespace(owner_id=u.id)
+    assert is_owner(obj, u) is True
+
+
+def test_is_owner_non_matching_id():
+    u = _user()
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner(obj, u) is False
+
+
+def test_is_owner_admin_is_not_automatic_owner():
+    """`is_owner` checks ownership only; admin-override is the caller's
+    job to compose (`is_owner(...) or is_admin(...)`)."""
+    u = _user(is_superuser=True)
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner(obj, u) is False
+
+
+def test_is_owner_custom_owner_attr():
+    u = _user()
+    obj = SimpleNamespace(user_id=u.id)
+    assert is_owner(obj, u, owner_attr="user_id") is True
+
+
+# --- assert_owner_or_admin (composes is_owner + is_admin) ------------------
 
 
 def test_owner_passes():

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -26,6 +26,7 @@
     {% endif %}
   </head>
   <body>
+    {% if is_authenticated %}
     <nav aria-label="Primary">
       <ul id="primary-nav">
         <li><a href="/posts">Posts</a></li>
@@ -34,6 +35,7 @@
         <li><a href="/users/me">Me</a></li>
       </ul>
     </nav>
+    {% endif %}
     {% block content %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- New \`base_context(user)\` in \`src/api/common/responses.py\` returns flat chrome scalars: \`is_authenticated\`, \`is_admin\`, \`current_username\`, \`current_user_id\`.
- \`APIResponse.html_response\` takes \`current_user=\` and merges chrome scalars over caller context (chrome wins — handlers can't accidentally lie about admin status).
- \`mount_*\` functions thread \`requesting_user\` into \`current_user\`. Auth-page handlers (no auth dep) take the default \`None\`.
- \`base.html\` wraps the primary nav in \`{% if is_authenticated %}\` — anon visitors on \`/auth/login\`, \`/auth/register\`, etc. no longer see links to sections they can't reach.

Stacked on #281 (already merged). Closes #278. Next in stack: #279, #280.

## Test plan
- [x] \`dev test\` — 506 passed
- [x] \`dev lint\` — clean
- [x] \`dev test contract\` — 16 passed
- [x] New tests in \`test_responses.py\` for \`base_context\` (anon / regular / admin)
- [x] New integration tests in \`test_users.py\`: nav appears for authenticated viewers, hidden on \`/auth/login\` for anon

🤖 Generated with [Claude Code](https://claude.com/claude-code)