### PR TITLE
Add mount_entity dispatcher; collapse route files (#332)

### DIFF
--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -79,10 +79,18 @@ class StateAxis:
 
 @dataclass(frozen=True, slots=True)
 class Templates:
-    """Static Jinja paths for the entity's read views."""
+    """Static Jinja paths for the entity's views.
+
+    `form_new` and `form_edit` correspond to the two `mount_form`
+    variants (create form / edit form). Posts uses neither (handler
+    returns `template_name` in context for per-kind dispatch);
+    providers uses both.
+    """
 
     list: str | None = None
     detail: str | None = None
+    form_new: str | None = None
+    form_edit: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -240,6 +248,13 @@ class EntitySpec:
 
     # Templates ----------------------------------------------------------
     templates: Templates = field(default_factory=Templates)
+
+    # Detail singleton alias (e.g. `/users/me`) -------------------------
+    # `mount_detail`'s `singleton_alias=` kwarg — additionally mounts
+    # `GET /<collection>/<alias>` whose id is sourced from a session
+    # dep instead of the URL. Used by users (`/users/me`); other
+    # entities leave as None.
+    singleton_alias: tuple[str, Callable[..., Any]] | None = None
 
     def __post_init__(self) -> None:
         # Mirror `ResourceSpec.__post_init__` — declaring private fields

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -803,6 +803,162 @@ def mount_related_list(
     router.get(path)(route_fn)
 
 
+def mount_entity(
+    router: Any,
+    entity: Any,  # `EntitySpec` — imported lazily to avoid a cycle
+    *,
+    handlers: dict[str, Callable[..., Awaitable[Any]]],
+    owned_subentities: tuple[Any, ...] = (),
+) -> None:
+    """Spec-driven dispatcher for an entity's full route surface.
+
+    Reads `entity.routes`, `entity.state_axes`, `entity.subresources`,
+    `entity.templates`, `entity.filters`, `entity.discriminator`, and
+    `entity.singleton_alias` and calls the appropriate underlying
+    `mount_*` helpers. The existing helpers stay unchanged; this is
+    dispatch glue.
+
+    `handlers` maps a verb-or-name to a callable:
+
+      - One per `RouteSet` flag that is `True`: `"list"`, `"detail"`,
+        `"create"`, `"update"`, `"delete"`, `"form_new"`, `"form_edit"`.
+      - One per `state_axes[i].name` (e.g. `"activation"`).
+      - One per `subresources[i].child_spec.collection` (e.g.
+        `"providers"` for the user → providers related list).
+      - For each `owned_subentities[i]`: one per opted-in verb keyed
+        `f"{owned.name}.{verb}"` (e.g. `"provider_licensure.create"`).
+
+    Validates loudly at mount time:
+      - Every opted-in route / state-axis / subresource must have a
+        handler. Missing keys raise `KeyError` from the handlers
+        dict.
+      - Extra handler keys not consumed by any spec entry raise
+        `ValueError` — catches typos and stale handler bindings the
+        spec used to declare.
+      - `owned_subentities[i].parent` must equal `entity` (catches a
+        passed-in spec from the wrong family).
+    """
+    spec = entity.to_resource_spec()
+
+    consumed: set[str] = set()
+
+    # Registration order matters: literal-segment paths (`/form`,
+    # `/{id}/form`) must register before the parametric `/{id}` path
+    # so FastAPI doesn't try to parse `form` as a UUID. The order
+    # below mirrors the route-file ordering each entity used pre-B4.
+
+    if entity.routes.list:
+        mount_list(
+            router,
+            spec,
+            handler=handlers["list"],
+            query_params=tuple(entity.filters),
+        )
+        consumed.add("list")
+    if entity.routes.create:
+        mount_create(router, spec, handler=handlers["create"])
+        consumed.add("create")
+    if entity.routes.form_new:
+        query_params: tuple[QueryParam, ...] = ()
+        if entity.discriminator is not None:
+            # Polymorphic entities' create-form `?kind=` query param
+            # derives its Literal universe from the discriminator
+            # registry — single source of truth for the kind names.
+            from typing import Literal
+
+            names = entity.discriminator.names
+            query_params = (QueryParam("kind", Literal[*names], names[0]),)
+        mount_form(
+            router,
+            spec,
+            handler=handlers["form_new"],
+            template=entity.templates.form_new,
+            query_params=query_params,
+        )
+        consumed.add("form_new")
+    if entity.routes.form_edit:
+        mount_form(
+            router,
+            spec,
+            handler=handlers["form_edit"],
+            on_existing=True,
+            template=entity.templates.form_edit,
+        )
+        consumed.add("form_edit")
+    if entity.routes.detail:
+        mount_detail(
+            router,
+            spec,
+            handler=handlers["detail"],
+            singleton_alias=entity.singleton_alias,
+        )
+        consumed.add("detail")
+    if entity.routes.update:
+        mount_update(router, spec, handler=handlers["update"])
+        consumed.add("update")
+    if entity.routes.delete:
+        mount_delete(router, spec, handler=handlers["delete"])
+        consumed.add("delete")
+
+    for axis in entity.state_axes:
+        mount_state_axis(
+            router,
+            spec,
+            handler=handlers[axis.name],
+            axis_name=axis.name,
+            body_schema=axis.body_schema,
+            response_to_dict=axis.response_to_dict,
+        )
+        consumed.add(axis.name)
+
+    for sub in entity.subresources:
+        key = sub.child_spec.collection
+        mount_related_list(
+            router,
+            parent_spec=spec,
+            child_spec=sub.child_spec,
+            handler=handlers[key],
+            template=sub.template,
+            singleton_alias=sub.singleton_alias,
+        )
+        consumed.add(key)
+
+    # Owned-subentity recursion: each child entity gets its own
+    # `mount_entity` call with its own slice of the handlers dict
+    # (keyed by `<owned.name>.<verb>`).
+    for owned in owned_subentities:
+        if owned.parent is not entity:
+            raise ValueError(
+                f"mount_entity: owned_subentity {owned.name!r} has "
+                f"parent {owned.parent.name if owned.parent else None!r}, "
+                f"not {entity.name!r}"
+            )
+        owned_handlers: dict[str, Callable[..., Awaitable[Any]]] = {}
+        for verb in (
+            "list",
+            "detail",
+            "create",
+            "update",
+            "delete",
+            "form_new",
+            "form_edit",
+        ):
+            if getattr(owned.routes, verb):
+                k = f"{owned.name}.{verb}"
+                owned_handlers[verb] = handlers[k]
+                consumed.add(k)
+        mount_entity(router, owned, handlers=owned_handlers)
+
+    # Typo detection — surface stale keys at mount time.
+    extras = set(handlers) - consumed
+    if extras:
+        raise ValueError(
+            f"mount_entity({entity.name!r}): handler keys not consumed "
+            f"by any spec entry: {sorted(extras)}. Check for typos or "
+            "stale bindings."
+        )
+
+
 def _walk_parent_chain(spec: ResourceSpec) -> list[ResourceSpec]:
     """Return ancestors top-to-bottom including ``spec`` itself.
 

--- a/src/api/common/specs/provider.py
+++ b/src/api/common/specs/provider.py
@@ -84,5 +84,7 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     templates=Templates(
         list="providers/list.html",
         detail="providers/detail.html",
+        form_new="providers/new.html",
+        form_edit="providers/edit.html",
     ),
 )

--- a/src/api/common/specs/user.py
+++ b/src/api/common/specs/user.py
@@ -82,4 +82,6 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
         list="users/list.html",
         detail="users/detail.html",
     ),
+    # `/users/me` — detail page id sourced from the session.
+    singleton_alias=("me", current_active_user),
 )

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -1091,6 +1091,274 @@ def test_mount_state_axis_no_response_to_dict_returns_empty_body():
     assert resp.headers["HX-Refresh"] == "true"
 
 
+# --- mount_entity dispatcher tests ---------------------------------------
+
+
+from src.api.common.entity_spec import EntitySpec as _EntitySpec  # noqa: E402
+from src.api.common.entity_spec import (  # noqa: E402
+    RelatedListSubresource as _RelatedSub,
+)
+from src.api.common.entity_spec import RouteSet as _RouteSet  # noqa: E402
+from src.api.common.entity_spec import StateAxis as _StateAxis  # noqa: E402
+from src.api.common.entity_spec import Templates as _Templates  # noqa: E402
+from src.api.common.resource_routes import mount_entity  # noqa: E402
+from src.logic.audit import AuditAction as _AuditAction  # noqa: E402
+from src.logic.audit import AuditedResource as _AuditedResource  # noqa: E402
+
+
+def _stub_audit() -> _AuditedResource:
+    return _AuditedResource(
+        type="thing",
+        snapshot=lambda obj: {"id": "x"},
+        create=_AuditAction.CREATE_USER,
+        update=_AuditAction.UPDATE_USER,
+        delete=_AuditAction.DELETE_USER,
+    )
+
+
+def test_mount_entity_skips_routes_not_opted_in():
+    """`mount_entity` only mounts the verbs `entity.routes` opts into.
+    With everything False, no helpers are called."""
+    calls = []
+    import src.api.common.resource_routes as rr
+
+    monkeys = []
+    for fn_name in (
+        "mount_list",
+        "mount_detail",
+        "mount_create",
+        "mount_update",
+        "mount_delete",
+        "mount_form",
+        "mount_state_axis",
+        "mount_related_list",
+    ):
+        orig = getattr(rr, fn_name)
+
+        def _capture(*args, _name=fn_name, **kw):
+            calls.append(_name)
+
+        monkeys.append((fn_name, orig))
+        setattr(rr, fn_name, _capture)
+    try:
+        spec = _EntitySpec(
+            name="thing",
+            url_collection="things",
+            id_param="thing_id",
+            model=SimpleNamespace,
+            audit=_stub_audit(),
+        )
+        mount_entity(None, spec, handlers={})
+    finally:
+        for n, orig in monkeys:
+            setattr(rr, n, orig)
+    assert calls == []  # nothing opted in → nothing dispatched
+
+
+def test_mount_entity_dispatches_each_opted_in_verb():
+    """`RouteSet` flags drive dispatch to the matching mount helpers."""
+    calls = []
+    import src.api.common.resource_routes as rr
+
+    monkeys = []
+    for fn_name in (
+        "mount_list",
+        "mount_detail",
+        "mount_create",
+        "mount_update",
+        "mount_delete",
+        "mount_form",
+    ):
+        orig = getattr(rr, fn_name)
+        setattr(
+            rr,
+            fn_name,
+            lambda *a, _n=fn_name, **k: calls.append((_n, k)),
+        )
+        monkeys.append((fn_name, orig))
+    try:
+        from pydantic import TypeAdapter
+
+        spec = _EntitySpec(
+            name="thing",
+            url_collection="things",
+            id_param="thing_id",
+            model=SimpleNamespace,
+            audit=_stub_audit(),
+            routes=_RouteSet(
+                list=True,
+                detail=True,
+                create=True,
+                update=True,
+                delete=True,
+                form_new=True,
+                form_edit=True,
+            ),
+            create_adapter=TypeAdapter(_AxisBody),
+            update_adapter=TypeAdapter(_AxisBody),
+            templates=_Templates(
+                list="t/list.html",
+                detail="t/detail.html",
+                form_new="t/new.html",
+                form_edit="t/edit.html",
+            ),
+        )
+        mount_entity(
+            None,
+            spec,
+            handlers={
+                "list": lambda: None,
+                "detail": lambda: None,
+                "create": lambda: None,
+                "update": lambda: None,
+                "delete": lambda: None,
+                "form_new": lambda: None,
+                "form_edit": lambda: None,
+            },
+        )
+    finally:
+        for n, orig in monkeys:
+            setattr(rr, n, orig)
+
+    names = [c[0] for c in calls]
+    assert "mount_list" in names
+    assert "mount_detail" in names
+    assert "mount_create" in names
+    assert "mount_update" in names
+    assert "mount_delete" in names
+    # form_new + form_edit both → mount_form (twice)
+    assert names.count("mount_form") == 2
+
+
+def test_mount_entity_dispatches_state_axes():
+    calls = []
+    import src.api.common.resource_routes as rr
+
+    orig = rr.mount_state_axis
+    rr.mount_state_axis = lambda *a, **k: calls.append(k)
+    try:
+        spec = _EntitySpec(
+            name="thing",
+            url_collection="things",
+            id_param="thing_id",
+            model=SimpleNamespace,
+            audit=_stub_audit(),
+            state_axes=(
+                _StateAxis(
+                    name="activation",
+                    body_schema=_AxisBody,
+                    action=_AuditAction.SET_USER_ACTIVATION,
+                ),
+            ),
+        )
+        mount_entity(None, spec, handlers={"activation": lambda: None})
+    finally:
+        rr.mount_state_axis = orig
+    assert len(calls) == 1
+    assert calls[0]["axis_name"] == "activation"
+
+
+def test_mount_entity_dispatches_related_list_subresources():
+    calls = []
+    import src.api.common.resource_routes as rr
+
+    orig = rr.mount_related_list
+    rr.mount_related_list = lambda *a, **k: calls.append(k)
+    try:
+        child_spec = ResourceSpec(
+            collection="children",
+            id_param="child_id",
+            repo_dep=lambda: None,
+        )
+        spec = _EntitySpec(
+            name="parent",
+            url_collection="parents",
+            id_param="parent_id",
+            model=SimpleNamespace,
+            audit=_stub_audit(),
+            subresources=(_RelatedSub(child_spec=child_spec, template="x/list.html"),),
+        )
+        mount_entity(None, spec, handlers={"children": lambda: None})
+    finally:
+        rr.mount_related_list = orig
+    assert len(calls) == 1
+    assert calls[0]["template"] == "x/list.html"
+
+
+def test_mount_entity_missing_handler_raises_key_error():
+    """If a route is opted in but the handler is missing → KeyError."""
+    spec = _EntitySpec(
+        name="thing",
+        url_collection="things",
+        id_param="thing_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+        routes=_RouteSet(list=True),
+    )
+    import src.api.common.resource_routes as rr
+
+    orig = rr.mount_list
+    rr.mount_list = lambda *a, **k: None
+    try:
+        with pytest.raises(KeyError):
+            mount_entity(None, spec, handlers={})  # missing "list"
+    finally:
+        rr.mount_list = orig
+
+
+def test_mount_entity_extra_handler_keys_raises_value_error():
+    """Typos in handler keys are caught at mount time, not silently no-op."""
+    spec = _EntitySpec(
+        name="thing",
+        url_collection="things",
+        id_param="thing_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+        routes=_RouteSet(list=True),
+    )
+    import src.api.common.resource_routes as rr
+
+    orig = rr.mount_list
+    rr.mount_list = lambda *a, **k: None
+    try:
+        with pytest.raises(ValueError, match="not consumed"):
+            mount_entity(
+                None,
+                spec,
+                handlers={"list": lambda: None, "lsit": lambda: None},
+            )
+    finally:
+        rr.mount_list = orig
+
+
+def test_mount_entity_owned_subentity_parent_mismatch_raises():
+    """Catches a passed-in owned subentity whose `parent` is wrong entity."""
+    other_parent = _EntitySpec(
+        name="other",
+        url_collection="others",
+        id_param="other_id",
+        model=SimpleNamespace,
+    )
+    child = _EntitySpec(
+        name="part",
+        url_collection="parts",
+        id_param="part_id",
+        model=SimpleNamespace,
+        parent=other_parent,
+        routes=_RouteSet(delete=True),
+        audit=_stub_audit(),
+    )
+    correct_parent = _EntitySpec(
+        name="thing",
+        url_collection="things",
+        id_param="thing_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+    )
+    with pytest.raises(ValueError, match="parent"):
+        mount_entity(None, correct_parent, handlers={}, owned_subentities=(child,))
+
+
 def test_mount_delete_404_propagates_from_handler():
     """If the handler raises NotFoundError, the route surfaces it as 404
     (decorator translation). Confirms the mount doesn't swallow exceptions."""

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -1,18 +1,9 @@
 import logging
-from typing import Literal
 
 from fastapi import APIRouter
 
 from src.api.common import BaseRouter
-from src.api.common.resource_routes import (
-    QueryParam,
-    mount_create,
-    mount_delete,
-    mount_detail,
-    mount_form,
-    mount_list,
-    mount_update,
-)
+from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.post import POST_ENTITY
 from src.logic._generic import (
     make_create_handler,
@@ -31,70 +22,35 @@ router = BaseRouter(router=posts_api_router, default_tags=["posts"])
 logger = logging.getLogger(__name__)
 
 
-# `POST_ENTITY` is the single declaration of identity (audit binding,
-# adapters, redirects, route flags, templates, polymorphism). The mount
-# helpers still consume `ResourceSpec`, so we bridge via
-# `to_resource_spec()`.
-POST_SPEC = POST_ENTITY.to_resource_spec()
+def _named(handler, name):
+    """Give a factory-built handler a stable module attribute so
+    contract-test patches at `src.api.routes.posts._handle_<verb>_post`
+    flow through the mount layer's `_resolve_handler`."""
+    handler.__name__ = name
+    handler.__qualname__ = name
+    handler.__module__ = __name__
+    return handler
 
 
-# Route registration order matters: literal segments and longer paths must
-# be registered before the more general `/{post_id}` so FastAPI doesn't
-# match `form` as a UUID. The order below mirrors the path specificity.
-
-# GET /posts — list page.
-mount_list(router, POST_SPEC, handler=handle_list_posts)
+_handle_create_post = _named(make_create_handler(POST_ENTITY), "_handle_create_post")
+_handle_update_post = _named(make_update_handler(POST_ENTITY), "_handle_update_post")
+_handle_delete_post = _named(make_delete_handler(POST_ENTITY), "_handle_delete_post")
 
 
-# GET /posts/form?kind=<X> — `kind` query param picks the per-kind create
-# template at request time. The handler returns `template_name` in the
-# context dict; mount_form's three-source resolution picks it up. The
-# kind Literal is built from the spec's discriminator binding so the
-# spec is the source of truth for which kinds are valid.
-_post_kind_names = POST_ENTITY.discriminator.names
-mount_form(
+mount_entity(
     router,
-    POST_SPEC,
-    handler=handle_get_post_form,
-    query_params=(
-        QueryParam(
-            "kind",
-            Literal[*_post_kind_names],
-            _post_kind_names[0],
-            description="Which post kind's create form to render.",
-        ),
-    ),
+    POST_ENTITY,
+    handlers={
+        "list": handle_list_posts,
+        "detail": handle_get_post_detail,
+        # All three mutations are framework-generated; posts is fully
+        # spec-driven for CRUD. The form handlers stay custom because
+        # they return `template_name` in context for per-kind template
+        # dispatch.
+        "create": _handle_create_post,
+        "update": _handle_update_post,
+        "delete": _handle_delete_post,
+        "form_new": handle_get_post_form,
+        "form_edit": handle_get_post_edit_form,
+    },
 )
-
-
-# GET /posts/{post_id}/form — handler returns `template_name` in context
-# so mount_form picks the right kind-specific edit template at request time.
-mount_form(
-    router,
-    POST_SPEC,
-    handler=handle_get_post_edit_form,
-    on_existing=True,
-)
-
-
-# GET /posts/{post_id} — detail page. Registered after /form and /{id}/form
-# so literal segments take precedence.
-mount_detail(router, POST_SPEC, handler=handle_get_post_detail)
-
-
-# Mutations — methods differ from the GETs above so order is independent.
-# Generic create: `make_create_handler` reads the spec's discriminator
-# to dispatch by `payload.kind` and build the right detail row.
-_handle_create_post = make_create_handler(POST_ENTITY)
-_handle_create_post.__module__ = __name__
-mount_create(router, POST_SPEC, handler=_handle_create_post)
-# Generic update: kind-invariant + detail-row patch via spec.discriminator.
-_handle_update_post = make_update_handler(POST_ENTITY)
-_handle_update_post.__module__ = __name__
-mount_update(router, POST_SPEC, handler=_handle_update_post)
-# Named module-level attribute so test monkeypatching (contract tests)
-# can target `src.api.routes.posts._handle_delete_post` and the mount
-# layer's `_resolve_handler` picks up the patched version.
-_handle_delete_post = make_delete_handler(POST_ENTITY)
-_handle_delete_post.__module__ = __name__
-mount_delete(router, POST_SPEC, handler=_handle_delete_post)

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -3,14 +3,7 @@ import logging
 from fastapi import APIRouter
 
 from src.api.common import BaseRouter
-from src.api.common.resource_routes import (
-    mount_create,
-    mount_delete,
-    mount_detail,
-    mount_form,
-    mount_list,
-    mount_update,
-)
+from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.provider import PROVIDER_ENTITY
 from src.api.common.specs.provider_certification import CERTIFICATION_ENTITY
 from src.api.common.specs.provider_education import EDUCATION_ENTITY
@@ -33,88 +26,48 @@ router = BaseRouter(router=providers_api_router, default_tags=["providers"])
 logger = logging.getLogger(__name__)
 
 
-# All four route-level ResourceSpecs are derived from their EntitySpecs.
-# The entity specs in `src/api/common/specs/` are the single declaration
-# of identity (audit binding, adapters, redirects, filters, route flags,
-# templates); the mount helpers still consume `ResourceSpec`, so we
-# bridge via `to_resource_spec()`.
-PROVIDER_SPEC = PROVIDER_ENTITY.to_resource_spec()
-LICENSURE_SPEC = LICENSURE_ENTITY.to_resource_spec()
-EDUCATION_SPEC = EDUCATION_ENTITY.to_resource_spec()
-CERTIFICATION_SPEC = CERTIFICATION_ENTITY.to_resource_spec()
+# Named module-level attributes for framework-built handlers so
+# contract-test patches (e.g. `src.api.routes.providers._handle_update_provider`)
+# flow through the mount layer's `_resolve_handler`. The `__module__`
+# is rebound so `_resolve_handler` looks up against this module.
+def _named(handler, name):
+    handler.__name__ = name
+    handler.__qualname__ = name
+    handler.__module__ = __name__
+    return handler
 
 
-# --- Provider collection routes ------------------------------------------
-
-# GET /providers — authenticated listing with optional license_type /
-# issuing_state filters. The filter shape is declared on the entity spec
-# so the canonical declaration lives upstream of the mount call.
-mount_list(
-    router,
-    PROVIDER_SPEC,
-    handler=handle_list_providers,
-    query_params=PROVIDER_ENTITY.filters,
+_handle_update_provider = _named(
+    make_update_handler(PROVIDER_ENTITY), "_handle_update_provider"
 )
-
-# POST /providers — owner inferred from session.
-mount_create(router, PROVIDER_SPEC, handler=handle_create_provider)
-
-
-# --- Form routes --------------------------------------------------------
-# Mounted before `/{provider_id}` so the literal `form` segment is not
-# parsed as a UUID. Two form templates: `new.html` (create) and
-# `edit.html` (edit, identifies the provider from the URL id).
-mount_form(
-    router,
-    PROVIDER_SPEC,
-    handler=handle_get_provider_form,
-    template="providers/new.html",
-)
-mount_form(
-    router,
-    PROVIDER_SPEC,
-    handler=handle_get_provider_edit_form,
-    template="providers/edit.html",
-    on_existing=True,
+_handle_delete_provider = _named(
+    make_delete_handler(PROVIDER_ENTITY), "_handle_delete_provider"
 )
 
 
-# --- Provider item routes ------------------------------------------------
-
-# GET /providers/{provider_id} — detail page. The `is_favorited` per-viewer
-# flag (computed in the handler against `UserFavoriteRepository`) lives in
-# the template context; the handler's typed signature is enough — the
-# mount's signature synthesis resolves the favorites repo via the type
-# registry, no explicit wiring needed.
-mount_detail(router, PROVIDER_SPEC, handler=handle_get_provider_detail)
-
-
-# PATCH /providers/{provider_id} — partial update, owner-or-admin.
-# Named module-level attribute so contract-test patches target
-# `src.api.routes.providers._handle_update_provider`.
-_handle_update_provider = make_update_handler(PROVIDER_ENTITY)
-_handle_update_provider.__module__ = __name__
-mount_update(router, PROVIDER_SPEC, handler=_handle_update_provider)
-# DELETE /providers/{provider_id} — hard delete, sub-rows cascade.
-# Generic delete: `make_delete_handler` builds a callable from the entity
-# spec (audit binding + write_authz). See `src/logic/_generic.py`.
-mount_delete(router, PROVIDER_SPEC, handler=make_delete_handler(PROVIDER_ENTITY))
-
-
-# --- Sub-resource CRUD (licensure / education / certification) ----------
-# Each sub-resource's spec carries `parent=PROVIDER_ENTITY` (resolved on
-# the entity spec), so `to_resource_spec()` produces a `ResourceSpec`
-# whose `parent` is a derived `PROVIDER_SPEC`. The mount functions walk
-# that parent chain to build paths like
-# `/{provider_id}/licensures/{licensure_id}` and inject parent ids into
-# the handler under their declared kwarg names.
-
-
-for _spec, _entity in (
-    (LICENSURE_SPEC, LICENSURE_ENTITY),
-    (EDUCATION_SPEC, EDUCATION_ENTITY),
-    (CERTIFICATION_SPEC, CERTIFICATION_ENTITY),
-):
-    mount_create(router, _spec, handler=make_create_handler(_entity))
-    mount_update(router, _spec, handler=make_update_handler(_entity))
-    mount_delete(router, _spec, handler=make_delete_handler(_entity))
+mount_entity(
+    router,
+    PROVIDER_ENTITY,
+    handlers={
+        "list": handle_list_providers,
+        "detail": handle_get_provider_detail,
+        # Bespoke create (inline credentials append); other verbs are
+        # generic factory-built.
+        "create": handle_create_provider,
+        "update": _handle_update_provider,
+        "delete": _handle_delete_provider,
+        "form_new": handle_get_provider_form,
+        "form_edit": handle_get_provider_edit_form,
+        # Owned-subentity verbs, keyed by `<owned.name>.<verb>`.
+        "provider_licensure.create": make_create_handler(LICENSURE_ENTITY),
+        "provider_licensure.update": make_update_handler(LICENSURE_ENTITY),
+        "provider_licensure.delete": make_delete_handler(LICENSURE_ENTITY),
+        "provider_education.create": make_create_handler(EDUCATION_ENTITY),
+        "provider_education.update": make_update_handler(EDUCATION_ENTITY),
+        "provider_education.delete": make_delete_handler(EDUCATION_ENTITY),
+        "provider_certification.create": make_create_handler(CERTIFICATION_ENTITY),
+        "provider_certification.update": make_update_handler(CERTIFICATION_ENTITY),
+        "provider_certification.delete": make_delete_handler(CERTIFICATION_ENTITY),
+    },
+    owned_subentities=(LICENSURE_ENTITY, EDUCATION_ENTITY, CERTIFICATION_ENTITY),
+)

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -3,15 +3,8 @@ import logging
 from fastapi import APIRouter
 
 from src.api.common import BaseRouter
-from src.api.common.resource_routes import (
-    mount_delete,
-    mount_detail,
-    mount_list,
-    mount_related_list,
-    mount_state_axis,
-)
+from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.user import USER_ENTITY
-from src.auth_config import current_active_user
 from src.logic.providers.provider_processing import handle_list_user_providers
 from src.logic.users.user_processing import (
     handle_delete_user,
@@ -25,65 +18,23 @@ router = BaseRouter(router=users_api_router, default_tags=["users"])
 logger = logging.getLogger(__name__)
 
 
-# Derive the mount-time `ResourceSpec` from the entity spec. `USER_ENTITY`
-# is the single declaration of identity (audit binding, private-field
-# visibility, route flags, state-axis shape, subresources, templates);
-# `mount_*` helpers still consume `ResourceSpec`, so we bridge.
-USER_SPEC = USER_ENTITY.to_resource_spec()
-
-
-# GET /users
-mount_list(router, USER_SPEC, handler=handle_list_users)
-# GET /users/{user_id} AND GET /users/me — `singleton_alias=("me", session_dep)`
-# also mounts `/users/me`, which sources the id from the session. Same
-# template, same handler — `me` is purely an id-derivation convenience.
-# `handle_get_user_detail` takes the provider repo to embed the
-# owned-providers list; the mount injects it under `provider_repo`
-# (derived from `get_provider_repository`).
-mount_detail(
+# `handle_delete_user` is bespoke (self-guard); the other handlers are
+# unchanged from prior phases. `mount_entity` reads `USER_ENTITY`'s
+# routes / state_axes / subresources / singleton_alias and dispatches
+# to the appropriate `mount_*` helpers — collapsing what used to be
+# five separate mount calls into one.
+mount_entity(
     router,
-    USER_SPEC,
-    handler=handle_get_user_detail,
-    singleton_alias=("me", current_active_user),
-)
-
-
-# GET /users/{user_id}/providers AND GET /users/me/providers — related-list,
-# scoped to the parent user. The subresource shape (child spec, template,
-# `/me` alias) is declared once on `USER_ENTITY.subresources`; the mount
-# call reads from there so the spec stays the single source of truth.
-_providers_subresource = USER_ENTITY.subresources[0]
-mount_related_list(
-    router,
-    parent_spec=USER_SPEC,
-    child_spec=_providers_subresource.child_spec,
-    handler=handle_list_user_providers,
-    template=_providers_subresource.template,
-    singleton_alias=_providers_subresource.singleton_alias,
-)
-
-
-# PUT /users/{user_id}/activation — admin-only state-axis flip.
-# Axis shape (name, body schema, response projection) is declared on
-# `USER_ENTITY.state_axes`; the handler is bound here because phase 1
-# does not carry handler references on the spec (see the docstring on
-# `src/api/common/entity_spec.py` for the import-direction rationale).
-_activation_axis = USER_ENTITY.state_axis("activation")
-mount_state_axis(
-    router,
-    USER_SPEC,
-    handler=handle_set_user_activation,
-    axis_name=_activation_axis.name,
-    body_schema=_activation_axis.body_schema,
-    response_to_dict=_activation_axis.response_to_dict,
-)
-
-
-# DELETE /users/{user_id} is mounted via the unified ResourceSpec grammar.
-# Admin-only: hard-delete a user. The handler uses `mutate(verb="delete")`
-# so the audit row + commit are owned by the context manager.
-mount_delete(
-    router,
-    USER_SPEC,
-    handler=handle_delete_user,
+    USER_ENTITY,
+    handlers={
+        "list": handle_list_users,
+        "detail": handle_get_user_detail,
+        "delete": handle_delete_user,
+        # State axis (activation): action + body schema + response
+        # projection all declared on `USER_ENTITY.state_axes[0]`.
+        "activation": handle_set_user_activation,
+        # Related-list subresource (providers); singleton-alias
+        # `/users/me/providers` declared on the spec.
+        "providers": handle_list_user_providers,
+    },
 )


### PR DESCRIPTION
Closes #332. Fourth PR of phase 2.

## Summary

Introduces `mount_entity(router, entity, handlers={...})` — a single spec-driven dispatcher that reads `entity.routes`, `state_axes`, `subresources`, `templates`, `filters`, `discriminator`, and `singleton_alias` and dispatches to the existing `mount_*` helpers. Migrates the 3 main route files (users, providers, posts) to use it; line counts shrink ~50%.

## Spec extensions (minimal)

- **`EntitySpec.singleton_alias`** — for the detail mount's `/me` alias. USER_ENTITY now declares `("me", current_active_user)`.
- **`Templates.form_new` / `Templates.form_edit`** — for mount_form template kwargs. PROVIDER_ENTITY now declares both.

## `mount_entity` dispatch

- **RouteSet flags** → `mount_list` / `mount_detail` / `mount_create` / `mount_update` / `mount_delete` / `mount_form` helpers.
- **`state_axes`** → `mount_state_axis` (one per axis).
- **`subresources`** → `mount_related_list` (keyed by child collection name).
- **`owned_subentities`** recursively mounted; handlers keyed `f"{owned.name}.{verb}"`.
- **Discriminator-aware:** posts' `form_new` auto-derives the kind `Literal` query param from `entity.discriminator.names`.
- **Validates loudly:** missing handler keys raise `KeyError`; extra handler keys raise `ValueError` (catches typos); owned subentity's `parent` must equal `entity` (catches wrong family).

Registration order: literal-segment paths (`/form`, `/{id}/form`) before parametric `/{id}` so FastAPI doesn't try to parse `form` as a UUID.

## Migrated route files

`users.py`, `providers.py`, `posts.py` collapse from 90+ lines of individual `mount_*` calls to ~25-50 lines of a single `mount_entity(...)` call plus a handlers dict. Named module-level handler attributes (`_handle_create_post`, `_handle_update_provider`, etc.) preserved for contract-test patching.

Favorites stays hand-rolled — edge ops aren't CRUD-shaped; introducing edge mount helpers is out of scope.

## Framework tests

7 new tests covering: dispatch matrix (each route flag wired), state axes, subresources, missing handler key (KeyError), extra handler key (ValueError), owned-subentity parent mismatch (ValueError).

## Verification

- `dev test` (703 passed) ✅
- `dev test contract` (16 passed) ✅
- `dev lint` ✅
- Wire contract unchanged.

## Test plan

- [x] `dev test` passes
- [x] `dev test contract` passes
- [x] `dev lint` passes
- [ ] CI green

## Note on phase 2 progress

After B4 the framework has collapsed the major route-layer + handler-layer boilerplate for the migrated entities. The original phase-2 plan mentioned possible B5/B6 PRs (schema generation, template generation). Per the issue's "honest framing": both have substantially higher complexity-vs-payoff than B1-B4 (discriminated-union schemas, kind-aware templates, custom Pydantic validators). Whether to continue is a judgment call I'll surface separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)