### PR TITLE
Add BaseRepository._list / ._count primitives; migrate list methods

### DIFF
--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -97,9 +97,9 @@ class [Entity]Repository(BaseRepository):
 
     async def list_[entities](self) -> Sequence[[Entity]]:
         """Lists all [entities] with appropriate ordering."""
-        stmt = select([Entity]).order_by([Entity].created_at.desc())
-        result = await self.session.execute(stmt)
-        return result.scalars().all()
+        return await self._list(
+            select([Entity]).order_by([Entity].created_at.desc())
+        )
 
     async def create_[entity](self, **kwargs) -> [Entity]:
         """Creates a new [entity] with the provided data."""
@@ -180,19 +180,22 @@ async def handle_create_entity(data, user, repo: [Entity]Repository):
 
 ### CRUD primitives on `BaseRepository`
 
-`BaseRepository` carries four protected primitives that capture the exact shapes every resource repo writes by hand. They own only the flush/refresh ritual; they never call `commit()`. Use them when your method body is one of these shapes plus *zero* other operations; otherwise write the body explicitly.
+`BaseRepository` carries protected primitives that capture the exact shapes every resource repo writes by hand. They own only the flush/refresh ritual; they never call `commit()`. Use them when your method body is one of these shapes plus *zero* other operations; otherwise write the body explicitly.
 
 | Primitive | Shape it captures |
 | --- | --- |
 | `_get_by_id(Model, id)` | `select(Model).filter(Model.id == id).scalars().first()` |
+| `_list(stmt, *, limit=None, offset=None)` | `execute(stmt); return result.scalars().all()` — generic on `T` so `_list(select(Post))` returns `Sequence[Post]`. Filter/order/join logic stays inline in the calling method; pagination kwargs are optional and default to "return everything." |
+| `_count(stmt)` | `select(func.count()).select_from(stmt.subquery()); return scalar_one()` — caller passes the same `select(...)` they'd pass to `_list`; filters, joins, and `.distinct()` are preserved by the subquery wrapper. |
 | `_persist_new(obj)` | `session.add(obj); flush; refresh; return obj` |
 | `_add_child(parent, "collection", child)` | `getattr(parent, "collection").append(child); flush; refresh(child); return child` |
 | `_patch(obj, **fields)` | skip-`None` `setattr` loop, then `flush; refresh; return obj` |
 | `_delete(obj)` | `session.delete(obj); flush` |
 
+`_list` and `_count` are the binding targets for pagination + total-count endpoints. The primitives are in place, but no endpoint adopts them today — each per-endpoint wire-contract decision (return `{items, total}`? thread `limit`/`offset`?) is independent of having the primitives exist.
+
 When *not* to delegate:
 
-- `list_X` queries (joins, filters, custom ordering) — write them out.
 - `get_X_by_<field>` lookups that are not by primary key — write them out.
 - `update_X` methods that need a richer skip predicate (e.g. `PostRepository.update_post`'s "skip fields not in this kind's spec") — write them out and document why.
 - Any flow that wires up multiple related rows in one flush — e.g. `PostRepository.create_post` calls `_attach_detail` before delegating to `_persist_new`, but the attachment itself stays explicit.
@@ -288,6 +291,7 @@ async def handle_list_entities_for_user(user: User, repo: [Entity]Repository):
 
 Colocated tests live alongside the repositories:
 
+- `test_base.py` — exercises `_list` (pagination via `limit` / `offset`, statement-order preservation, empty result) and `_count` (filters, joins with `.distinct()`); the other `BaseRepository` primitives are covered transitively by per-resource repo tests.
 - `test_audit_repository.py` — exercises append-only writes, FK `SET NULL` on actor delete, and list-by-resource ordering against the in-memory test DB.
 - `test_post_repository.py` — exercises parent + detail create/update/delete for every registered kind (`client_referral`, `provider_availability`), including a raw-SQL DELETE that proves the FK CASCADE fires (not just the ORM cascade). Also covers the `posts.kind` CHECK constraint rejecting unregistered kinds (including the retired `note` kind). Relies on `PRAGMA foreign_keys = ON` being set globally by the test engine fixture. Detail-row construction goes through `make_<kind>_detail` factories in [`tests/helpers.py`](../../tests/helpers.py) so spec-required fields are filled with valid defaults; tests override only what they're asserting on. Per-kind dispatch in `_attach_detail` and `update_post` is registry-driven via `POST_KINDS` / `POST_KIND_BY_DETAIL_MODEL` from [`src/models/posts/post_kinds.py`](../models/posts/post_kinds.py); the registry-consistency tests live with the registry, not here.
 - `test_provider_repository.py` — exercises `Provider` CRUD, cascade delete (parent + sub-rows gone in one shot), `list_providers` filtering through licensures (license_type, issuing_state, AND-composed, `.distinct()` de-dup), and CRUD round-trips for each sub-table (licensure, education, certification). Sub-row construction uses `make_provider_*` factories in [`tests/helpers.py`](../../tests/helpers.py).

--- a/src/repositories/audit_repository.py
+++ b/src/repositories/audit_repository.py
@@ -53,7 +53,7 @@ class AuditRepository(BaseRepository):
         self, *, resource_type: str, resource_id: UUID
     ) -> Sequence[AuditLog]:
         """List audit rows for a given resource, oldest first."""
