### PR TITLE
Delete trivial repo get_by_id wrappers with no non-test callers

### DIFF
--- a/src/logic/test_audit.py
+++ b/src/logic/test_audit.py
@@ -19,6 +19,7 @@ from src.logic.audit import (
     mutate,
     record_audit,
 )
+from src.models import AuditLog
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.posts.post_repository import PostRepository
 from tests.helpers import create_test_user
@@ -141,7 +142,7 @@ async def test_record_audit_round_trips_through_repo(
         )
         await session.commit()
 
-        fetched = await repo.get_by_id(row.id)
+        fetched = await repo.get_by_model_id(AuditLog, row.id)
         assert fetched is not None
         assert fetched.action == AuditAction.CREATE_POST
         assert fetched.before is None

--- a/src/repositories/audit_repository.py
+++ b/src/repositories/audit_repository.py
@@ -45,10 +45,6 @@ class AuditRepository(BaseRepository):
             )
         )
 
-    async def get_by_id(self, audit_id: UUID) -> AuditLog | None:
-        """Look up a single audit row. Primarily for tests."""
-        return await self._get_by_id(AuditLog, audit_id)
-
     async def list_for_resource(
         self, *, resource_type: str, resource_id: UUID
     ) -> Sequence[AuditLog]:

--- a/src/repositories/posts/post_repository.py
+++ b/src/repositories/posts/post_repository.py
@@ -1,5 +1,4 @@
 from typing import Sequence
-from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,11 +11,6 @@ from ..base import BaseRepository
 class PostRepository(BaseRepository):
     def __init__(self, session: AsyncSession):
         super().__init__(session)
-
-    async def get_post_by_id(self, post_id: UUID) -> Post | None:
-        """Retrieves a post by its ID. Per-kind detail relationships are
-        eager-loaded via `lazy="selectin"` on the model."""
-        return await self._get_by_id(Post, post_id)
 
     async def list_posts(self) -> Sequence[Post]:
         """Lists all posts, newest first. Detail relationships are eager-loaded."""

