### PR TITLE
Replace stale README recipes with pointers to source-of-truth files

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -15,44 +15,25 @@ This directory contains all files and documentation related to deploying the Bed
 
 ```
 deployment/
-├── README.md                     # This documentation
-├── droplet-files/               # Files deployed to /opt/bedlam-connect/ on droplet
-│   ├── deploy.sh               # Main deployment script (blue-green)
-│   ├── docker-compose.blue-green.yml  # Docker Compose configuration
-│   ├── cleanup-docker.sh       # Docker cleanup utility
-│   └── promote-admin.sh        # Bootstrap/manage admin users on prod
-└── scripts/                    # Helper scripts (future use)
+├── README.md          # This documentation
+├── droplet-files/     # Files synced to /opt/bedlam-connect/deployment/ on the droplet
+└── scripts/           # Helper scripts run by CI (e.g. deploy-copy-files.sh)
 ```
+
+The actual contents of each subdirectory are the source of truth — `ls deployment/droplet-files/` and `ls deployment/scripts/` always tell you what's there.
 
 ## 🔄 How automated deployment works
 
 ### GitHub actions workflow
 
-1. **Build Phase**: Docker image is built and pushed to GitHub Container Registry
-2. **SCP Phase**: Deployment files are automatically copied to droplet via SCP
-3. **Deploy Phase**: `deploy.sh` is executed on the droplet for zero-downtime deployment
+The deploy pipeline lives in [`.github/workflows/cd.yml`](../.github/workflows/cd.yml). It runs in two jobs:
 
-### Scp automation details
+1. **`build-and-push`** — builds the Docker image from [`deployment/docker/Dockerfile`](docker/Dockerfile) and pushes it to GitHub Container Registry.
+2. **`deploy`** — copies deployment files to the droplet by running [`deployment/scripts/deploy-copy-files.sh`](scripts/deploy-copy-files.sh), then SSHes in and executes `deploy.sh` for zero-downtime deployment.
 
-The GitHub Actions workflow (`.github/workflows/build-and-push.yml`) includes:
+**Where files land:** `deploy-copy-files.sh` SCPs `deployment/droplet-files/*` to **`/opt/bedlam-connect/deployment/`** on the droplet (not `/opt/bedlam-connect/`). The deploy step then `cd`s into that directory before running `./deploy.sh`.
 
-```yaml
-- name: Copy deployment files to droplet
-  uses: appleboy/scp-action@v0.1.7
-  with:
-    host: ${{ secrets.DROPLET_HOST }}
-    username: ${{ secrets.DROPLET_USERNAME }}
-    key: ${{ secrets.DROPLET_SSH_KEY }}
-    source: 'deployment/droplet-files/*'
-    target: '/opt/bedlam-connect/'
-    strip_components: 2
-```
-
-**Key Points:**
-
-- `strip_components: 2` removes `deployment/droplet-files/` from the path
-- Files end up directly in `/opt/bedlam-connect/` on the droplet
-- No more manual SCP required!
+For the exact SCP and SSH steps, read [`cd.yml`](../.github/workflows/cd.yml) and [`scripts/deploy-copy-files.sh`](scripts/deploy-copy-files.sh) — they're the source of truth, not this README.
 
 ## 🏗️ Blue-Green deployment process
 
@@ -76,9 +57,9 @@ The app has no admin user out of the box, and admin actions (delete user, deacti
 
 ```bash
 ssh user@your-droplet-ip
-cd /opt/bedlam-connect
-./promote-admin you@example.com           # grant
-./promote-admin you@example.com --revoke  # revoke
+cd /opt/bedlam-connect/deployment
+./promote-admin.sh you@example.com           # grant
+./promote-admin.sh you@example.com --revoke  # revoke
 ```
 
 The wrapper auto-detects the running blue/green container and execs the promotion script inside it — no `docker exec` incantation to remember. It's idempotent (safe to re-run) and refuses on a missing user (won't auto-create from a typo).