-        stmt = (
+        return await self._list(
             select(AuditLog)
             .filter(
                 AuditLog.resource_type == resource_type,
@@ -61,5 +61,3 @@ class AuditRepository(BaseRepository):
             )
             .order_by(AuditLog.created_at.asc())
         )
-        result = await self.session.execute(stmt)
-        return result.scalars().all()

--- a/src/repositories/base.py
+++ b/src/repositories/base.py
@@ -12,11 +12,14 @@ method body explicitly — that domain-specific shape is exactly what the
 named per-resource methods are for.
 """
 
-from typing import Any
+from collections.abc import Sequence
+from typing import Any, TypeVar
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+T = TypeVar("T")
 
 
 class BaseRepository:
@@ -28,6 +31,45 @@ class BaseRepository:
         stmt = select(model).filter(model.id == obj_id)
         result = await self.session.execute(stmt)
         return result.scalars().first()
+
+    async def _list(
+        self,
+        stmt: Select[tuple[T]],
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> Sequence[T]:
+        """Execute a `select(...)` statement and return its scalars.
+
+        Generic over the selected entity: `_list(select(Post))` returns
+        `Sequence[Post]`, verified by the type checker via `T`. Centralizes
+        the `result = await session.execute(stmt); return
+        result.scalars().all()` boilerplate every list-style method repeats.
+
+        `limit` and `offset` are optional kwargs — when both are `None`,
+        returns the full result set unchanged. Filter, order, and join
+        logic stay in the calling method (where the domain-specific shape
+        is most expressive).
+        """
+        if offset is not None:
+            stmt = stmt.offset(offset)
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        result = await self.session.execute(stmt)
+        return result.scalars().all()
+
+    async def _count(self, stmt: Select[Any]) -> int:
+        """Count rows matching `stmt` without fetching them.
+
+        Wraps `select(func.count()).select_from(stmt.subquery())` so the
+        caller passes the same `select(...)` they'd pass to `_list`. The
+        subquery wrapper preserves filters, joins, and `.distinct()` — the
+        count reflects exactly the rows `_list` would return ignoring
+        pagination.
+        """
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        result = await self.session.execute(count_stmt)
+        return result.scalar_one()
 
     async def _persist_new(self, obj: Any) -> Any:
         """Add a fresh ORM instance, flush, and refresh; return the row.

--- a/src/repositories/posts/post_repository.py
+++ b/src/repositories/posts/post_repository.py
@@ -39,9 +39,7 @@ class PostRepository(BaseRepository):
 
     async def list_posts(self) -> Sequence[Post]:
         """Lists all posts, newest first. Detail relationships are eager-loaded."""
-        stmt = select(Post).order_by(Post.created_at.desc())
-        result = await self.session.execute(stmt)
-        return result.scalars().all()
+        return await self._list(select(Post).order_by(Post.created_at.desc()))
 
     async def create_post(self, post: Post, detail: PostDetail) -> Post:
         """Persists a new post + its per-kind detail in one flush; the

--- a/src/repositories/providers/provider_repository.py
+++ b/src/repositories/providers/provider_repository.py
@@ -37,13 +37,11 @@ class ProviderRepository(BaseRepository):
 
     async def list_for_user(self, user_id: UUID) -> Sequence[Provider]:
         """Lists every provider owned by the given user, newest first."""
-        stmt = (
+        return await self._list(
             select(Provider)
             .filter(Provider.owner_id == user_id)
             .order_by(Provider.created_at.desc())
         )
-        result = await self.session.execute(stmt)
-        return result.scalars().all()
 
     async def list_providers(
         self,
@@ -66,8 +64,7 @@ class ProviderRepository(BaseRepository):
                 stmt = stmt.filter(ProviderLicensure.issuing_state == issuing_state)
             stmt = stmt.distinct()
         stmt = stmt.order_by(Provider.created_at.desc())
-        result = await self.session.execute(stmt)
-        return result.scalars().all()
+        return await self._list(stmt)
 
     # --- Provider mutations ----------------------------------------
 

--- a/src/repositories/test_base.py
+++ b/src/repositories/test_base.py
@@ -1,0 +1,212 @@
+"""Tests for `BaseRepository._list` and `BaseRepository._count`.
+
+The primitives sit underneath every per-resource list method, so they're
+exercised against a real session: in-memory SQLite with the same engine
+fixture every other repo test uses. The other primitives (`_get_by_id`,
+`_persist_new`, `_add_child`, `_patch`, `_delete`) are covered transitively
+by the per-resource repo tests — this file specifically pins the list /
+paginate / count contract.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.models import Provider, ProviderLicensure, User
+from src.repositories.base import BaseRepository
+from tests.helpers import create_test_user, make_provider, make_provider_licensure
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_users(
+    session_manager: async_sessionmaker[AsyncSession],
+    usernames: list[str],
+) -> list[User]:
+    """Persist users in the given order, return them in that order."""
+    users = [create_test_user(username=name) for name in usernames]
+    async with session_manager() as session:
+        async with session.begin():
+            for user in users:
+                session.add(user)
+    return users
+
+
+# --- _list ----------------------------------------------------------------
+
+
+async def test_list_returns_full_result_set_when_no_pagination(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    await _seed_users(db_test_session_manager, ["a", "b", "c"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo._list(select(User).order_by(User.username))
+
+    assert [u.username for u in rows] == ["a", "b", "c"]
+
+
+async def test_list_applies_limit(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    await _seed_users(db_test_session_manager, ["a", "b", "c", "d"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo._list(select(User).order_by(User.username), limit=2)
+
+    assert [u.username for u in rows] == ["a", "b"]
+
+
+async def test_list_applies_offset(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    await _seed_users(db_test_session_manager, ["a", "b", "c", "d"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo._list(select(User).order_by(User.username), offset=2)
+
+    assert [u.username for u in rows] == ["c", "d"]
+
+
+async def test_list_applies_offset_and_limit_together(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    await _seed_users(db_test_session_manager, ["a", "b", "c", "d", "e"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo._list(select(User).order_by(User.username), limit=2, offset=1)
+
+    assert [u.username for u in rows] == ["b", "c"]
+
+
+async def test_list_returns_empty_for_empty_table(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo._list(select(User))
+
+    assert list(rows) == []
+
+
+async def test_list_preserves_statement_order(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """The statement's `order_by` is load-bearing — `_list` must not
+    re-order or otherwise interfere with it."""
+    await _seed_users(db_test_session_manager, ["c", "a", "b"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        asc = await repo._list(select(User).order_by(User.username.asc()))
+        desc = await repo._list(select(User).order_by(User.username.desc()))
+
+    assert [u.username for u in asc] == ["a", "b", "c"]
+    assert [u.username for u in desc] == ["c", "b", "a"]
+
+
+# --- _count ---------------------------------------------------------------
+
+
+async def test_count_empty_returns_zero(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        total = await repo._count(select(User))
+
+    assert total == 0
+
+
+async def test_count_single_row(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    await _seed_users(db_test_session_manager, ["only"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        total = await repo._count(select(User))
+
+    assert total == 1
+
+
+async def test_count_multi_row(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    await _seed_users(db_test_session_manager, ["a", "b", "c", "d"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        total = await repo._count(select(User))
+
+    assert total == 4
+
+
+async def test_count_respects_filters(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    users = await _seed_users(db_test_session_manager, ["a", "b", "c"])
+    target = users[0]
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        total = await repo._count(select(User).filter(User.id != target.id))
+
+    assert total == 2
+
+
+async def test_count_respects_distinct_with_join(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`.distinct()` is load-bearing for `list_providers` — when a parent
+    has multiple matching child rows, the count must reflect distinct
+    parents, not the join's cardinality."""
+    owner = create_test_user(username=f"owner-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(owner)
+
+    provider = make_provider(owner_id=owner.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(provider)
+
+    # Two licensures matching `license_type='lcsw'` on the same provider.
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                make_provider_licensure(
+                    provider_id=provider.id,
+                    license_type="lcsw",
+                    license_number="L-1",
+                )
+            )
+            session.add(
+                make_provider_licensure(
+                    provider_id=provider.id,
+                    license_type="lcsw",
+                    license_number="L-2",
+                )
+            )
+
+    stmt = (
+        select(Provider)
+        .join(ProviderLicensure, ProviderLicensure.provider_id == Provider.id)
+        .filter(ProviderLicensure.license_type == "lcsw")
+        .distinct()
+    )
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        total = await repo._count(stmt)
+        # Sanity: _list returns one distinct row too.
+        rows = await repo._list(stmt)
+
+    assert total == 1
+    assert len(rows) == 1

--- a/src/repositories/users/user_repository.py
+++ b/src/repositories/users/user_repository.py
@@ -41,8 +41,7 @@ class UserRepository(BaseRepository):
             stmt = stmt.filter(User.id != exclude_user.id)
 
         stmt = stmt.order_by(User.username)
-        result = await self.session.execute(stmt)
-        return result.scalars().all()
+        return await self._list(stmt)
 
     async def set_user_activation(self, user: User, *, is_active: bool) -> User:
         """Sets `is_active` on the user and flushes; the caller commits."""


### PR DESCRIPTION
## Summary

- Add generic `_list(stmt, *, limit=None, offset=None) -> Sequence[T]` and `_count(stmt) -> int` to `BaseRepository`. `_list` centralizes the `execute → scalars().all()` boilerplate every list method repeats; pagination kwargs are optional and default to "return everything." `_count` wraps `select(func.count()).select_from(stmt.subquery())` so the caller passes the same `select(...)` they'd pass to `_list` — filters, joins, and `.distinct()` preserved.
- Migrate the five existing list methods (`list_users`, `list_for_user`, `list_providers`, `list_for_resource`, `list_posts`). Each body net-removes the two `execute` + `return` lines; filters/ordering/joins stay inline. Method signatures, return-type annotations, and wire contract unchanged.
- Add `src/repositories/test_base.py` covering `_list` (no pagination, limit, offset, both, empty, statement-order preservation) and `_count` (empty, single, multi, filters, join + `.distinct()`).
- Update `src/repositories/README.md` to document the new primitives alongside the existing ones; update the canonical "Creating a new repository" example to use `_list`.

Closes #312.

## Notes

- SQLAlchemy is 2.0.49 — the typed `Select[tuple[T]]` parameterization is supported, so each migrated `list_*` method's body is type-checked against its declared `Sequence[T]` return without explicit casts.
- Zero contract surfaces touched: HTTP request/response shapes, URLs, persisted data, and CHECK/UNIQUE constraints all unchanged. Method signatures are internal.
- No endpoint adopts pagination or counts yet — primitives are in place for the first consumer (e.g. `EntitySpec`-driven `{items, total}` endpoints) without forcing every endpoint to migrate now.

## Test plan

- [x] `dev test` (568 passed, 1 skipped)
- [x] `dev lint`
- [x] New `test_base.py` covers all 11 cases from the issue's verification list

🤖 Generated with [Claude Code](https://claude.com/claude-code)