### PR TITLE
Add mount_state_axis; migrate PUT /users/{id}/activation (#302)

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -78,7 +78,7 @@ Common utilities handle concerns that span multiple routes and domains.
 - `responses.py` - Standardized response formatting for JSON and HTML
 - `decorators.py` - Error handling and logging decorators applied to all routes
 - `exceptions.py` - `APIException` subclasses (`NotFoundError`, `ForbiddenError`, ...) raised by logic, plus the fastapi-users → HTTP translator
-- `forms.py` - HTTP-adapter primitives for form-encoded route bodies: `parse_form_to_payload(request)` (form → dict, lists for repeated keys) and `validate_or_422(adapter, payload_dict)` (run a `TypeAdapter`, translate `ValidationError` to 422 with `[{"loc","msg","type"}]`). Home for any HTTP-adapter primitive that two or more route modules would otherwise import from each other.
+- `forms.py` - HTTP-adapter primitives for request bodies: `parse_form_to_payload(request)` (form → dict, lists for repeated keys), `validate_or_422(adapter, payload_dict)` (run a `TypeAdapter`, translate `ValidationError` to 422 with `[{"loc","msg","type"}]`), and the back-to-back wrappers `parse_and_validate_form` / `parse_and_validate_json` (form-encoded vs. JSON body — state-axis subresources use the JSON variant). Home for any HTTP-adapter primitive that two or more route modules would otherwise import from each other.
 - `resource_routes.py` - Unified `ResourceSpec` + opt-in `mount_*` grammar (covers top-level *and* sub-resource CRUD via `parent=`). See [Unified resource grammar](#unified-resource-grammar) below.
 
 **Package infrastructure:**
@@ -145,6 +145,7 @@ Secondary repos (e.g. `user_repo: UserRepository` in the multi-repo `handle_list
 | `mount_form` | Landed (slice 5 / #250) | `providers` (GET /form, GET /{id}/form); `posts` (edit form via handler-returned template_name) |
 | `mount_create` / `mount_update` | Landed (slice 6 / #251) | `providers`, `posts`, `licensures`, `educations`, `certifications` |
 | `mount_related_list` | Landed (slice 9 / #254) | `users` (GET /{id}/providers) |
+| `mount_state_axis` | Landed (#302) | `users` (PUT /{id}/activation) |
 | Sub-resource via `parent=` | Landed (slice 8 / #253) | `licensures`, `educations`, `certifications` (under providers) |
 
 ### Multi-repo handlers: `extra_repo_deps`
@@ -224,7 +225,6 @@ Per-mount docstrings in `resource_routes.py` are the canonical reference for req
 The grammar fits resource-shaped routes. It's deliberately **not** a home for:
 
 - **Auth flows** — register/login/verify/reset-password live in `auth_routes.py` / `auth_pages.py`. State-machine semantics, not CRUD.
-- **State-mutation actions like `PUT /users/{id}/activation`** — idempotent set with `HX-Refresh`, not partial edit with `HX-Redirect`. Doesn't match `mount_update` semantics.
 - **Utility endpoints** — `/`, `/health`.
 
 Slice 10 (#255) documents these explicitly. If a future case suggests the grammar should grow to fit them, that's the moment to reshape `ResourceSpec`, not to escape-hatch around it.
@@ -417,8 +417,9 @@ Both decorators are wrapped onto every endpoint by `BaseRouter`; route files don
 # Mutation helpers (module-level functions in responses.py)
 created_response(id, location, hx_redirect=None)   # 201, sets Location + HX-Redirect
 updated_response(body=None, hx_redirect=...)       # 200 + HX-Redirect
+updated_response(body=..., hx_refresh=True)        # 200 + HX-Refresh (state-axis flips)
 deleted_response(hx_redirect=...)                  # 204 + HX-Redirect
-refreshed_response()                               # 200 + HX-Refresh: true
+refreshed_response()                               # 200 + HX-Refresh: true (no body)
 
 # HTML responses (method on APIResponse)
 APIResponse.html_response(template_name, context, request, current_user=None)

--- a/src/api/common/forms.py
+++ b/src/api/common/forms.py
@@ -56,3 +56,19 @@ async def parse_and_validate_form(request: Request, adapter: TypeAdapter):
     """
     payload_dict = await parse_form_to_payload(request)
     return validate_or_422(adapter, payload_dict)
+
+
+async def parse_and_validate_json(request: Request, adapter: TypeAdapter):
+    """Parse a JSON request body and validate it through `adapter`.
+
+    Mirrors `parse_and_validate_form` for state-axis subresources whose
+    PUT bodies arrive as JSON (e.g. `PUT /users/{id}/activation`). Form
+    encoding is the standard for HTML forms; state-axis flips are
+    typically issued by HTMX with a JSON body since there's no form to
+    submit (just a button).
+    """
+    try:
+        payload_dict = await request.json()
+    except Exception:
+        raise HTTPException(status_code=422, detail="Invalid JSON body")
+    return validate_or_422(adapter, payload_dict)

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -42,7 +42,7 @@ from uuid import UUID
 from fastapi import Depends, Query, Request, status
 from pydantic import TypeAdapter
 
-from src.api.common.forms import parse_and_validate_form
+from src.api.common.forms import parse_and_validate_form, parse_and_validate_json
 from src.api.common.responses import (
     APIResponse,
     created_response,
@@ -644,6 +644,89 @@ def mount_update(
         ),
     )
     router.patch(path)(_update)
+
+
+def mount_state_axis(
+    router: Any,
+    spec: ResourceSpec,
+    handler: Callable[..., Awaitable[Any]],
+    *,
+    axis_name: str,
+    body_schema: type,
+    audit_repo_dep: Callable[..., Any],
+    response_to_dict: Callable[[Any], dict] | None = None,
+) -> None:
+    """Mount ``PUT /<collection>/{<id_param>}/<axis_name>``.
+
+    Implements the state-axis subresource shape from
+    ``src/api/routes/RESOURCE_GRAMMAR.md`` (lines 44-51): a PUT that
+    idempotently sets a state value on a resource. Distinct from
+    ``mount_update`` (PATCH on the parent for ordinary fields) — the
+    response uses ``HX-Refresh: true`` instead of ``HX-Redirect`` because
+    the surrounding page renders affordances based on the new state and
+    needs to re-fetch in place.
+
+    Parses a JSON body via ``body_schema`` (a Pydantic ``BaseModel``
+    subclass) and calls the handler with the resource id under
+    ``spec.id_param``, ``payload=`` (the validated body), ``repo=``,
+    ``audit_repo=``, and ``requesting_user=``. The handler owns the
+    mutation and audit row — state-axis actions like
+    ``SET_USER_ACTIVATION`` live outside the
+    ``AuditedResource(create, update, delete)`` triple, so they call
+    ``record_audit`` directly rather than going through ``mutate()``.
+    This mount stays minimum-disruption: it does *not* thread the
+    ``AuditAction`` to the handler.
+
+    ``body_schema`` is explicit (not auto-derived from the axis name's
+    Literal tuple) because state-axis bodies may carry richer payloads
+    than ``{<axis>: <value>}`` for some axes — e.g. a deactivation
+    reason or a verified-by id. Single-field bodies still pay one
+    declaration to keep the surface uniform.
+
+    Response is ``200 OK`` with body = ``response_to_dict(updated)`` (if
+    set, else ``{}``) and ``HX-Refresh: true``. The projection is
+    per-mount because each axis surfaces a different field
+    (activation → ``is_active``; verification → ``is_verified``).
+
+    Requires: ``spec.write_user_dep``, ``body_schema``.
+    """
+    if spec.write_user_dep is None:
+        raise ValueError(
+            f"mount_state_axis requires {spec.collection!r} to set write_user_dep."
+        )
+    if spec.parent is not None:
+        raise NotImplementedError(
+            "mount_state_axis with spec.parent is not supported yet."
+        )
+
+    id_param = spec.id_param
+    body_adapter = TypeAdapter(body_schema)
+    path = f"/{{{id_param}}}/{axis_name}"
+
+    async def _state_axis(**kwargs: Any) -> Any:
+        request: Request = kwargs["request"]
+        payload = await parse_and_validate_json(request, body_adapter)
+        resource_id: UUID = kwargs[id_param]
+        updated = await _resolve_handler(handler)(
+            **{id_param: resource_id},
+            payload=payload,
+            repo=kwargs["repo"],
+            audit_repo=kwargs["audit_repo"],
+            requesting_user=kwargs["requesting_user"],
+        )
+        body = response_to_dict(updated) if response_to_dict else None
+        return updated_response(body=body, hx_refresh=True)
+
+    _set_route_signature(
+        _state_axis,
+        path_params=(("request", Request), (id_param, UUID)),
+        deps=(
+            ("repo", spec.repo_dep),
+            ("audit_repo", audit_repo_dep),
+            ("requesting_user", spec.write_user_dep),
+        ),
+    )
+    router.put(path)(_state_axis)
 
 
 def mount_related_list(

--- a/src/api/common/responses.py
+++ b/src/api/common/responses.py
@@ -77,12 +77,33 @@ def created_response(
     )
 
 
-def updated_response(*, body: dict | None = None, hx_redirect: str) -> JSONResponse:
-    """200 OK with optional body and `HX-Redirect: <hx_redirect>`."""
+def updated_response(
+    *,
+    body: dict | None = None,
+    hx_redirect: str | None = None,
+    hx_refresh: bool = False,
+) -> JSONResponse:
+    """200 OK with optional body and exactly one of HX-Redirect / HX-Refresh.
+
+    `hx_redirect` sends HTMX to a new URL (PATCH on a parent resource —
+    edit succeeded, here's where to go). `hx_refresh=True` tells HTMX to
+    reload the current page in place (PUT on a state-axis subresource —
+    activation flipped, re-render so the affordances update). Mutually
+    exclusive — set one.
+    """
+    if (hx_redirect is None) == (not hx_refresh):
+        raise ValueError(
+            "updated_response requires exactly one of hx_redirect or hx_refresh"
+        )
+    headers = (
+        {"HX-Redirect": hx_redirect}
+        if hx_redirect is not None
+        else {"HX-Refresh": "true"}
+    )
     return JSONResponse(
         status_code=status.HTTP_200_OK,
         content=body or {},
-        headers={"HX-Redirect": hx_redirect},
+        headers=headers,
     )
 
 

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -12,11 +12,13 @@ mount functions end-to-end. Validates that:
 """
 
 from types import SimpleNamespace
+from typing import Literal
 from uuid import uuid4
 
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 
 from src.api.common.resource_routes import (
     QueryParam,
@@ -26,6 +28,7 @@ from src.api.common.resource_routes import (
     mount_form,
     mount_list,
     mount_related_list,
+    mount_state_axis,
 )
 
 
@@ -697,6 +700,139 @@ def test_mount_related_list_requires_template():
             handler=lambda **_: {},
             template="",
         )
+
+
+# --- mount_state_axis ----------------------------------------------------
+
+
+class _AxisBody(BaseModel):
+    state: Literal["on", "off"]
+
+
+def _build_state_axis_app(spec: ResourceSpec, handler, *, axis_name="toggle", **kwargs):
+    app = FastAPI()
+    router = APIRouter(prefix=f"/{spec.collection}")
+    mount_state_axis(
+        router,
+        spec,
+        handler=handler,
+        axis_name=axis_name,
+        body_schema=_AxisBody,
+        audit_repo_dep=lambda: SimpleNamespace(name="audit_repo"),
+        **kwargs,
+    )
+    app.include_router(router)
+    return app
+
+
+def test_mount_state_axis_happy_path_returns_hx_refresh_with_projected_body():
+    """PUT /<collection>/{id}/<axis> calls handler, projects via
+    response_to_dict, returns 200 + HX-Refresh + projected body."""
+    captured: dict = {}
+
+    async def handler(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id=kwargs["widget_id"], name="w1", state="on")
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+    app = _build_state_axis_app(
+        spec,
+        handler,
+        response_to_dict=lambda w: {"id": str(w.id), "name": w.name, "state": w.state},
+    )
+    widget_id = uuid4()
+    resp = TestClient(app).put(f"/widgets/{widget_id}/toggle", json={"state": "on"})
+    assert resp.status_code == 200
+    assert resp.headers["HX-Refresh"] == "true"
+    assert "HX-Redirect" not in resp.headers
+    body = resp.json()
+    assert body == {"id": str(widget_id), "name": "w1", "state": "on"}
+    # Handler received id under the spec's id_param + the validated payload.
+    assert str(captured["widget_id"]) == str(widget_id)
+    assert isinstance(captured["payload"], _AxisBody)
+    assert captured["payload"].state == "on"
+    assert captured["repo"].name == "repo"
+    assert captured["audit_repo"].name == "audit_repo"
+
+
+def test_mount_state_axis_invalid_body_returns_422():
+    async def handler(**kwargs):
+        raise AssertionError("handler should not be called for invalid body")
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+    app = _build_state_axis_app(spec, handler)
+    resp = TestClient(app).put(f"/widgets/{uuid4()}/toggle", json={"state": "bogus"})
+    assert resp.status_code == 422
+
+
+def test_mount_state_axis_path_includes_axis_name():
+    """Wrong axis segment ⇒ 404 (route not registered under that path)."""
+
+    async def handler(**kwargs):
+        return SimpleNamespace(id=uuid4())
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+    app = _build_state_axis_app(spec, handler, axis_name="activation")
+    # Right axis works:
+    ok = TestClient(app).put(f"/widgets/{uuid4()}/activation", json={"state": "on"})
+    assert ok.status_code == 200
+    # Wrong axis 404s:
+    bad = TestClient(app).put(f"/widgets/{uuid4()}/somethingelse", json={"state": "on"})
+    assert bad.status_code == 404
+
+
+def test_mount_state_axis_requires_write_user_dep():
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: None,
+        # write_user_dep intentionally omitted
+    )
+    router = APIRouter()
+    with pytest.raises(ValueError, match="write_user_dep"):
+        mount_state_axis(
+            router,
+            spec,
+            handler=lambda **_: None,
+            axis_name="toggle",
+            body_schema=_AxisBody,
+            audit_repo_dep=lambda: None,
+        )
+
+
+def test_mount_state_axis_no_response_to_dict_returns_empty_body():
+    """Without `response_to_dict`, the body is `{}` — handler still runs
+    and the HX-Refresh header still fires."""
+
+    async def handler(**kwargs):
+        return SimpleNamespace(id=kwargs["widget_id"])
+
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+    app = _build_state_axis_app(spec, handler)
+    resp = TestClient(app).put(f"/widgets/{uuid4()}/toggle", json={"state": "off"})
+    assert resp.status_code == 200
+    assert resp.json() == {}
+    assert resp.headers["HX-Refresh"] == "true"
 
 
 def test_mount_delete_404_propagates_from_handler():

--- a/src/api/common/test_responses.py
+++ b/src/api/common/test_responses.py
@@ -4,6 +4,8 @@ import json
 import uuid
 from types import SimpleNamespace
 
+import pytest
+
 from .responses import (
     base_context,
     created_response,
@@ -89,3 +91,23 @@ def test_refreshed_response_204_with_hx_refresh():
     resp = refreshed_response()
     assert resp.status_code == 200
     assert resp.headers["HX-Refresh"] == "true"
+
+
+def test_updated_response_hx_refresh_sets_header_with_body():
+    """`hx_refresh=True` swaps the HX-Redirect header for HX-Refresh while
+    keeping the optional body — the shape state-axis subresources need."""
+    resp = updated_response(body={"id": "u1", "is_active": False}, hx_refresh=True)
+    assert resp.status_code == 200
+    assert json.loads(resp.body) == {"id": "u1", "is_active": False}
+    assert resp.headers["HX-Refresh"] == "true"
+    assert "HX-Redirect" not in resp.headers
+
+
+def test_updated_response_requires_one_of_redirect_or_refresh():
+    with pytest.raises(ValueError, match="hx_redirect or hx_refresh"):
+        updated_response(body={"x": 1})
+
+
+def test_updated_response_rejects_both_redirect_and_refresh():
+    with pytest.raises(ValueError, match="hx_redirect or hx_refresh"):
+        updated_response(hx_redirect="/x", hx_refresh=True)

--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -99,7 +99,6 @@ The unified grammar fits resource-shaped CRUD. Several existing routes intention
 | `POST /auth/register` | `auth_routes.py` | Auth-flow protocol (token issuance, fastapi-users hooks). Not CRUD on a domain entity. |
 | `GET /auth/{register,login,forgot-password,reset-password/{token}}` | `auth_pages.py` | Pure form rendering, no resource. Could fit a hypothetical `mount_static_form` but not worth it for 4 routes. |
 | `GET /users/me`, `GET /users/me/providers` | `users.py` (mounted via `singleton_alias=`) | Singleton aliases — no parent id, session-sourced. Mounted as additional paths on the existing `mount_detail` / `mount_related_list` calls; see [`api/common/README.md`](../common/README.md#singleton-aliases-eg-usersme). |
-| `PUT /users/{user_id}/activation` | `users.py` | Idempotent state set with `HX-Refresh` (not `HX-Redirect`); admin-only verb. Doesn't match `mount_update` semantics. |
 | `GET /`, `GET /health` | `main.py` | Utility endpoints. Not resource-shaped. |
 
 If a future case suggests the grammar should grow to fit one of these, that's the moment to reshape `ResourceSpec` — not to escape-hatch around it.

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -1,8 +1,6 @@
 import logging
-from uuid import UUID
 
-from fastapi import APIRouter, Depends
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter
 
 from src.api.common import BaseRouter
 from src.api.common.resource_routes import (
@@ -11,6 +9,7 @@ from src.api.common.resource_routes import (
     mount_detail,
     mount_list,
     mount_related_list,
+    mount_state_axis,
 )
 from src.api.routes.providers import PROVIDER_SPEC
 from src.auth_config import current_active_user, current_admin_user
@@ -22,14 +21,11 @@ from src.logic.users.user_processing import (
     handle_list_users,
     handle_set_user_activation,
 )
-from src.models import User
-from src.repositories.audit_repository import AuditRepository
 from src.repositories.dependencies import (
     get_audit_repository,
     get_provider_repository,
     get_user_repository,
 )
-from src.repositories.users.user_repository import UserRepository
 from src.schemas.users.user import UserActivationUpdate
 
 users_api_router = APIRouter(prefix="/users")
@@ -82,30 +78,23 @@ mount_related_list(
 )
 
 
-@router.put("/{user_id}/activation")
-async def set_user_activation(
-    user_id: UUID,
-    payload: UserActivationUpdate,
-    user_repo: UserRepository = Depends(get_user_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    admin: User = Depends(current_admin_user),
-):
-    """Admin-only: activate or deactivate a user."""
-    updated = await handle_set_user_activation(
-        user_id=user_id,
-        payload=payload,
-        repo=user_repo,
-        audit_repo=audit_repo,
-        requesting_user=admin,
-    )
-    return JSONResponse(
-        content={
-            "id": str(updated.id),
-            "username": updated.username,
-            "is_active": updated.is_active,
-        },
-        headers={"HX-Refresh": "true"},
-    )
+# PUT /users/{user_id}/activation — admin-only state-axis flip.
+# `response_to_dict` projects the User into the activation-axis wire shape
+# (`is_active` is the field this axis can change; `id`/`username` are
+# included for client-side reconciliation).
+mount_state_axis(
+    router,
+    USER_SPEC,
+    handler=handle_set_user_activation,
+    axis_name="activation",
+    body_schema=UserActivationUpdate,
+    audit_repo_dep=get_audit_repository,
+    response_to_dict=lambda user: {
+        "id": str(user.id),
+        "username": user.username,
+        "is_active": user.is_active,
+    },
+)
 
 
 # DELETE /users/{user_id} is mounted via the unified ResourceSpec grammar.

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -124,7 +124,7 @@ class MockDataFactory:
             user_read = cls.create_user_read(is_active=False)
 
         return {
-            "src.api.routes.users.handle_set_user_activation": {
+            "src.logic.users.user_processing.handle_set_user_activation": {
                 "return_value_config": user_read
             }
         }


### PR DESCRIPTION
## Summary

Closes #302.

- Add `mount_state_axis(router, spec, handler, *, axis_name, body_schema, audit_repo_dep, response_to_dict=None)` to `src/api/common/resource_routes.py`. Same shape as the other mounts (BaseRouter decoration, kwargs injection, `spec.write_user_dep` auth, asserts `parent is None` like other top-level mounts did pre-slice-8).
- Migrate `PUT /users/{user_id}/activation` (one hand-rolled route → one `mount_state_axis(...)` call). `from fastapi.responses import JSONResponse` disappears from `users.py`.
- Wire contract preserved exactly: PUT JSON `{state}`, response `{id, username, is_active}` + `HX-Refresh: true`. All 31 `test_users.py` tests pass unchanged; activation Pact contract verifies green.

## Plumbing this needed

The "minimum-disruption" path the issue lays out runs into two shape gaps. Both are addressed here as small parallel helpers, not new abstractions:

- `parse_and_validate_json` in `src/api/common/forms.py` — JSON-body sibling of `parse_and_validate_form`. State-axis flips arrive as JSON (existing route, existing tests, and the existing Pact contract all assume JSON body), so the form-encoded helper doesn't fit.
- `updated_response` extended with `hx_refresh: bool = False` (mutually exclusive with `hx_redirect`). State-axis needs a body **plus** `HX-Refresh: true`; neither `updated_response` (body + Redirect) nor `refreshed_response` (no body, Refresh) previously fit. Validation: exactly one of `hx_redirect` / `hx_refresh`.

## Open design question (per the issue), decided

**Minimum-disruption** — the helper does NOT thread `AuditAction` to the handler. `handle_set_user_activation` keeps owning `record_audit` directly, matching today and unchanged by this PR. The handler kwarg shape stays identical to the other mount-fronted handlers (`<id_param>=`, `payload=`, `repo=`, `audit_repo=`, `requesting_user=`).

## Contract-test mock retargeted

Surfaced by the migration: the old hand-rolled route resolved `handle_set_user_activation` via the route module's binding, so the contract mock patched `src.api.routes.users.handle_set_user_activation`. The mount-based path uses `_resolve_handler` which reads from the function's `__module__`, so the mock now patches `src.logic.users.user_processing.handle_set_user_activation` — aligns it with how every other contract mock (provider/post/auth) targets the logic module. All 16 contract tests pass.

## READMEs

- `src/api/common/README.md` — new row in the "what's mounted today" table; removed the "not meant for this grammar" exclusion for state-mutation routes; new line for `parse_and_validate_json` and `updated_response(hx_refresh=...)`.
- `src/api/routes/README.md` — removed the bespoke-routes table row for `PUT /users/{user_id}/activation`.

## Test plan

- [x] `dev test` — 533 passed, 1 skipped
- [x] `dev test contract` — 16 passed (activation Pact verifies)
- [x] `dev lint` — clean
- [x] `dev test src/api/routes/test_users.py` — 31 tests pass unchanged (wire contract preserved)
- [x] New `mount_state_axis` tests cover happy path, 422 invalid body, axis-name path interpolation, missing-`write_user_dep` raise, default empty-body projection
- [x] New `updated_response` tests cover `hx_refresh` body shape and the redirect-XOR-refresh validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)