### PR TITLE
Strip behavioral descriptions and ghost references from five READMEs (#289)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,7 +86,7 @@ Run `dev --help` for the live, authoritative list. As of this writing:
 | `dev logs [-f] [service]` | Show logs from the dev environment, optionally following or scoped to one service. |
 | `dev restart [service]` | Restart the whole dev environment or a single service. |
 | `dev test [-v] [--tb MODE] [-m MARKERS] [-k KEYWORDS] [path ...]` | Run pytest. Each `path` can be a directory, a file, or a `file::testname` selector; pass several to run unrelated targets in one invocation. The literal token `contract` is a shortcut that expands to `tests/test_contract` — that directory is excluded from default collection (see [`../tests/test_contract/README.md`](../tests/test_contract/README.md)) and is easy to forget the path to. |
-| `dev lint` | Run black, isort, autoflake, and the title-case checker. Pre-commit runs the same checks automatically. |
+| `dev lint` | Run all linting checks. Pre-commit runs the same checks automatically. See [`scripts/dev_cli.py`](dev_cli.py)'s `QualityCommands.lint` for the live list. |
 | `dev fmt` | Auto-fix formatting in place by running `black .` and `isort .` in write mode. The natural pre-commit companion to `dev lint`. |
 | `dev seed` | Apply any pending Alembic migrations, then seed the dev database with fixture users for manual testing. Migrations run first so a freshly added revision doesn't cause the seed to crash against a stale schema. |
 | `dev routes [prefix]` | Print every HTTP route registered on `src.main:app` grouped by path prefix. Surfaces router shadowing — two `include_router` calls registering handlers on overlapping paths — without spinning up the server. |

--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -84,8 +84,9 @@ Routes are organized by domain with consistent delegation patterns.
 
 - One route file per resource: `<resource>.py` defines the HTTP endpoints for that resource. Per-resource specifics — exact endpoints, mutation-response shapes, sub-resources, HX-Redirect behavior — live in that file's docstrings and (when worth writing down) in any cluster-level doc the resource owns.
 - `auth_routes.py` and `auth_pages.py` are the JSON-API and HTML-page split for authentication; both follow the same delegation pattern as resource routes.
-- `me.py` holds the `/users/me/*` aliases — current-user shortcuts whose handlers delegate to the same logic functions as the user-scoped routes, so behavior stays identical.
 - `__init__.py` re-exports the route modules.
+
+Singleton-alias routes like `/users/me` and `/users/me/providers` are mounted alongside their parametric counterparts via `singleton_alias=` on `mount_detail` / `mount_related_list` (see the [unified resource grammar](../common/README.md#singleton-aliases-eg-usersme)). They are not a separate route file.
 
 The URL shape every resource MUST follow is defined in [`RESOURCE_GRAMMAR.md`](RESOURCE_GRAMMAR.md). This README documents how routes are wired; the grammar documents what URLs and lifecycles a resource MUST present.
 
@@ -97,7 +98,7 @@ The unified grammar fits resource-shaped CRUD. Several existing routes intention
 |---|---|---|
 | `POST /auth/register` | `auth_routes.py` | Auth-flow protocol (token issuance, fastapi-users hooks). Not CRUD on a domain entity. |
 | `GET /auth/{register,login,forgot-password,reset-password/{token}}` | `auth_pages.py` | Pure form rendering, no resource. Could fit a hypothetical `mount_static_form` but not worth it for 4 routes. |
-| `GET /users/me`, `GET /users/me/profile`, `GET /users/me/providers` | `me.py` | Singleton aliases — no parent id, session-sourced. Adding a `singleton_alias` knob to every spec for 3 routes would be a bad trade. |
+| `GET /users/me`, `GET /users/me/providers` | `users.py` (mounted via `singleton_alias=`) | Singleton aliases — no parent id, session-sourced. Mounted as additional paths on the existing `mount_detail` / `mount_related_list` calls; see [`api/common/README.md`](../common/README.md#singleton-aliases-eg-usersme). |
 | `PUT /users/{user_id}/activation` | `users.py` | Idempotent state set with `HX-Refresh` (not `HX-Redirect`); admin-only verb. Doesn't match `mount_update` semantics. |
 | `GET /`, `GET /health` | `main.py` | Utility endpoints. Not resource-shaped. |
 
@@ -275,7 +276,7 @@ async def create_entity():
 
 ### Main application route registration
 
-The `me` router MUST be registered **before** the `users` router so that requests to `/users/me` match the literal `me` handler instead of being parsed as a UUID by the `/users/{user_id}` parametric route. More generally, any route that adds a literal segment under another resource's parametric path must be registered first.
+The order in which `app.include_router(...)` calls fire determines route precedence: any route adding a literal segment under another resource's parametric path must be registered first (or, if both come from the same router, mounted first inside it — `singleton_alias=` does this for `/users/me`).
 
 The actual registration order lives in [`src/main.py`](../../main.py) — that's the source of truth, not this README.
 

--- a/src/models/providers/README.md
+++ b/src/models/providers/README.md
@@ -13,7 +13,7 @@ A `Provider` is **not** the same thing as a `ProviderAvailabilityDetail`. They l
 - `provider_licensure.py` — `ProviderLicensure`. One row per professional license held by a provider. CASCADE on the parent FK keeps the credential list in lockstep with the `Provider`. `license_type` CHECKs against `LICENSE_TYPES`; `issuing_state` CHECKs against `US_STATES`.
 - `provider_education.py` — `ProviderEducation`. One row per educational credential. CASCADE on the parent FK. `education_type` CHECKs against `EDUCATION_TYPES`. `month_completed` is `Text` storing `"YYYY-MM"` rather than a `Date` — the form captures month precision only.
 - `provider_certification.py` — `ProviderCertification`. One row per professional certification. CASCADE on the parent FK. `certification_type` CHECKs against `CERTIFICATION_TYPES`.
-- `test_provider_models.py` — direct DB-layer coverage of the cluster: per-user FK behavior, the cascade from a `Provider` down to its credential lists (raw-SQL `DELETE` on the parent proves FK CASCADE fires, not just the ORM cascade), and `IntegrityError` on each enum CHECK rejection.
+- `test_provider_models.py` — direct DB-layer coverage of the cluster. See the file for the exact assertions; test names are the source of truth.
 - `test_provider_enums.py` — guardrail asserting every value in the credential vocabularies (`LICENSE_TYPES`, `EDUCATION_TYPES`, `CERTIFICATION_TYPES`) has a matching entry in its `*_LABELS` dict in [`../enums.py`](../enums.py). The form-render macros look up labels by value at request time; missing keys would 500 the request.
 
 ## Why this cluster, not flat siblings

--- a/src/schemas/README.md
+++ b/src/schemas/README.md
@@ -1,247 +1,30 @@
 # Schemas: Request/response validation and serialization
 
-The `schemas/` directory contains **Pydantic schemas** that define the structure and validation rules for API requests and responses, providing type safety, automatic serialization, and comprehensive validation.
-
-## Core philosophy: Type-safe API contracts
-
-Schemas serve as **API contracts** that ensure data consistency between clients and the server while providing automatic validation, serialization, and comprehensive error messages for invalid data.
-
-### What we do
-
-- **Request validation**: Validate incoming API data with clear error messages
-- **Response serialization**: Convert database models to JSON with proper field selection
-- **Type safety**: Provide full type annotations for IDE support and runtime validation
-- **Configuration**: Use Pydantic's ConfigDict for ORM integration and serialization control
-
-**Example**: Schema with ORM integration:
-
-```python
-class UserRead(schemas.BaseUser):
-    username: str
-
-    model_config = ConfigDict(from_attributes=True)  # ORM integration
-```
-
-### What we don't do
-
-- **Business logic**: Schemas only define structure and basic validation, no business rules
-- **Database operations**: Schemas don't interact with databases directly
-- **Complex computed fields**: Keep schemas focused on data structure
-- **Authentication logic**: Authentication concerns stay in auth layer
-
-**Example**: Don't implement business logic in schemas:
-
-```python
-# Bad - business logic in schema
-class UserCreateRequest(BaseModel):
-    username: str
-
-    def validate_user_can_register(self, existing_users):  # Business logic
-        if len(existing_users) >= MAX_USERS:
-            raise ValueError("Too many users")
-
-# Good - structure and validation only
-class UserCreateRequest(BaseModel):
-    username: str
-
-    @field_validator('username')
-    def validate_username(cls, v):
-        if len(v.strip()) == 0:
-            raise ValueError('Username cannot be empty')
-        return v.strip()
-```
-
-## Architecture: Request/response boundary layer
-
-**API Routes -> Schema Validation -> Logic / Repositories -> Schema Serialization -> Response**
-
-Schemas act as the data contract layer between HTTP and business logic.
+The `schemas/` directory contains **Pydantic schemas** that define the structure and validation rules for API requests and responses.
 
 ## Layer organization
 
 Schemas follow the [cluster pattern](../README.md#domain-entities-and-the-cluster-pattern):
 
-- One cluster directory per domain entity (`<entity>/`). Each holds the Pydantic Create/Update/Read/AuditSnapshot variants for that entity (and its sub-entities, if any), plus the colocated test file. Per-entity specifics — discriminator unions, controlled-vocabulary fields, embedded sub-entities — live inside the cluster, with a `<entity>/README.md` if anything is non-obvious.
+- One cluster directory per domain entity (`<entity>/`). Each holds the Pydantic Create / Update / Read / AuditSnapshot variants for that entity (and its sub-entities, if any), plus the colocated test file. Per-entity specifics — discriminator unions, controlled-vocabulary fields, embedded sub-entities — live inside the cluster, with a `<entity>/README.md` if anything is non-obvious.
 - Parent-level shared tier (`_validators.py`) — `Annotated[T, AfterValidator(fn)]` aliases and helpers used by 2+ clusters. Add to it when a primitive is used by 2+ schema modules, or when two modules are about to define near-duplicates of the same helper. An alias may also attach an `HtmlPattern(pattern=..., maxlength=...)` marker (from [`src/core/form_fields.py`](../core/form_fields.py)) when the alias's regex/length constraint should also be exposed as the form's client-side `pattern`/`maxlength` — keeps both surfaces aligned at the alias's definition site rather than duplicated per template.
 
 A schema cluster does not import from a peer cluster; cross-cluster reuse happens via the shared tier ([lint-enforced](../README.md#domain-entities-and-the-cluster-pattern)).
 
 The labels-vs-tuple guardrail (`test_schema_literals_match_model_tuples`) lives alongside each cluster's tests; it asserts the cluster's `Literal[*TUPLE]` types stay aligned with the source-of-truth tuples in [`src/models/enums.py`](../models/enums.py).
 
-## Implementation patterns
+## Naming
 
-### Creating request/response schema pairs
-
-Most domains have both request (input) and response (output) schemas:
-
-```python
-# Request schema - validates incoming data
-class [Entity]CreateRequest(BaseModel):
-    name: str  # Required field
-
-    @field_validator('name')
-    def validate_name_not_empty(cls, v):
-        if not v.strip():
-            raise ValueError('Name cannot be empty')
-        return v.strip()
-
-# Response schema - serializes outgoing data
-class [Entity]Response(BaseModel):
-    id: UUID
-    name: str
-    created_at: datetime
-
-    model_config = ConfigDict(from_attributes=True)  # Enable ORM conversion
-```
-
-### Orm integration pattern
-
-Use ConfigDict to enable automatic conversion from SQLAlchemy models:
-
-```python
-class [Entity]Response(BaseModel):
-    id: UUID
-    name: str
-    created_at: datetime
-
-    model_config = ConfigDict(from_attributes=True)
-
-# Usage in routes - automatic conversion
-@router.get("/[entities]/{entity_id}")
-async def get_entity(entity_id: UUID) -> [Entity]Response:
-    entity = await repo.get_by_id(entity_id)
-    return [Entity]Response.model_validate(entity)  # Auto-converts from ORM
-```
-
-### FastAPI users integration pattern
-
-Extend FastAPI Users schemas for authentication:
-
-```python
-from fastapi_users import schemas
-
-class UserRead(schemas.BaseUser):
-    username: str  # Add custom fields to base user
-
-class UserCreate(schemas.BaseUserCreate):
-    username: str  # Add custom fields to registration
-
-class UserUpdate(schemas.BaseUserUpdate):
-    username: str  # Add custom fields to updates
-```
-
-## Common schema issues and solutions
-
-### Issue: Missing validation leading to bad data
-
-**Problem**: Invalid data gets through to business logic
-**Solution**: Add comprehensive field validation
-
-```python
-# Bad - no validation
-class [Entity]CreateRequest(BaseModel):
-    name: str
-
-# Good - comprehensive validation
-class [Entity]CreateRequest(BaseModel):
-    name: str
-
-    @field_validator('name')
-    def validate_name(cls, v):
-        v = v.strip()
-        if not v:
-            raise ValueError('Name cannot be empty')
-        if len(v) > 200:
-            raise ValueError('Name too long (max 200 characters)')
-        return v
-```
-
-### Issue: Inconsistent ORM conversion
-
-**Problem**: Some schemas work with ORM models, others don't
-**Solution**: Consistently use ConfigDict(from_attributes=True)
-
-```python
-# Bad - missing ORM configuration
-class [Entity]Response(BaseModel):
-    id: UUID
-    name: str
-    # Will fail when converting from SQLAlchemy model
-
-# Good - proper ORM integration
-class [Entity]Response(BaseModel):
-    id: UUID
-    name: str
-
-    model_config = ConfigDict(from_attributes=True)
-```
-
-### Issue: Exposing internal fields in responses
-
-**Problem**: Response schemas include fields that shouldn't be public
-**Solution**: Explicitly define what fields to include/exclude
-
-```python
-# Bad - exposing internal fields
-class UserResponse(BaseModel):
-    id: UUID
-    username: str
-    email: str
-    password_hash: str  # Should not be exposed!
-
-# Good - only expose public fields
-class UserResponse(BaseModel):
-    id: UUID
-    username: str
-    email: str
-    created_at: datetime
-
-    model_config = ConfigDict(from_attributes=True)
-```
-
-## Schema naming conventions
-
-### Consistent naming patterns
-
-```python
-# Request schemas - data coming IN
-[Domain]CreateRequest
-[Domain]UpdateRequest
-
-# Response schemas - data going OUT
-[Domain]Response
-[Domain]ListResponse
-
-# Enums - controlled vocabularies
-[Domain]Status
-[Domain]Type
-```
-
-### Example naming consistency
-
-```python
-# User domain (follows FastAPI users pattern)
-UserRead
-UserCreate
-UserUpdate
-
-# New domain example
-[Entity]CreateRequest
-[Entity]Response
-[Entity]Status  # Enum
-```
+The conventions are visible in the existing schemas (`ClientReferralCreate`, `ClientReferralRead`, `ClientReferralUpdate`, `ClientReferralAuditSnapshot`, etc.). The User cluster follows fastapi-users' `UserRead` / `UserCreate` / `UserUpdate` shape. Match the surrounding cluster when adding a new schema.
 
 ## Tests
 
-Colocated tests live inside each cluster directory:
-
-- `posts/test_post.py` — exercises the kind-discriminated `PostCreate`/`PostUpdate` unions: explicit-kind variants, the `extra="forbid"` boundary (rejects `owner_id`, unknown fields, cross-kind field bleed), per-kind whitespace stripping, ZIP regex, controlled-vocabulary rejection, and the partial-update at-least-one-field rule. Also covers `post_audit_snapshot` flattening through the right detail relationship for each registered kind, and the `test_schema_literals_match_model_tuples` guardrail that asserts the `Literal[*TUPLE]` types here stay aligned with the source-of-truth tuples in `src/models/enums.py`.
-- `providers/test_provider.py` — covers the four provider entities (`Provider` + licensure + education + certification): controlled-vocabulary rejection, `extra="forbid"` rejection, the at-least-one-field rule on each Update variant, `ProviderRead.model_validate` round-trip on a nested dict, and the `test_schema_literals_match_model_tuples` guardrail aligning `Literal[*TUPLE]` types with `src/models/enums.py`.
+Each cluster owns its colocated `test_*.py`. See `posts/test_post.py` and `providers/test_provider.py` for the existing examples; their test names are the source of truth for what's covered.
 
 Add `src/schemas/<entity>/test_<file>.py` when a schema has non-trivial validators or computed fields whose behavior isn't obvious from the field definitions.
 
 ## Related documentation
 
-- [API Routes](../api/routes/README.md) - API routes that use these schemas for validation
-- [Models Layer](../models/README.md) - Database models that schemas serialize
-- [API Layer](../api/README.md) - Overall API architecture showing schema role
+- [API Routes](../api/routes/README.md) — routes that use these schemas for validation
+- [Models Layer](../models/README.md) — database models that schemas serialize
+- [API Layer](../api/README.md) — overall API architecture

--- a/src/templates/posts/README.md
+++ b/src/templates/posts/README.md
@@ -1,6 +1,6 @@
 # Posts templates
 
-Jinja templates for the post CRUD flows. HTMX-driven; forms submit JSON via `hx-ext="json-enc"`. Every multi-checkbox group on the forms (`desired_times`, `services`, and `settings`) relies on stock json-enc semantics (0 boxes → key absent, 1 box → scalar, 2+ → array) plus a `_scalar_to_list` `BeforeValidator` on the wire schema that wraps the 1-element scalar back into a list — see [`src/schemas/post.py`](../../schemas/post.py). Keeping the normalization in Python avoids a JS-only failure mode that's invisible to server tests.
+Jinja templates for the post CRUD flows. HTMX-driven; forms submit form-encoded data via `hx-{post,patch}` (see [`_client_referral_form.html`](_client_referral_form.html) / [`_provider_availability_form.html`](_provider_availability_form.html)). Multi-checkbox fields (`desired_times`, `services`, `settings`) are normalized on the wire schema by `_scalar_to_list` in [`src/schemas/posts/post.py`](../../schemas/posts/post.py).
 
 ## Files
 


### PR DESCRIPTION
## Summary

Closes #289. Per-paragraph cleanup of README drift identified by the 2026-05-10 audit. Each instance was re-verified against current code before editing — the verb is *delete*, not *polish*.

- **`scripts/README.md`** — `dev lint` description listed `autoflake` (not actually run) and omitted the template/cluster boundary checks (which *are* run). Replaced the per-tool list with a pointer to `QualityCommands.lint` so the linter list can't drift again.
- **`src/models/providers/README.md`** — claim that the cascade test fires a "raw-SQL DELETE" was wrong; the test uses `session.delete(loaded)` (ORM). Stripped the parenthetical.
- **`src/templates/posts/README.md`** — claim that forms submit JSON via `hx-ext="json-enc"` was wrong; the form macros use `hx-{{ method }}` with no `hx-ext`, so submissions are form-encoded (the `_client_referral_form.html` docstring says so explicitly). Replaced the wrong description with a one-liner + pointer to the actual partials.
- **`src/api/routes/README.md`** — three references to a deleted `me.py`; the `/users/me` functionality folded into `users.py` via `singleton_alias=` (slice 9). Updated the file listing, the bespoke-routes table, and the route-registration note.
- **`src/schemas/README.md`** — fictional `[Entity]CreateRequest` / `[Entity]Response` examples didn't match the real conventions (`ClientReferralCreate`, `ClientReferralRead`, etc.). Removed the prescriptive example walls; kept the cluster-pattern + shared-tier rules and the test guardrail pointer.

Two READMEs listed in #289 had no remaining drift to fix:
- `tests/README.md` — the `create_test_user` example already uses the real kwarg signature.
- `src/api/common/README.md` — the `APIResponse.success/error` ghosts were removed in #288.

## Test plan

- [x] `dev lint` passes
- [x] `dev test` passes (520 passed, 1 skipped)
- [x] Each drift instance verified against current code before editing
- [x] No code changes; map content (cluster pattern, layer rules, dependency constraints) preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)