### PR TITLE
Remove misleading PHASE2_REDUNDANT markers from route tests

### DIFF
--- a/src/api/routes/test_posts.py
+++ b/src/api/routes/test_posts.py
@@ -55,7 +55,6 @@ def _make_test_post(owner: User, *, description: str | None = None) -> Post:
 # --- Listing -------------------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_list empty state.
 async def test_list_posts_empty(
     authenticated_client: AsyncClient,
     logged_in_user: User,
@@ -133,7 +132,6 @@ async def test_list_posts_orders_newest_first(
 # --- Update (PATCH) ------------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — write_authz binding on mount_update.
 async def test_non_owner_cannot_patch_post(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -159,7 +157,6 @@ async def test_non_owner_cannot_patch_post(
         assert refreshed.client_referral_detail.description == "orig"
 
 
-# PHASE2_REDUNDANT: framework-shaped — admin override on mount_update.
 async def test_admin_can_patch_anyone_post(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/api/routes/test_providers.py
+++ b/src/api/routes/test_providers.py
@@ -140,7 +140,6 @@ async def test_create_provider_allows_multiple_per_user(
 # --- Provider reads -------------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_detail rendering happy path.
 async def test_get_provider_renders_detail_page(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -194,7 +193,6 @@ async def test_get_provider_hides_edit_link_for_non_owner(
 # --- Provider listing -----------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_list rendering happy path.
 async def test_list_providers_renders_html(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -220,7 +218,6 @@ async def test_list_providers_renders_html(
     assert "Open House" in response.text
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_list empty state.
 async def test_list_providers_renders_empty_state(
     authenticated_client: AsyncClient,
 ):
@@ -314,7 +311,6 @@ async def test_list_providers_treats_empty_filter_values_as_absent(
 # --- Provider update ------------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_update happy path.
 async def test_patch_provider_updates_fields(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -342,7 +338,6 @@ async def test_patch_provider_updates_fields(
         assert refreshed.practice_name == "New Name"
 
 
-# PHASE2_REDUNDANT: framework-shaped — write_authz binding on mount_update.
 async def test_patch_provider_returns_403_if_not_owner(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -408,7 +403,6 @@ async def test_delete_provider_returns_204_and_cascades(
 # --- Licensure sub-resource ---------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_update subrow happy path.
 async def test_patch_licensure_updates_fields(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -464,7 +458,6 @@ async def test_patch_licensure_returns_404_for_mismatched_provider(
 # --- Create form page (GET /providers/form) ----------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_form (new) rendering happy path.
 async def test_get_provider_form_renders(
     authenticated_client: AsyncClient,
     logged_in_user: User,

--- a/src/api/routes/test_users.py
+++ b/src/api/routes/test_users.py
@@ -52,7 +52,6 @@ async def test_base_template_hides_nav_for_anonymous_visitors(
 # --- Listing -------------------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — generic mount_list rendering.
 async def test_list_users_empty(
     authenticated_client: AsyncClient,
     logged_in_user: User,
@@ -69,7 +68,6 @@ async def test_list_users_empty(
     assert link_node is not None, "Refresh link not found"
 
 
-# PHASE2_REDUNDANT: framework-shaped — generic mount_list rendering.
 async def test_list_users_multiple_users(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -170,7 +168,6 @@ async def test_list_shows_reactivate_for_deactivated_user(
 # --- Detail page ---------------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — generic mount_detail rendering.
 async def test_get_user_detail_renders(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -293,7 +290,6 @@ async def test_detail_hides_admin_actions_for_non_admin(
     assert tree.css_first("span.admin-actions") is None
 
 
-# PHASE2_REDUNDANT: framework-shaped — related-list empty state via mount_related_list.
 async def test_detail_shows_providers_empty_state(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -314,7 +310,6 @@ async def test_detail_shows_providers_empty_state(
     assert "No providers yet" in empty.text()
 
 
-# PHASE2_REDUNDANT: framework-shaped — related-list rendering via mount_related_list.
 async def test_detail_lists_owned_providers(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -346,7 +341,6 @@ async def test_detail_lists_owned_providers(
 # --- Activation endpoint -------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_state_axis happy path.
 async def test_admin_can_deactivate_user(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -374,7 +368,6 @@ async def test_admin_can_deactivate_user(
         assert refreshed.is_active is False
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_state_axis happy path (inverse).
 async def test_admin_can_reactivate_user(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -427,7 +420,6 @@ async def test_admin_cannot_deactivate_self(
     assert response.status_code == 403
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_state_axis 404 wiring.
 async def test_activation_404_for_unknown_user(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -444,7 +436,6 @@ async def test_activation_404_for_unknown_user(
 # --- Delete endpoint -----------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — mount_delete happy path + HX-Redirect.
 async def test_admin_can_delete_user(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -478,7 +469,6 @@ async def test_admin_cannot_delete_self(
 # --- Audit log -----------------------------------------------------------
 
 
-# PHASE2_REDUNDANT: framework-shaped — audit binding via state-axis action.
 async def test_set_user_activation_writes_audit_row(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -509,7 +499,6 @@ async def test_set_user_activation_writes_audit_row(
         assert row.after == {"is_active": False}
 
 
-# PHASE2_REDUNDANT: framework-shaped — audit-on-success-only guarantee.
 async def test_failed_activation_writes_no_audit_row(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -532,7 +521,6 @@ async def test_failed_activation_writes_no_audit_row(
         assert rows == []
 
 
-# PHASE2_REDUNDANT: framework-shaped — audit binding via AuditedResource on mutate().
 async def test_delete_user_writes_audit_row(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],


### PR DESCRIPTION
## Summary

- Removes 22 inline `# PHASE2_REDUNDANT:` markers across `test_posts.py`, `test_providers.py`, `test_users.py`
- The markers implied the annotated tests duplicated framework coverage and were safe to delete in a phase-2 sweep
- Audit (this session) confirmed the implication is wrong: every marked test asserts HTTP status/headers, real DB persistence, real `audit_log` rows, or rendered HTML structure — none of which framework tests cover (those use `_FakeRepo` / `_FakeAuditRepo` and assert handler internals only)
- Removing the markers so future readers don't walk into the same trap

## Test plan

- [x] `grep -rn PHASE2_REDUNDANT src/` returns nothing
- [x] pre-commit hooks pass (black, isort, autoflake)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)