### PR TITLE
Gate user-detail private fields by can_view_private projection

### DIFF
--- a/src/api/routes/test_users.py
+++ b/src/api/routes/test_users.py
@@ -186,6 +186,77 @@ async def test_get_user_detail_renders(
     assert target_username in tree.body.text()
 
 
+async def test_detail_hides_private_fields_from_strangers(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A non-admin viewer looking at *someone else's* profile must not
+    see email, is_active, or is_verified — those are private to the
+    user themselves and admins. The handler's projection omits the
+    fields entirely from context, so even the values can't leak via
+    a forgotten template guard."""
+    target_email = f"private-{uuid.uuid4()}@example.com"
+    target = create_test_user(
+        username=f"target-{uuid.uuid4()}",
+        email=target_email,
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(target)
+
+    response = await authenticated_client.get(f"/users/{target.id}")
+
+    assert response.status_code == 200
+    body = response.text
+    assert target_email not in body
+    # The labels themselves are gated, not just the values — no
+    # `<dt>Email</dt>` row should render at all.
+    assert "<dt>Email</dt>" not in body
+    assert "<dt>Active</dt>" not in body
+    assert "<dt>Verified</dt>" not in body
+
+
+async def test_detail_shows_private_fields_to_self(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """The user viewing their own profile (via /users/me or
+    /users/<own-id>) sees their email, active, and verified rows."""
+    response = await authenticated_client.get("/users/me")
+
+    assert response.status_code == 200
+    body = response.text
+    assert logged_in_user.email in body
+    assert "<dt>Email</dt>" in body
+    assert "<dt>Active</dt>" in body
+    assert "<dt>Verified</dt>" in body
+
+
+async def test_detail_shows_private_fields_to_admin(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """An admin viewing any user's profile sees the private fields."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    target_email = f"target-{uuid.uuid4()}@example.com"
+    target = create_test_user(
+        username=f"target-{uuid.uuid4()}",
+        email=target_email,
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(target)
+
+    response = await authenticated_client.get(f"/users/{target.id}")
+
+    assert response.status_code == 200
+    body = response.text
+    assert target_email in body
+    assert "<dt>Email</dt>" in body
+
+
 async def test_detail_shows_admin_actions_for_admin(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -102,13 +102,31 @@ async def handle_get_user_detail(
     # Admin actions never apply to the viewer's own profile, so the
     # self-guard composes with the admin check at flag-computation time;
     # the partial just checks the flag.
-    can_admin_actions = is_admin(requesting_user) and target.id != requesting_user.id
+    is_self = requesting_user is not None and target.id == requesting_user.id
+    can_admin_actions = is_admin(requesting_user) and not is_self
+    can_view_private = is_self or is_admin(requesting_user)
+
+    # Project target_user into a dict that omits private fields
+    # (email, is_active, is_verified) for viewers who aren't the user
+    # themselves or an admin. Defense in depth: a forgotten template
+    # guard can re-leak; a missing dict key can't. The same projection
+    # extends naturally to any future JSON endpoint on this resource.
+    target_view = {
+        "id": target.id,
+        "username": target.username,
+    }
+    if can_view_private:
+        target_view["email"] = target.email
+        target_view["is_active"] = target.is_active
+        target_view["is_verified"] = target.is_verified
+
     return {
         "request": request,
-        "target_user": target,
+        "target_user": target_view,
         "providers": providers,
         "current_user": requesting_user,
         "can_admin_actions": can_admin_actions,
+        "can_view_private": can_view_private,
     }
 
 

--- a/src/templates/users/detail.html
+++ b/src/templates/users/detail.html
@@ -3,11 +3,17 @@
 {% block content %}
 <h1>{{ target_user.username }}</h1>
 
+{# Private rows (email, active, verified) are gated by `can_view_private`,
+   computed in handle_get_user_detail as `is_self OR is_admin(viewer)`.
+   The handler also omits these fields from the `target_user` projection
+   for non-authorized viewers, so a forgotten guard here cannot re-leak. #}
+{% if can_view_private %}
 <dl>
   <dt>Email</dt><dd>{{ target_user.email }}</dd>
   <dt>Active</dt><dd>{{ "yes" if target_user.is_active else "no" }}</dd>
   <dt>Verified</dt><dd>{{ "yes" if target_user.is_verified else "no" }}</dd>
 </dl>
+{% endif %}
 
 {% include "users/_admin_actions.html" %}
 


### PR DESCRIPTION
## Summary
- \`handle_get_user_detail\` projects \`target_user\` into a context dict that omits \`email\`, \`is_active\`, \`is_verified\` for viewers who aren't the user themselves or an admin.
- \`users/detail.html\` guards the \`<dl>\` on \`can_view_private\`. Defense in depth — handler omission means a forgotten template guard still can't re-leak; the same projection extends to any future JSON endpoint on this resource.

This is the actual privacy bug fix in the four-PR stack. Predecessors #281, #282, #283 are all merged. Closes #280.

## Test plan
- [x] \`dev test\` — 509 passed (includes 3 new tests: stranger / self / admin viewing user-detail)
- [x] \`dev lint\` — clean
- [x] \`dev test contract\` — 16 passed
- [x] Stranger viewing another user does not see email / is_active / is_verified rows
- [x] User viewing \`/users/me\` sees them
- [x] Admin viewing any user sees them

## Out of scope (follow-up candidates)
- \`users/list.html\` line 9 still surfaces every user's \`is_active\` to all viewers via a CSS class + "(deactivated)" copy. Same shape of leak as the detail page, narrower in surface (no email). Worth filing as a separate audit issue rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)