### PR TITLE
Declarative private-field projection on ResourceSpec; migrate user detail

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -93,7 +93,7 @@ Everything else (schemas, models, templates) supports these main layers. There i
 | Layer            | Status   | Responsibility                                              | Example Files       | Dependencies                          |
 | ---------------- | -------- | ----------------------------------------------------------- | ------------------- | ------------------------------------- |
 | **API**          | active   | HTTP handling, routing, validation                          | `api/routes/*.py`   | Logic, Repositories, Schemas          |
-| **Logic**        | active   | Business logic, orchestration, transaction commit           | `logic/*.py`        | Repositories, Schemas, Models, API common exceptions |
+| **Logic**        | active   | Business logic, orchestration, transaction commit           | `logic/*.py`        | Repositories, Schemas, Models, API common exceptions + pure helpers (projections) |
 | **Repositories** | active   | Data access, queries                                        | `repositories/*.py` | Models, Database                      |
 | **Models**       | active   | Database schema, relationships                              | `models/*.py`       | SQLAlchemy                            |
 | **Schemas**      | active   | Request/response validation                                 | `schemas/*.py`      | Pydantic, Models (enums + registries only), Core (`form_fields.HtmlPattern` marker only) |

--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -68,6 +68,7 @@ Common utilities handle concerns that span multiple routes and domains.
 | **Decorators**  | Cross-cutting concerns | Error handling, logging                                         | BaseRouter (automatic)   |
 | **Exceptions**  | Error vocabulary       | API exception classes raised by logic; fastapi-users translator | Logic handlers, decorator |
 | **Forms**       | Form-encoded request glue | `parse_form_to_payload` and `validate_or_422`                | Route handlers that accept form-encoded bodies |
+| **projections** | View-projection with field-level visibility | `project_view(obj, public_fields, actor, private_fields, private_field_predicate)` — gate fields per viewer | Handlers building per-viewer response dicts (user detail today) |
 | **resource_routes** | Unified `ResourceSpec` grammar | Declare a resource once, opt into the operations to expose via `mount_*`; sub-resources nest via `parent=` | Route files for any CRUD-shaped resource (top-level and sub-resource) |
 
 ## Directory structure
@@ -79,6 +80,7 @@ Common utilities handle concerns that span multiple routes and domains.
 - `decorators.py` - Error handling and logging decorators applied to all routes
 - `exceptions.py` - `APIException` subclasses (`NotFoundError`, `ForbiddenError`, ...) raised by logic, plus the fastapi-users → HTTP translator
 - `forms.py` - HTTP-adapter primitives for request bodies: `parse_form_to_payload(request)` (form → dict, lists for repeated keys), `validate_or_422(adapter, payload_dict)` (run a `TypeAdapter`, translate `ValidationError` to 422 with `[{"loc","msg","type"}]`), and the back-to-back wrappers `parse_and_validate_form` / `parse_and_validate_json` (form-encoded vs. JSON body — state-axis subresources use the JSON variant). Home for any HTTP-adapter primitive that two or more route modules would otherwise import from each other.
