### PR TITLE
Codify default-to-no-README posture in grammar-not-alphabet section (#295)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,14 @@ The same rule applies recursively. A cluster's own README (`<layer>/<entity>/REA
 
 This complements the [single-source-of-truth rule](#one-source-of-truth--link-dont-copy): that rule says facts have one home; this rule says parent READMEs prefer rules over rosters.
 
+**Default to not creating a new README.** A README earns its existence by documenting something `ls` and the code can't:
+
+- A non-obvious pattern (registry-driven dispatch, polymorphic discriminator, cardinality decision).
+- A deliberate deviation from the layer's grammar.
+- A constraint or contract that spans files in non-obvious ways.
+
+If the only thing a candidate README would say is enumerate-what-`ls`-shows or restate-the-layer-rules, don't write it. Empty or aspirational READMEs are net-negative — they tell the next reader to expect content that isn't load-bearing.
+
 ## Where to look
 
 | Topic | Where it lives |


### PR DESCRIPTION
## Summary

Closes #295. Folds a ~50-word paragraph into the existing *Grammar, not alphabet* section in `CLAUDE.md` to make the default posture explicit: **no README unless writing one would document something genuinely non-obvious**.

The 2026-05-10 audit found that healthy cluster READMEs (`models/posts/`, `models/providers/`, `templates/posts/`) all earned their existence by documenting something `ls` + the code can't. The unhealthy ones (`config/`, `src/middleware/`) were written defensively to fill a perceived doc obligation. The existing section already nudges toward the right posture but didn't make the default explicit.

Folded into the section rather than added as a new top-level section — keeping CLAUDE.md tight is the same shape of discipline this whole audit train has been applying to READMEs.

## Test plan

- [x] `dev lint` passes
- [x] `dev test` passes (520 passed, 1 skipped)
- [x] Section flow still reads as one section, not two stitched together
- [x] No duplication with existing CLAUDE.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)