@@ -95,15 +76,17 @@ If GitHub Actions fails, you can deploy manually:
 
 ```bash
 ssh user@your-droplet-ip
-cd /opt/bedlam-connect
+cd /opt/bedlam-connect/deployment
 ```
 
 ### 2. update files (if needed)
 
 ```bash
-# Copy files from your local machine
-scp deployment/droplet-files/* user@droplet-ip:/opt/bedlam-connect/
+# From your local machine
+scp deployment/droplet-files/* user@droplet-ip:/opt/bedlam-connect/deployment/
 ```
+
+(or run `deployment/scripts/deploy-copy-files.sh` with the right env vars set — same as CI does.)
 
 ### 3. run deployment
 
@@ -257,7 +240,7 @@ docker system df
 
 ### Emergency contacts
 
-- **GitHub Actions**: Check `.github/workflows/build-and-push.yml`
+- **GitHub Actions**: Check [`.github/workflows/cd.yml`](../.github/workflows/cd.yml)
 - **Droplet Access**: SSH key and connection details in GitHub secrets
 - **DNS/SSL**: Managed by Certbot on droplet
 
@@ -274,4 +257,4 @@ Deployment is working correctly when:
 - ✅ Zero downtime during deployment
 - ✅ Old instances are properly cleaned up
 
-**Remember**: This automated setup means you should never need to manually SCP files to the droplet again. All deployment file changes are handled automatically through GitHub Actions!
+CI handles the SCP step for you on every push to `main` — manual SCP from your laptop is the emergency fallback above, not the everyday workflow.

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,272 +1,39 @@
 # API layer: HTTP routes and request handling
 
-The `api/` directory contains all HTTP-related code, organized around **domain-driven routing** with consistent patterns for error handling, logging, and response formatting.
+The `api/` directory contains all HTTP-related code. Routes are **thin wrappers** that parse requests, delegate business logic to `logic/`, and format responses. They never touch repositories or sessions directly.
 
-## Core philosophy: Thin routes with standardized patterns
+## Contract
 
-API routes are **thin wrappers** that delegate business logic to services while providing consistent HTTP concerns like validation, error handling, and response formatting.
-
-### What we do
-
-- **Domain-organized routes**: Routes grouped by business domain (users, auth)
-- **Standardized router patterns**: BaseRouter provides consistent decorators and error handling
-- **Delegated business logic**: Routes call processing logic, not implement it
-- **Consistent response formats**: APIResponse class standardizes JSON and HTML responses
-- **Automatic error handling**: Decorators catch and transform service exceptions to HTTP responses
-
-**Example**: Clean route that delegates to processing logic:
-
-```python
-@router.get("/users")
-async def list_users(
-    request: Request,
-    user: User = Depends(current_active_user),
-    user_repo: UserRepository = Depends(get_user_repository),
-):
-    result = await handle_list_users(
-        user_repo=user_repo,
-        requesting_user=user,
-    )
-    return APIResponse.html_response(
-        template_name="users/list.html",
-        context=result,
-        request=request,
-    )
-```
-
-### What we don't do
-
-- **Business logic in routes**: Complex validation and processing stays in the `logic/` layer
-- **Direct database access**: Routes never touch repositories or sessions directly
-- **Inconsistent error handling**: All routes use standardized error decorators
-- **Raw APIRouter usage**: Always wrap with BaseRouter for consistent patterns
-
-**Example**: Don't implement business logic in routes:
-
-```python
-# Bad - business logic in route
-@router.post("/[entities]")
-async def create_entity(data: dict, session: AsyncSession = Depends()):
-    if not data.get("name"):
-        raise HTTPException(400, "Name required")
-    entity = [Entity](**data)
-    session.add(entity)
-    await session.commit()
-    return entity
-
-# Good - delegate to logic handler
-@router.post("/[entities]")
-async def create_entity(
-    data: [Entity]Create,
-    user: User = Depends(current_active_user),
-    repo: [Entity]Repository = Depends(get_[entity]_repository),
-):
-    return await handle_create_entity(data, user, repo)
-```
-
-## Architecture: Domain-driven routing
-
-**HTTP Request -> Route -> Logic Handler -> Repository -> Response**
-
-Routes are organized by domain and use consistent patterns for common concerns.
+- **Routes are HTTP adapters, not business logic.** Validation, authorization, and side effects live in `logic/<entity>/<entity>_processing.py` `handle_*` functions. See [`../logic/README.md`](../logic/README.md).
+- **No direct data access.** Routes inject repositories via FastAPI `Depends()` and pass them through to logic handlers; they never call `session.execute(...)` themselves.
+- **Form-encoded mutations + HTMX response shape are the standard** for resource routes. JSON bodies are not the default — see [`routes/README.md`](routes/README.md) and [`routes/RESOURCE_GRAMMAR.md`](routes/RESOURCE_GRAMMAR.md).
+- **CRUD routes use the unified `ResourceSpec` + `mount_*` grammar** in `common/resource_routes.py`. Hand-written routes are reserved for cases the grammar doesn't fit (auth flows, singletons, idempotent state setters) — see the bespoke-routes table in [`routes/README.md`](routes/README.md#bespoke-routes).
+- **Errors are raised, not caught.** Logic raises `APIException` subclasses (`NotFoundError`, `ForbiddenError`, `BadRequestError`); `BaseRouter`'s decorator chain translates them. See [`common/README.md`](common/README.md).
 
 ## Layer organization
 
