### PR TITLE
Synthesize FastAPI signatures from handler params (closes #316)

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -111,12 +111,7 @@ USER_SPEC = ResourceSpec(
     write_user_dep=current_admin_user,
 )
 
-mount_delete(
-    router,
-    USER_SPEC,
-    handler=handle_delete_user,
-    audit_repo_dep=get_audit_repository,
-)
+mount_delete(router, USER_SPEC, handler=handle_delete_user)
 ```
 
 ### Why this shape
@@ -126,17 +121,20 @@ mount_delete(
 - **Sub-resources nest via `parent`.** A child `ResourceSpec` carrying `parent=parent_spec` produces paths like `/providers/{provider_id}/licensures/{licensure_id}` — same `mount_create`/`mount_update`/`mount_delete` functions as top-level resources. The router's prefix is the topmost ancestor's collection (e.g. `APIRouter(prefix="/providers")`); the mount walks the parent chain to build the rest of the path. Handler kwargs include every parent id by its declared `id_param` name (`provider_id=...`, then the resource's own id).
 - **Polymorphic resources via handler-driven knobs.** Posts dispatch templates by `kind`; the route doesn't need to. The handler returns a `template_name` in its context dict and the mount honors it. This keeps the spec's shape stable even when the resource's behavior is polymorphic — `mount_form` for `GET /posts/{id}/form` uses this in slice 7. The grammar isn't infinitely flexible though: `GET /posts/form?kind=X` (where the *query param* picks the template) stays bespoke because mount_form's contract doesn't carry query params, and widening it for one case would bloat every spec.
 
-### Handler signatures
+### Handler signatures drive dep wiring
 
-Mount functions invoke handlers with a fixed shape so the spec can plumb args generically. Every handler the mounts call expects:
+The mount layer reads each handler's **typed signature** and synthesizes a FastAPI route function that pairs every parameter with the right source. There is no per-mount `extra_repo_deps` / `audit_repo_dep` wiring — the handler's annotations are the contract.
 
-- **`<id_param>=<UUID>`** for routes with an id in the path (detail/update/delete), under the per-resource kwarg name declared in the spec (`user_id`, `post_id`, ...).
-- **`repo=<primary repo>`** for the resource's primary repository, sourced from `spec.repo_dep`.
-- **`audit_repo=<AuditRepository>`** for mutation handlers, sourced from `audit_repo_dep` passed to the mount call (it's a layer-wide concern, not a per-resource knob).
-- **`requesting_user=<User>`** for any handler that gates on auth, sourced from `spec.read_user_dep` or `spec.write_user_dep`.
-- **`payload=<validated body>`** for create/update handlers (slices 6–7).
+Synthesis recognizes:
 
-Secondary repos (e.g. `user_repo: UserRepository` in the multi-repo `handle_list_user_providers`) keep their typed name per the [logic-layer convention](../../logic/README.md#handler-kwarg-naming) and arrive via `spec.extra_repo_deps`.
+- **`<id_param>: UUID`** (and any parent ids for sub-resources) — bound from the URL path.
+- **`repo: <RepoType>`** — `Depends(spec.repo_dep)`. The annotation is informational; the spec is the source of truth for which resolver to call.
+- **`audit_repo: AuditRepository`** and any other **`<name>: <RepoType>`** — resolved via the type→resolver registry in [`src/repositories/dependencies.py`](../../repositories/dependencies.py). Adding a new repo type means adding one entry to `_REPO_TYPE_RESOLVERS`.
+- **`requesting_user: User`** — `Depends(spec.read_user_dep)` on reads, `Depends(spec.write_user_dep)` on writes. Declare as **`User | None`** for routes that may run anonymously (e.g. `mount_list(..., public=True)`).
+- **`payload: <PydanticType>`** — parsed from the request body via the spec's `create_adapter` / `update_adapter` (or the mount's `body_schema` for `mount_state_axis`).
+- **Query params** — declared in the mount's `query_params=` tuple; the handler param's name must match `QueryParam.name`.
+
+Forgetting to register a new repo type in `_REPO_TYPE_RESOLVERS` raises `MountError` at app startup with a message naming the unresolved type — the failure mode is loud and immediate.
 
 ### What's mounted today
 
@@ -150,22 +148,23 @@ Secondary repos (e.g. `user_repo: UserRepository` in the multi-repo `handle_list
 | `mount_state_axis` | Landed (#302) | `users` (PUT /{id}/activation) |
 | Sub-resource via `parent=` | Landed (slice 8 / #253) | `licensures`, `educations`, `certifications` (under providers) |
 
-### Multi-repo handlers: `extra_repo_deps`
+### Multi-repo handlers
 
-Some handlers need more than the resource's primary repo — e.g. `handle_get_user_detail` takes both the user repo (the primary) and the provider repo (to embed the owned-providers list on the user-detail page). The mount that needs them passes them via the `extra_repo_deps` kwarg:
+Some handlers need more than the resource's primary repo — e.g. `handle_get_user_detail` takes both the user repo (the primary) and the provider repo (to embed the owned-providers list on the user-detail page). Just declare each as a typed parameter:
 
 ```python
-mount_detail(
-    router,
-    USER_SPEC,
-    handler=handle_get_user_detail,
-    extra_repo_deps=(get_provider_repository,),
-)
+async def handle_get_user_detail(
+    request: Request,
+    user_id: UUID,
+    repo: UserRepository,
+    provider_repo: ProviderRepository,
+    requesting_user: User,
+) -> dict: ...
+
+mount_detail(router, USER_SPEC, handler=handle_get_user_detail)
 ```
 
-The mount derives the kwarg name from the dep callable: `get_provider_repository` → `provider_repo` (strip `get_` prefix, replace `_repository` suffix with `_repo`). The handler must take the same name. If the dep doesn't follow the `get_<entity>_repository` convention, the mount raises at registration time — silent name-mismatches would be a request-time bug.
-
-`extra_repo_deps` is per-mount, not per-spec, because different mounts on the same resource often need different extras (the list view doesn't need provider_repo even though the detail view does).
+The mount introspects the signature and resolves `provider_repo` via the type registry — no `extra_repo_deps=` wiring on the call. Adding a new repo to an existing handler is a one-line change in the handler's signature; the mount picks it up automatically.
 
 ### Query-param mounts
 
@@ -200,7 +199,6 @@ For the kind-picks-template case, the handler returns `template_name=...` in its
 ```python
 mount_detail(
     router, USER_SPEC, handler=handle_get_user_detail,
-    extra_repo_deps=(get_provider_repository,),
     singleton_alias=("me", current_active_user),
 )
 # Mounts BOTH GET /users/{user_id} AND GET /users/me; same handler with
@@ -210,7 +208,6 @@ mount_related_list(
     router, parent_spec=USER_SPEC, child_spec=PROVIDER_SPEC,
     handler=handle_list_user_providers,
     template="users/providers_list.html",
-    extra_repo_deps=(get_user_repository,),
     singleton_alias=("me", current_active_user),
 )
 # Mounts /users/{user_id}/providers AND /users/me/providers.

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -35,12 +35,14 @@ others. See the per-mount docstrings for the exact handler kwargs each
 expects.
 """
 
+import inspect
+import types
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Union, get_args, get_origin
 from uuid import UUID
 
 from fastapi import Depends, Query, Request, status
-from pydantic import TypeAdapter
+from pydantic import BaseModel, TypeAdapter
 
 from src.api.common.forms import parse_and_validate_form, parse_and_validate_json
 from src.api.common.responses import (
@@ -50,6 +52,7 @@ from src.api.common.responses import (
     updated_response,
 )
 from src.logic.audit import AuditedResource
+from src.repositories.dependencies import UnknownRepoTypeError, resolver_for
 
 _UNSET = object()
 
@@ -122,11 +125,10 @@ class ResourceSpec:
         read mounts. Polymorphic resources (e.g. posts kind-dispatch)
         may return ``template_name`` in the handler's context dict to
         override these per-request.
-      (Per-mount ``extra_repo_deps`` kwargs let an individual mount
-        inject additional repos beyond ``repo_dep`` for handlers that
-        need them — e.g. ``handle_get_user_detail`` takes the provider
-        repo. They're per-mount, not per-spec, because different mounts
-        on the same spec may need different extras.)
+      (Additional repos beyond ``repo_dep`` are not declared on the
+        spec — handlers spell each one out as a typed parameter and
+        the mount layer resolves it via the type→resolver registry in
+        ``src.repositories.dependencies``.)
       create_redirect / update_redirect / delete_redirect: callables
         receiving the path params + (for create/update) the resource id,
         returning the ``HX-Redirect`` URL. ``None`` means use a sensible
@@ -194,26 +196,19 @@ def mount_delete(
     router: Any,
     spec: ResourceSpec,
     handler: Callable[..., Awaitable[None]],
-    *,
-    audit_repo_dep: Callable[..., Any],
 ) -> None:
     """Mount ``DELETE /<collection>/{<id_param>}`` on ``router``.
 
-    The handler is invoked with the resource id (under ``spec.id_param``),
-    ``repo`` (from ``spec.repo_dep``), ``audit_repo`` (from
-    ``audit_repo_dep``), and ``requesting_user`` (from
-    ``spec.write_user_dep``). The handler is expected to use
-    ``mutate(verb="delete")`` so the audit row is written and the
-    transaction commits inside the same scope.
+    The handler's typed signature drives dep wiring: parameters named
+    `repo`, `audit_repo`, `requesting_user`, and the resource id (under
+    ``spec.id_param``, plus any parent ids for sub-resources) are bound
+    automatically. The handler is expected to use ``mutate(verb="delete")``
+    so the audit row is written and the transaction commits inside the
+    same scope.
 
     Response is ``204 No Content`` with ``HX-Redirect`` set by
     ``spec.delete_redirect(**path_params)`` if provided, else
     ``f"/{spec.collection}"``.
-
-    `audit_repo_dep` is passed in rather than read from the spec because
-    the audit repo dependency is a layer-wide concern, not a per-resource
-    knob — every mounted mutation uses the same one. Callers import it
-    once and reuse it across all `mount_*` calls.
 
     Sub-resources nest via ``spec.parent``. The router's prefix is the
     topmost ancestor's collection; the mount produces a path like
@@ -229,36 +224,32 @@ def mount_delete(
         )
 
     path = _path_segments_under_router(spec, with_id=True)
-    parent_path_params = _parent_path_param_pairs(spec)
+    parent_id_names = tuple(p[0] for p in _parent_path_param_pairs(spec))
     id_param = spec.id_param
     delete_redirect = spec.delete_redirect
     default_redirect = f"/{spec.collection}"
 
-    async def _delete(**kwargs: Any) -> Any:
-        path_kwargs = _kwargs_for_handler_path(spec, kwargs, with_id=True)
-        await _resolve_handler(handler)(
-            **path_kwargs,
-            repo=kwargs["repo"],
-            audit_repo=kwargs["audit_repo"],
-            requesting_user=kwargs["requesting_user"],
-        )
+    async def response_builder(*, handler, handler_kwarg_names, kwargs):
+        await _call_handler_with(handler, handler_kwarg_names, kwargs)
+        path_kwargs = {name: kwargs[name] for name in (*parent_id_names, id_param)}
         if delete_redirect is not None:
             hx_redirect = delete_redirect(**path_kwargs)
         else:
             hx_redirect = default_redirect
         return deleted_response(hx_redirect=hx_redirect)
 
-    _set_route_signature(
-        _delete,
-        path_params=(*parent_path_params, (id_param, UUID)),
-        deps=(
-            ("repo", spec.repo_dep),
-            ("audit_repo", audit_repo_dep),
-            ("requesting_user", spec.write_user_dep),
+    route_fn = _synthesize_route_fn(
+        handler=handler,
+        spec=spec,
+        options=_SynthOptions(
+            user_dep=spec.write_user_dep,
+            path_param_names=(*parent_id_names, id_param),
+            inject_request=False,
         ),
+        response_builder=response_builder,
     )
 
-    router.delete(path, status_code=status.HTTP_204_NO_CONTENT)(_delete)
+    router.delete(path, status_code=status.HTTP_204_NO_CONTENT)(route_fn)
 
 
 def mount_list(
@@ -266,17 +257,17 @@ def mount_list(
     spec: ResourceSpec,
     handler: Callable[..., Awaitable[dict]],
     *,
-    extra_repo_deps: tuple[Callable[..., Any], ...] = (),
     query_params: tuple[QueryParam, ...] = (),
     public: bool = False,
 ) -> None:
     """Mount ``GET /<collection>`` rendering ``spec.list_template``.
 
-    The handler is invoked with ``request``, ``repo`` (from
-    ``spec.repo_dep``), ``requesting_user`` (from ``spec.read_user_dep``,
-    or ``None`` if no auth gate is set), each ``query_params`` entry
-    under its declared name, and any ``extra_repo_deps`` under their dep
-    callable's name (``get_<entity>_repository`` → ``<entity>_repo``).
+    The handler's typed signature drives dep wiring: parameters named
+    `repo`, `requesting_user`, and any additional repo-typed params
+    (resolved via the type registry in
+    ``src.repositories.dependencies``) are bound automatically. Each
+    ``query_params`` entry is added to the route as a FastAPI
+    ``Query(...)`` and passed to the handler under its declared name.
     The handler returns a context dict; the mount renders
     ``spec.list_template`` with it.
 
@@ -286,17 +277,15 @@ def mount_list(
     becomes a FastAPI ``Query(...)`` parameter on the route, with full
     OpenAPI doc support and 422-on-invalid validation.
 
-    ``extra_repo_deps`` is per-mount for the same reason — different
-    mounts on the same resource often need different extras.
-
     Polymorphic resources can override the template by returning
     ``template_name`` in the context (the same precedence
     ``mount_form`` uses).
 
     ``public=True`` overrides ``spec.read_user_dep`` for this mount only —
     used when a resource's list is public but its detail/form pages are
-    authenticated (e.g. providers). The handler still receives
-    ``requesting_user=None`` so it can branch if needed.
+    authenticated (e.g. providers). The handler should declare
+    ``requesting_user: User | None`` so the synthesis can pass ``None``
+    for anonymous viewers.
     """
     if spec.parent is not None:
         raise NotImplementedError(
@@ -308,19 +297,10 @@ def mount_list(
             f"mount_list requires {spec.collection!r} to set list_template."
         )
     list_template = spec.list_template
-    extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
-    query_param_names = tuple(qp.name for qp in query_params)
 
-    async def _list(**kwargs: Any) -> Any:
+    async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
-        context = await _resolve_handler(handler)(
-            request=request,
-            repo=kwargs["repo"],
-            requesting_user=kwargs.get("requesting_user"),
-            **{name: kwargs[name] for name, _ in extra_deps_named},
-            **{name: kwargs[name] for name in query_param_names},
-        )
-        # Honor handler-context override for polymorphic templates.
+        context = await _call_handler_with(handler, handler_kwarg_names, kwargs)
         resolved_template = context.pop("template_name", None) or list_template
         return APIResponse.html_response(
             template_name=resolved_template,
@@ -329,21 +309,17 @@ def mount_list(
             current_user=kwargs.get("requesting_user"),
         )
 
-    if public:
-        # Build deps without the spec's read_user_dep — handler receives
-        # `requesting_user=None`.
-        deps: list[tuple[str, Callable[..., Any]]] = [("repo", spec.repo_dep)]
-        deps.extend(extra_deps_named)
-        list_deps = tuple(deps)
-    else:
-        list_deps = _read_route_deps(spec, extra_deps_named)
-    _set_route_signature(
-        _list,
-        path_params=(("request", Request),),
-        query_params=query_params,
-        deps=list_deps,
+    user_dep = None if public else spec.read_user_dep
+    route_fn = _synthesize_route_fn(
+        handler=handler,
+        spec=spec,
+        options=_SynthOptions(
+            user_dep=user_dep,
+            query_params=query_params,
+        ),
+        response_builder=response_builder,
     )
-    router.get("")(_list)
+    router.get("")(route_fn)
 
 
 def mount_detail(
@@ -351,19 +327,21 @@ def mount_detail(
     spec: ResourceSpec,
     handler: Callable[..., Awaitable[dict]],
     *,
-    extra_repo_deps: tuple[Callable[..., Any], ...] = (),
     singleton_alias: tuple[str, Callable[..., Any]] | None = None,
 ) -> None:
     """Mount ``GET /<collection>/{<id_param>}`` rendering ``spec.detail_template``.
 
-    The handler is invoked with ``request``, the resource id under
-    ``spec.id_param``, ``repo``, ``requesting_user``, and any
-    ``extra_repo_deps`` under their derived kwarg name. Returns a
-    context dict; the mount renders ``spec.detail_template`` with it.
+    The handler's typed signature drives dep wiring: ``request``, the
+    resource id under ``spec.id_param``, ``repo``, ``requesting_user``,
+    and any extra repos (resolved via the type registry in
+    ``src.repositories.dependencies``) are bound automatically. The
+    handler returns a context dict; the mount renders
+    ``spec.detail_template`` with it.
 
     The multi-repo case (e.g. ``handle_get_user_detail`` takes both a
-    user repo and a provider repo) is the canonical reason
-    ``extra_repo_deps`` exists.
+    user repo and a provider repo) just requires the handler to declare
+    each repo as a typed param — the synthesis finds the resolver in
+    the registry.
 
     ``singleton_alias=("me", current_active_user)`` additionally mounts
     ``GET /<collection>/<alias>`` (e.g. ``/users/me``). The id is sourced
@@ -373,7 +351,7 @@ def mount_detail(
     """
     if spec.parent is not None:
         raise NotImplementedError(
-            "mount_detail with spec.parent is not supported yet " "(slice 8 / #253)."
+            "mount_detail with spec.parent is not supported yet (slice 8 / #253)."
         )
     if spec.detail_template is None:
         raise ValueError(
@@ -381,18 +359,10 @@ def mount_detail(
         )
     id_param = spec.id_param
     detail_template = spec.detail_template
-    extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
 
-    async def _detail(**kwargs: Any) -> Any:
+    async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
-        resource_id: UUID = kwargs[id_param]
-        context = await _resolve_handler(handler)(
-            request=request,
-            repo=kwargs["repo"],
-            requesting_user=kwargs.get("requesting_user"),
-            **{id_param: resource_id},
-            **{name: kwargs[name] for name, _ in extra_deps_named},
-        )
+        context = await _call_handler_with(handler, handler_kwarg_names, kwargs)
         return APIResponse.html_response(
             template_name=detail_template,
             context=context,
@@ -400,10 +370,14 @@ def mount_detail(
             current_user=kwargs.get("requesting_user"),
         )
 
-    _set_route_signature(
-        _detail,
-        path_params=(("request", Request), (id_param, UUID)),
-        deps=_read_route_deps(spec, extra_deps_named),
+    route_fn = _synthesize_route_fn(
+        handler=handler,
+        spec=spec,
+        options=_SynthOptions(
+            user_dep=spec.read_user_dep,
+            path_param_names=(id_param,),
+        ),
+        response_builder=response_builder,
     )
 
     if singleton_alias is not None:
@@ -412,24 +386,33 @@ def mount_detail(
         # to parse `me` as a UUID against `/users/{user_id}`.
         alias_segment, session_dep = singleton_alias
 
-        async def _detail_alias(**kwargs: Any) -> Any:
+        async def alias_response_builder(*, handler, handler_kwarg_names, kwargs):
+            # Source the resource id from the session-resolved user.
             session_user = kwargs["__session_user__"]
-            kwargs[id_param] = session_user.id
-            kwargs["requesting_user"] = session_user
-            return await _detail(**kwargs)
+            kwargs = {
+                **kwargs,
+                id_param: session_user.id,
+                "requesting_user": session_user,
+            }
+            return await response_builder(
+                handler=handler, handler_kwarg_names=handler_kwarg_names, kwargs=kwargs
+            )
 
-        _set_route_signature(
-            _detail_alias,
-            path_params=(("request", Request),),
-            deps=(
-                ("repo", spec.repo_dep),
-                ("__session_user__", session_dep),
-                *extra_deps_named,
+        alias_route_fn = _synthesize_route_fn(
+            handler=handler,
+            spec=spec,
+            options=_SynthOptions(
+                user_dep=None,  # session_dep supplies the user; don't double-inject
+                # Tell synthesis that `id_param` and `requesting_user` come
+                # from the wrapper, not from the URL or auth dep.
+                handler_supplied_names=(id_param, "requesting_user"),
+                extra_static_deps=(("__session_user__", session_dep),),
             ),
+            response_builder=alias_response_builder,
         )
-        router.get(f"/{alias_segment}")(_detail_alias)
+        router.get(f"/{alias_segment}")(alias_route_fn)
 
-    router.get(f"/{{{id_param}}}")(_detail)
+    router.get(f"/{{{id_param}}}")(route_fn)
 
 
 def mount_form(
@@ -439,7 +422,6 @@ def mount_form(
     *,
     template: str | None = None,
     on_existing: bool = False,
-    extra_repo_deps: tuple[Callable[..., Any], ...] = (),
     query_params: tuple[QueryParam, ...] = (),
 ) -> None:
     """Mount a form-rendering route.
@@ -460,39 +442,21 @@ def mount_form(
     Handler kwargs: ``request``, ``repo``, ``requesting_user``, the
     resource id under ``spec.id_param`` (only when ``on_existing=True``),
     each ``query_params`` entry under its declared name, and any
-    ``extra_repo_deps``. Pure create-form handlers that don't use the
-    repo still have to accept ``repo=`` (just ignore it) — uniform
-    mount-handler contract beats a special case.
+    typed repos the handler declares (resolved via the registry).
     """
     if spec.parent is not None:
         raise NotImplementedError(
             "mount_form with spec.parent is not supported yet (slice 8 / #253)."
         )
     id_param = spec.id_param
-    extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
     spec_template = spec.form_template
-    query_param_names = tuple(qp.name for qp in query_params)
 
-    if on_existing:
-        path = f"/{{{id_param}}}/form"
-        path_params = (("request", Request), (id_param, UUID))
-    else:
-        path = "/form"
-        path_params = (("request", Request),)
+    path = f"/{{{id_param}}}/form" if on_existing else "/form"
+    path_param_names = (id_param,) if on_existing else ()
 
-    async def _form(**kwargs: Any) -> Any:
+    async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
-        handler_kwargs: dict[str, Any] = {
-            "request": request,
-            "repo": kwargs["repo"],
-            "requesting_user": kwargs.get("requesting_user"),
-            **{name: kwargs[name] for name, _ in extra_deps_named},
-            **{name: kwargs[name] for name in query_param_names},
-        }
-        if on_existing:
-            handler_kwargs[id_param] = kwargs[id_param]
-
-        context = await _resolve_handler(handler)(**handler_kwargs)
+        context = await _call_handler_with(handler, handler_kwarg_names, kwargs)
         # Resolve template: handler context > per-mount kwarg > spec field.
         # `pop` so the template name doesn't leak into the rendered context.
         resolved_template = (
@@ -512,29 +476,32 @@ def mount_form(
             current_user=kwargs.get("requesting_user"),
         )
 
-    _set_route_signature(
-        _form,
-        path_params=path_params,
-        query_params=query_params,
-        deps=_read_route_deps(spec, extra_deps_named),
+    route_fn = _synthesize_route_fn(
+        handler=handler,
+        spec=spec,
+        options=_SynthOptions(
+            user_dep=spec.read_user_dep,
+            query_params=query_params,
+            path_param_names=path_param_names,
+        ),
+        response_builder=response_builder,
     )
-    router.get(path)(_form)
+    router.get(path)(route_fn)
 
 
 def mount_create(
     router: Any,
     spec: ResourceSpec,
     handler: Callable[..., Awaitable[Any]],
-    *,
-    audit_repo_dep: Callable[..., Any],
 ) -> None:
     """Mount ``POST /<collection>``.
 
     Parses a form-encoded body via ``spec.create_adapter`` (a Pydantic
-    ``TypeAdapter``) and calls the handler with ``payload=``, ``repo=``,
-    ``audit_repo=``, ``requesting_user=``. The handler is expected to use
-    ``mutate(verb="create")`` so the audit row + commit are owned by the
-    context manager.
+    ``TypeAdapter``) and calls the handler with ``payload=``, plus any
+    typed deps the handler declares (``repo``, ``audit_repo``,
+    ``requesting_user``, any extra repos via the registry). The handler
+    is expected to use ``mutate(verb="create")`` so the audit row +
+    commit are owned by the context manager.
 
     Response is ``201 Created`` with ``Location`` and ``HX-Redirect`` set.
     Defaults: ``Location: /<collection>/<new_id>``, ``HX-Redirect`` =
@@ -560,19 +527,13 @@ def mount_create(
     create_redirect = spec.create_redirect
 
     path = _path_segments_under_router(spec, with_id=False)
-    parent_path_params = _parent_path_param_pairs(spec)
+    parent_id_names = tuple(p[0] for p in _parent_path_param_pairs(spec))
 
-    async def _create(**kwargs: Any) -> Any:
+    async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
-        payload = await parse_and_validate_form(request, create_adapter)
-        path_kwargs = _kwargs_for_handler_path(spec, kwargs, with_id=False)
-        created = await _resolve_handler(handler)(
-            **path_kwargs,
-            payload=payload,
-            repo=kwargs["repo"],
-            audit_repo=kwargs["audit_repo"],
-            requesting_user=kwargs["requesting_user"],
-        )
+        kwargs["payload"] = await parse_and_validate_form(request, create_adapter)
+        created = await _call_handler_with(handler, handler_kwarg_names, kwargs)
+        path_kwargs = {name: kwargs[name] for name in parent_id_names}
         # Default Location is the canonical resource URL — for a top-level
         # resource that's /<collection>/{id}; for a sub-resource we point
         # at the parent because the spec doesn't have a "list children"
@@ -583,10 +544,6 @@ def mount_create(
         else:
             top = _walk_parent_chain(spec)[0]
             top_id = path_kwargs[top.id_param]
-            # Conservative: redirect to the parent detail page. If a
-            # resource needs a different canonical URL it should set
-            # create_redirect explicitly (which sets the HX-Redirect; the
-            # Location header still points at the parent).
             location = f"/{top.collection}/{top_id}"
         if create_redirect is not None:
             hx = create_redirect(**path_kwargs, **{id_param: created.id})
@@ -594,30 +551,29 @@ def mount_create(
             hx = location
         return created_response(id=created.id, location=location, hx_redirect=hx)
 
-    _set_route_signature(
-        _create,
-        path_params=(("request", Request), *parent_path_params),
-        deps=(
-            ("repo", spec.repo_dep),
-            ("audit_repo", audit_repo_dep),
-            ("requesting_user", spec.write_user_dep),
+    route_fn = _synthesize_route_fn(
+        handler=handler,
+        spec=spec,
+        options=_SynthOptions(
+            user_dep=spec.write_user_dep,
+            body_adapter=create_adapter,
+            path_param_names=parent_id_names,
         ),
+        response_builder=response_builder,
     )
-    router.post(path, status_code=status.HTTP_201_CREATED)(_create)
+    router.post(path, status_code=status.HTTP_201_CREATED)(route_fn)
 
 
 def mount_update(
     router: Any,
     spec: ResourceSpec,
     handler: Callable[..., Awaitable[Any]],
-    *,
-    audit_repo_dep: Callable[..., Any],
 ) -> None:
     """Mount ``PATCH /<collection>/{<id_param>}``.
 
     Parses a form-encoded body via ``spec.update_adapter`` and calls the
     handler with the resource id (under ``spec.id_param``), ``payload=``,
-    ``repo=``, ``audit_repo=``, ``requesting_user=``. Handler uses
+    and any typed deps the handler declares. Handler uses
     ``mutate(verb="update")``.
 
     Response is ``200 OK`` with body = ``spec.read_to_dict(updated)`` (if
@@ -644,19 +600,13 @@ def mount_update(
     read_to_dict = spec.read_to_dict
 
     path = _path_segments_under_router(spec, with_id=True)
-    parent_path_params = _parent_path_param_pairs(spec)
+    parent_id_names = tuple(p[0] for p in _parent_path_param_pairs(spec))
 
-    async def _update(**kwargs: Any) -> Any:
+    async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
-        payload = await parse_and_validate_form(request, update_adapter)
-        path_kwargs = _kwargs_for_handler_path(spec, kwargs, with_id=True)
-        updated = await _resolve_handler(handler)(
-            **path_kwargs,
-            payload=payload,
-            repo=kwargs["repo"],
-            audit_repo=kwargs["audit_repo"],
-            requesting_user=kwargs["requesting_user"],
-        )
+        kwargs["payload"] = await parse_and_validate_form(request, update_adapter)
+        updated = await _call_handler_with(handler, handler_kwarg_names, kwargs)
+        path_kwargs = {name: kwargs[name] for name in (*parent_id_names, id_param)}
         body = read_to_dict(updated) if read_to_dict else None
         if update_redirect is not None:
             hx = update_redirect(**path_kwargs)
@@ -664,16 +614,17 @@ def mount_update(
             hx = f"/{collection}/{updated.id}"
         return updated_response(body=body, hx_redirect=hx)
 
-    _set_route_signature(
-        _update,
-        path_params=(("request", Request), *parent_path_params, (id_param, UUID)),
-        deps=(
-            ("repo", spec.repo_dep),
-            ("audit_repo", audit_repo_dep),
-            ("requesting_user", spec.write_user_dep),
+    route_fn = _synthesize_route_fn(
+        handler=handler,
+        spec=spec,
+        options=_SynthOptions(
+            user_dep=spec.write_user_dep,
+            body_adapter=update_adapter,
+            path_param_names=(*parent_id_names, id_param),
         ),
+        response_builder=response_builder,
     )
-    router.patch(path)(_update)
+    router.patch(path)(route_fn)
 
 
 def mount_state_axis(
@@ -683,7 +634,6 @@ def mount_state_axis(
     *,
     axis_name: str,
     body_schema: type,
-    audit_repo_dep: Callable[..., Any],
     response_to_dict: Callable[[Any], dict] | None = None,
 ) -> None:
     """Mount ``PUT /<collection>/{<id_param>}/<axis_name>``.
@@ -733,30 +683,25 @@ def mount_state_axis(
     body_adapter = TypeAdapter(body_schema)
     path = f"/{{{id_param}}}/{axis_name}"
 
-    async def _state_axis(**kwargs: Any) -> Any:
+    async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
-        payload = await parse_and_validate_json(request, body_adapter)
-        resource_id: UUID = kwargs[id_param]
-        updated = await _resolve_handler(handler)(
-            **{id_param: resource_id},
-            payload=payload,
-            repo=kwargs["repo"],
-            audit_repo=kwargs["audit_repo"],
-            requesting_user=kwargs["requesting_user"],
-        )
+        kwargs["payload"] = await parse_and_validate_json(request, body_adapter)
+        updated = await _call_handler_with(handler, handler_kwarg_names, kwargs)
         body = response_to_dict(updated) if response_to_dict else None
         return updated_response(body=body, hx_refresh=True)
 
-    _set_route_signature(
-        _state_axis,
-        path_params=(("request", Request), (id_param, UUID)),
-        deps=(
-            ("repo", spec.repo_dep),
-            ("audit_repo", audit_repo_dep),
-            ("requesting_user", spec.write_user_dep),
+    route_fn = _synthesize_route_fn(
+        handler=handler,
+        spec=spec,
+        options=_SynthOptions(
+            user_dep=spec.write_user_dep,
+            body_adapter=body_adapter,
+            body_format="json",
+            path_param_names=(id_param,),
         ),
+        response_builder=response_builder,
     )
-    router.put(path)(_state_axis)
+    router.put(path)(route_fn)
 
 
 def mount_related_list(
@@ -766,7 +711,6 @@ def mount_related_list(
     handler: Callable[..., Awaitable[dict]],
     *,
     template: str,
-    extra_repo_deps: tuple[Callable[..., Any], ...] = (),
     singleton_alias: tuple[str, Callable[..., Any]] | None = None,
 ) -> None:
     """Mount ``GET /<parent.collection>/{<parent.id_param>}/<child.collection>``.
@@ -775,10 +719,11 @@ def mount_related_list(
     ``GET /users/{user_id}/providers`` lists the providers owned by a user.
 
     Handler kwargs: ``request``, the parent id under
-    ``parent_spec.id_param`` (e.g. ``user_id=...``), ``repo`` (the *child's*
-    repo, since the handler returns children), ``requesting_user``, and any
-    ``extra_repo_deps`` under their derived kwarg name. Returns a context
-    dict; the mount renders ``template``.
+    ``parent_spec.id_param`` (e.g. ``user_id=...``), ``repo`` (the
+    *child's* repo, since the handler returns children),
+    ``requesting_user``, and any typed repos the handler declares
+    (resolved via the type registry). Returns a context dict; the
+    mount renders ``template``.
 
     ``template`` is a per-mount kwarg (not on the spec) because related-list
     templates often live in the parent's namespace
@@ -803,19 +748,11 @@ def mount_related_list(
             "the parent's namespace."
         )
     parent_id_param = parent_spec.id_param
-    extra_deps_named = _name_extra_repo_deps(extra_repo_deps)
     path = f"/{{{parent_id_param}}}/{child_spec.collection}"
 
-    async def _related_list(**kwargs: Any) -> Any:
+    async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
-        parent_id: UUID = kwargs[parent_id_param]
-        context = await _resolve_handler(handler)(
-            request=request,
-            **{parent_id_param: parent_id},
-            repo=kwargs["repo"],
-            requesting_user=kwargs.get("requesting_user"),
-            **{name: kwargs[name] for name, _ in extra_deps_named},
-        )
+        context = await _call_handler_with(handler, handler_kwarg_names, kwargs)
         return APIResponse.html_response(
             template_name=template,
             context=context,
@@ -823,43 +760,47 @@ def mount_related_list(
             current_user=kwargs.get("requesting_user"),
         )
 
-    deps: list[tuple[str, Callable[..., Any]]] = [("repo", child_spec.repo_dep)]
-    if parent_spec.read_user_dep is not None:
-        deps.append(("requesting_user", parent_spec.read_user_dep))
-    deps.extend(extra_deps_named)
-
-    _set_route_signature(
-        _related_list,
-        path_params=(("request", Request), (parent_id_param, UUID)),
-        deps=tuple(deps),
+    # The route renders children, so the synthesis hands the handler the
+    # *child's* repo under `repo`. The parent-id path param is bound by
+    # name from the URL. Auth follows the *parent's* read user dep.
+    route_fn = _synthesize_route_fn(
+        handler=handler,
+        spec=child_spec,
+        options=_SynthOptions(
+            user_dep=parent_spec.read_user_dep,
+            path_param_names=(parent_id_param,),
+        ),
+        response_builder=response_builder,
     )
 
     if singleton_alias is not None:
-        # Register the literal alias path BEFORE the parametric path so
-        # FastAPI matches `/users/me/providers` against the alias instead
-        # of trying to parse `me` as a UUID.
         alias_segment, session_dep = singleton_alias
         alias_path = f"/{alias_segment}/{child_spec.collection}"
 
-        async def _related_list_alias(**kwargs: Any) -> Any:
+        async def alias_response_builder(*, handler, handler_kwarg_names, kwargs):
             session_user = kwargs["__session_user__"]
-            kwargs[parent_id_param] = session_user.id
-            kwargs["requesting_user"] = session_user
-            return await _related_list(**kwargs)
+            kwargs = {
+                **kwargs,
+                parent_id_param: session_user.id,
+                "requesting_user": session_user,
+            }
+            return await response_builder(
+                handler=handler, handler_kwarg_names=handler_kwarg_names, kwargs=kwargs
+            )
 
-        alias_deps: list[tuple[str, Callable[..., Any]]] = [
-            ("repo", child_spec.repo_dep),
-            ("__session_user__", session_dep),
-        ]
-        alias_deps.extend(extra_deps_named)
-        _set_route_signature(
-            _related_list_alias,
-            path_params=(("request", Request),),
-            deps=tuple(alias_deps),
+        alias_route_fn = _synthesize_route_fn(
+            handler=handler,
+            spec=child_spec,
+            options=_SynthOptions(
+                user_dep=None,
+                handler_supplied_names=(parent_id_param, "requesting_user"),
+                extra_static_deps=(("__session_user__", session_dep),),
+            ),
+            response_builder=alias_response_builder,
         )
-        router.get(alias_path)(_related_list_alias)
+        router.get(alias_path)(alias_route_fn)
 
-    router.get(path)(_related_list)
+    router.get(path)(route_fn)
 
 
 def _walk_parent_chain(spec: ResourceSpec) -> list[ResourceSpec]:
@@ -918,20 +859,6 @@ def _parent_path_param_pairs(spec: ResourceSpec) -> tuple[tuple[str, type], ...]
     return tuple(out)
 
 
-def _kwargs_for_handler_path(
-    spec: ResourceSpec, kwargs: dict[str, Any], *, with_id: bool
-) -> dict[str, Any]:
-    """Pluck the parent ids (and the spec's own id if ``with_id``) out of
-    the route's kwargs into a fresh dict suitable for splatting into a
-    handler call as ``**path_kwargs``."""
-    out: dict[str, Any] = {}
-    for name, _ in _parent_path_param_pairs(spec):
-        out[name] = kwargs[name]
-    if with_id:
-        out[spec.id_param] = kwargs[spec.id_param]
-    return out
-
-
 def _resolve_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Look up a handler in its home module at call time so test
     monkey-patches applied via ``setattr(<module>, "<name>", mock)`` take
@@ -953,103 +880,317 @@ def _resolve_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
     return getattr(mod, fn_name, fn)
 
 
-def _name_extra_repo_deps(
-    deps: tuple[Callable[..., Any], ...],
-) -> tuple[tuple[str, Callable[..., Any]], ...]:
-    """Derive the kwarg name each extra repo dep is passed under.
+# --- Signature synthesis -------------------------------------------------
+#
+# `_synthesize_route_fn` introspects each handler's typed signature and
+# pairs every parameter with the right source (path / Depends / Query /
+# body parser). The handler's signature becomes the single source of
+# truth: forgetting to wire a dep is a registration-time `MountError`,
+# not a first-request crash.
+#
+# Each mount supplies the response shape via `response_builder`. The
+# synthesis helper handles the boring middle: introspection, signature
+# construction, kwarg routing.
 
-    Convention: ``get_provider_repository`` → ``provider_repo``,
-    ``get_audit_repository`` → ``audit_repo``. Strips the ``get_`` prefix
-    and the ``ository`` suffix on ``_repository``. If a dep has a name
-    that doesn't match the convention, raise — silent name-mismatches
-    would be a bug at the kwarg-injection site.
+
+class MountError(TypeError):
+    """Raised at mount-registration time when the handler signature is
+    incompatible with what the mount can supply. The error names the
+    handler, the offending parameter, and (where applicable) the type
+    that lacks a registry entry. App startup fails immediately rather
+    than the first request 500-ing."""
+
+
+def _is_optional(annotation: Any) -> tuple[bool, Any]:
+    """If `annotation` is `T | None` / `Optional[T]`, return `(True, T)`;
+    otherwise `(False, annotation)`. Handles both the 3.10+ pipe syntax
+    (`types.UnionType`) and `typing.Union[..., None]`."""
+    origin = get_origin(annotation)
+    if origin in (Union, types.UnionType):
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        if len(args) == 1 and type(None) in get_args(annotation):
+            return True, args[0]
+    return False, annotation
+
+
+def _is_pydantic_model(annotation: Any) -> bool:
+    return isinstance(annotation, type) and issubclass(annotation, BaseModel)
+
+
+@dataclass(frozen=True)
+class _SynthOptions:
+    """Per-mount configuration the synthesis helper needs beyond the
+    handler signature.
+
+    - `user_dep` resolves `requesting_user`. `None` means the route is
+      public (the spec's read user dep was bypassed, e.g. `public=True`
+      on `mount_list`).
+    - `body_adapter` parses `payload` from the request body when the
+      handler takes a `payload` param. `body_format` picks form-encoded
+      vs JSON parsing.
+    - `query_params` are declarative query params the mount injects.
+    - `path_param_names` lists every URL path param the route binds
+      (the resource id + any parent ids for sub-resources).
+    - `handler_supplied_names` lists handler kwargs that the response
+      builder will populate itself before calling the handler (used by
+      `singleton_alias` routes that derive the resource id and the
+      `requesting_user` from a session dep instead of the URL/auth).
+      The synthesis skips these from the FastAPI signature entirely;
+      the response builder must fill them via `kwargs[name] = ...`
+      before delegating.
+    - `extra_static_deps` are additional `Depends(...)` bindings the
+      synthesis can't derive from the handler signature (e.g.
+      `__session_user__` for alias routes). Keyed by the kwarg name the
+      route fn receives; mount-supplied callables consume them inside
+      `response_builder`.
+    - `inject_request` adds a `request: Request` to the route fn even
+      if the handler doesn't take one — needed when the response builder
+      reads the request (template rendering uses it for chrome).
     """
-    out: list[tuple[str, Callable[..., Any]]] = []
-    for dep in deps:
-        name = getattr(dep, "__name__", None)
-        if not name or not name.startswith("get_"):
-            raise ValueError(
-                f"extra_repo_deps callable {dep!r} must be named "
-                "'get_<entity>_repository' so the kwarg can be derived."
-            )
-        bare = name[len("get_") :]
-        if bare.endswith("_repository"):
-            kwarg = bare[: -len("_repository")] + "_repo"
-        else:
-            kwarg = bare
-        out.append((kwarg, dep))
-    return tuple(out)
+
+    user_dep: Callable[..., Any] | None
+    body_adapter: TypeAdapter | None = None
+    body_format: str = "form"  # "form" or "json"
+    query_params: tuple[QueryParam, ...] = ()
+    path_param_names: tuple[str, ...] = ()
+    handler_supplied_names: tuple[str, ...] = ()
+    extra_static_deps: tuple[tuple[str, Callable[..., Any]], ...] = ()
+    inject_request: bool = True
 
 
-def _read_route_deps(
-    spec: ResourceSpec,
-    extra_deps_named: tuple[tuple[str, Callable[..., Any]], ...],
-) -> tuple[tuple[str, Callable[..., Any]], ...]:
-    """Build the (kwarg, callable) pairs for the dep-injected params on a
-    read route. Includes the primary repo, optional read user dep, and
-    each extra repo. ``read_user_dep=None`` means public — the route is
-    mounted without a user dep, and the handler receives
-    ``requesting_user=None``."""
-    deps: list[tuple[str, Callable[..., Any]]] = [("repo", spec.repo_dep)]
-    if spec.read_user_dep is not None:
-        deps.append(("requesting_user", spec.read_user_dep))
-    deps.extend(extra_deps_named)
-    return tuple(deps)
-
-
-def _set_route_signature(
-    fn: Callable[..., Any],
+def _synthesize_route_fn(
     *,
-    path_params: tuple[tuple[str, type], ...],
-    deps: tuple[tuple[str, Callable[..., Any]], ...],
-    query_params: tuple[QueryParam, ...] = (),
-) -> None:
-    """Advertise an explicit signature on a `**kwargs`-based route handler.
+    handler: Callable[..., Any],
+    spec: ResourceSpec,
+    options: _SynthOptions,
+    response_builder: Callable[..., Awaitable[Any]],
+) -> Callable[..., Any]:
+    """Build a FastAPI route function from `handler`'s typed signature.
 
-    FastAPI introspects `inspect.signature(fn)` to figure out path params
-    and dependencies. The mount helpers define the actual handler with
-    `**kwargs` (so the parameter names can be data-driven from the
-    `ResourceSpec`) and call this to publish the signature FastAPI sees.
+    Walks the handler's parameters; for each one, decides whether it's
+    a path param, a body, a query param, or a `Depends`-injected value
+    (repo / user / audit_repo / extra repo via the type registry).
+    Builds a wrapper whose `__signature__` is what FastAPI sees;
+    delegates response shaping to `response_builder`.
 
-    `path_params` are positional-or-keyword params with a type annotation
-    and no default — FastAPI binds them from the URL.
-    `query_params` (optional) are positional-or-keyword params whose
-    default is `Query(...)` — FastAPI parses them from the query string,
-    validates against the annotation, and 422s on invalid input.
-    `deps` are positional-or-keyword params whose default is `Depends(...)`
-    — FastAPI resolves them via the injection system.
+    `response_builder` receives the FULL kwarg dict the wrapper resolves
+    (handler kwargs + `request` + any `extra_static_deps`) so each mount
+    can pick what it needs to build the response. It is responsible for
+    calling the handler (via `_resolve_handler`) and returning the
+    Response.
+
+    Raises `MountError` at registration time if the handler signature
+    has a parameter the synthesis can't classify.
     """
-    from inspect import Parameter, Signature
+    handler_sig = inspect.signature(handler)
+    path_set = set(options.path_param_names)
+    handler_supplied_set = set(options.handler_supplied_names)
+    query_names = {qp.name for qp in options.query_params}
+    qp_by_name = {qp.name: qp for qp in options.query_params}
 
-    params: list[Parameter] = []
-    for name, ann in path_params:
-        params.append(
-            Parameter(
-                name=name,
-                kind=Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=ann,
+    # Names we'll route through to the handler when it's called.
+    handler_kwarg_names: list[str] = []
+    # Handler kwargs that the synthesis fills with `None` itself (public
+    # route + `User | None` requesting_user). The route wrapper merges
+    # these into kwargs before calling the handler so the param is
+    # present in the call.
+    auto_none_handler_kwargs: list[str] = []
+    # FastAPI-visible parameter list for the synthesized signature.
+    synth_params: list[inspect.Parameter] = []
+
+    # Always inject `request` into the wrapper signature if requested,
+    # even when the handler doesn't take one — `response_builder` may
+    # still need it for template rendering.
+    request_in_handler = "request" in handler_sig.parameters
+    if options.inject_request or request_in_handler:
+        synth_params.append(
+            inspect.Parameter(
+                name="request",
+                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Request,
             )
         )
-    for qp in query_params:
-        if qp.default is _UNSET:
-            default = Query(..., description=qp.description or None)
-        else:
-            default = Query(qp.default, description=qp.description or None)
-        params.append(
-            Parameter(
-                name=qp.name,
-                kind=Parameter.POSITIONAL_OR_KEYWORD,
-                default=default,
-                annotation=qp.annotation,
+        if request_in_handler:
+            handler_kwarg_names.append("request")
+
+    for param_name, param in handler_sig.parameters.items():
+        if param_name == "request":
+            continue  # already handled
+        # Skip *args / **kwargs — they're not part of the FastAPI-visible
+        # contract. The handler may use them for forwarding, but the
+        # synthesis only resolves named typed params.
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        annotation = param.annotation
+        is_opt, base_ann = _is_optional(annotation)
+
+        # Handler-supplied: the response builder fills this kwarg before
+        # calling the handler (e.g. alias routes derive `id_param` and
+        # `requesting_user` from a session dep). Skip the FastAPI param
+        # entirely; the handler kwarg name is recorded so the wrapper
+        # forwards it.
+        if param_name in handler_supplied_set:
+            handler_kwarg_names.append(param_name)
+            continue
+
+        # Path param? The handler asks for it by name; FastAPI binds it
+        # from the URL when the route's path string contains it.
+        if param_name in path_set:
+            synth_params.append(
+                inspect.Parameter(
+                    name=param_name,
+                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=UUID,
+                )
+            )
+            handler_kwarg_names.append(param_name)
+            continue
+
+        # Query param? Declared on the mount.
+        if param_name in query_names:
+            qp = qp_by_name[param_name]
+            default = (
+                Query(..., description=qp.description or None)
+                if qp.default is _UNSET
+                else Query(qp.default, description=qp.description or None)
+            )
+            synth_params.append(
+                inspect.Parameter(
+                    name=param_name,
+                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=qp.annotation,
+                    default=default,
+                )
+            )
+            handler_kwarg_names.append(param_name)
+            continue
+
+        # `payload`: parsed from the request body by `response_builder`.
+        # No Depends — body parsing happens inside the wrapper because
+        # form-encoded bodies need the raw request.
+        if param_name == "payload":
+            if options.body_adapter is None:
+                raise MountError(
+                    f"{handler.__qualname__} declares a `payload` parameter "
+                    "but the mount did not supply a body adapter. This is a "
+                    "mount/spec misconfiguration."
+                )
+            handler_kwarg_names.append(param_name)
+            continue
+
+        # `requesting_user`: the auth-resolved actor. `User | None`
+        # means "may be None for anonymous viewers"; require the mount
+        # to have a user dep set, OR accept None when `user_dep is None`
+        # and the annotation is Optional.
+        if param_name == "requesting_user":
+            if options.user_dep is None:
+                if not is_opt:
+                    raise MountError(
+                        f"{handler.__qualname__} declares "
+                        "`requesting_user: User` but the mount is public "
+                        "(no user dep). Either declare the param as "
+                        "`User | None` or set a user dep on the spec."
+                    )
+                # Public route with optional user: pass None directly
+                # (no Depends; no FastAPI-visible param). The wrapper
+                # fills `kwargs[param_name] = None` before delegating.
+                handler_kwarg_names.append(param_name)
+                auto_none_handler_kwargs.append(param_name)
+                continue
+            synth_params.append(
+                inspect.Parameter(
+                    name=param_name,
+                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=annotation,
+                    default=Depends(options.user_dep),
+                )
+            )
+            handler_kwarg_names.append(param_name)
+            continue
+
+        # `repo`: the spec's primary repo. Type is informational only —
+        # we don't verify it matches `spec.repo_dep`'s return type
+        # because tests intentionally use stub callables that return
+        # `SimpleNamespace`. The spec is the source of truth for which
+        # resolver to use; the annotation just documents intent.
+        if param_name == "repo":
+            synth_params.append(
+                inspect.Parameter(
+                    name=param_name,
+                    kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=annotation,
+                    default=Depends(spec.repo_dep),
+                )
+            )
+            handler_kwarg_names.append(param_name)
+            continue
+
+        # Extra repos: resolve via the type registry. Includes `audit_repo`
+        # and any per-handler additional repos (e.g. `user_favorite_repo`
+        # on the provider-detail handler).
+        if not isinstance(base_ann, type):
+            raise MountError(
+                f"{handler.__qualname__} parameter {param_name!r} has "
+                f"annotation {annotation!r} that is not a class — the "
+                "synthesis helper cannot decide how to inject it. Path "
+                "params should match the spec's id_param (or a parent's "
+                "id_param); query params must be declared in the mount's "
+                "`query_params=`."
+            )
+        try:
+            resolver = resolver_for(base_ann)
+        except UnknownRepoTypeError as exc:
+            raise MountError(
+                f"{handler.__qualname__} parameter {param_name!r}: " f"{exc}"
+            ) from None
+        synth_params.append(
+            inspect.Parameter(
+                name=param_name,
+                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=annotation,
+                default=Depends(resolver),
             )
         )
-    for name, dep in deps:
-        params.append(
-            Parameter(
+        handler_kwarg_names.append(param_name)
+
+    # Extra static deps (alias session dep, etc.) — FastAPI-visible,
+    # not passed to the handler unless the wrapper does so explicitly.
+    for name, dep in options.extra_static_deps:
+        synth_params.append(
+            inspect.Parameter(
                 name=name,
-                kind=Parameter.POSITIONAL_OR_KEYWORD,
-                default=Depends(dep),
+                kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
                 annotation=Any,
+                default=Depends(dep),
             )
         )
-    fn.__signature__ = Signature(parameters=params)  # type: ignore[attr-defined]
+
+    async def _route(**kwargs: Any) -> Any:
+        for name in auto_none_handler_kwargs:
+            kwargs.setdefault(name, None)
+        return await response_builder(
+            handler=handler,
+            handler_kwarg_names=handler_kwarg_names,
+            kwargs=kwargs,
+        )
+
+    _route.__signature__ = inspect.Signature(parameters=synth_params)  # type: ignore[attr-defined]
+    return _route
+
+
+async def _call_handler_with(
+    handler: Callable[..., Any],
+    handler_kwarg_names: list[str],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Call `handler` with the subset of `kwargs` matching the
+    introspected handler kwargs. Goes through `_resolve_handler` so
+    test monkey-patching against the handler's home module takes effect.
+    """
+    handler_kwargs = {
+        name: kwargs[name] for name in handler_kwarg_names if name in kwargs
+    }
+    return await _resolve_handler(handler)(**handler_kwargs)

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -9,18 +9,27 @@ mount functions end-to-end. Validates that:
     equivalents.
   - Misconfigurations (missing `write_user_dep`, sub-resource specs
     until slice 8) raise at mount time, not at request time.
+
+Handlers in these tests use real repository types (`UserRepository`,
+`AuditRepository`, etc.) as type annotations so the signature-synthesis
+machinery in the mount layer can resolve them via the registry in
+`src.repositories.dependencies`. The actual instances injected at call
+time come from `app.dependency_overrides` substitutions that return
+`SimpleNamespace` stubs — the test doesn't need a real DB, just to
+observe the kwargs that reach the handler.
 """
 
 from types import SimpleNamespace
-from typing import Literal
-from uuid import uuid4
+from typing import Any, Literal
+from uuid import UUID, uuid4
 
 import pytest
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 from src.api.common.resource_routes import (
+    MountError,
     QueryParam,
     ResourceSpec,
     mount_delete,
@@ -30,26 +39,114 @@ from src.api.common.resource_routes import (
     mount_related_list,
     mount_state_axis,
 )
+from src.models import User
+from src.repositories.audit_repository import AuditRepository
+from src.repositories.dependencies import get_audit_repository
+from src.repositories.users.user_repository import UserRepository
 
 
-def _build_app(spec: ResourceSpec, captured: dict) -> FastAPI:
+def _override_audit(app: FastAPI, *, stub: Any = None) -> SimpleNamespace:
+    """Substitute `get_audit_repository` with a stub returning a
+    `SimpleNamespace` so a test app can satisfy `audit_repo: AuditRepository`
+    without a real DB session. Returns the stub the resolver returns so
+    callers can identity-check it in assertions."""
+    sentinel = stub if stub is not None else SimpleNamespace(name="audit_repo")
+    app.dependency_overrides[get_audit_repository] = lambda: sentinel
+    return sentinel
+
+
+def _build_delete_app(spec: ResourceSpec, captured: dict) -> FastAPI:
     """Mount `mount_delete` for `spec` and capture every handler call into
     `captured`. Stub deps return predictable sentinels so kwargs are
     inspectable in assertions."""
+    id_param = spec.id_param
 
-    async def delete_handler(**kwargs):
-        captured.update(kwargs)
+    async def delete_handler(
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+        **path_kwargs: UUID,
+    ):
+        captured["repo"] = repo
+        captured["audit_repo"] = audit_repo
+        captured["requesting_user"] = requesting_user
+        captured.update(path_kwargs)
+
+    # The synthesis introspects the handler signature for known param
+    # names. Path params come in via `**path_kwargs` here because the
+    # tests parameterize `id_param` and we can't statically declare a
+    # name that varies; so we explicitly tell the synthesis about it via
+    # a wrapper handler whose signature names the actual param.
+    # (Production handlers spell out e.g. `user_id: UUID` directly.)
+    handler = _name_path_params(
+        delete_handler, [id_param] + [s.id_param for s in _ancestors(spec)]
+    )
 
     app = FastAPI()
-    router = APIRouter(prefix=f"/{spec.collection}")
-    mount_delete(
-        router,
-        spec,
-        handler=delete_handler,
-        audit_repo_dep=lambda: SimpleNamespace(name="audit_repo"),
+    router = APIRouter(
+        prefix=(
+            f"/{spec.collection}"
+            if spec.parent is None
+            else f"/{_topmost(spec).collection}"
+        )
     )
+    _override_audit(app)
+    mount_delete(router, spec, handler=handler)
     app.include_router(router)
     return app
+
+
+def _ancestors(spec: ResourceSpec) -> list[ResourceSpec]:
+    out: list[ResourceSpec] = []
+    s = spec.parent
+    while s is not None:
+        out.append(s)
+        s = s.parent
+    return out
+
+
+def _topmost(spec: ResourceSpec) -> ResourceSpec:
+    s = spec
+    while s.parent is not None:
+        s = s.parent
+    return s
+
+
+def _name_path_params(handler, path_names: list[str]):
+    """Wrap `handler` so it accepts `path_names` as explicit typed
+    parameters. Used by parametric tests where the path-param name is
+    derived from the spec rather than literal."""
+    import inspect as _inspect
+
+    orig_sig = _inspect.signature(handler)
+    new_params = []
+    for name in path_names:
+        new_params.append(
+            _inspect.Parameter(
+                name=name,
+                kind=_inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=UUID,
+            )
+        )
+    for p in orig_sig.parameters.values():
+        if p.kind == _inspect.Parameter.VAR_KEYWORD:
+            continue
+        new_params.append(p)
+    new_params.append(
+        _inspect.Parameter(
+            name="__path_kwargs__",
+            kind=_inspect.Parameter.VAR_KEYWORD,
+        )
+    )
+
+    async def wrapper(**kwargs):
+        path_kwargs = {n: kwargs.pop(n) for n in path_names if n in kwargs}
+        return await handler(**kwargs, **path_kwargs)
+
+    wrapper.__signature__ = _inspect.Signature(parameters=new_params)  # type: ignore[attr-defined]
+    wrapper.__name__ = handler.__name__
+    wrapper.__module__ = handler.__module__
+    return wrapper
 
 
 def test_mount_delete_returns_204_with_hx_redirect_default():
@@ -60,7 +157,7 @@ def test_mount_delete_returns_204_with_hx_redirect_default():
         write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
     )
     captured: dict = {}
-    client = TestClient(_build_app(spec, captured))
+    client = TestClient(_build_delete_app(spec, captured))
 
     widget_id = uuid4()
     resp = client.delete(f"/widgets/{widget_id}")
@@ -77,7 +174,7 @@ def test_mount_delete_passes_id_under_spec_kwarg_name():
         write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
     )
     captured: dict = {}
-    client = TestClient(_build_app(spec, captured))
+    client = TestClient(_build_delete_app(spec, captured))
 
     gadget_id = uuid4()
     resp = client.delete(f"/gadgets/{gadget_id}")
@@ -101,7 +198,7 @@ def test_mount_delete_uses_custom_redirect_callable():
         delete_redirect=custom_redirect,
     )
     captured: dict = {}
-    client = TestClient(_build_app(spec, captured))
+    client = TestClient(_build_delete_app(spec, captured))
 
     sprocket_id = uuid4()
     resp = client.delete(f"/sprockets/{sprocket_id}")
@@ -114,10 +211,7 @@ def test_mount_delete_subresource_path_includes_parent_id():
     """A child ResourceSpec with `parent=` mounts the path under the
     parent's id-param. Handler receives both ids by their declared kwarg
     names. The router prefix carries the topmost ancestor's collection."""
-    captured = {}
-
-    async def delete_handler(**kwargs):
-        captured.update(kwargs)
+    captured: dict = {}
 
     parent = ResourceSpec(
         collection="parents",
@@ -134,13 +228,21 @@ def test_mount_delete_subresource_path_includes_parent_id():
     )
 
     app = FastAPI()
-    router = APIRouter(prefix="/parents")  # topmost collection lives in prefix
-    mount_delete(
-        router,
-        child,
-        handler=delete_handler,
-        audit_repo_dep=lambda: SimpleNamespace(name="audit_repo"),
-    )
+    router = APIRouter(prefix="/parents")
+    _override_audit(app)
+
+    async def delete_handler(
+        parent_id: UUID,
+        child_id: UUID,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        captured["parent_id"] = parent_id
+        captured["child_id"] = child_id
+        captured["repo"] = repo
+
+    mount_delete(router, child, handler=delete_handler)
     app.include_router(router)
     client = TestClient(app)
 
@@ -149,8 +251,8 @@ def test_mount_delete_subresource_path_includes_parent_id():
     resp = client.delete(f"/parents/{parent_id}/children/{child_id}")
 
     assert resp.status_code == 204
-    assert str(captured["parent_id"]) == str(parent_id)
-    assert str(captured["child_id"]) == str(child_id)
+    assert captured["parent_id"] == parent_id
+    assert captured["child_id"] == child_id
     assert captured["repo"].name == "child_repo"
 
 
@@ -200,25 +302,27 @@ def test_mount_delete_requires_write_user_dep():
         # write_user_dep intentionally omitted
     )
     router = APIRouter()
+
+    async def stub(
+        widget_id: UUID,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        pass
+
     with pytest.raises(ValueError, match="write_user_dep"):
-        mount_delete(
-            router,
-            spec,
-            handler=lambda **_: None,
-            audit_repo_dep=lambda: None,
-        )
+        mount_delete(router, spec, handler=stub)
 
 
-def _build_read_app(
-    spec: ResourceSpec, list_handler, detail_handler, *, detail_extra=()
-):
-    """Mount mount_list + mount_detail and return a TestClient. Handlers
+def _build_read_app(spec: ResourceSpec, list_handler, detail_handler):
+    """Mount mount_list + mount_detail and return a FastAPI app. Handlers
     return a context dict that the templating layer can render against
     a stub template."""
     app = FastAPI()
     router = APIRouter(prefix=f"/{spec.collection}")
     mount_list(router, spec, handler=list_handler)
-    mount_detail(router, spec, handler=detail_handler, extra_repo_deps=detail_extra)
+    mount_detail(router, spec, handler=detail_handler)
     app.include_router(router)
     return app
 
@@ -226,11 +330,20 @@ def _build_read_app(
 def test_mount_list_renders_template_with_handler_context(monkeypatch):
     captured = {}
 
-    async def list_handler(**kwargs):
-        captured.update(kwargs)
+    async def list_handler(
+        request: Request,
+        repo: UserRepository,
+        requesting_user: User,
+    ):
+        captured["repo"] = repo
+        captured["requesting_user"] = requesting_user
         return {"users": ["alice", "bob"]}
 
-    async def detail_handler(**kwargs):
+    async def detail_handler(
+        widget_id: UUID,
+        repo: UserRepository,
+        requesting_user: User,
+    ):
         return {}
 
     spec = ResourceSpec(
@@ -266,20 +379,30 @@ def test_mount_list_renders_template_with_handler_context(monkeypatch):
     assert captured["repo"].name == "widget_repo"
 
 
-def test_mount_detail_injects_extra_repo_deps_under_derived_name(monkeypatch):
-    """`get_widget_repository` → `widget_repo` kwarg. Confirms the
-    derived-kwarg-name convention reaches the handler."""
-    captured = {}
+def test_mount_detail_injects_extra_typed_repo_from_registry(monkeypatch):
+    """A handler asks for a typed repo (e.g. `audit_repo: AuditRepository`),
+    and the synthesis resolves it via the registry in
+    `src.repositories.dependencies`. No `extra_repo_deps` wiring on the
+    mount call — the handler's signature IS the contract."""
+    captured: dict = {}
 
-    async def list_handler(**kwargs):
+    async def list_handler(
+        request: Request,
+        repo: UserRepository,
+        requesting_user: User,
+    ):
         return {}
 
-    async def detail_handler(**kwargs):
-        captured.update(kwargs)
-        return {"widget": kwargs.get("widget_id")}
-
-    def get_audit_repository():
-        return SimpleNamespace(name="audit_repo")
+    async def detail_handler(
+        gadget_id: UUID,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        captured["gadget_id"] = gadget_id
+        captured["repo"] = repo
+        captured["audit_repo"] = audit_repo
+        return {"widget": gadget_id}
 
     spec = ResourceSpec(
         collection="gadgets",
@@ -299,19 +422,21 @@ def test_mount_detail_injects_extra_repo_deps_under_derived_name(monkeypatch):
         ),
     )
 
-    client = TestClient(
-        _build_read_app(
-            spec, list_handler, detail_handler, detail_extra=(get_audit_repository,)
-        )
-    )
+    app = FastAPI()
+    router = APIRouter(prefix="/gadgets")
+    _override_audit(app)
+    mount_list(router, spec, handler=list_handler)
+    mount_detail(router, spec, handler=detail_handler)
+    app.include_router(router)
+    client = TestClient(app)
+
     gadget_id = uuid4()
     resp = client.get(f"/gadgets/{gadget_id}")
 
     assert resp.status_code == 200
-    assert "audit_repo" in captured  # derived from `get_audit_repository`
-    assert captured["audit_repo"].name == "audit_repo"
-    assert "gadget_id" in captured
-    assert str(captured["gadget_id"]) == str(gadget_id)
+    assert captured["audit_repo"].name == "audit_repo"  # via registry → override
+    assert captured["gadget_id"] == gadget_id
+    assert captured["repo"].name == "gadget_repo"
 
 
 def test_mount_list_requires_list_template():
@@ -323,8 +448,12 @@ def test_mount_list_requires_list_template():
         # list_template intentionally omitted
     )
     router = APIRouter()
+
+    async def stub(request: Request, repo: UserRepository, requesting_user: User):
+        return {}
+
     with pytest.raises(ValueError, match="list_template"):
-        mount_list(router, spec, handler=lambda **_: {})
+        mount_list(router, spec, handler=stub)
 
 
 def test_mount_detail_requires_detail_template():
@@ -335,25 +464,40 @@ def test_mount_detail_requires_detail_template():
         read_user_dep=lambda: None,
     )
     router = APIRouter()
+
+    async def stub(widget_id: UUID, repo: UserRepository, requesting_user: User):
+        return {}
+
     with pytest.raises(ValueError, match="detail_template"):
-        mount_detail(router, spec, handler=lambda **_: {})
+        mount_detail(router, spec, handler=stub)
 
 
-def test_extra_repo_deps_must_be_named_get_x_repository():
+def test_mount_raises_when_handler_asks_for_unregistered_repo_type():
+    """If a handler param's type is not in the registry, the mount fails
+    at registration with a clear `MountError`. Converts late 500s into
+    early startup errors."""
+
+    class _SomeUnregisteredRepo:
+        pass
+
+    async def stub(
+        widget_id: UUID,
+        repo: UserRepository,
+        weird_repo: _SomeUnregisteredRepo,
+        requesting_user: User,
+    ):
+        return {}
+
     spec = ResourceSpec(
         collection="widgets",
         id_param="widget_id",
         repo_dep=lambda: None,
         read_user_dep=lambda: None,
-        list_template="widgets/list.html",
         detail_template="widgets/detail.html",
     )
-    badly_named = lambda: None  # noqa: E731 — anonymous lambda has no usable __name__
     router = APIRouter()
-    with pytest.raises(ValueError, match="get_<entity>_repository"):
-        mount_detail(
-            router, spec, handler=lambda **_: {}, extra_repo_deps=(badly_named,)
-        )
+    with pytest.raises(MountError, match="_SomeUnregisteredRepo"):
+        mount_detail(router, spec, handler=stub)
 
 
 def _stub_html_response(monkeypatch):
@@ -408,8 +552,13 @@ def test_mount_form_edit_route_at_id_form_path(monkeypatch):
     """on_existing=True mounts GET /<collection>/{id}/form, passes id to handler."""
     captured_handler: dict = {}
 
-    async def form_handler(**kwargs):
-        captured_handler.update(kwargs)
+    async def form_handler(
+        request: Request,
+        gadget_id: UUID,
+        repo: UserRepository,
+        requesting_user: User,
+    ):
+        captured_handler["gadget_id"] = gadget_id
         return {}
 
     spec = ResourceSpec(
@@ -495,8 +644,15 @@ def test_mount_list_passes_query_params_to_handler(monkeypatch):
     """Each `QueryParam` reaches the handler under its declared name."""
     captured = {}
 
-    async def list_handler(**kwargs):
-        captured.update(kwargs)
+    async def list_handler(
+        request: Request,
+        repo: UserRepository,
+        requesting_user: User,
+        kind: str | None,
+        active: bool,
+    ):
+        captured["kind"] = kind
+        captured["active"] = active
         return {"items": []}
 
     spec = ResourceSpec(
@@ -529,11 +685,16 @@ def test_mount_list_passes_query_params_to_handler(monkeypatch):
 
 def test_mount_list_public_skips_auth_dep(monkeypatch):
     """`public=True` overrides the spec's read_user_dep; handler still
-    receives `requesting_user=None` for kwarg uniformity."""
+    receives `requesting_user=None` for kwarg uniformity. Handler must
+    declare `requesting_user: User | None` to opt in to the public path."""
     captured = {}
 
-    async def list_handler(**kwargs):
-        captured.update(kwargs)
+    async def list_handler(
+        request: Request,
+        repo: UserRepository,
+        requesting_user: User | None,
+    ):
+        captured["requesting_user"] = requesting_user
         return {"items": []}
 
     def required_user():
@@ -563,8 +724,12 @@ def test_mount_form_query_param_drives_handler_template_choice(monkeypatch):
     `template_name` in context picks the rendered template — the existing
     precedence chain handles polymorphic-by-query forms."""
 
-    async def form_handler(**kwargs):
-        kind = kwargs["kind"]
+    async def form_handler(
+        request: Request,
+        repo: UserRepository,
+        requesting_user: User,
+        kind: str,
+    ):
         return {"template_name": f"widgets/{kind}.html"}
 
     spec = ResourceSpec(
@@ -597,8 +762,13 @@ def test_mount_detail_singleton_alias_sources_id_from_session(monkeypatch):
     captured = {}
     session_user_id = uuid4()
 
-    async def detail_handler(**kwargs):
-        captured.update(kwargs)
+    async def detail_handler(
+        widget_id: UUID,
+        repo: UserRepository,
+        requesting_user: User,
+    ):
+        captured["widget_id"] = widget_id
+        captured["requesting_user"] = requesting_user
         return {"x": 1}
 
     spec = ResourceSpec(
@@ -639,8 +809,14 @@ def test_mount_related_list_singleton_alias_sources_id_from_session(monkeypatch)
     captured = {}
     session_user_id = uuid4()
 
-    async def list_handler(**kwargs):
-        captured.update(kwargs)
+    async def list_handler(
+        request: Request,
+        parent_id: UUID,
+        repo: UserRepository,
+        requesting_user: User,
+    ):
+        captured["parent_id"] = parent_id
+        captured["requesting_user"] = requesting_user
         return {"items": []}
 
     parent = ResourceSpec(
@@ -678,12 +854,18 @@ def test_mount_related_list_singleton_alias_sources_id_from_session(monkeypatch)
 
 def test_mount_related_list_path_under_parent_id(monkeypatch):
     """`mount_related_list` mounts GET /<parent>/{parent_id}/<child>. The
-    handler is invoked with the parent id under parent_spec.id_param,
-    `repo` from the *child* spec, and any extra_repo_deps."""
+    handler is invoked with the parent id under parent_spec.id_param and
+    `repo` is the *child's* repo (the handler returns children)."""
     captured = {}
 
-    async def list_handler(**kwargs):
-        captured.update(kwargs)
+    async def list_handler(
+        request: Request,
+        parent_id: UUID,
+        repo: UserRepository,
+        requesting_user: User,
+    ):
+        captured["parent_id"] = parent_id
+        captured["repo"] = repo
         return {"profiles": []}
 
     parent = ResourceSpec(
@@ -750,13 +932,13 @@ class _AxisBody(BaseModel):
 def _build_state_axis_app(spec: ResourceSpec, handler, *, axis_name="toggle", **kwargs):
     app = FastAPI()
     router = APIRouter(prefix=f"/{spec.collection}")
+    _override_audit(app)
     mount_state_axis(
         router,
         spec,
         handler=handler,
         axis_name=axis_name,
         body_schema=_AxisBody,
-        audit_repo_dep=lambda: SimpleNamespace(name="audit_repo"),
         **kwargs,
     )
     app.include_router(router)
@@ -768,9 +950,18 @@ def test_mount_state_axis_happy_path_returns_hx_refresh_with_projected_body():
     response_to_dict, returns 200 + HX-Refresh + projected body."""
     captured: dict = {}
 
-    async def handler(**kwargs):
-        captured.update(kwargs)
-        return SimpleNamespace(id=kwargs["widget_id"], name="w1", state="on")
+    async def handler(
+        widget_id: UUID,
+        payload: _AxisBody,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        captured["widget_id"] = widget_id
+        captured["payload"] = payload
+        captured["repo"] = repo
+        captured["audit_repo"] = audit_repo
+        return SimpleNamespace(id=widget_id, name="w1", state="on")
 
     spec = ResourceSpec(
         collection="widgets",
@@ -791,7 +982,7 @@ def test_mount_state_axis_happy_path_returns_hx_refresh_with_projected_body():
     body = resp.json()
     assert body == {"id": str(widget_id), "name": "w1", "state": "on"}
     # Handler received id under the spec's id_param + the validated payload.
-    assert str(captured["widget_id"]) == str(widget_id)
+    assert captured["widget_id"] == widget_id
     assert isinstance(captured["payload"], _AxisBody)
     assert captured["payload"].state == "on"
     assert captured["repo"].name == "repo"
@@ -799,7 +990,13 @@ def test_mount_state_axis_happy_path_returns_hx_refresh_with_projected_body():
 
 
 def test_mount_state_axis_invalid_body_returns_422():
-    async def handler(**kwargs):
+    async def handler(
+        widget_id: UUID,
+        payload: _AxisBody,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
         raise AssertionError("handler should not be called for invalid body")
 
     spec = ResourceSpec(
@@ -816,8 +1013,14 @@ def test_mount_state_axis_invalid_body_returns_422():
 def test_mount_state_axis_path_includes_axis_name():
     """Wrong axis segment ⇒ 404 (route not registered under that path)."""
 
-    async def handler(**kwargs):
-        return SimpleNamespace(id=uuid4())
+    async def handler(
+        widget_id: UUID,
+        payload: _AxisBody,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        return SimpleNamespace(id=widget_id)
 
     spec = ResourceSpec(
         collection="widgets",
@@ -842,14 +1045,23 @@ def test_mount_state_axis_requires_write_user_dep():
         # write_user_dep intentionally omitted
     )
     router = APIRouter()
+
+    async def stub(
+        widget_id: UUID,
+        payload: _AxisBody,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        pass
+
     with pytest.raises(ValueError, match="write_user_dep"):
         mount_state_axis(
             router,
             spec,
-            handler=lambda **_: None,
+            handler=stub,
             axis_name="toggle",
             body_schema=_AxisBody,
-            audit_repo_dep=lambda: None,
         )
 
 
@@ -857,8 +1069,14 @@ def test_mount_state_axis_no_response_to_dict_returns_empty_body():
     """Without `response_to_dict`, the body is `{}` — handler still runs
     and the HX-Refresh header still fires."""
 
-    async def handler(**kwargs):
-        return SimpleNamespace(id=kwargs["widget_id"])
+    async def handler(
+        widget_id: UUID,
+        payload: _AxisBody,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        return SimpleNamespace(id=widget_id)
 
     spec = ResourceSpec(
         collection="widgets",
@@ -879,7 +1097,12 @@ def test_mount_delete_404_propagates_from_handler():
 
     from src.api.common.exceptions import NotFoundError
 
-    async def raising_handler(**kwargs):
+    async def raising_handler(
+        widget_id: UUID,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
         raise NotFoundError(detail="missing")
 
     spec = ResourceSpec(
@@ -890,12 +1113,8 @@ def test_mount_delete_404_propagates_from_handler():
     )
     app = FastAPI()
     router = APIRouter(prefix=f"/{spec.collection}")
-    mount_delete(
-        router,
-        spec,
-        handler=raising_handler,
-        audit_repo_dep=lambda: SimpleNamespace(name="audit_repo"),
-    )
+    _override_audit(app)
+    mount_delete(router, spec, handler=raising_handler)
     app.include_router(router)
     client = TestClient(app)
 

--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -35,14 +35,8 @@ USER_SPEC = ResourceSpec(
 )
 
 mount_list(router, USER_SPEC, handler=handle_list_users)
-mount_detail(
-    router, USER_SPEC, handler=handle_get_user_detail,
-    extra_repo_deps=(get_provider_repository,),  # multi-repo handler
-)
-mount_delete(
-    router, USER_SPEC, handler=handle_delete_user,
-    audit_repo_dep=get_audit_repository,
-)
+mount_detail(router, USER_SPEC, handler=handle_get_user_detail)
+mount_delete(router, USER_SPEC, handler=handle_delete_user)
 ```
 
 The full grammar (knobs, mount kwargs, polymorphism via handler-context, sub-resources) is documented in [`api/common/README.md`](../common/README.md#unified-resource-grammar).
@@ -144,9 +138,9 @@ mount_list(router, <ENTITY>_SPEC, handler=handle_list_<entity>)
 mount_detail(router, <ENTITY>_SPEC, handler=handle_get_<entity>_detail)
 mount_form(router, <ENTITY>_SPEC, handler=handle_get_<entity>_form, template="<entities>/new.html")
 mount_form(router, <ENTITY>_SPEC, handler=handle_get_<entity>_edit_form, template="<entities>/edit.html", on_existing=True)
-mount_create(router, <ENTITY>_SPEC, handler=handle_create_<entity>, audit_repo_dep=get_audit_repository)
-mount_update(router, <ENTITY>_SPEC, handler=handle_update_<entity>, audit_repo_dep=get_audit_repository)
-mount_delete(router, <ENTITY>_SPEC, handler=handle_delete_<entity>, audit_repo_dep=get_audit_repository)
+mount_create(router, <ENTITY>_SPEC, handler=handle_create_<entity>)
+mount_update(router, <ENTITY>_SPEC, handler=handle_update_<entity>)
+mount_delete(router, <ENTITY>_SPEC, handler=handle_delete_<entity>)
 ```
 
 2. Register the router in `src/main.py`. (Order matters when literal segments would shadow parametric ones — e.g. `/me/*` must be registered before the `/users` router.)
@@ -170,9 +164,9 @@ LICENSURE_SPEC = ResourceSpec(
     read_to_dict=_licensure_read_dict,
     parent=PROVIDER_SPEC,
 )
-mount_create(router, LICENSURE_SPEC, handler=handle_create_licensure, audit_repo_dep=get_audit_repository)
-mount_update(router, LICENSURE_SPEC, handler=handle_update_licensure, audit_repo_dep=get_audit_repository)
-mount_delete(router, LICENSURE_SPEC, handler=handle_delete_licensure, audit_repo_dep=get_audit_repository)
+mount_create(router, LICENSURE_SPEC, handler=handle_create_licensure)
+mount_update(router, LICENSURE_SPEC, handler=handle_update_licensure)
+mount_delete(router, LICENSURE_SPEC, handler=handle_delete_licensure)
 ```
 
 The handler receives both `provider_id=` and `licensure_id=` (plus `payload=`, `repo=`, `audit_repo=`, `requesting_user=`).

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -27,7 +27,7 @@ from src.logic.posts.post_processing import (
     handle_update_post,
 )
 from src.models import POST_KIND_NAMES, POST_KINDS
-from src.repositories.dependencies import get_audit_repository, get_post_repository
+from src.repositories.dependencies import get_post_repository
 from src.schemas.posts.post import post_create_adapter, post_update_adapter
 
 posts_api_router = APIRouter(prefix="/posts")
@@ -111,12 +111,6 @@ mount_detail(router, POST_SPEC, handler=handle_get_post_detail)
 
 
 # Mutations — methods differ from the GETs above so order is independent.
-mount_create(
-    router, POST_SPEC, handler=handle_create_post, audit_repo_dep=get_audit_repository
-)
-mount_update(
-    router, POST_SPEC, handler=handle_update_post, audit_repo_dep=get_audit_repository
-)
-mount_delete(
-    router, POST_SPEC, handler=handle_delete_post, audit_repo_dep=get_audit_repository
-)
+mount_create(router, POST_SPEC, handler=handle_create_post)
+mount_update(router, POST_SPEC, handler=handle_update_post)
+mount_delete(router, POST_SPEC, handler=handle_delete_post)

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -36,11 +36,7 @@ from src.logic.providers.provider_processing import (
     handle_update_licensure,
     handle_update_provider,
 )
-from src.repositories.dependencies import (
-    get_audit_repository,
-    get_provider_repository,
-    get_user_favorite_repository,
-)
+from src.repositories.dependencies import get_provider_repository
 from src.schemas.providers.provider import (
     ProviderCertificationRead,
     ProviderEducationRead,
@@ -110,12 +106,7 @@ mount_list(
 )
 
 # POST /providers — owner inferred from session.
-mount_create(
-    router,
-    PROVIDER_SPEC,
-    handler=handle_create_provider,
-    audit_repo_dep=get_audit_repository,
-)
+mount_create(router, PROVIDER_SPEC, handler=handle_create_provider)
 
 
 # --- Form routes --------------------------------------------------------
@@ -141,29 +132,19 @@ mount_form(
 
 # GET /providers/{provider_id} — detail page. The `is_favorited` per-viewer
 # flag (computed in the handler against `UserFavoriteRepository`) lives in
-# the template context, so the mount injects the favorites repo via
-# `extra_repo_deps`.
-mount_detail(
-    router,
-    PROVIDER_SPEC,
-    handler=handle_get_provider_detail,
-    extra_repo_deps=(get_user_favorite_repository,),
-)
+# the template context; the handler's typed signature is enough — the
+# mount's signature synthesis resolves the favorites repo via the type
+# registry, no explicit wiring needed.
+mount_detail(router, PROVIDER_SPEC, handler=handle_get_provider_detail)
 
 
 # PATCH /providers/{provider_id} — partial update, owner-or-admin (handler enforces).
-mount_update(
-    router,
-    PROVIDER_SPEC,
-    handler=handle_update_provider,
-    audit_repo_dep=get_audit_repository,
-)
+mount_update(router, PROVIDER_SPEC, handler=handle_update_provider)
 # DELETE /providers/{provider_id} — hard delete, sub-rows cascade.
 mount_delete(
     router,
     PROVIDER_SPEC,
     handler=handle_delete_provider,
-    audit_repo_dep=get_audit_repository,
 )
 
 
@@ -247,6 +228,6 @@ for _spec, _create, _update, _delete in (
         handle_delete_certification,
     ),
 ):
-    mount_create(router, _spec, handler=_create, audit_repo_dep=get_audit_repository)
-    mount_update(router, _spec, handler=_update, audit_repo_dep=get_audit_repository)
-    mount_delete(router, _spec, handler=_delete, audit_repo_dep=get_audit_repository)
+    mount_create(router, _spec, handler=_create)
+    mount_update(router, _spec, handler=_update)
+    mount_delete(router, _spec, handler=_delete)

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -23,11 +23,7 @@ from src.logic.users.user_processing import (
     handle_list_users,
     handle_set_user_activation,
 )
-from src.repositories.dependencies import (
-    get_audit_repository,
-    get_provider_repository,
-    get_user_repository,
-)
+from src.repositories.dependencies import get_user_repository
 from src.schemas.users.user import UserActivationUpdate
 
 users_api_router = APIRouter(prefix="/users")
@@ -67,7 +63,6 @@ mount_detail(
     router,
     USER_SPEC,
     handler=handle_get_user_detail,
-    extra_repo_deps=(get_provider_repository,),
     singleton_alias=("me", current_active_user),
 )
 
@@ -83,7 +78,6 @@ mount_related_list(
     child_spec=PROVIDER_SPEC,
     handler=handle_list_user_providers,
     template="users/providers_list.html",
-    extra_repo_deps=(get_user_repository,),
     singleton_alias=("me", current_active_user),
 )
 
@@ -98,7 +92,6 @@ mount_state_axis(
     handler=handle_set_user_activation,
     axis_name="activation",
     body_schema=UserActivationUpdate,
-    audit_repo_dep=get_audit_repository,
     response_to_dict=lambda user: {
         "id": str(user.id),
         "username": user.username,
@@ -114,5 +107,4 @@ mount_delete(
     router,
     USER_SPEC,
     handler=handle_delete_user,
-    audit_repo_dep=get_audit_repository,
 )

--- a/src/repositories/dependencies.py
+++ b/src/repositories/dependencies.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable
+
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -43,3 +45,50 @@ def get_user_favorite_repository(
 ) -> UserFavoriteRepository:
     """Dependency provider for UserFavoriteRepository."""
     return UserFavoriteRepository(session)
+
+
+# Type → resolver registry. The single source of truth for "how do I inject
+# a repository of type T into a route?" The mount layer in
+# `src/api/common/resource_routes.py` reads this map to synthesize FastAPI
+# route signatures from handler type annotations — a handler param typed
+# `repo: ProviderRepository` automatically resolves to
+# `Depends(get_provider_repository)`, with no separate declaration on the
+# mount call. Adding a new repo means adding one entry here, not threading
+# the resolver through every mount call site.
+#
+# Keep this dict and the resolver definitions above in sync: every entry
+# here must point at a callable defined in this module. Conversely, a
+# resolver that is *not* in this map cannot be auto-injected by the mount
+# layer and would need to be passed via a non-registry path (which we
+# currently don't have).
+_REPO_TYPE_RESOLVERS: dict[type, Callable[..., Any]] = {
+    UserRepository: get_user_repository,
+    PostRepository: get_post_repository,
+    AuditRepository: get_audit_repository,
+    ProviderRepository: get_provider_repository,
+    UserFavoriteRepository: get_user_favorite_repository,
+}
+
+
+class UnknownRepoTypeError(KeyError):
+    """Raised when a handler asks for a repo type that is not in
+    `_REPO_TYPE_RESOLVERS`. The error names the type and points at this
+    module so the fix is obvious."""
+
+
+def resolver_for(repo_type: type) -> Callable[..., Any]:
+    """Return the FastAPI `Depends`-style resolver for `repo_type`.
+
+    Raises `UnknownRepoTypeError` with a clear message if the type is not
+    registered. The mount layer surfaces this at app startup, so a
+    forgotten registry entry fails before serving traffic.
+    """
+    try:
+        return _REPO_TYPE_RESOLVERS[repo_type]
+    except KeyError:
+        raise UnknownRepoTypeError(
+            f"No Depends resolver registered for repository type "
+            f"{repo_type!r}. Add an entry to `_REPO_TYPE_RESOLVERS` in "
+            f"src/repositories/dependencies.py pointing at the matching "
+            f"`get_<entity>_repository` function."
+        ) from None


### PR DESCRIPTION
## Summary

- Mount helpers now introspect each handler's typed signature and synthesize a real FastAPI route function with `Depends(...)` defaults derived from a type→resolver registry. Handler signatures are the single source of truth for deps; forgetting to register a new repo type fails at app startup with `MountError` instead of first-request 500.
- Drops `extra_repo_deps=(...)` and `audit_repo_dep=...` from every mount call site (auto-resolved via the registry).
- Removes the dead helpers `_set_route_signature`, `_name_extra_repo_deps`, `_read_route_deps`, `_kwargs_for_handler_path` (superseded by `_synthesize_route_fn`).

Closes #316.

## What changed

- New: `_REPO_TYPE_RESOLVERS` + `resolver_for(type)` in `src/repositories/dependencies.py`. Type-keyed registry mapping `UserRepository → get_user_repository` etc. One entry per repo; adding a new repo means adding one line.
- New: `_synthesize_route_fn` in `src/api/common/resource_routes.py`. Each of the 8 mount helpers (`mount_create`, `mount_detail`, `mount_list`, `mount_update`, `mount_delete`, `mount_form`, `mount_state_axis`, `mount_related_list`) now delegates to it, supplying only a response builder for the mount's specific shape.
- Edge cases preserved: `singleton_alias=("me", ...)`, `User | None` for public reads, query params, sub-resource parent-id chains, form vs JSON body parsing.
- Tests in `test_resource_routes.py` rewritten to use typed handlers + `app.dependency_overrides[get_audit_repository]` substitution. The behavioral assertions (status codes, redirect headers, parametric paths) are unchanged.

## Test plan

- [x] `dev test` — 599 passed.
- [x] `dev test contract` — 16 passed.
- [x] `dev lint` — all checks pass.
- [x] New `test_mount_raises_when_handler_asks_for_unregistered_repo_type` pins the registration-time error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)