### PR TITLE
Factor out make_audited_resource() to remove per-spec audit boilerplate

### DIFF
--- a/src/api/common/specs/_credential.py
+++ b/src/api/common/specs/_credential.py
@@ -19,7 +19,7 @@ from src.api.common.entity_spec import EntitySpec, RouteSet
 from src.api.common.specs.provider import PROVIDER_ENTITY, _provider_form_redirect
 from src.auth_config import current_active_user
 from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
-from src.logic.audit import AuditAction, AuditedResource, make_snapshotter
+from src.logic.audit import make_audited_resource
 from src.repositories.dependencies import get_provider_repository
 
 
@@ -29,7 +29,7 @@ def make_provider_credential_entity(
     url_collection: str,
     id_param: str,
     model: type,
-    audit_actions: tuple[AuditAction, AuditAction, AuditAction],
+    audit_stem: str,
     snapshot_schema: type[BaseModel],
     read_schema: type[BaseModel],
     create_adapter: TypeAdapter,
@@ -37,18 +37,17 @@ def make_provider_credential_entity(
 ) -> EntitySpec:
     """Build a credential-subentity `EntitySpec` from its varying pieces.
 
-    `audit_actions` is a `(create, update, delete)` triple of
-    `AuditAction` enum values. `snapshot_schema` is the Pydantic
-    schema used for audit before/after snapshots; `read_schema` is
-    the response shape for `PATCH` (consumed via `read_to_dict`).
+    `audit_stem` is the `AuditAction` enum stem (e.g. `"licensure"` for
+    the `CREATE_LICENSURE` / `UPDATE_LICENSURE` / `DELETE_LICENSURE`
+    triple) — the credential enum stems diverge from the entity `name`
+    (which is `"provider_licensure"`) so the stem is passed explicitly.
+    `snapshot_schema` is the Pydantic schema used for audit before/after
+    snapshots; `read_schema` is the response shape for `PATCH` (consumed
+    via `read_to_dict`).
     """
 
-    audited_resource = AuditedResource(
-        type=name,
-        snapshot=make_snapshotter(snapshot_schema),
-        create=audit_actions[0],
-        update=audit_actions[1],
-        delete=audit_actions[2],
+    audited_resource = make_audited_resource(
+        name, snapshot_schema, action_stem=audit_stem
     )
 
     def read_to_dict(row: Any) -> dict:

--- a/src/api/common/specs/post.py
+++ b/src/api/common/specs/post.py
@@ -23,7 +23,7 @@ from typing import Final
 from src.api.common.entity_spec import EntitySpec, RouteSet, Templates
 from src.auth_config import current_active_user
 from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
-from src.logic.audit import AuditAction, AuditedResource
+from src.logic.audit import AuditedResource, make_audited_resource
 from src.models import POST_KINDS, Post
 from src.repositories.dependencies import get_post_repository
 from src.schemas.posts.post import (
@@ -32,12 +32,8 @@ from src.schemas.posts.post import (
     post_update_adapter,
 )
 
-POST_AUDITED_RESOURCE: Final[AuditedResource] = AuditedResource(
-    type="post",
-    snapshot=post_audit_snapshot,
-    create=AuditAction.CREATE_POST,
-    update=AuditAction.UPDATE_POST,
-    delete=AuditAction.DELETE_POST,
+POST_AUDITED_RESOURCE: Final[AuditedResource] = make_audited_resource(
+    "post", post_audit_snapshot
 )
 
 

--- a/src/api/common/specs/provider.py
+++ b/src/api/common/specs/provider.py
@@ -22,7 +22,7 @@ from src.api.common.entity_spec import EntitySpec, RouteSet, Templates
 from src.api.common.resource_routes import QueryParam
 from src.auth_config import current_active_user
 from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
-from src.logic.audit import AuditAction, AuditedResource, make_snapshotter
+from src.logic.audit import AuditedResource, make_audited_resource
 from src.models import Provider
 from src.repositories.dependencies import get_provider_repository
 from src.schemas.providers.provider import (
@@ -32,12 +32,8 @@ from src.schemas.providers.provider import (
     provider_update_adapter,
 )
 
-PROVIDER_AUDITED_RESOURCE: Final[AuditedResource] = AuditedResource(
-    type="provider",
-    snapshot=make_snapshotter(ProviderAuditSnapshot),
-    create=AuditAction.CREATE_PROVIDER,
-    update=AuditAction.UPDATE_PROVIDER,
-    delete=AuditAction.DELETE_PROVIDER,
+PROVIDER_AUDITED_RESOURCE: Final[AuditedResource] = make_audited_resource(
+    "provider", ProviderAuditSnapshot
 )
 
 

--- a/src/api/common/specs/provider_certification.py
+++ b/src/api/common/specs/provider_certification.py
@@ -8,7 +8,6 @@ from typing import Final
 
 from src.api.common.entity_spec import EntitySpec
 from src.api.common.specs._credential import make_provider_credential_entity
-from src.logic.audit import AuditAction
 from src.models import ProviderCertification
 from src.schemas.providers.provider import (
     ProviderCertificationAuditSnapshot,
@@ -22,11 +21,7 @@ CERTIFICATION_ENTITY: Final[EntitySpec] = make_provider_credential_entity(
     url_collection="certifications",
     id_param="certification_id",
     model=ProviderCertification,
-    audit_actions=(
-        AuditAction.CREATE_CERTIFICATION,
-        AuditAction.UPDATE_CERTIFICATION,
-        AuditAction.DELETE_CERTIFICATION,
-    ),
+    audit_stem="certification",
     snapshot_schema=ProviderCertificationAuditSnapshot,
     read_schema=ProviderCertificationRead,
     create_adapter=certification_create_adapter,

--- a/src/api/common/specs/provider_education.py
+++ b/src/api/common/specs/provider_education.py
@@ -8,7 +8,6 @@ from typing import Final
 
 from src.api.common.entity_spec import EntitySpec
 from src.api.common.specs._credential import make_provider_credential_entity
-from src.logic.audit import AuditAction
 from src.models import ProviderEducation
 from src.schemas.providers.provider import (
     ProviderEducationAuditSnapshot,
@@ -22,11 +21,7 @@ EDUCATION_ENTITY: Final[EntitySpec] = make_provider_credential_entity(
     url_collection="educations",
     id_param="education_id",
     model=ProviderEducation,
-    audit_actions=(
-        AuditAction.CREATE_EDUCATION,
-        AuditAction.UPDATE_EDUCATION,
-        AuditAction.DELETE_EDUCATION,
-    ),
+    audit_stem="education",
     snapshot_schema=ProviderEducationAuditSnapshot,
     read_schema=ProviderEducationRead,
     create_adapter=education_create_adapter,

--- a/src/api/common/specs/provider_licensure.py
+++ b/src/api/common/specs/provider_licensure.py
@@ -14,7 +14,6 @@ from typing import Final
 
 from src.api.common.entity_spec import EntitySpec
 from src.api.common.specs._credential import make_provider_credential_entity
-from src.logic.audit import AuditAction
 from src.models import ProviderLicensure
 from src.schemas.providers.provider import (
     ProviderLicensureAuditSnapshot,
@@ -28,11 +27,7 @@ LICENSURE_ENTITY: Final[EntitySpec] = make_provider_credential_entity(
     url_collection="licensures",
     id_param="licensure_id",
     model=ProviderLicensure,
-    audit_actions=(
-        AuditAction.CREATE_LICENSURE,
-        AuditAction.UPDATE_LICENSURE,
-        AuditAction.DELETE_LICENSURE,
-    ),
+    audit_stem="licensure",
     snapshot_schema=ProviderLicensureAuditSnapshot,
     read_schema=ProviderLicensureRead,
     create_adapter=licensure_create_adapter,

--- a/src/api/common/specs/user.py
+++ b/src/api/common/specs/user.py
@@ -28,17 +28,13 @@ from src.api.common.entity_spec import (
 from src.api.common.specs.provider import PROVIDER_ENTITY
 from src.auth_config import current_active_user, current_admin_user
 from src.logic._authz import is_self_or_admin
-from src.logic.audit import AuditAction, AuditedResource, make_snapshotter
+from src.logic.audit import AuditAction, AuditedResource, make_audited_resource
 from src.models import User
 from src.repositories.dependencies import get_user_repository
 from src.schemas.users.user import UserActivationUpdate, UserAuditSnapshot
 
-USER_AUDITED_RESOURCE: Final[AuditedResource] = AuditedResource(
-    type="user",
-    snapshot=make_snapshotter(UserAuditSnapshot),
-    create=AuditAction.CREATE_USER,
-    update=AuditAction.UPDATE_USER,
-    delete=AuditAction.DELETE_USER,
+USER_AUDITED_RESOURCE: Final[AuditedResource] = make_audited_resource(
+    "user", UserAuditSnapshot
 )
 
 

--- a/src/logic/audit.py
+++ b/src/logic/audit.py
@@ -102,16 +102,13 @@ Verb = Literal["create", "update", "delete"]
 class AuditedResource:
     """Declarative bundle for a CRUD-shaped audited resource.
 
-    Module-level constants are the intended use:
+    Module-level constants are the intended use. The
+    `make_audited_resource(name, snapshot_schema)` factory derives the
+    create/update/delete `AuditAction` triple from the name by
+    convention (`CREATE_<NAME.upper()>`, ...), so callers don't retype
+    the enum stems:
 
-        PROVIDER = AuditedResource(
-            type="provider",
-            snapshot=lambda obj: ProviderAuditSnapshot
-                .model_validate(obj).model_dump(mode="json"),
-            create=AuditAction.CREATE_PROVIDER,
-            update=AuditAction.UPDATE_PROVIDER,
-            delete=AuditAction.DELETE_PROVIDER,
-        )
+        PROVIDER = make_audited_resource("provider", ProviderAuditSnapshot)
 
     Each handler then calls `record_audit_for(audit_repo, resource=PROVIDER,
     verb="update", ...)` instead of typing `resource_type=`, `action=`, and
@@ -129,6 +126,51 @@ class AuditedResource:
 
     def action_for(self, verb: Verb) -> AuditAction:
         return getattr(self, verb)
+
+
+def make_audited_resource(
+    name: str,
+    snapshot: Callable[[Any], dict[str, Any]] | type[BaseModel],
+    *,
+    action_stem: str | None = None,
+) -> AuditedResource:
+    """Build an `AuditedResource` from a name + snapshot.
+
+    The create/update/delete `AuditAction` members are looked up by
+    convention: `CREATE_<STEM>`, `UPDATE_<STEM>`, `DELETE_<STEM>` where
+    `<STEM>` defaults to `name.upper()`. Entities whose enum stems
+    diverge from `name` pass `action_stem` explicitly (e.g. the
+    `provider_licensure` entity's actions are `CREATE_LICENSURE`,
+    not `CREATE_PROVIDER_LICENSURE`).
+
+    `snapshot` may be either a callable (used as-is) or a Pydantic
+    schema class (wrapped via `make_snapshotter`). The two-form input
+    matches the two callsites: most specs pass a schema class; posts
+    pass a hand-rolled discriminated-union snapshot callable.
+
+    Raises `ValueError` at import time if any of the three derived
+    `AuditAction` members is missing — the failure surfaces before
+    serving traffic.
+    """
+    stem = (action_stem or name).upper()
+    if isinstance(snapshot, type) and issubclass(snapshot, BaseModel):
+        snapshot_fn: Callable[[Any], dict[str, Any]] = make_snapshotter(snapshot)
+    else:
+        snapshot_fn = snapshot  # type: ignore[assignment]
+    try:
+        return AuditedResource(
+            type=name,
+            snapshot=snapshot_fn,
+            create=AuditAction[f"CREATE_{stem}"],
+            update=AuditAction[f"UPDATE_{stem}"],
+            delete=AuditAction[f"DELETE_{stem}"],
+        )
+    except KeyError as exc:
+        raise ValueError(
+            f"make_audited_resource({name!r}): AuditAction has no member "
+            f"matching CREATE_{stem}/UPDATE_{stem}/DELETE_{stem}. Add the "
+            "members to AuditAction or pass action_stem= explicitly."
+        ) from exc
 
 
 async def record_audit(

--- a/src/logic/test_audit.py
+++ b/src/logic/test_audit.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from src.logic.audit import (
     AuditAction,
     AuditedResource,
+    make_audited_resource,
     make_snapshotter,
     mutate,
     record_audit,
@@ -51,6 +52,69 @@ def test_make_snapshotter_returns_json_mode_dict():
         "name": "foo",
         "when": "2026-01-01T12:00:00",
     }
+
+
+# --- make_audited_resource() --------------------------------------------
+
+
+def test_make_audited_resource_derives_actions_from_name():
+    """Default path: stem = name.upper(), actions looked up by convention."""
+    resource = make_audited_resource("user", _ExampleSnapshot)
+    assert resource.type == "user"
+    assert resource.create is AuditAction.CREATE_USER
+    assert resource.update is AuditAction.UPDATE_USER
+    assert resource.delete is AuditAction.DELETE_USER
+
+
+def test_make_audited_resource_wraps_schema_class_via_snapshotter():
+    """A Pydantic schema class is wrapped so the snapshot callable behaves
+    identically to one built via `make_snapshotter` directly."""
+
+    class _Row:
+        def __init__(self):
+            self.id = uuid.uuid4()
+            self.name = "foo"
+            self.when = datetime(2026, 1, 1, 12, 0, 0)
+
+    resource = make_audited_resource("user", _ExampleSnapshot)
+    row = _Row()
+    assert resource.snapshot(row) == {
+        "id": str(row.id),
+        "name": "foo",
+        "when": "2026-01-01T12:00:00",
+    }
+
+
+def test_make_audited_resource_accepts_prebuilt_callable():
+    """Posts' audit-snapshot is a hand-rolled discriminated-union callable
+    rather than a single Pydantic class; the factory accepts it as-is."""
+    sentinel = {"shape": "custom"}
+
+    def _snap(_obj):
+        return sentinel
+
+    resource = make_audited_resource("post", _snap)
+    assert resource.snapshot(object()) is sentinel
+    assert resource.create is AuditAction.CREATE_POST
+
+
+def test_make_audited_resource_honors_action_stem_override():
+    """`provider_licensure` -> `CREATE_LICENSURE` etc. — entity name and
+    enum stem diverge, so the caller passes `action_stem` explicitly."""
+    resource = make_audited_resource(
+        "provider_licensure", _ExampleSnapshot, action_stem="licensure"
+    )
+    assert resource.type == "provider_licensure"
+    assert resource.create is AuditAction.CREATE_LICENSURE
+    assert resource.update is AuditAction.UPDATE_LICENSURE
+    assert resource.delete is AuditAction.DELETE_LICENSURE
+
+
+def test_make_audited_resource_raises_on_missing_action():
+    """Surfacing the missing-member case at import time beats a runtime
+    KeyError from inside a mutation."""
+    with pytest.raises(ValueError, match="CREATE_NONEXISTENT"):
+        make_audited_resource("nonexistent", _ExampleSnapshot)
 
 
 async def test_record_audit_round_trips_through_repo(


### PR DESCRIPTION
## Summary
- Add `make_audited_resource(name, snapshot, *, action_stem=None)` to `src/logic/audit.py`. Derives the create/update/delete `AuditAction` triple from the entity name by convention (`CREATE_<NAME.upper()>`, ...); `action_stem` overrides when the enum stems diverge (e.g. `provider_licensure` → `CREATE_LICENSURE`).
- Refactor six entity specs (`user`, `provider`, `post`, the three provider-credential subentities via `_credential.py`) from 6-line `AuditedResource(...)` blocks to 1-line factory calls. Drops `AuditAction` imports where no longer needed.
- Snapshot input is `Callable | type[BaseModel]` — Pydantic schema classes are auto-wrapped via `make_snapshotter`; posts' hand-rolled discriminated-union snapshot callable passes through unchanged.
- Factory raises `ValueError` at import time if any derived `AuditAction` member is missing (loud failure before serving traffic).

Pure refactor — every resulting `AuditedResource` instance is equivalent to the previous hand-rolled one (same `type`, same actions, same snapshot fn).

## Test plan
- [x] `dev test` (734 passed)
- [x] `dev test contract` (16 passed)
- [x] `dev lint`
- [x] New unit tests for `make_audited_resource`: default-stem derivation, schema-class wrapping, prebuilt-callable passthrough, `action_stem` override, and `ValueError` on missing enum member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)