-- `routes/` — HTTP endpoint definitions, one file per resource. See [`routes/README.md`](routes/README.md) for the route organization contract and the URL grammar that every resource follows ([`routes/RESOURCE_GRAMMAR.md`](routes/RESOURCE_GRAMMAR.md)).
-- `common/` — shared API infrastructure: `BaseRouter` (auto-applied error handling + logging decorators), `APIException` subclasses (`NotFoundError`, `ForbiddenError`, etc.) raised by logic and passed through to FastAPI, the fastapi-users error translator, and the standardized `APIResponse` helpers. See [`common/README.md`](common/README.md).
+- [`routes/`](routes/README.md) — one file per resource. Defines HTTP endpoints via `ResourceSpec` + `mount_*` (or hand-written when warranted). The route organization contract and URL grammar live there.
+- [`common/`](common/README.md) — shared API infrastructure: `BaseRouter`, `ResourceSpec` and the `mount_*` family, `APIResponse` helpers, `APIException` hierarchy, the fastapi-users error translator.
 
-## Implementation patterns
+## Where to look for the canonical example
 
-### Creating a new route file
+Read an existing resource route alongside the contract docs:
 
-1. **Create domain router** in `routes/[domain].py`:
-
-```python
-from fastapi import APIRouter, Depends
-
-from src.api.common import BaseRouter
-from src.auth_config import current_active_user
-from src.logic.[domain]_processing import handle_create_[domain], handle_list_[domain]
-from src.models import User
-from src.repositories.dependencies import get_[domain]_repository
-from src.repositories.[domain]_repository import [Domain]Repository
-
-# Create standard APIRouter and wrap with BaseRouter
-[domain]_api_router = APIRouter()
-router = BaseRouter(router=[domain]_api_router, default_tags=["[domain]"])
-```
-
-2. **Add route handlers**:
-
-```python
-@router.get("/[domain]")
-async def list_[domain](
-    user: User = Depends(current_active_user),
-    repo: [Domain]Repository = Depends(get_[domain]_repository),
-):
-    return await handle_list_[domain](repo, requesting_user=user)
-
-@router.post("/[domain]")
-async def create_[domain](
-    data: [Domain]Create,
-    user: User = Depends(current_active_user),
-    repo: [Domain]Repository = Depends(get_[domain]_repository),
-):
-    return await handle_create_[domain](data, user, repo)
-```
-
-3. **Register in main.py**:
-
-```python
-from src.api.routes import [domain]
-app.include_router([domain].[domain]_api_router, tags=["[domain]"])
-```
-
-### Baserouter pattern
-
-All routes use BaseRouter for consistent behavior:
-
-```python
-from src.api.common import BaseRouter
-
-# Wrap apirouter with baserouter
-router = BaseRouter(
-    router=APIRouter(),
-    default_tags=["domain"],
-    default_dependencies=[Depends(some_common_dependency)]
-)
-
-# Routes automatically GET:
-# - error handling decorator
-# - logging decorator
-# - common tags and dependencies
-@router.get("/endpoint")
-async def endpoint_handler():
-    # Route logic here
-    pass
-```
-
-### Response patterns
-
-Use APIResponse for consistent formatting:
-
-```python
-from src.api.common import APIResponse
-
-# JSON API responses
-@router.get("/api/data")
-async def get_data():
-    data = await service.get_data()
-    return APIResponse.success(data, "Data retrieved successfully")
-
-# HTML page responses
-@router.get("/pages/data")
-async def get_data_page(request: Request):
-    data = await service.get_data()
-    return APIResponse.html_response(
-        template_name="data/list.html",
-        context={"data": data},
-        request=request
-    )
-```
-
-### Error handling pattern
-
-Logic handlers raise the API exception classes directly; the decorator passes them through to FastAPI:
-
-```python
-# logic/<entity>_processing.py raises APIException subclasses directly.
-@router.post("/[entities]")
-async def create_entity(
-    data: [Entity]Create,
-    user: User = Depends(current_active_user),
-    repo: [Entity]Repository = Depends(get_[entity]_repository),
-):
-    # Inside handle_create_entity:
-    #   raise NotFoundError(...)   → 404
-    #   raise ForbiddenError(...)  → 403
-    #   raise BadRequestError(...) → 400
-    return await handle_create_entity(data, user, repo)
-```
-
-## Common issues and solutions
-
-### Issue: Business logic creeping into routes
-
-**Problem**: Routes become complex with validation, database operations, etc.
-**Solution**: Keep routes thin - delegate to processing logic in `../logic/` directory
-
-```python
-# Bad - complex logic in route
-@router.post("/[entities]")
-async def create_entity(name: str, user: User = Depends()):
-    if len(name) < 3:
-        raise HTTPException(400, "Name too short")
-    if await entity_exists(name):
-        raise HTTPException(409, "Entity exists")
-
-# Good - delegate to logic handler
-@router.post("/[entities]")
-async def create_entity(
-    data: [Entity]Create,
-    user: User = Depends(current_active_user),
-    repo: [Entity]Repository = Depends(get_[entity]_repository),
-):
-    return await handle_create_entity(data, user, repo)
-```
-
-### Issue: Inconsistent error handling
-
-**Problem**: Some routes handle errors differently than others
-**Solution**: Always use BaseRouter which applies standard error decorators
-
-```python
-# Bad - manual error handling
-@APIRouter().post("/endpoint")
-async def endpoint():
-    try:
-        result = await service.do_something()
-        return {"data": result}
-    except SomeError as e:
-        raise HTTPException(400, str(e))
-
-# Good - automatic error handling via BaseRouter
-@router.post("/endpoint")  # router is BaseRouter instance
-async def endpoint(service: Service = Depends()):
-    return await service.do_something()  # Errors automatically handled
-```
-
-### Issue: Response format inconsistency
-
-**Problem**: Different routes return different response formats
-**Solution**: Use APIResponse class for consistent formatting
-
-```python
-# Bad - inconsistent response formats
-@router.get("/data")
-async def get_data():
-    return {"result": data}  # Raw dict
-
-@router.get("/other")
-async def get_other():
-    return JSONResponse({"status": "ok", "data": data})  # Different format
-
-# Good - consistent response format
-@router.get("/data")
-async def get_data():
-    return APIResponse.success(data, "Data retrieved")
-
-@router.get("/other")
-async def get_other():
-    return APIResponse.success(data, "Other data retrieved")
-```
+- [`routes/users.py`](routes/users.py) and [`routes/providers.py`](routes/providers.py) for the unified `ResourceSpec` + `mount_*` pattern.
+- [`routes/auth_routes.py`](routes/auth_routes.py) and [`routes/auth_pages.py`](routes/auth_pages.py) for hand-written routes that don't fit the grammar.
+- [`../main.py`](../main.py) for `/` and `/health` (mounted directly on the app, not under `routes/`).
 
 ## Tests
 