+- `projections.py` - `project_view(obj, *, public_fields, actor, private_fields=(), private_field_predicate=None)` builds a dict of `public_fields` from `obj` and conditionally appends `private_fields` when `private_field_predicate(actor, obj)` is true. Used by handlers that gate fields per viewer (today: user detail, where `email` / `is_active` / `is_verified` are visible only to the user themselves or an admin). Defense in depth alongside template-level guards: omitting keys at projection time means a forgotten `{% if %}` cannot re-leak. `ResourceSpec.private_fields` / `private_field_predicate` store the same primitives as declarative metadata so future cross-layer readers (JSON endpoint, audit snapshot, OpenAPI doc) can read the rule without rediscovering it.
 - `resource_routes.py` - Unified `ResourceSpec` + opt-in `mount_*` grammar (covers top-level *and* sub-resource CRUD via `parent=`). See [Unified resource grammar](#unified-resource-grammar) below.
 
 **Package infrastructure:**
@@ -447,6 +449,7 @@ Colocated tests cover the helpers in this directory:
 
 - `test_responses.py` — `APIResponse`, `created_response`, `updated_response`, `deleted_response`, `refreshed_response`.
 - `test_resource_routes.py` — `ResourceSpec` + per-mount tests (covers sub-resource routes via `parent=` since slice 8 / #253). Add a test here whenever a new mount function lands or an existing one grows a knob.
+- `test_projections.py` — `project_view` (per-viewer field gating).
 - `test_middleware.py` — ASGI middleware (currently just `StripEmptyQueryParamsMiddleware`'s pair-stripping helper; integration coverage lives next to the routes it affects).
 
 Route-level tests under `../routes/` exercise the mounts indirectly via the resources that use them; the unit tests here cover spec validation, error handling at mount time, and the path-param wiring that the route-level tests can't easily isolate.

--- a/src/api/common/projections.py
+++ b/src/api/common/projections.py
@@ -1,0 +1,49 @@
+"""View-projection helper shared by handlers that gate fields per viewer.
+
+`project_view` builds a dict containing only the keys the viewer is
+allowed to see. The technique — omit private keys at projection time, on
+top of any template-level guard — is defense in depth: a forgotten
+template `{% if %}` cannot re-leak a value the dict never contained.
+
+The split between `public_fields` (per call) and `private_fields` (a
+spec-level declaration) is deliberate: different views of the same
+resource (list row vs. detail) want different *public* shapes, so
+pinning a single `public_fields` to the spec would force premature
+consolidation. The spec only declares *what is private*; the call site
+declares *which view this is*.
+
+`project_view` takes the privacy primitives directly (rather than a
+`ResourceSpec`) so logic-layer handlers can call it without a layer-cross
+through `api.routes.<entity>` — which would also be a circular import for
+entities where the spec sits in the route file that imports the handler.
+The spec stores the same primitives as declarative metadata for any
+future cross-layer reader (JSON endpoint, audit snapshot, OpenAPI doc).
+"""
+
+from typing import Any, Callable
+
+
+def project_view(
+    obj: Any,
+    *,
+    public_fields: tuple[str, ...],
+    actor: Any,
+    private_fields: tuple[str, ...] = (),
+    private_field_predicate: Callable[..., bool] | None = None,
+) -> dict:
+    """Project `obj` into a dict of `public_fields`, optionally adding
+    `private_fields` when `private_field_predicate(actor, obj)` is true.
+
+    `private_fields` without a predicate is a misconfiguration (the
+    fields would silently leak); raises `ValueError` to surface it.
+    """
+    if private_fields and private_field_predicate is None:
+        raise ValueError(
+            "project_view received private_fields without a "
+            "private_field_predicate — fields would silently leak."
+        )
+    view: dict[str, Any] = {f: getattr(obj, f) for f in public_fields}
+    if private_fields and private_field_predicate(actor, obj):
+        for f in private_fields:
+            view[f] = getattr(obj, f)
+    return view

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -131,6 +131,18 @@ class ResourceSpec:
         receiving the path params + (for create/update) the resource id,
         returning the ``HX-Redirect`` URL. ``None`` means use a sensible
         default per mount.
+      private_fields: tuple of attribute names that are visible only to
+        viewers for whom ``private_field_predicate(actor, target)`` is
+        true. Empty tuple means no field-level gating; the resource is
+        either fully public or fully gated by the route's auth dep.
+        Read by ``src.api.common.projections.project_view`` so the
+        gating rule can be applied uniformly anywhere a view dict is
+        built. Declaring private fields without a predicate raises at
+        construction time.
+      private_field_predicate: ``Callable[[actor, target], bool]``
+        invoked by ``project_view`` to decide whether ``private_fields``
+        should appear in the projected view. Required when
+        ``private_fields`` is non-empty.
       parent: another ``ResourceSpec`` for sub-resources. Slice 8 (#253)
         wires this through; until then ``mount_delete`` asserts
         ``parent is None``.
@@ -157,7 +169,25 @@ class ResourceSpec:
     update_redirect: Callable[..., str] | None = None
     delete_redirect: Callable[..., str] | None = None
 
+    private_fields: tuple[str, ...] = ()
+    private_field_predicate: Callable[..., bool] | None = None
+
     parent: "ResourceSpec | None" = None
+
+    def __post_init__(self) -> None:
+        # Field-level visibility metadata: `private_fields` names the
+        # attributes gated by `private_field_predicate(actor, target)`.
+        # Read by `src.api.common.projections.project_view` (and any
+        # future layer — JSON endpoint, audit snapshot, OpenAPI doc —
+        # that needs to know which fields are private). Declaring fields
+        # without a predicate would silently leak them, so require both
+        # together.
+        if self.private_fields and self.private_field_predicate is None:
+            raise ValueError(
+                f"ResourceSpec({self.collection!r}) declares private_fields="
+                f"{self.private_fields!r} but no private_field_predicate — "
+                "private fields cannot be gated without a predicate."
+            )
 
 
 def mount_delete(

--- a/src/api/common/test_projections.py
+++ b/src/api/common/test_projections.py
@@ -1,0 +1,92 @@
+"""Tests for `src/api/common/projections.py`."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.common.projections import project_view
+
+
+def test_project_view_no_private_fields_returns_only_public():
+    obj = SimpleNamespace(id=1, name="w", secret="hidden")
+    view = project_view(obj, public_fields=("id", "name"), actor=None)
+    assert view == {"id": 1, "name": "w"}
+
+
+def test_project_view_predicate_false_omits_private():
+    obj = SimpleNamespace(id=1, name="w", secret="hidden")
+    view = project_view(
+        obj,
+        public_fields=("id", "name"),
+        actor=None,
+        private_fields=("secret",),
+        private_field_predicate=lambda actor, target: False,
+    )
+    assert view == {"id": 1, "name": "w"}
+    assert "secret" not in view
+
+
+def test_project_view_predicate_true_includes_private():
+    obj = SimpleNamespace(id=1, name="w", secret="hidden")
+    view = project_view(
+        obj,
+        public_fields=("id", "name"),
+        actor=None,
+        private_fields=("secret",),
+        private_field_predicate=lambda actor, target: True,
+    )
+    assert view == {"id": 1, "name": "w", "secret": "hidden"}
+
+
+def test_project_view_predicate_receives_actor_and_target():
+    """The predicate gets (actor, target) so callers can implement
+    self-or-admin, owner-or-admin, etc. without re-deriving inputs."""
+    received: dict = {}
+
+    def predicate(actor, target):
+        received["actor"] = actor
+        received["target"] = target
+        return True
+
+    obj = SimpleNamespace(id=1, secret="hidden")
+    sentinel_actor = SimpleNamespace(name="actor")
+    project_view(
+        obj,
+        public_fields=("id",),
+        actor=sentinel_actor,
+        private_fields=("secret",),
+        private_field_predicate=predicate,
+    )
+    assert received["actor"] is sentinel_actor
+    assert received["target"] is obj
+
+
+def test_project_view_different_public_fields_per_view():
+    """Same private rule, different call sites can ask for different
+    public shapes (e.g. a list row vs. a detail page)."""
+    obj = SimpleNamespace(id=1, name="w", description="d", secret="hidden")
+    kwargs = dict(
+        actor=None,
+        private_fields=("secret",),
+        private_field_predicate=lambda actor, target: True,
+    )
+    list_view = project_view(obj, public_fields=("id", "name"), **kwargs)
+    detail_view = project_view(
+        obj, public_fields=("id", "name", "description"), **kwargs
+    )
+    assert set(list_view.keys()) == {"id", "name", "secret"}
+    assert set(detail_view.keys()) == {"id", "name", "description", "secret"}
+
+
+def test_project_view_private_fields_without_predicate_raises():
+    """Declaring private_fields without a predicate would silently leak
+    them — match the spec-level construction guard."""
+    obj = SimpleNamespace(id=1, secret="hidden")
+    with pytest.raises(ValueError, match="private_field_predicate"):
+        project_view(
+            obj,
+            public_fields=("id",),
+            actor=None,
+            private_fields=("secret",),
+            # private_field_predicate intentionally omitted
+        )

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -154,6 +154,44 @@ def test_mount_delete_subresource_path_includes_parent_id():
     assert captured["repo"].name == "child_repo"
 
 
+def test_resource_spec_private_fields_without_predicate_raises():
+    """Declaring `private_fields` without a predicate would silently leak
+    them — the construction-time guard makes the misconfiguration loud."""
+    with pytest.raises(ValueError, match="private_field_predicate"):
+        ResourceSpec(
+            collection="widgets",
+            id_param="widget_id",
+            repo_dep=lambda: None,
+            private_fields=("secret",),
+            # private_field_predicate intentionally omitted
+        )
+
+
+def test_resource_spec_private_fields_with_predicate_constructs():
+    """Both set: construction succeeds and the fields round-trip."""
+    predicate = lambda actor, target: False  # noqa: E731
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: None,
+        private_fields=("secret",),
+        private_field_predicate=predicate,
+    )
+    assert spec.private_fields == ("secret",)
+    assert spec.private_field_predicate is predicate
+
+
+def test_resource_spec_no_private_fields_no_predicate_constructs():
+    """Default case (no private fields at all): predicate may stay None."""
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: None,
+    )
+    assert spec.private_fields == ()
+    assert spec.private_field_predicate is None
+
+
 def test_mount_delete_requires_write_user_dep():
     spec = ResourceSpec(
         collection="widgets",

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -13,9 +13,11 @@ from src.api.common.resource_routes import (
 )
 from src.api.routes.providers import PROVIDER_SPEC
 from src.auth_config import current_active_user, current_admin_user
+from src.logic._authz import is_self_or_admin
 from src.logic.providers.provider_processing import handle_list_user_providers
 from src.logic.users.user_processing import (
     USER,
+    USER_PRIVATE_FIELDS,
     handle_delete_user,
     handle_get_user_detail,
     handle_list_users,
@@ -42,6 +44,14 @@ USER_SPEC = ResourceSpec(
     write_user_dep=current_admin_user,
     list_template="users/list.html",
     detail_template="users/detail.html",
+    # Field-level visibility: viewers outside `is_self_or_admin` see only
+    # public fields. The same tuple + predicate are applied by
+    # `project_view` inside `handle_get_user_detail`; declaring them on
+    # the spec makes the gating rule readable by any future cross-layer
+    # consumer (JSON endpoint, audit snapshot, OpenAPI doc). Template
+    # `{% if can_view_private %}` guard remains as defense in depth.
+    private_fields=USER_PRIVATE_FIELDS,
+    private_field_predicate=is_self_or_admin,
 )
 
 

--- a/src/logic/_authz.py
+++ b/src/logic/_authz.py
@@ -30,6 +30,18 @@ def is_owner(obj, user: User | None, *, owner_attr: str = "owner_id") -> bool:
     return getattr(obj, owner_attr) == user.id
 
 
+def is_self_or_admin(actor: User | None, target) -> bool:
+    """True iff `actor` is authenticated and is either `target` itself or a superuser.
+
+    Distinct signature from `is_owner`: the resource *is* the user, not
+    an FK to one, so there is no `owner_attr` knob — equality is between
+    `actor.id` and `target.id` directly.
+    """
+    if actor is None:
+        return False
+    return actor.id == target.id or actor.is_superuser
+
+
 def assert_owner_or_admin(
     obj,
     user: User,

--- a/src/logic/test__authz.py
+++ b/src/logic/test__authz.py
@@ -6,7 +6,12 @@ from types import SimpleNamespace
 import pytest
 
 from src.api.common.exceptions import ForbiddenError
-from src.logic._authz import assert_owner_or_admin, is_admin, is_owner
+from src.logic._authz import (
+    assert_owner_or_admin,
+    is_admin,
+    is_owner,
+    is_self_or_admin,
+)
 
 
 def _user(*, is_superuser: bool = False, id_=None):
@@ -60,6 +65,31 @@ def test_is_owner_custom_owner_attr():
     u = _user()
     obj = SimpleNamespace(user_id=u.id)
     assert is_owner(obj, u, owner_attr="user_id") is True
+
+
+# --- is_self_or_admin ------------------------------------------------------
+
+
+def test_is_self_or_admin_none_actor():
+    target = _user()
+    assert is_self_or_admin(None, target) is False
+
+
+def test_is_self_or_admin_self():
+    u = _user()
+    assert is_self_or_admin(u, u) is True
+
+
+def test_is_self_or_admin_admin_other():
+    admin = _user(is_superuser=True)
+    target = _user()
+    assert is_self_or_admin(admin, target) is True
+
+
+def test_is_self_or_admin_stranger():
+    actor = _user()
+    target = _user()
+    assert is_self_or_admin(actor, target) is False
 
 
 # --- assert_owner_or_admin (composes is_owner + is_admin) ------------------

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -4,7 +4,8 @@ from uuid import UUID
 from fastapi import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
-from src.logic._authz import is_admin
+from src.api.common.projections import project_view
+from src.logic._authz import is_admin, is_self_or_admin
 from src.logic.audit import (
     AuditAction,
     AuditedResource,
@@ -34,6 +35,14 @@ USER = AuditedResource(
     update=AuditAction.UPDATE_USER,
     delete=AuditAction.DELETE_USER,
 )
+
+# Field-level visibility: `email`, `is_active`, `is_verified` are gated
+# by `is_self_or_admin(actor, target)`. Declared here so both the
+# handler (which applies the projection) and the route layer (which
+# declares the same tuple on `USER_SPEC.private_fields` for any future
+# cross-layer reader) share one source of truth — keeping them aligned
+# without a circular import between logic and api/routes.
+USER_PRIVATE_FIELDS: tuple[str, ...] = ("email", "is_active", "is_verified")
 
 
 async def handle_list_users(
@@ -90,21 +99,18 @@ async def handle_get_user_detail(
     # the partial just checks the flag.
     is_self = requesting_user is not None and target.id == requesting_user.id
     can_admin_actions = is_admin(requesting_user) and not is_self
-    can_view_private = is_self or is_admin(requesting_user)
+    can_view_private = is_self_or_admin(requesting_user, target)
 
-    # Project target_user into a dict that omits private fields
-    # (email, is_active, is_verified) for viewers who aren't the user
-    # themselves or an admin. Defense in depth: a forgotten template
-    # guard can re-leak; a missing dict key can't. The same projection
-    # extends naturally to any future JSON endpoint on this resource.
-    target_view = {
-        "id": target.id,
-        "username": target.username,
-    }
-    if can_view_private:
-        target_view["email"] = target.email
-        target_view["is_active"] = target.is_active
-        target_view["is_verified"] = target.is_verified
+    # Project target_user into a dict that omits private fields for
+    # viewers outside the predicate. Defense in depth: a forgotten
+    # template guard can re-leak; a missing dict key can't.
+    target_view = project_view(
+        target,
+        public_fields=("id", "username"),
+        actor=requesting_user,
+        private_fields=USER_PRIVATE_FIELDS,
+        private_field_predicate=is_self_or_admin,
+    )
 
     return {
         "request": request,


### PR DESCRIPTION
## Summary

- Adds `is_self_or_admin(actor, target)` to `src/logic/_authz.py`.
- Adds `private_fields` + `private_field_predicate` to `ResourceSpec`, with a construction-time guard that rejects fields-without-predicate.
- Adds `project_view(obj, public_fields, actor, private_fields=, private_field_predicate=)` in `src/api/common/projections.py`.
- Migrates `handle_get_user_detail` to call `project_view(...)`; `USER_SPEC` declares the same `private_fields` / predicate as metadata.

Closes #304.

## Deviation from the issue

The issue proposed `project_view(obj, *, spec: ResourceSpec, actor, public_fields)`. Implementing that signature literally would require the logic-layer handler to import `USER_SPEC` from `src/api/routes/users.py`, which in turn imports the handler — a circular import.

Instead, `project_view` takes the privacy primitives (`private_fields`, `private_field_predicate`) directly. `USER_SPEC` still declares the same primitives as declarative metadata for any future cross-layer reader (JSON endpoint, audit snapshot, OpenAPI doc) — which is the issue's stated motivation. `USER_PRIVATE_FIELDS` lives in `src/logic/users/user_processing.py` so both the handler and the spec read from one source.

`src/README.md`'s Logic-layer dependency column was extended from "API common exceptions" to "API common exceptions + pure helpers (projections)" to reflect the new dependency direction.

## Behavior

The projection technique chosen in #280 (omit-and-guard + template `{% if can_view_private %}` defense in depth) is preserved exactly. The route-level regression net from #280 (`src/api/routes/test_users.py::test_detail_*_private_fields_*`) and the logic-level net from #292 (`src/logic/users/test_user_processing.py`) both pass **unchanged**.

## Test plan

- [x] `dev test` (546 passed, 1 skipped)
- [x] `dev test contract` (16 passed)
- [x] `dev lint` (all checks green; pre-commit hooks pass)
- [x] Regression tests from #280 and #292 pass unchanged
- [x] New tests cover: `is_self_or_admin` (4 cases), `ResourceSpec` private-field validation (3 cases), `project_view` (6 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)