### PR TITLE
mount_entity auto-binds standard CRUD handlers for owned subentities

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -240,7 +240,7 @@ Migrated route files compose the individual `mount_*` helpers through `mount_ent
 - `entity.filters` — passed as `query_params=` to `mount_list`.
 - `entity.discriminator` — if set, the form-new mount auto-derives `Literal[*entity.discriminator.names]` for the `?kind=` query param.
 - `entity.read_user_dep` — `None` means public read; `mount_list` is called with `public=True`.
-- `owned_subentities` — a tuple of child `EntitySpec`s whose `parent` is `entity`. Each is mounted recursively via the same dispatcher; the handlers dict for an owned subentity is keyed `f"{owned.name}.{verb}"` (e.g. `"licensure.create"`).
+- `owned_subentities` — a tuple of child `EntitySpec`s whose `parent` is `entity`. Each is mounted recursively via the same dispatcher; the handlers dict for an owned subentity is keyed `f"{owned.name}.{verb}"` (e.g. `"licensure.create"`). For verbs that match the standard CRUD-framework factories (`create`, `update`, `delete`, `detail`, `form_edit`), the explicit key is optional — `mount_entity` falls back to `make_<verb>_handler(owned)`, which is the common case for subentities whose mutations are entirely standard. Verbs without a default factory (`list`, `form_new`) still require an explicit entry; supplying any explicit key overrides the factory default.
 
 The handlers dict is validated at mount time: every opted-in flag / state axis / subresource must have a matching key, and any extra keys raise (typo detection). Missing entries fail loudly at app startup.
 

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -803,6 +803,38 @@ def mount_related_list(
     router.get(path)(route_fn)
 
 
+def _owned_factory_makers() -> dict[str, Callable[..., Callable[..., Awaitable[Any]]]]:
+    """Lazy-import the generic CRUD-framework factories for owned subentities.
+
+    Imported on demand to avoid a module-import cycle: this module is
+    imported by ``src.api.common.entity_spec`` (for ``ResourceSpec`` and
+    ``QueryParam``), and ``src.logic._generic`` imports ``EntitySpec``.
+    Doing the import inside ``mount_entity``'s owned-subentity branch
+    breaks the cycle — by the time we reach this code at runtime, the
+    logic module has finished initializing.
+
+    Only verbs whose factory delegates to a standard ritual appear
+    here. ``list`` and ``form_new`` have no defaults because their
+    bespoke knobs (custom repo query / template selection) make
+    auto-binding unsafe.
+    """
+    from src.logic._generic import (
+        make_create_handler,
+        make_delete_handler,
+        make_detail_handler,
+        make_edit_form_handler,
+        make_update_handler,
+    )
+
+    return {
+        "create": make_create_handler,
+        "update": make_update_handler,
+        "delete": make_delete_handler,
+        "detail": make_detail_handler,
+        "form_edit": make_edit_form_handler,
+    }
+
+
 def mount_entity(
     router: Any,
     entity: Any,  # `EntitySpec` — imported lazily to avoid a cycle
@@ -827,6 +859,12 @@ def mount_entity(
         `"providers"` for the user → providers related list).
       - For each `owned_subentities[i]`: one per opted-in verb keyed
         `f"{owned.name}.{verb}"` (e.g. `"provider_licensure.create"`).
+        Verbs that match the generic CRUD-framework factories
+        (`create`, `update`, `delete`, `detail`, `form_edit`) fall
+        back to ``make_<verb>_handler(owned)`` when no explicit key
+        is supplied — the common case for subentities whose
+        mutations are entirely standard. Supplying the explicit key
+        still works and overrides the default.
 
     Validates loudly at mount time:
       - Every opted-in route / state-axis / subresource must have a
@@ -926,6 +964,15 @@ def mount_entity(
     # Owned-subentity recursion: each child entity gets its own
     # `mount_entity` call with its own slice of the handlers dict
     # (keyed by `<owned.name>.<verb>`).
+    #
+    # For verbs whose generic CRUD-framework factory exists
+    # (`make_<verb>_handler` in `src.logic._generic`), we auto-bind a
+    # factory-built handler when the explicit key is absent — the
+    # default case for credential-style subentities whose mutations
+    # are entirely standard. Supplying the explicit key still works
+    # and overrides the default; that's the escape hatch for
+    # subentities that need bespoke creates / updates / deletes.
+    factory_makers = _owned_factory_makers() if owned_subentities else {}
     for owned in owned_subentities:
         if owned.parent is not entity:
             raise ValueError(
@@ -943,10 +990,21 @@ def mount_entity(
             "form_new",
             "form_edit",
         ):
-            if getattr(owned.routes, verb):
-                k = f"{owned.name}.{verb}"
+            if not getattr(owned.routes, verb):
+                continue
+            k = f"{owned.name}.{verb}"
+            if k in handlers:
                 owned_handlers[verb] = handlers[k]
                 consumed.add(k)
+            elif verb in factory_makers:
+                owned_handlers[verb] = factory_makers[verb](owned)
+            else:
+                raise KeyError(
+                    f"mount_entity({entity.name!r}): owned subentity "
+                    f"{owned.name!r} opts into {verb!r} but no handler "
+                    f"was supplied at handlers[{k!r}] and no default "
+                    "factory exists for this verb."
+                )
         mount_entity(router, owned, handlers=owned_handlers)
 
     # Typo detection — surface stale keys at mount time.

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -1359,6 +1359,137 @@ def test_mount_entity_owned_subentity_parent_mismatch_raises():
         mount_entity(None, correct_parent, handlers={}, owned_subentities=(child,))
 
 
+def test_mount_entity_owned_subentity_auto_binds_default_factory():
+    """Standard CRUD verbs on an owned subentity bind to
+    `make_<verb>_handler(child)` when no explicit
+    `<owned.name>.<verb>` key is supplied."""
+    from pydantic import TypeAdapter
+
+    parent = _EntitySpec(
+        name="parent",
+        url_collection="parents",
+        id_param="parent_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+    )
+    child = _EntitySpec(
+        name="child",
+        url_collection="children",
+        id_param="child_id",
+        model=SimpleNamespace,
+        parent=parent,
+        audit=_stub_audit(),
+        create_adapter=TypeAdapter(_AxisBody),
+        update_adapter=TypeAdapter(_AxisBody),
+        routes=_RouteSet(create=True, update=True, delete=True),
+    )
+
+    captured: list[Callable[..., Any]] = []
+    import src.api.common.resource_routes as rr
+
+    originals = {}
+    for fn_name in ("mount_create", "mount_update", "mount_delete"):
+        originals[fn_name] = getattr(rr, fn_name)
+        setattr(
+            rr,
+            fn_name,
+            lambda *a, _n=fn_name, **k: captured.append((_n, k.get("handler"))),
+        )
+    try:
+        mount_entity(None, parent, handlers={}, owned_subentities=(child,))
+    finally:
+        for n, orig in originals.items():
+            setattr(rr, n, orig)
+
+    handler_names = {n: h.__name__ for n, h in captured}
+    assert handler_names == {
+        "mount_create": "_handle_create_child",
+        "mount_update": "_handle_update_child",
+        "mount_delete": "_handle_delete_child",
+    }
+
+
+def test_mount_entity_owned_subentity_explicit_handler_overrides_default():
+    """An explicit `<owned.name>.<verb>` key wins over the
+    auto-bound factory default."""
+    from pydantic import TypeAdapter
+
+    parent = _EntitySpec(
+        name="parent",
+        url_collection="parents",
+        id_param="parent_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+    )
+    child = _EntitySpec(
+        name="child",
+        url_collection="children",
+        id_param="child_id",
+        model=SimpleNamespace,
+        parent=parent,
+        audit=_stub_audit(),
+        create_adapter=TypeAdapter(_AxisBody),
+        update_adapter=TypeAdapter(_AxisBody),
+        routes=_RouteSet(create=True, update=True, delete=True),
+    )
+
+    async def bespoke_create(**_kw):  # pragma: no cover
+        return None
+
+    captured: list[Callable[..., Any]] = []
+    import src.api.common.resource_routes as rr
+
+    originals = {}
+    for fn_name in ("mount_create", "mount_update", "mount_delete"):
+        originals[fn_name] = getattr(rr, fn_name)
+        setattr(
+            rr,
+            fn_name,
+            lambda *a, _n=fn_name, **k: captured.append((_n, k.get("handler"))),
+        )
+    try:
+        mount_entity(
+            None,
+            parent,
+            handlers={"child.create": bespoke_create},
+            owned_subentities=(child,),
+        )
+    finally:
+        for n, orig in originals.items():
+            setattr(rr, n, orig)
+
+    by_mount = dict(captured)
+    assert by_mount["mount_create"] is bespoke_create
+    # update + delete fall back to factory defaults.
+    assert by_mount["mount_update"].__name__ == "_handle_update_child"
+    assert by_mount["mount_delete"].__name__ == "_handle_delete_child"
+
+
+def test_mount_entity_owned_subentity_no_default_factory_raises():
+    """Opting an owned subentity into a verb without a default factory
+    (e.g. `list`, `form_new`) requires an explicit handler — missing
+    one raises `KeyError` at mount time."""
+    parent = _EntitySpec(
+        name="parent",
+        url_collection="parents",
+        id_param="parent_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+    )
+    child = _EntitySpec(
+        name="child",
+        url_collection="children",
+        id_param="child_id",
+        model=SimpleNamespace,
+        parent=parent,
+        audit=_stub_audit(),
+        routes=_RouteSet(list=True),
+        templates=_Templates(list="x/list.html"),
+    )
+    with pytest.raises(KeyError, match="no default factory"):
+        mount_entity(None, parent, handlers={}, owned_subentities=(child,))
+
+
 def test_mount_delete_404_propagates_from_handler():
     """If the handler raises NotFoundError, the route surfaces it as 404
     (decorator translation). Confirms the mount doesn't swallow exceptions."""

--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -173,7 +173,9 @@ The `_handle_<verb>_<entity>` named module attributes exist so contract tests ca
 
 ### Adding a sub-resource
 
-Declare the child entity with `parent=PARENT_ENTITY` on its spec (see `specs/provider_licensure.py` etc.). Pass the child entity through `owned_subentities=` on the parent's `mount_entity` call; the dispatcher walks the chain to build paths like `/providers/{provider_id}/licensures/{licensure_id}` and route handlers under keys prefixed by the child's name:
+Declare the child entity with `parent=PARENT_ENTITY` on its spec (see `specs/provider_licensure.py` etc.). Pass the child entity through `owned_subentities=` on the parent's `mount_entity` call; the dispatcher walks the chain to build paths like `/providers/{provider_id}/licensures/{licensure_id}`.
+
+For each opted-in verb on the child, `mount_entity` looks for `handlers["<child.name>.<verb>"]`; if absent and the verb has a default CRUD factory (`create`, `update`, `delete`, `detail`, `form_edit`), it auto-binds `make_<verb>_handler(child)`. Common case — credentials' subrow CRUD is entirely standard:
 
 ```python
 mount_entity(
@@ -181,14 +183,15 @@ mount_entity(
     PROVIDER_ENTITY,
     handlers={
         # ... parent handlers ...
-        "licensure.create": _handle_create_licensure,
-        "licensure.update": _handle_update_licensure,
-        "licensure.delete": _handle_delete_licensure,
-        # ... ditto for education / certification ...
+        # No `licensure.*` / `education.*` / `certification.*` entries needed:
+        # mount_entity auto-binds make_create_handler / make_update_handler /
+        # make_delete_handler for each opted-in verb on each owned subentity.
     },
     owned_subentities=(LICENSURE_ENTITY, EDUCATION_ENTITY, CERTIFICATION_ENTITY),
 )
 ```
+
+Supply `handlers["<child.name>.<verb>"]` only when the child needs a bespoke handler for that verb (e.g. a subentity create with side effects). Verbs without a default factory (`list`, `form_new`) always require an explicit entry — auto-binding would need bespoke knobs (custom repo query / template selection) that can't be inferred.
 
 Each factory-built handler receives both `provider_id=` and the child id (e.g. `licensure_id=`), plus `payload=`, `repo=`, `audit_repo=`, `requesting_user=`.
 

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -9,7 +9,6 @@ from src.api.common.specs.provider_certification import CERTIFICATION_ENTITY
 from src.api.common.specs.provider_education import EDUCATION_ENTITY
 from src.api.common.specs.provider_licensure import LICENSURE_ENTITY
 from src.logic._generic import (
-    make_create_handler,
     make_delete_handler,
     make_detail_handler,
     make_edit_form_handler,
@@ -58,6 +57,10 @@ _handle_get_provider_detail = _named(
 )
 
 
+# Owned-subentity verbs (credentials' create/update/delete) get
+# auto-bound by `mount_entity` from `make_<verb>_handler(child)` — see
+# the dispatcher's owned-subentity branch. No explicit `provider_<x>.<verb>`
+# entries needed unless the verb wants a bespoke handler.
 mount_entity(
     router,
     PROVIDER_ENTITY,
@@ -73,16 +76,6 @@ mount_entity(
         "delete": _handle_delete_provider,
         "form_new": handle_get_provider_form,
         "form_edit": _handle_get_provider_edit_form,
-        # Owned-subentity verbs, keyed by `<owned.name>.<verb>`.
-        "provider_licensure.create": make_create_handler(LICENSURE_ENTITY),
-        "provider_licensure.update": make_update_handler(LICENSURE_ENTITY),
-        "provider_licensure.delete": make_delete_handler(LICENSURE_ENTITY),
-        "provider_education.create": make_create_handler(EDUCATION_ENTITY),
-        "provider_education.update": make_update_handler(EDUCATION_ENTITY),
-        "provider_education.delete": make_delete_handler(EDUCATION_ENTITY),
-        "provider_certification.create": make_create_handler(CERTIFICATION_ENTITY),
-        "provider_certification.update": make_update_handler(CERTIFICATION_ENTITY),
-        "provider_certification.delete": make_delete_handler(CERTIFICATION_ENTITY),
     },
     owned_subentities=(LICENSURE_ENTITY, EDUCATION_ENTITY, CERTIFICATION_ENTITY),
 )


### PR DESCRIPTION
## Summary

- `mount_entity` falls back to `make_<verb>_handler(child)` for owned subentities when `handlers["<child.name>.<verb>"]` is absent and the verb has a default factory (create / update / delete / detail / form_edit). Explicit keys still win — bespoke creates / updates / deletes are unchanged.
- Removes the nine boilerplate handler entries from `src/api/routes/providers.py` for licensure / education / certification (their three opted-in verbs each are entirely standard).
- Verbs without a default factory (`list`, `form_new`) still require an explicit entry — auto-binding would need bespoke knobs.
- Lazy-imports the factories from `src.logic._generic` inside `mount_entity` to avoid the `resource_routes → _generic → entity_spec → resource_routes` cycle.

This is a follow-on from the spec-framework audit: the owned-subentity verb wiring had clear linear repetition (3 credentials × 3 verbs = 9 entries) with zero variance, and the dispatcher already had `owned_subentities=` plus a per-verb loop ready to consume it.

## Test plan

- [x] `dev test` (729 passed)
- [x] `dev lint`
- [x] `dev test contract` (16 passed)
- [x] Three new unit tests in `test_resource_routes.py` cover: (a) auto-bind when explicit key absent, (b) explicit key wins over default, (c) opting into a verb without a default factory still raises `KeyError` at mount time