-API behavior is exercised by route-level tests colocated under [`routes/`](routes/) (e.g. `routes/test_auth_routes.py`, `routes/test_users.py`). There is no test file at this directory level — tests live next to the specific routes they cover.
+API behavior is exercised by route-level tests colocated under [`routes/`](routes/) (e.g. `routes/test_users.py`, `routes/test_providers.py`, `routes/test_auth_routes.py`). There is no test file at this directory level — tests live next to the specific routes they cover.
+
+Pact contract pairs for HTML forms and HX-driven buttons live under [`tests/test_contract/`](../../tests/test_contract/README.md).
 
 ## Related documentation
 
-- [Logic Layer Documentation](../logic/README.md) - Business logic, orchestration, transaction commits
-- [Schemas Documentation](../schemas/README.md) - Request/response validation
-- [Main Architecture](../README.md) - How API fits in overall architecture
+- [`routes/README.md`](routes/README.md) — route organization, `ResourceSpec` + `mount_*` recipe, bespoke-routes table, registration order.
+- [`routes/RESOURCE_GRAMMAR.md`](routes/RESOURCE_GRAMMAR.md) — URL shape, lifecycle states, subresource conventions every resource MUST follow.
+- [`common/README.md`](common/README.md) — `BaseRouter`, mount helpers, `APIResponse`, exception classes.
+- [`../logic/README.md`](../logic/README.md) — what routes delegate to.
+- [`../schemas/README.md`](../schemas/README.md) — request/response validation.
+- [`../README.md`](../README.md) — layered architecture and dependency rules.

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -173,23 +173,28 @@ Use HTMX for progressive enhancement of forms and interactions:
 
 ### Template context pattern
 
