### PR TITLE
Strip empty query-string pairs at request entry

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -458,6 +458,7 @@ Colocated tests cover the helpers in this directory:
 - `test_responses.py` — `APIResponse`, `created_response`, `updated_response`, `deleted_response`, `refreshed_response`.
 - `test_subresource_routes.py` — `SubresourceSpec` + `register_subresource_routes` (slice 8 / #253 folds this into `resource_routes`).
 - `test_resource_routes.py` — `ResourceSpec` + per-mount tests. Add a test here whenever a new mount function lands or an existing one grows a knob.
+- `test_middleware.py` — ASGI middleware (currently just `StripEmptyQueryParamsMiddleware`'s pair-stripping helper; integration coverage lives next to the routes it affects).
 
 Route-level tests under `../routes/` exercise the mounts indirectly via the resources that use them; the unit tests here cover spec validation, error handling at mount time, and the path-param wiring that the route-level tests can't easily isolate.
 

--- a/src/api/common/middleware.py
+++ b/src/api/common/middleware.py
@@ -1,0 +1,71 @@
+"""Custom ASGI middleware shared across the application.
+
+Each middleware here exists to enforce a convention at the request-entry
+boundary, before FastAPI's parameter binding runs — once at the layer
+where the convention belongs, instead of every handler remembering it.
+"""
+
+from typing import Callable
+
+
+class StripEmptyQueryParamsMiddleware:
+    """Treat ``?key=`` (and ``?key`` with no ``=``) as if the key were
+    absent from the URL.
+
+    HTML forms submit every named field's current value, including
+    empty selections (``<select>`` whose selected option has
+    ``value=""``). Without this middleware, a route declaring
+    ``filter: str | None = None`` receives the empty string instead of
+    its declared default — the default only fires when FastAPI binds
+    no value for the parameter, and ``?filter=`` is "value bound to
+    empty string", not "value absent". Likewise a ``Literal[...]``
+    param with a default 422s on an empty submission instead of
+    falling back to the default.
+
+    Stripping empty pairs at the URL layer encodes the HTML-form
+    convention ("empty = no opinion") once, so every route's declared
+    default fires naturally and no per-handler coercion is needed.
+
+    The trade-off: a route can no longer distinguish "client sent
+    ``?x=`` deliberately" from "client omitted ``?x=``". If a future
+    route genuinely needs that distinction it should use a non-empty
+    sentinel value (``?x=__empty__``) and decode it explicitly — that
+    is the convention every other major API uses for the same
+    situation, since browsers can't be coaxed into omitting empty
+    fields without per-form JavaScript.
+    """
+
+    def __init__(self, app: Callable):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            qs: bytes = scope.get("query_string", b"")
+            if qs:
+                stripped = _strip_empty_pairs(qs)
+                if stripped != qs:
+                    scope = {**scope, "query_string": stripped}
+        await self.app(scope, receive, send)
+
+
+def _strip_empty_pairs(query_string: bytes) -> bytes:
+    """Return `query_string` with empty-valued pairs removed.
+
+    A pair is "empty" when the bytes after the first ``=`` are empty,
+    or when the pair contains no ``=`` at all (flag-style key with no
+    value). Everything else passes through unchanged — whitespace
+    values (``key=%20``) are real values and are kept.
+    """
+    kept: list[bytes] = []
+    for pair in query_string.split(b"&"):
+        if not pair:
+            continue
+        eq = pair.find(b"=")
+        if eq == -1:
+            # `?key` with no `=` — flag-style, treated as no value.
+            continue
+        if eq == len(pair) - 1:
+            # `?key=` — value is empty.
+            continue
+        kept.append(pair)
+    return b"&".join(kept)

--- a/src/api/common/test_middleware.py
+++ b/src/api/common/test_middleware.py
@@ -1,0 +1,42 @@
+"""Tests for `src/api/common/middleware.py`."""
+
+from .middleware import _strip_empty_pairs
+
+
+def test_strip_empty_value():
+    assert _strip_empty_pairs(b"x=") == b""
+
+
+def test_strip_keeps_non_empty():
+    assert _strip_empty_pairs(b"x=1") == b"x=1"
+
+
+def test_strip_mixed_keeps_only_non_empty():
+    assert _strip_empty_pairs(b"a=&b=2&c=") == b"b=2"
+
+
+def test_strip_keeps_whitespace_value():
+    """`%20` is an encoded space — a real value, not empty."""
+    assert _strip_empty_pairs(b"x=%20") == b"x=%20"
+
+
+def test_strip_flag_style_no_equals():
+    """`?key` with no `=` has no value; treat as absent."""
+    assert _strip_empty_pairs(b"flag") == b""
+
+
+def test_strip_keeps_value_containing_equals():
+    """`x=a=b` has value `a=b`; only the FIRST `=` separates name and value."""
+    assert _strip_empty_pairs(b"x=a=b") == b"x=a=b"
+
+
+def test_strip_collapses_repeated_ampersands():
+    assert _strip_empty_pairs(b"a=1&&b=2") == b"a=1&b=2"
+
+
+def test_strip_repeated_key_keeps_non_empty_instances():
+    assert _strip_empty_pairs(b"x=a&x=&x=b") == b"x=a&x=b"
+
+
+def test_strip_empty_input_returns_empty():
+    assert _strip_empty_pairs(b"") == b""

--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -562,6 +562,23 @@ async def test_get_post_form_default_kind_is_client_referral(
     assert kind_input.attributes.get("value") == "client_referral"
 
 
+async def test_get_post_form_treats_empty_kind_as_absent(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`GET /posts/form?kind=` should fall back to the default kind
+    rather than 422 against the `Literal[...]` annotation. The
+    middleware strips the empty pair at request entry so FastAPI sees
+    the param as absent and the route's default (`KIND_NAMES[0]`)
+    fires."""
+    response = await authenticated_client.get("/posts/form?kind=")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    kind_input = tree.css_first('input[name="kind"]')
+    assert kind_input is not None
+    assert kind_input.attributes.get("value") == "client_referral"
+
+
 async def test_list_renders_client_referral_row(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/api/routes/test_providers.py
+++ b/src/api/routes/test_providers.py
@@ -284,6 +284,33 @@ async def test_list_profiles_filters_by_license_type(
     assert selected.attributes.get("value") == "psyd"
 
 
+async def test_list_profiles_treats_empty_filter_values_as_absent(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Pressing "Apply" on the filter form with no selection submits
+    `?license_type=&issuing_state=` — empty values, not absent. The
+    `StripEmptyQueryParamsMiddleware` removes those pairs at request
+    entry so the route's declared defaults fire and every profile
+    renders, the same as visiting `/providers` with no query string.
+    Without the middleware the empty strings reach the repo's filter
+    and zero rows match (the bug this regression test guards)."""
+    other = create_test_user(username=f"empty-filter-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+    await _seed_provider_for(
+        db_test_session_manager, user_id=other.id, practice_name="Filter Test"
+    )
+
+    response = await authenticated_client.get("/providers?license_type=&issuing_state=")
+
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    items = tree.css("ul.profiles-list li")
+    assert len(items) == 1, "Empty filter values should not exclude rows"
+
+
 # --- Profile update ------------------------------------------------------
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
 
+from src.api.common.middleware import StripEmptyQueryParamsMiddleware
 from src.api.routes import auth_routes
 from src.auth_config import auth_backend, fastapi_users
 from src.db import check_database_health
@@ -47,6 +48,12 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Bedlam Connect", lifespan=lifespan)
+
+# Strip empty query-string pairs at request entry so HTML-form
+# submissions ("Apply" with no filter selected → `?x=`) behave the same
+# as omitting the param. See `src/api/common/middleware.py` for the
+# full convention rationale.
+app.add_middleware(StripEmptyQueryParamsMiddleware)
 
 
 @app.exception_handler(HTTPException)


### PR DESCRIPTION
## Summary

HTML forms submit every named field's current value — including empty selections (a \`<select>\` whose "Any" option has \`value=""\`). That meant pressing **Apply** on the providers filter form with no selection sent \`?license_type=&issuing_state=\` and the empty strings reached the repo's filter, returning zero rows. Same shape on \`/posts/form?kind=\`: the empty value 422'd against the \`Literal[...]\` default instead of falling back to \`KIND_NAMES[0]\`.

The fix is a small ASGI middleware (\`src/api/common/middleware.py\`) that strips empty pairs from the query string at request entry. Empty pairs disappear → FastAPI sees the param as absent → the route's declared default fires naturally. Convention encoded once at the URL layer instead of per-handler coercion or per-form JS.

The trade-off, surfaced in the middleware's docstring: a route can no longer distinguish "client deliberately sent \`?x=\`" from "client omitted \`?x=\`". A future route that genuinely needs that distinction should use a non-empty sentinel (\`?x=__empty__\`) — that's the convention every other major API uses, since browsers can't be coaxed into omitting empty fields without per-form JavaScript.

## Test plan
- [x] \`dev test\` — 517 passed
- [x] \`dev lint\` — clean
- [x] \`dev test contract\` — 16 passed
- [x] Unit coverage on the strip helper (mixed pairs, whitespace values, flag-style keys, repeated \`&\`, repeated keys, empty input)
- [x] Regression: \`GET /providers?license_type=&issuing_state=\` returns the same row set as \`GET /providers\`
- [x] Smoke: \`GET /posts/form?kind=\` falls back to the default kind instead of 422-ing

🤖 Generated with [Claude Code](https://claude.com/claude-code)