### PR TITLE
Derive EntitySpec.children from parent= declarations (#366)

### DIFF
--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -314,6 +314,15 @@ class EntitySpec:
     # entities leave as None.
     singleton_alias: tuple[str, Callable[..., Any]] | None = None
 
+    # Owned-subentity registry. Populated in __post_init__: when a spec
+    # is constructed with `parent=<P>`, the child appends itself to
+    # `P._children` (in-place mutation; the frozen dataclass guarantees
+    # only forbids field reassignment, not list mutation). Exposed via
+    # the `children` property as an immutable tuple.
+    _children: list["EntitySpec"] = field(
+        default_factory=list, repr=False, compare=False
+    )
+
     def __post_init__(self) -> None:
         # Mirror `ResourceSpec.__post_init__` — declaring private fields
         # without a predicate would silently leak them.
@@ -362,6 +371,12 @@ class EntitySpec:
                 f"{self.parent.name!r} but no routes are opted in — "
                 "the subentity would be unreachable."
             )
+        # Register this child with its parent's owned-subentity list
+        # so `parent.children` reflects the construction order. List
+        # mutation on a frozen dataclass is permitted (we never reassign
+        # `_children`, just mutate the existing list in place).
+        if self.parent is not None:
+            self.parent._children.append(self)
         # CRUD-shaped vs edge-shaped audit binding is an either/or
         # choice; declaring both would be ambiguous and almost
         # certainly a misconfiguration.
@@ -465,6 +480,20 @@ class EntitySpec:
             or r.form_new
             or r.form_edit
         )
+
+    @property
+    def children(self) -> tuple["EntitySpec", ...]:
+        """Owned-subentity specs whose ``parent`` is this entity.
+
+        Populated automatically as children declare ``parent=self``;
+        order matches the children's construction order. Returned as a
+        tuple so callers cannot mutate the underlying registry.
+
+        Consumers: ``handle_create_provider`` derives the inline-credential
+        loop from ``PROVIDER_ENTITY.children`` instead of restating
+        the (collection, model) pairs.
+        """
+        return tuple(self._children)
 
     def to_resource_spec(self) -> ResourceSpec:
         """Derive a `ResourceSpec` for the mount helpers.

--- a/src/api/common/test_entity_spec.py
+++ b/src/api/common/test_entity_spec.py
@@ -417,6 +417,52 @@ def test_update_adapter_passes_prebuilt_type_adapter_through():
     assert spec.update_adapter is pre_built
 
 
+def test_children_registry_populates_in_construction_order():
+    """A spec with ``parent=<P>`` appends itself to ``P.children``.
+    Order matches construction order, exposed as an immutable tuple."""
+    parent = _make_spec(name="parent", url_collection="parents", id_param="parent_id")
+    child_a = _make_spec(
+        name="child_a",
+        url_collection="child_as",
+        id_param="child_a_id",
+        parent=parent,
+        routes=RouteSet(create=True),
+        create_adapter=_DummyBody,
+    )
+    child_b = _make_spec(
+        name="child_b",
+        url_collection="child_bs",
+        id_param="child_b_id",
+        parent=parent,
+        routes=RouteSet(create=True),
+        create_adapter=_DummyBody,
+    )
+    assert parent.children == (child_a, child_b)
+
+
+def test_children_returns_immutable_tuple():
+    """Callers cannot leak through `parent.children` to mutate the
+    underlying registry list."""
+    parent = _make_spec(
+        name="parent2", url_collection="parents2", id_param="parent2_id"
+    )
+    _make_spec(
+        name="child_x",
+        url_collection="child_xs",
+        id_param="child_x_id",
+        parent=parent,
+        routes=RouteSet(create=True),
+        create_adapter=_DummyBody,
+    )
+    children = parent.children
+    assert isinstance(children, tuple)
+
+
+def test_top_level_spec_has_no_children():
+    spec = _make_spec(name="lonely", url_collection="lonelies", id_param="lonely_id")
+    assert spec.children == ()
+
+
 def test_auth_policy_expands_to_write_authz_and_can_write():
     """`auth_policy=POLICY` populates both fields with the matched callables."""
     spec = _make_spec(auth_policy=OWNER_OR_ADMIN)

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -21,17 +21,17 @@ from uuid import UUID
 
 from fastapi import Request
 
+# Importing the credential spec modules registers their `parent=PROVIDER_ENTITY`
+# children on `PROVIDER_ENTITY.children` via the EntitySpec post-init
+# registry — referenced by `handle_create_provider`'s inline-credential loop.
+import src.api.common.specs.provider_certification  # noqa: F401
+import src.api.common.specs.provider_education  # noqa: F401
+import src.api.common.specs.provider_licensure  # noqa: F401
 from src.api.common.exceptions import ForbiddenError, NotFoundError
 from src.api.common.specs.provider import PROVIDER_ENTITY
-from src.api.common.specs.provider_certification import CERTIFICATION_ENTITY
-from src.api.common.specs.provider_education import EDUCATION_ENTITY
-from src.api.common.specs.provider_licensure import LICENSURE_ENTITY
 from src.logic.audit import mutate
 from src.models import (
     Provider,
-    ProviderCertification,
-    ProviderEducation,
-    ProviderLicensure,
     User,
 )
 from src.repositories.audit_repository import AuditRepository
@@ -45,31 +45,9 @@ from src.schemas.providers.provider import (
 logger = logging.getLogger(__name__)
 
 
-# --- Audited-resource bindings -------------------------------------------
-#
-# The four declarations themselves now live in
-# `src/api/common/specs/<entity>.py`; these module-level constants are
-# thin re-exports so handler bodies can keep their existing
-# `resource=PROVIDER` / `resource=LICENSURE` shape without churn. The
-# spec is the source of truth.
-
-
+# The audit binding lives on `PROVIDER_ENTITY.audit`; this re-export
+# keeps the handler body's `resource=PROVIDER` shape without churn.
 PROVIDER = PROVIDER_ENTITY.audit
-LICENSURE = LICENSURE_ENTITY.audit
-EDUCATION = EDUCATION_ENTITY.audit
-CERTIFICATION = CERTIFICATION_ENTITY.audit
-
-
-# Inline-credential kinds appended on provider create. Each tuple pairs
-# the Provider relationship name (also the `url_collection` on the
-# credential's spec) with the ORM model class. Driven by a single
-# `repo.add_child(...)` loop in `handle_create_provider` so adding a
-# fourth credential kind is one line here, not a fourth repo method.
-_INLINE_CREDENTIAL_KINDS: tuple[tuple[str, type], ...] = (
-    ("licensures", ProviderLicensure),
-    ("educations", ProviderEducation),
-    ("certifications", ProviderCertification),
-)
 
 
 # --- Provider handlers ----------------------------------------------------
@@ -165,14 +143,21 @@ async def handle_create_provider(
     sub-rows — the snapshot schema embeds the nested credential lists,
     so a single row captures the full create.
     """
