### PR TITLE
Add EntitySpec.can_write predicate; collapse can_edit duplication (#339)

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -309,6 +309,7 @@ Per-entity instances at `src/api/common/specs/<entity>.py` carry:
 - **Identity** — `name`, `url_collection`, `id_param`, `model`, `owner_attr`.
 - **Ownership chain** — `parent: EntitySpec | None` for owned subentities (the three provider credential entities set `parent=PROVIDER_ENTITY`).
 - **FastAPI deps** — `repo_dep`, `read_user_dep`, `write_user_dep`. `read_user_dep=None` declares a public read.
+- **Write authorization** — `write_authz: Callable[..., None] | None` is the raising form (consumed by mutation handlers in the generic CRUD framework); `can_write: Callable[..., bool] | None` is the predicate sibling (bound to detail-handler `can_edit` flags so the rule isn't re-derived in handler bodies). Convention: where both are set, they encode the same rule (e.g. `assert_owner_or_admin` + `is_owner_or_admin` for owner-or-admin entities); a spec-correctness test pins the pair on each entity.
 - **Audit binding** — exactly one of: `audit: AuditedResource` for CRUD-shaped entities, or `edge_audit: EdgeAudit` for non-CRUD edges (favorites uses `edge_audit` with the `(add, remove)` verb map). Mutually exclusive; construction-time validation enforces.
 - **Visibility** — `private_fields`, `private_field_predicate` (the projection rule from #304).
 - **Route opt-ins** — `routes: RouteSet` flags: `list`, `detail`, `create`, `update`, `delete`, `form_new`, `form_edit`. Phase 1 reads these for documentation + spec-correctness tests; `mount_entity` (added in phase 2) consumes them at mount time.

--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -200,6 +200,15 @@ class EntitySpec:
     read_user_dep: Callable[..., Any] | None = None
     write_user_dep: Callable[..., Any] | None = None
     write_authz: Callable[..., None] | None = None
+    # Predicate form of `write_authz` — non-raising boolean returning
+    # True iff the user is allowed to mutate the target. Bound directly
+    # to detail-handler context flags (`can_edit = entity.can_write(
+    # target, user)`) so handlers don't re-derive the composition.
+    # Convention: where `write_authz` is set, `can_write` carries the
+    # same rule (e.g. both are `assert_owner_or_admin` / `is_owner_or_admin`
+    # for owner-or-admin entities). Not validator-enforced — a spec test
+    # asserts the pair on each entity.
+    can_write: Callable[..., bool] | None = None
 
     # Audit --------------------------------------------------------------
     # `audit` and `edge_audit` are mutually exclusive — CRUD-shaped

--- a/src/api/common/specs/_credential.py
+++ b/src/api/common/specs/_credential.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, TypeAdapter
 from src.api.common.entity_spec import EntitySpec, RouteSet
 from src.api.common.specs.provider import PROVIDER_ENTITY, _provider_form_redirect
 from src.auth_config import current_active_user
-from src.logic._authz import assert_owner_or_admin
+from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
 from src.logic.audit import AuditAction, AuditedResource, make_snapshotter
 from src.repositories.dependencies import get_provider_repository
 
@@ -63,6 +63,7 @@ def make_provider_credential_entity(
         repo_dep=get_provider_repository,
         write_user_dep=current_active_user,
         write_authz=assert_owner_or_admin,
+        can_write=is_owner_or_admin,
         audit=audited_resource,
         create_adapter=create_adapter,
         update_adapter=update_adapter,

--- a/src/api/common/specs/post.py
+++ b/src/api/common/specs/post.py
@@ -22,7 +22,7 @@ from typing import Final
 
 from src.api.common.entity_spec import EntitySpec, RouteSet, Templates
 from src.auth_config import current_active_user
-from src.logic._authz import assert_owner_or_admin
+from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
 from src.logic.audit import AuditAction, AuditedResource
 from src.models import POST_KINDS, Post
 from src.repositories.dependencies import get_post_repository
@@ -73,6 +73,7 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
     read_user_dep=current_active_user,
     write_user_dep=current_active_user,
     write_authz=assert_owner_or_admin,
+    can_write=is_owner_or_admin,
     audit=POST_AUDITED_RESOURCE,
     create_adapter=post_create_adapter,
     update_adapter=post_update_adapter,

--- a/src/api/common/specs/provider.py
+++ b/src/api/common/specs/provider.py
@@ -21,7 +21,7 @@ from typing import Final
 from src.api.common.entity_spec import EntitySpec, RouteSet, Templates
 from src.api.common.resource_routes import QueryParam
 from src.auth_config import current_active_user
-from src.logic._authz import assert_owner_or_admin
+from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
 from src.logic.audit import AuditAction, AuditedResource, make_snapshotter
 from src.models import Provider
 from src.repositories.dependencies import get_provider_repository
@@ -62,6 +62,7 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     read_user_dep=current_active_user,
     write_user_dep=current_active_user,
     write_authz=assert_owner_or_admin,
+    can_write=is_owner_or_admin,
     audit=PROVIDER_AUDITED_RESOURCE,
     create_adapter=provider_create_adapter,
     update_adapter=provider_update_adapter,

--- a/src/api/common/specs/test_post.py
+++ b/src/api/common/specs/test_post.py
@@ -2,7 +2,7 @@
 
 from src.api.common.entity_spec import RouteSet
 from src.api.common.specs.post import POST_ENTITY
-from src.logic._authz import assert_owner_or_admin
+from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
 from src.logic.audit import AuditAction
 from src.models import POST_KINDS, Post
 from src.schemas.posts.post import post_create_adapter, post_update_adapter
@@ -77,6 +77,12 @@ def test_read_to_dict_flattens_via_post_kinds():
 
 def test_write_authz_is_assert_owner_or_admin():
     assert POST_ENTITY.write_authz is assert_owner_or_admin
+
+
+def test_can_write_is_is_owner_or_admin():
+    """Predicate sibling of `write_authz` — read by detail handlers for
+    `can_edit` flags so the rule lives in exactly one place."""
+    assert POST_ENTITY.can_write is is_owner_or_admin
 
 
 # --- Redirects -----------------------------------------------------------

--- a/src/api/common/specs/test_provider.py
+++ b/src/api/common/specs/test_provider.py
@@ -6,7 +6,7 @@ Asserts the spec declares the right things — not that CRUD works
 
 from src.api.common.entity_spec import RouteSet
 from src.api.common.specs.provider import PROVIDER_ENTITY
-from src.logic._authz import assert_owner_or_admin
+from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
 from src.logic.audit import AuditAction
 from src.models import Provider
 from src.schemas.providers.provider import (
@@ -88,6 +88,12 @@ def test_read_to_dict_returns_provider_read_shape():
 
 def test_write_authz_is_assert_owner_or_admin():
     assert PROVIDER_ENTITY.write_authz is assert_owner_or_admin
+
+
+def test_can_write_is_is_owner_or_admin():
+    """Predicate sibling of `write_authz` — read by detail handlers for
+    `can_edit` flags so the rule lives in exactly one place."""
+    assert PROVIDER_ENTITY.can_write is is_owner_or_admin
 
 
 # --- List filters --------------------------------------------------------

--- a/src/api/common/specs/test_provider_credentials.py
+++ b/src/api/common/specs/test_provider_credentials.py
@@ -14,7 +14,7 @@ from src.api.common.specs.provider import PROVIDER_ENTITY
 from src.api.common.specs.provider_certification import CERTIFICATION_ENTITY
 from src.api.common.specs.provider_education import EDUCATION_ENTITY
 from src.api.common.specs.provider_licensure import LICENSURE_ENTITY
-from src.logic._authz import assert_owner_or_admin
+from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
 from src.logic.audit import AuditAction
 from src.models import ProviderCertification, ProviderEducation, ProviderLicensure
 from src.schemas.providers.provider import (
@@ -185,6 +185,25 @@ def test_write_authz_is_assert_owner_or_admin(
     update_adapter,
 ):
     assert entity.write_authz is assert_owner_or_admin
+
+
+@pytest.mark.parametrize(
+    "entity,name,url_collection,id_param,model,audit_actions,create_adapter,update_adapter",
+    CREDENTIALS,
+)
+def test_can_write_is_is_owner_or_admin(
+    entity,
+    name,
+    url_collection,
+    id_param,
+    model,
+    audit_actions,
+    create_adapter,
+    update_adapter,
+):
+    """Predicate sibling of `write_authz` — read by detail handlers for
+    `can_edit` flags so the rule lives in exactly one place."""
+    assert entity.can_write is is_owner_or_admin
 
 
 @pytest.mark.parametrize(

--- a/src/logic/_authz.py
+++ b/src/logic/_authz.py
@@ -3,11 +3,14 @@
 The leading-underscore filename matches `src/schemas/_validators.py` —
 shared infra at the layer's parent level, importable from every cluster.
 
-The boolean predicates (`is_admin`, `is_owner`) are the source of truth
-for the authorization rules. Handlers compose them to compute
-template-context flags (`can_edit = is_owner(post, user) or is_admin(user)`),
-and the asserting form (`assert_owner_or_admin`) wraps the same
-composition for use as a single-callable in `ResourceSpec.write_authz`.
+The boolean predicates (`is_admin`, `is_owner`, `is_owner_or_admin`)
+are the source of truth for the authorization rules. The asserting
+form (`assert_owner_or_admin`) wraps `is_owner_or_admin` for use as a
+single-callable in `EntitySpec.write_authz` (the raising form, consumed
+by mutation handlers); the predicate is bound directly to
+`EntitySpec.can_write` for use in template-context flags
+(`can_edit = entity.can_write(target, user)`) so detail handlers don't
+re-derive the composition.
 """
 
 from src.api.common.exceptions import ForbiddenError
@@ -32,6 +35,18 @@ def is_owner(obj, user: User | None, *, owner_attr: str = "owner_id") -> bool:
     return getattr(obj, owner_attr) == user.id
 
 
+def is_owner_or_admin(obj, user: User | None, *, owner_attr: str = "owner_id") -> bool:
+    """True iff `user` owns `obj` (by FK) or is a superuser.
+
+    Predicate form of `assert_owner_or_admin`. The two forms share one
+    composition — `assert_owner_or_admin` delegates here — so a future
+    rule change happens in exactly one place. Bound to
+    `EntitySpec.can_write` for entities whose write rule is owner-or-admin
+    (posts, providers, provider credentials).
+    """
+    return is_owner(obj, user, owner_attr=owner_attr) or is_admin(user)
+
+
 def is_self_or_admin(actor: User | None, target) -> bool:
     """True iff `actor` is authenticated and is either `target` itself or a superuser.
 
@@ -53,8 +68,10 @@ def assert_owner_or_admin(
 ) -> None:
     """Raise `ForbiddenError` unless `user` owns `obj` or is a superuser.
 
+    Asserting wrapper over `is_owner_or_admin` — the predicate is the
+    rule, this function is the raising form for `EntitySpec.write_authz`.
     `action` is interpolated into the error message: ``"Only the owner
     or an admin can {action}"``.
     """
-    if not (is_owner(obj, user, owner_attr=owner_attr) or is_admin(user)):
+    if not is_owner_or_admin(obj, user, owner_attr=owner_attr):
         raise ForbiddenError(detail=f"Only the owner or an admin can {action}")

--- a/src/logic/posts/post_processing.py
+++ b/src/logic/posts/post_processing.py
@@ -5,7 +5,6 @@ from fastapi import Request
 
 from src.api.common.exceptions import NotFoundError
 from src.api.common.specs.post import POST_ENTITY
-from src.logic._authz import is_admin, is_owner
 from src.models import POST_KINDS, User
 from src.repositories.posts.post_repository import PostRepository
 from src.schemas.posts.post import (
@@ -53,9 +52,10 @@ async def handle_get_post_detail(
 ):
     """Loads a single post for the detail page; 404s if missing.
 
-    Computes `can_edit` (owner-or-admin) so the owner-actions partial
-    can render based on a single named flag instead of re-deriving the
-    rule against `current_user`.
+    `can_edit` is the post's owner-or-admin predicate, read from
+    `POST_ENTITY.can_write` so the rule lives in exactly one place
+    (the spec); the asserting form on the same spec
+    (`POST_ENTITY.write_authz`) gates mutations.
     """
     post = await repo.get_post_by_id(post_id)
     if post is None:
@@ -65,7 +65,7 @@ async def handle_get_post_detail(
         "request": request,
         "post": post,
         "current_user": requesting_user,
-        "can_edit": is_owner(post, requesting_user) or is_admin(requesting_user),
+        "can_edit": POST_ENTITY.can_write(post, requesting_user),
     }
 
 

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -26,7 +26,6 @@ from src.api.common.specs.provider import PROVIDER_ENTITY
 from src.api.common.specs.provider_certification import CERTIFICATION_ENTITY
 from src.api.common.specs.provider_education import EDUCATION_ENTITY
 from src.api.common.specs.provider_licensure import LICENSURE_ENTITY
-from src.logic._authz import is_admin, is_owner
 from src.logic.audit import mutate
 from src.models import (
     Provider,
@@ -117,7 +116,7 @@ async def handle_get_provider_detail(
     round-trip.
     """
     provider = await _load_provider_or_404(provider_id, repo)
-    can_edit = is_owner(provider, requesting_user) or is_admin(requesting_user)
+    can_edit = PROVIDER_ENTITY.can_write(provider, requesting_user)
     if requesting_user is None:
         is_favorited = False
     else:

--- a/src/logic/test__authz.py
+++ b/src/logic/test__authz.py
@@ -10,6 +10,7 @@ from src.logic._authz import (
     assert_owner_or_admin,
     is_admin,
     is_owner,
+    is_owner_or_admin,
     is_self_or_admin,
 )
 
@@ -54,8 +55,8 @@ def test_is_owner_non_matching_id():
 
 
 def test_is_owner_admin_is_not_automatic_owner():
-    """`is_owner` checks ownership only; admin-override is the caller's
-    job to compose (`is_owner(...) or is_admin(...)`)."""
+    """`is_owner` checks ownership only; admin-override is the
+    `is_owner_or_admin` composition's job, not `is_owner`'s."""
     u = _user(is_superuser=True)
     obj = SimpleNamespace(owner_id=uuid.uuid4())
     assert is_owner(obj, u) is False
@@ -65,6 +66,38 @@ def test_is_owner_custom_owner_attr():
     u = _user()
     obj = SimpleNamespace(user_id=u.id)
     assert is_owner(obj, u, owner_attr="user_id") is True
+
+
+# --- is_owner_or_admin -----------------------------------------------------
+
+
+def test_is_owner_or_admin_none_user():
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner_or_admin(obj, None) is False
+
+
+def test_is_owner_or_admin_owner_passes():
+    u = _user()
+    obj = SimpleNamespace(owner_id=u.id)
+    assert is_owner_or_admin(obj, u) is True
+
+
+def test_is_owner_or_admin_admin_passes_even_if_not_owner():
+    admin = _user(is_superuser=True)
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner_or_admin(obj, admin) is True
+
+
+def test_is_owner_or_admin_stranger_fails():
+    u = _user()
+    obj = SimpleNamespace(owner_id=uuid.uuid4())
+    assert is_owner_or_admin(obj, u) is False
+
+
+def test_is_owner_or_admin_custom_owner_attr():
+    u = _user()
+    obj = SimpleNamespace(user_id=u.id)
+    assert is_owner_or_admin(obj, u, owner_attr="user_id") is True
 
 
 # --- is_self_or_admin ------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `is_owner_or_admin` predicate to `_authz.py`; `assert_owner_or_admin` now delegates to it — one composition, two forms.
- Adds `EntitySpec.can_write` field for the predicate binding (sibling of `write_authz`); post, provider, and the three credential specs adopt it.
- `handle_get_post_detail` and `handle_get_provider_detail` now read `<ENTITY>.can_write(target, user)` instead of re-deriving `is_owner(...) or is_admin(...)` inline.
- Closes #339.

## Test plan

- [x] `dev test` — 719 passed, 1 skipped (10 new tests)
- [x] `dev test contract` — 16 passed
- [x] `dev lint` — clean
- [x] Spec-correctness tests on post / provider / credentials assert `can_write is is_owner_or_admin`
- [x] `grep -rn "is_owner(.*) or is_admin(" src/` returns only the composition itself + docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)