### PR TITLE
Add neighbor-README sweep to CLAUDE.md contract-surface check (#293)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,14 @@ Before writing code on any change that modifies a schema, route, template, or pe
 
 3. **For each breaking surface, who decides?** If the breakage is scoped (only internal callers, only your tests) you can absorb it. If it leaks past your boundary (HTML forms, external API consumers, persisted data already in production) **surface the choice to the user explicitly** before implementing — *"this changes X for existing clients; OK, or do you want me to prep first?"* Don't decide silently inside the implementation.
 
+4. **Which other READMEs reference symbols, files, or paths I'm renaming, deleting, or changing?** Layer-by-layer planning catches *which layers a change touches*; it doesn't catch *which other layers' READMEs reference the symbols being changed*. For each renamed or removed identifier, run:
+
+   ```bash
+   grep -rn "<old-name>" $(find . -name README.md -not -path './.claude/*' -not -path './.pytest_cache/*')
+   ```
+
+   Update or delete any matches as part of the same PR — neighbor-README drift is otherwise invisible until the next reader hits a stale claim.
+
 The cost of skipping this check is one end-of-PR realization that you took the wrong shape — by which point unwinding is more work than the prep PR would have been.
 
 ## Plan mode


### PR DESCRIPTION
## Summary

Closes #293. Adds a fourth question to CLAUDE.md's existing *contract-surface check* section, with the literal grep command for sweeping other READMEs that reference symbols being renamed/removed.

The audit train caught three concrete examples of neighbor-README drift:
- `me.py` → `users.py` consolidation left a stale claim in `src/api/routes/README.md` (cleaned in #294).
- `profile` → `provider` rename left an `hx-ext=\"json-enc\"` claim in `src/templates/posts/README.md` (cleaned in #294).
- A test rewrite left `src/models/providers/README.md` claiming a raw-SQL `DELETE` that never existed (cleaned in #294).

Layer-by-layer planning catches *which layers a change touches*. It doesn't catch *which other layers' READMEs reference the symbols being changed*. This is a 30-second habit, not a lint rule — runs at the moment the author already has the rename in their head and produces zero false positives because a human filters them.

## Test plan

- [x] `dev lint` passes
- [x] `dev test` passes (520 passed, 1 skipped)
- [x] Section flow still reads as one section, not two stitched together

🤖 Generated with [Claude Code](https://claude.com/claude-code)