### PR TITLE
Backfill audit_log provider_profile → provider; align code strings

### DIFF
--- a/alembic/versions/478d9e8f19f0_backfill_audit_log_provider_strings_to_.py
+++ b/alembic/versions/478d9e8f19f0_backfill_audit_log_provider_strings_to_.py
@@ -1,0 +1,68 @@
+"""backfill audit_log provider strings to provider
+
+Closes the rename drift left by `9f1a8b2c3d4e` (which renamed the
+`provider_profiles` table to `providers` but intentionally left the
+audit-log persisted strings alone). Rewrites
+`audit_log.resource_type = 'provider_profile'` → `'provider'` and the
+three matching `action` values (`create_provider_profile` →
+`create_provider`, etc.).
+
+Pure data migration — no schema change. Reversible: the downgrade
+rewrites the same rows back to the old strings. `UPDATE` of zero rows
+is a no-op, so this is safe against a fresh DB with no provider audit
+rows yet.
+
+Revision ID: 478d9e8f19f0
+Revises: 9f1a8b2c3d4e
+Create Date: 2026-05-10 12:23:09.995780
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "478d9e8f19f0"
+down_revision: Union[str, None] = "9f1a8b2c3d4e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_ACTION_RENAMES = (
+    ("create_provider_profile", "create_provider"),
+    ("update_provider_profile", "update_provider"),
+    ("delete_provider_profile", "delete_provider"),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE audit_log SET resource_type = :new " "WHERE resource_type = :old"
+        ),
+        {"old": "provider_profile", "new": "provider"},
+    )
+    for old, new in _ACTION_RENAMES:
+        bind.execute(
+            sa.text("UPDATE audit_log SET action = :new WHERE action = :old"),
+            {"old": old, "new": new},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for old, new in _ACTION_RENAMES:
+        bind.execute(
+            sa.text("UPDATE audit_log SET action = :old WHERE action = :new"),
+            {"old": old, "new": new},
+        )
+    bind.execute(
+        sa.text(
+            "UPDATE audit_log SET resource_type = :old " "WHERE resource_type = :new"
+        ),
+        {"old": "provider_profile", "new": "provider"},
+    )

--- a/src/api/routes/test_providers.py
+++ b/src/api/routes/test_providers.py
@@ -102,11 +102,11 @@ async def test_create_provider_happy_path(
 
     rows = await _audit_rows_for(
         db_test_session_manager,
-        resource_type="provider_profile",
+        resource_type="provider",
         resource_id=new_id,
     )
     assert len(rows) == 1
-    assert rows[0].action == "create_provider_profile"
+    assert rows[0].action == "create_provider"
     assert rows[0].actor_id == logged_in_user.id
 
 

--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -79,9 +79,9 @@ class AuditAction(str, Enum):
     UPDATE_USER = "update_user"
     DELETE_USER = "delete_user"
     REGISTER = "register"
-    CREATE_PROVIDER = "create_provider_profile"
-    UPDATE_PROVIDER = "update_provider_profile"
-    DELETE_PROVIDER = "delete_provider_profile"
+    CREATE_PROVIDER = "create_provider"
+    UPDATE_PROVIDER = "update_provider"
+    DELETE_PROVIDER = "delete_provider"
     CREATE_LICENSURE = "create_licensure"
     UPDATE_LICENSURE = "update_licensure"
     DELETE_LICENSURE = "delete_licensure"
@@ -103,7 +103,7 @@ class AuditedResource:
     Module-level constants are the intended use:
 
         PROVIDER = AuditedResource(
-            type="provider_profile",
+            type="provider",
             snapshot=lambda obj: ProviderAuditSnapshot
                 .model_validate(obj).model_dump(mode="json"),
             create=AuditAction.CREATE_PROVIDER,

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 
 
 PROVIDER = AuditedResource(
-    type="provider_profile",
+    type="provider",
     snapshot=make_snapshotter(ProviderAuditSnapshot),
     create=AuditAction.CREATE_PROVIDER,
     update=AuditAction.UPDATE_PROVIDER,

--- a/src/logic/providers/test_provider_processing.py
+++ b/src/logic/providers/test_provider_processing.py
@@ -362,7 +362,7 @@ async def test_create_provider_persists_row_and_writes_audit(
 
     rows = await _audit_rows_for(
         db_test_session_manager,
-        resource_type="provider_profile",
+        resource_type="provider",
         resource_id=created.id,
     )
     assert len(rows) == 1
@@ -399,7 +399,7 @@ async def test_create_provider_with_inline_children_captures_them_in_audit(
 
     rows = await _audit_rows_for(
         db_test_session_manager,
-        resource_type="provider_profile",
+        resource_type="provider",
         resource_id=created.id,
     )
     assert len(rows) == 1
@@ -471,7 +471,7 @@ async def test_update_provider_updates_fields_and_writes_audit(
     assert updated.practice_name == "New Name"
     rows = await _audit_rows_for(
         db_test_session_manager,
-        resource_type="provider_profile",
+        resource_type="provider",
         resource_id=provider_id,
     )
     assert len(rows) == 1
@@ -521,7 +521,7 @@ async def test_update_provider_succeeds_for_superuser(
     assert updated.practice_name == "By Admin"
     rows = await _audit_rows_for(
         db_test_session_manager,
-        resource_type="provider_profile",
+        resource_type="provider",
         resource_id=provider_id,
     )
     assert rows[0].actor_id == admin.id
@@ -573,7 +573,7 @@ async def test_delete_provider_removes_row_and_writes_audit(
 
     rows = await _audit_rows_for(
         db_test_session_manager,
-        resource_type="provider_profile",
+        resource_type="provider",
         resource_id=provider_id,
     )
     assert len(rows) == 1


### PR DESCRIPTION
## Summary
- Closes #306 — finishes the `provider_profile` → `provider` rename that #197/#202/#203 swept everywhere except the audit-log persisted strings.
- New data migration `478d9e8f19f0` rewrites `audit_log.resource_type` and the three `action` values from the legacy strings to `provider` / `create_provider` / `update_provider` / `delete_provider`. Reversible — `downgrade()` rewrites them back. `UPDATE` of zero rows is a no-op on a fresh DB.
- Code-side: `AuditAction.{CREATE,UPDATE,DELETE}_PROVIDER` enum *values* updated (member names already used `_PROVIDER`), `PROVIDER` AuditedResource `type="provider_profile"` → `"provider"` in `provider_processing.py:61`, docstring example in `audit.py:106` updated, seven test fixtures asserting on the old strings updated to match.

Per the prior migration's note (`9f1a8b2c3d4e`), audit strings were *intentionally* left alone at table-rename time as historical record. The issue reverses that stance: now is the cheapest moment to close the drift — nothing downstream reads `audit_log` yet, so backfill is internal-only.

## Test plan
- [x] `dev migrate roundtrip` — upgrade → downgrade → upgrade clean
- [x] `dev test` — 546 passed
- [x] `dev test contract` — 16 passed
- [x] `dev lint` — clean
- [x] `grep -rn provider_profile src/ tests/` — only the legitimate `uq_provider_profiles_user_id` constraint-name references and the `test_legacy_provider_profiles_paths_gone` test remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)