-Standard context structure passed from routes:
+Handlers pass **only resource-specific data**. Chrome scalars (`is_authenticated`, `is_admin`, `current_username`, `current_user_id`) and dev globals (`is_development`, livereload port) are merged in automatically by [`APIResponse.html_response`](../api/common/responses.py) — handlers never compute or pass them.
+
+The merge order (later tiers overwrite earlier ones):
+
+1. The caller's `context` dict — page data only.
+2. Dev/global context from `core.templating.get_template_context()`.
+3. Chrome scalars from `base_context(current_user)`.
+
+Because chrome overwrites the caller, a handler cannot accidentally lie about identity (e.g. pass `is_admin=True` for a non-admin viewer). The chrome scalars are *primitives*, not the `User` object, so templates can't reach into identity fields directly. See [`api/common/responses.py`](../api/common/responses.py) for `base_context()` and `html_response()`.
+
+In practice a handler returns:
 
 ```python
-# In route/processing function
-def prepare_template_context(request: Request, user: User, data: Any) -> dict:
-    """Standard context preparation for templates."""
-    return {
-        "request": request,          # Required by FastAPI templates
-        "current_user": user,        # Current authenticated user
-        "is_authenticated": bool(user), # Authentication status
-        **get_template_context(),    # Include environment context (safe development-only features)
-
-        # Page-specific data
-        "page_title": "Page Title",
-        "main_data": data,           # Primary page data
-    }
+return APIResponse.html_response(
+    template_name="users/list.html",
+    context={"users": users},     # page data only
+    request=request,
+    current_user=user,            # drives chrome scalars
+)
 ```
+
+For the canonical example, read [`api/routes/users.py`](../api/routes/users.py).
 
 ## Common template issues and solutions
 


### PR DESCRIPTION
src/api/README.md drops the obsolete BaseRouter+decorator and APIResponse.success/error recipes (the methods don't exist; the routing layer migrated to ResourceSpec + mount_*) and now points at routes/README.md and common/README.md.

deployment/README.md replaces the inline appleboy/scp-action YAML snippet with a pointer to .github/workflows/cd.yml and deployment/scripts/deploy-copy-files.sh, fixes the on-droplet path (/opt/bedlam-connect → /opt/bedlam-connect/deployment) and the promote-admin script name.

src/templates/README.md replaces the fabricated
prepare_template_context() example with a description of the actual APIResponse.html_response merge order and a pointer to api/common/responses.py.