--- a/src/repositories/posts/test_post_repository.py
+++ b/src/repositories/posts/test_post_repository.py
@@ -145,7 +145,7 @@ async def test_update_post_writes_to_client_referral_detail(
 
     async with db_test_session_manager() as session:
         repo = PostRepository(session)
-        post = await repo.get_post_by_id(post_id)
+        post = await repo.get_by_model_id(Post, post_id)
         # Detail fields live on the detail row; framework's handle_update
         # (B3) reads `kind_spec.detail_relationship` to pick the right
         # target. At the repo level we just patch the detail directly.
@@ -185,7 +185,7 @@ async def test_delete_post_cascades_client_referral_detail(
 
     async with db_test_session_manager() as session:
         repo = PostRepository(session)
-        post = await repo.get_post_by_id(post_id)
+        post = await repo.get_by_model_id(Post, post_id)
         await repo.delete(post)
         await session.commit()
 
@@ -266,7 +266,7 @@ async def test_update_post_writes_to_provider_availability_detail(
 
     async with db_test_session_manager() as session:
         repo = PostRepository(session)
-        post = await repo.get_post_by_id(post_id)
+        post = await repo.get_by_model_id(Post, post_id)
         await repo.patch(
             post.provider_availability_detail, practice_name="Acme Renamed"
         )
@@ -306,7 +306,7 @@ async def test_delete_post_cascades_provider_availability_detail(
 
     async with db_test_session_manager() as session:
         repo = PostRepository(session)
-        post = await repo.get_post_by_id(post_id)
+        post = await repo.get_by_model_id(Post, post_id)
         await repo.delete(post)
         await session.commit()
 

--- a/src/repositories/providers/provider_repository.py
+++ b/src/repositories/providers/provider_repository.py
@@ -73,9 +73,6 @@ class ProviderRepository(BaseRepository):
 
     # --- Licensure sub-table ----------------------------------------------
 
-    async def get_licensure_by_id(self, licensure_id: UUID) -> ProviderLicensure | None:
-        return await self._get_by_id(ProviderLicensure, licensure_id)
-
     async def add_licensure(
         self, provider: Provider, **fields: Any
     ) -> ProviderLicensure:
@@ -85,9 +82,6 @@ class ProviderRepository(BaseRepository):
 
     # --- Education sub-table ----------------------------------------------
 
-    async def get_education_by_id(self, education_id: UUID) -> ProviderEducation | None:
-        return await self._get_by_id(ProviderEducation, education_id)
-
     async def add_education(
         self, provider: Provider, **fields: Any
     ) -> ProviderEducation:
@@ -96,11 +90,6 @@ class ProviderRepository(BaseRepository):
         )
 
     # --- Certification sub-table ------------------------------------------
-
-    async def get_certification_by_id(
-        self, certification_id: UUID
-    ) -> ProviderCertification | None:
-        return await self._get_by_id(ProviderCertification, certification_id)
 
     async def add_certification(
         self, provider: Provider, **fields: Any

--- a/src/repositories/providers/test_provider_repository.py
+++ b/src/repositories/providers/test_provider_repository.py
@@ -429,21 +429,21 @@ async def test_licensure_crud_round_trip(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        found = await repo.get_licensure_by_id(licensure_id)
+        found = await repo.get_by_model_id(ProviderLicensure, licensure_id)
         assert found is not None
         await repo.patch(found, license_number="L-2")
         await session.commit()
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        found = await repo.get_licensure_by_id(licensure_id)
+        found = await repo.get_by_model_id(ProviderLicensure, licensure_id)
         assert found.license_number == "L-2"
         await repo.delete(found)
         await session.commit()
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        assert await repo.get_licensure_by_id(licensure_id) is None
+        assert await repo.get_by_model_id(ProviderLicensure, licensure_id) is None
 
 
 async def test_education_crud_round_trip(
@@ -471,21 +471,21 @@ async def test_education_crud_round_trip(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        found = await repo.get_education_by_id(education_id)
+        found = await repo.get_by_model_id(ProviderEducation, education_id)
         assert found is not None
         await repo.patch(found, institution="State U Renamed")
         await session.commit()
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        found = await repo.get_education_by_id(education_id)
+        found = await repo.get_by_model_id(ProviderEducation, education_id)
         assert found.institution == "State U Renamed"
         await repo.delete(found)
         await session.commit()
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        assert await repo.get_education_by_id(education_id) is None
+        assert await repo.get_by_model_id(ProviderEducation, education_id) is None
 
 
 async def test_certification_crud_round_trip(
@@ -513,18 +513,18 @@ async def test_certification_crud_round_trip(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        found = await repo.get_certification_by_id(cert_id)
+        found = await repo.get_by_model_id(ProviderCertification, cert_id)
         assert found is not None
         await repo.patch(found, certifying_body="Updated Body")
         await session.commit()
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        found = await repo.get_certification_by_id(cert_id)
+        found = await repo.get_by_model_id(ProviderCertification, cert_id)
         assert found.certifying_body == "Updated Body"
         await repo.delete(found)
         await session.commit()
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        assert await repo.get_certification_by_id(cert_id) is None
+        assert await repo.get_by_model_id(ProviderCertification, cert_id) is None

--- a/src/repositories/test_audit_repository.py
+++ b/src/repositories/test_audit_repository.py
@@ -11,7 +11,7 @@ import uuid
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.models import User
+from src.models import AuditLog, User
 from src.repositories.audit_repository import AuditRepository
 from tests.helpers import create_test_user
 
@@ -95,38 +95,6 @@ async def test_record_accepts_null_after_for_delete(
 
         assert row.before == {"username": "old"}
         assert row.after is None
-
-
-async def test_get_by_id_returns_row(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-):
-    actor = create_test_user(username=f"actor-{uuid.uuid4()}")
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(actor)
-
-    async with db_test_session_manager() as session:
-        repo = AuditRepository(session)
-        written = await repo.record(
-            actor_id=actor.id,
-            resource_type="post",
-            resource_id=uuid.uuid4(),
-            action="create_post",
-        )
-        await session.commit()
-
-        fetched = await repo.get_by_id(written.id)
-        assert fetched is not None
-        assert fetched.id == written.id
-
-
-async def test_get_by_id_returns_none_for_unknown_id(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-):
-    async with db_test_session_manager() as session:
-        repo = AuditRepository(session)
-        assert await repo.get_by_id(uuid.uuid4()) is None
 
 
 async def test_list_for_resource_returns_oldest_first(
@@ -240,6 +208,6 @@ async def test_actor_set_null_when_user_deleted(
 
     async with db_test_session_manager() as session:
         repo = AuditRepository(session)
-        fetched = await repo.get_by_id(written.id)
+        fetched = await repo.get_by_model_id(AuditLog, written.id)
         assert fetched is not None  # row not deleted
         assert fetched.actor_id is None  # actor reference nulled


### PR DESCRIPTION
## Summary

- Five repository methods (`PostRepository.get_post_by_id`, `ProviderRepository.get_{licensure,education,certification}_by_id`, `AuditRepository.get_by_id`) existed only to forward to `BaseRepository._get_by_id`, and none had a caller outside their own colocated tests.
- The generic CRUD framework already loads by id via the public alias `repo.get_by_model_id(spec.model, id)`, making these wrappers redundant.
- Test sites switch to `repo.get_by_model_id(<Model>, id)`. Drops two `test_get_by_id_*` audit tests that were exercising the deleted wrapper — `_get_by_id` semantics are covered by `test_base.py`.

Closes #349.

## Test plan

- [x] \`dev test\` (739 passed, 1 skipped — 2 fewer than main since the deleted wrapper tests are gone)
- [x] \`dev lint\`
- [x] \`dev test contract\` (16 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)