-    provider_fields = payload.model_dump(
-        exclude={"licensures", "educations", "certifications"}
+    # Inline-credential kinds derive from the parent → children registry
+    # on `PROVIDER_ENTITY`: each owned-credential spec registers itself
+    # when its module is imported. Adding a fourth credential is now a
+    # single new spec file — no edit here.
+    inline_collections = tuple(
+        child.url_collection for child in PROVIDER_ENTITY.children
     )
+    provider_fields = payload.model_dump(exclude=set(inline_collections))
     created = await repo.create_provider(user_id=requesting_user.id, **provider_fields)
 
-    for collection, Model in _INLINE_CREDENTIAL_KINDS:
-        for item in getattr(payload, collection):
-            await repo.add_child(created, collection, Model(**item.model_dump()))
+    for child in PROVIDER_ENTITY.children:
+        for item in getattr(payload, child.url_collection):
+            await repo.add_child(
+                created, child.url_collection, child.model(**item.model_dump())
+            )
 
     async with mutate(
         repo,


### PR DESCRIPTION
## Summary

- `EntitySpec.__post_init__` registers `self` on `self.parent._children` whenever `parent=` is set.
- `EntitySpec.children` property exposes the tuple in construction order.
- `provider_processing.handle_create_provider` derives the inline-credential loop from `PROVIDER_ENTITY.children` — drops the hand-maintained `_INLINE_CREDENTIAL_KINDS` table.
- Provider credential spec modules are explicitly imported at the top of `provider_processing.py` so the registry is populated before `handle_create_provider` runs.
- New tests in `test_entity_spec.py` cover the children-registry contract.

Closes #366.

## Test plan

- [x] `dev test` — 778 passed
- [x] `dev lint` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)