### PR TITLE
Collapse credential add_* trio into one loop on public add_child

### DIFF
--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -29,6 +29,9 @@ from src.api.common.specs.provider_licensure import LICENSURE_ENTITY
 from src.logic.audit import mutate
 from src.models import (
     Provider,
+    ProviderCertification,
+    ProviderEducation,
+    ProviderLicensure,
     User,
 )
 from src.repositories.audit_repository import AuditRepository
@@ -55,6 +58,18 @@ PROVIDER = PROVIDER_ENTITY.audit
 LICENSURE = LICENSURE_ENTITY.audit
 EDUCATION = EDUCATION_ENTITY.audit
 CERTIFICATION = CERTIFICATION_ENTITY.audit
+
+
+# Inline-credential kinds appended on provider create. Each tuple pairs
+# the Provider relationship name (also the `url_collection` on the
+# credential's spec) with the ORM model class. Driven by a single
+# `repo.add_child(...)` loop in `handle_create_provider` so adding a
+# fourth credential kind is one line here, not a fourth repo method.
+_INLINE_CREDENTIAL_KINDS: tuple[tuple[str, type], ...] = (
+    ("licensures", ProviderLicensure),
+    ("educations", ProviderEducation),
+    ("certifications", ProviderCertification),
+)
 
 
 # --- Provider handlers ----------------------------------------------------
@@ -182,12 +197,9 @@ async def handle_create_provider(
     )
     created = await repo.create_provider(user_id=requesting_user.id, **provider_fields)
 
-    for licensure in payload.licensures:
-        await repo.add_licensure(created, **licensure.model_dump())
-    for education in payload.educations:
-        await repo.add_education(created, **education.model_dump())
-    for certification in payload.certifications:
-        await repo.add_certification(created, **certification.model_dump())
+    for collection, Model in _INLINE_CREDENTIAL_KINDS:
+        for item in getattr(payload, collection):
+            await repo.add_child(created, collection, Model(**item.model_dump()))
 
     async with mutate(
         repo,

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -235,7 +235,7 @@ async def list_providers(
     return await self._list(stmt.order_by(Provider.created_at.desc()))
 ```
 
-Per-entity `create_X` / `update_X` / `delete_X` wrapper methods have been removed for non-bespoke entities — the generic CRUD framework calls the public aliases above directly. Bespoke handlers (provider create with nested credentials, edge operations) still have their entity-specific repo methods (`add_licensure`, `add_education`, `add_certification`, etc.) for the steps the framework can't subsume.
+Per-entity `create_X` / `update_X` / `delete_X` wrapper methods have been removed for non-bespoke entities — the generic CRUD framework calls the public aliases above directly. Bespoke handlers (provider create with nested credentials, edge operations) drive their entity-specific writes through the same public aliases: `handle_create_provider` loops over a `(collection, Model)` table and calls `repo.add_child(parent, collection, Model(**fields))` for each inline credential row, so adding a fourth credential kind is a one-line table entry rather than a fourth `add_X` method on the repo.
 
 ## Common issues and solutions
 

--- a/src/repositories/providers/provider_repository.py
+++ b/src/repositories/providers/provider_repository.py
@@ -4,12 +4,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models import (
-    Provider,
-    ProviderCertification,
-    ProviderEducation,
-    ProviderLicensure,
-)
+from src.models import Provider, ProviderLicensure
 
 from ..base import BaseRepository
 
@@ -70,30 +65,3 @@ class ProviderRepository(BaseRepository):
 
     async def create_provider(self, user_id: UUID, **fields: Any) -> Provider:
         return await self._persist_new(Provider(owner_id=user_id, **fields))
-
-    # --- Licensure sub-table ----------------------------------------------
-
-    async def add_licensure(
-        self, provider: Provider, **fields: Any
-    ) -> ProviderLicensure:
-        return await self._add_child(
-            provider, "licensures", ProviderLicensure(**fields)
-        )
-
-    # --- Education sub-table ----------------------------------------------
-
-    async def add_education(
-        self, provider: Provider, **fields: Any
-    ) -> ProviderEducation:
-        return await self._add_child(
-            provider, "educations", ProviderEducation(**fields)
-        )
-
-    # --- Certification sub-table ------------------------------------------
-
-    async def add_certification(
-        self, provider: Provider, **fields: Any
-    ) -> ProviderCertification:
-        return await self._add_child(
-            provider, "certifications", ProviderCertification(**fields)
-        )

--- a/src/repositories/providers/test_provider_repository.py
+++ b/src/repositories/providers/test_provider_repository.py
@@ -418,11 +418,14 @@ async def test_licensure_crud_round_trip(
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
         provider = await repo.get_by_id(provider_id)
-        licensure = await repo.add_licensure(
+        licensure = await repo.add_child(
             provider,
-            license_type="lcsw",
-            license_number="L-1",
-            issuing_state="IL",
+            "licensures",
+            ProviderLicensure(
+                license_type="lcsw",
+                license_number="L-1",
+                issuing_state="IL",
+            ),
         )
         await session.commit()
         licensure_id = licensure.id
@@ -461,10 +464,13 @@ async def test_education_crud_round_trip(
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
         provider = await repo.get_by_id(provider_id)
-        education = await repo.add_education(
+        education = await repo.add_child(
             provider,
-            education_type="msw",
-            institution="State U",
+            "educations",
+            ProviderEducation(
+                education_type="msw",
+                institution="State U",
+            ),
         )
         await session.commit()
         education_id = education.id
@@ -503,10 +509,13 @@ async def test_certification_crud_round_trip(
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
         provider = await repo.get_by_id(provider_id)
-        cert = await repo.add_certification(
+        cert = await repo.add_child(
             provider,
-            certification_type="emdr",
-            certifying_body="EMDRIA",
+            "certifications",
+            ProviderCertification(
+                certification_type="emdr",
+                certifying_body="EMDRIA",
+            ),
         )
         await session.commit()
         cert_id = cert.id


### PR DESCRIPTION
## Summary

- `ProviderRepository.add_licensure` / `add_education` / `add_certification` were three near-identical wrappers around `BaseRepository._add_child`, differing only in `(relationship_name, Model)`.
- Deleted. `handle_create_provider` now drives the inline-credential append from a `_INLINE_CREDENTIAL_KINDS` table at module scope, looping over `(collection, Model)` and calling the public alias `repo.add_child(parent, collection, Model(**fields))`. Adding a fourth credential kind is a one-line table entry rather than a fourth repo method.
- Repo round-trip tests switch to `repo.add_child(...)` directly. Repositories README note about bespoke handlers updated to describe the new shape.

Closes #351.

## Test plan

- [x] \`dev test\` (739 passed, 1 skipped)
- [x] \`dev lint\`
- [x] \`dev test contract\` (16 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)