### PR TITLE
Generate repo resolvers from a single tuple (#362)

### DIFF
--- a/src/repositories/dependencies.py
+++ b/src/repositories/dependencies.py
@@ -1,3 +1,18 @@
+"""FastAPI Depends resolvers for every repository class.
+
+Each repository takes the same constructor — a single ``AsyncSession`` —
+so the resolver shape is identical across entities. The resolvers are
+built once via :func:`_make_repo_resolver` rather than written by hand;
+adding a new repository class is a single entry in :data:`_REPO_TYPES`.
+
+The public ``get_<entity>_repository`` names exist as module-level
+bindings so spec files (``src/api/common/specs/<entity>.py``) keep
+importing them directly. The type → resolver registry is built from
+the same source, so a generated resolver and its registry entry can't
+drift.
+"""
+
+import re
 from typing import Any, Callable
 
 from fastapi import Depends
@@ -6,68 +21,67 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.db import get_db_session
 
 from .audit_repository import AuditRepository
+from .base import BaseRepository
 from .favorites.user_favorite_repository import UserFavoriteRepository
 from .posts.post_repository import PostRepository
 from .providers.provider_repository import ProviderRepository
 from .users.user_repository import UserRepository
 
-
-def get_user_repository(
-    session: AsyncSession = Depends(get_db_session),
-) -> UserRepository:
-    """Dependency provider for UserRepository."""
-    return UserRepository(session)
+_CAMEL_TO_SNAKE_RE = re.compile(r"(?<!^)(?=[A-Z])")
 
 
-def get_post_repository(
-    session: AsyncSession = Depends(get_db_session),
-) -> PostRepository:
-    """Dependency provider for PostRepository."""
-    return PostRepository(session)
+def _camel_to_snake(name: str) -> str:
+    """``UserFavoriteRepository`` → ``user_favorite_repository``."""
+    return _CAMEL_TO_SNAKE_RE.sub("_", name).lower()
 
 
-def get_audit_repository(
-    session: AsyncSession = Depends(get_db_session),
-) -> AuditRepository:
-    """Dependency provider for AuditRepository."""
-    return AuditRepository(session)
+def _make_repo_resolver(cls: type[BaseRepository]) -> Callable[..., Any]:
+    """Build a FastAPI ``Depends``-style resolver for `cls`.
+
+    Every repository's constructor is ``cls(session: AsyncSession)``, so
+    the resolver body is identical — wrap that single call in a closure
+    that FastAPI's dep system can `Depends(...)`.
+    """
+
+    def _resolver(session: AsyncSession = Depends(get_db_session)) -> Any:
+        return cls(session)
+
+    stem = _camel_to_snake(cls.__name__.removesuffix("Repository"))
+    _resolver.__name__ = f"get_{stem}_repository"
+    _resolver.__qualname__ = _resolver.__name__
+    return _resolver
 
 
-def get_provider_repository(
-    session: AsyncSession = Depends(get_db_session),
-) -> ProviderRepository:
-    """Dependency provider for ProviderRepository."""
-    return ProviderRepository(session)
+# Single source of truth for "which repository classes participate in
+# dep injection." Adding a new repo class means one entry here plus the
+# matching public-name binding below; the registry stays in sync because
+# it is built from this tuple.
+_REPO_TYPES: tuple[type[BaseRepository], ...] = (
+    UserRepository,
+    PostRepository,
+    AuditRepository,
+    ProviderRepository,
+    UserFavoriteRepository,
+)
 
 
-def get_user_favorite_repository(
-    session: AsyncSession = Depends(get_db_session),
-) -> UserFavoriteRepository:
-    """Dependency provider for UserFavoriteRepository."""
-    return UserFavoriteRepository(session)
-
-
-# Type → resolver registry. The single source of truth for "how do I inject
-# a repository of type T into a route?" The mount layer in
-# `src/api/common/resource_routes.py` reads this map to synthesize FastAPI
-# route signatures from handler type annotations — a handler param typed
-# `repo: ProviderRepository` automatically resolves to
-# `Depends(get_provider_repository)`, with no separate declaration on the
-# mount call. Adding a new repo means adding one entry here, not threading
-# the resolver through every mount call site.
-#
-# Keep this dict and the resolver definitions above in sync: every entry
-# here must point at a callable defined in this module. Conversely, a
-# resolver that is *not* in this map cannot be auto-injected by the mount
-# layer and would need to be passed via a non-registry path (which we
-# currently don't have).
+# Type → resolver registry consumed by the mount-layer signature
+# synthesis (see ``src/api/common/resource_routes.py``). A handler param
+# typed ``repo: ProviderRepository`` resolves to
+# ``Depends(_REPO_TYPE_RESOLVERS[ProviderRepository])`` automatically.
 _REPO_TYPE_RESOLVERS: dict[type, Callable[..., Any]] = {
-    UserRepository: get_user_repository,
-    PostRepository: get_post_repository,
-    AuditRepository: get_audit_repository,
-    ProviderRepository: get_provider_repository,
-    UserFavoriteRepository: get_user_favorite_repository,
+    cls: _make_repo_resolver(cls) for cls in _REPO_TYPES
 }
+
+
+# Public symbols — direct bindings to the generated resolvers so spec
+# files can ``from src.repositories.dependencies import get_X_repository``
+# the same way they always have.
+get_user_repository = _REPO_TYPE_RESOLVERS[UserRepository]
+get_post_repository = _REPO_TYPE_RESOLVERS[PostRepository]
+get_audit_repository = _REPO_TYPE_RESOLVERS[AuditRepository]
+get_provider_repository = _REPO_TYPE_RESOLVERS[ProviderRepository]
+get_user_favorite_repository = _REPO_TYPE_RESOLVERS[UserFavoriteRepository]
 
 
 class UnknownRepoTypeError(KeyError):
@@ -88,7 +102,6 @@ def resolver_for(repo_type: type) -> Callable[..., Any]:
     except KeyError:
         raise UnknownRepoTypeError(
             f"No Depends resolver registered for repository type "
-            f"{repo_type!r}. Add an entry to `_REPO_TYPE_RESOLVERS` in "
-            f"src/repositories/dependencies.py pointing at the matching "
-            f"`get_<entity>_repository` function."
+            f"{repo_type!r}. Add an entry to `_REPO_TYPES` in "
+            f"src/repositories/dependencies.py."
         ) from None

--- a/src/repositories/test_dependencies.py
+++ b/src/repositories/test_dependencies.py
@@ -1,0 +1,77 @@
+"""Tests for `dependencies.py` — the generated resolver factory.
+
+Verifies that every repository class in `_REPO_TYPES` has a working
+resolver registered in `_REPO_TYPE_RESOLVERS`, that the public
+`get_<entity>_repository` names map to the generated resolvers, and
+that `resolver_for` raises `UnknownRepoTypeError` for an unregistered
+class.
+"""
+
+import pytest
+
+from src.repositories import dependencies as deps
+from src.repositories.audit_repository import AuditRepository
+from src.repositories.dependencies import (
+    _REPO_TYPE_RESOLVERS,
+    _REPO_TYPES,
+    UnknownRepoTypeError,
+    get_audit_repository,
+    get_post_repository,
+    get_provider_repository,
+    get_user_favorite_repository,
+    get_user_repository,
+    resolver_for,
+)
+from src.repositories.favorites.user_favorite_repository import UserFavoriteRepository
+from src.repositories.posts.post_repository import PostRepository
+from src.repositories.providers.provider_repository import ProviderRepository
+from src.repositories.users.user_repository import UserRepository
+
+
+def test_every_repo_type_has_a_resolver():
+    for cls in _REPO_TYPES:
+        assert cls in _REPO_TYPE_RESOLVERS
+
+
+def test_public_names_match_registry():
+    """The public `get_<entity>_repository` exports are direct bindings
+    to the generated resolvers — same callables, not lookalikes."""
+    pairs = [
+        (UserRepository, get_user_repository),
+        (PostRepository, get_post_repository),
+        (AuditRepository, get_audit_repository),
+        (ProviderRepository, get_provider_repository),
+        (UserFavoriteRepository, get_user_favorite_repository),
+    ]
+    for cls, public_resolver in pairs:
+        assert _REPO_TYPE_RESOLVERS[cls] is public_resolver
+
+
+def test_resolver_for_returns_registered_resolver():
+    assert resolver_for(UserRepository) is _REPO_TYPE_RESOLVERS[UserRepository]
+
+
+def test_resolver_for_raises_on_unknown_type():
+    class _NotARepo:
+        pass
+
+    with pytest.raises(UnknownRepoTypeError):
+        resolver_for(_NotARepo)
+
+
+def test_generated_resolver_returns_an_instance():
+    """The closure body is `cls(session)`. Pass a sentinel session and
+    confirm the resolver builds an instance — proves the type-binding
+    closure works (no shared `cls` variable across resolvers)."""
+    sentinel_session = object()
+    user_repo = get_user_repository(session=sentinel_session)
+    assert isinstance(user_repo, UserRepository)
+    provider_repo = get_provider_repository(session=sentinel_session)
+    assert isinstance(provider_repo, ProviderRepository)
+
+
+def test_resolver_name_matches_convention():
+    """``_resolver.__name__`` should be ``get_<snake_case>_repository`` so
+    stack traces stay readable."""
+    assert deps.get_user_repository.__name__ == "get_user_repository"
+    assert deps.get_user_favorite_repository.__name__ == "get_user_favorite_repository"


### PR DESCRIPTION
## Summary

- `_make_repo_resolver(cls)` factory builds the FastAPI Depends-style closure for any repo class.
- `_REPO_TYPES` tuple is the single source of truth; `_REPO_TYPE_RESOLVERS` is a dict-comprehension over it.
- The five public `get_<entity>_repository` names stay as module-level bindings — spec-file imports are unchanged.
- New `test_dependencies.py` covers the factory, the public-name mapping, name convention, and the unknown-type guard.

Closes #362.

## Test plan

- [x] `dev test` — 769 passed
- [x] `dev lint` — green
- [x] New colocated `test_dependencies.py` covers the factory contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)