### PR TITLE
Generic inline-child create via spec.children; retire handle_create_provider (#368)

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -242,7 +242,7 @@ Migrated route files compose the individual `mount_*` helpers through `mount_ent
 - `entity.read_user_dep` — `None` means public read; `mount_list` is called with `public=True`.
 - `owned_subentities` — a tuple of child `EntitySpec`s whose `parent` is `entity`. Each is mounted recursively via the same dispatcher; the handlers dict for an owned subentity is keyed `f"{owned.name}.{verb}"` (e.g. `"licensure.create"`). For verbs that match the standard CRUD-framework factories (`create`, `update`, `delete`, `detail`, `form_edit`), the explicit key is optional — `mount_entity` falls back to `make_<verb>_handler(owned)`, which is the common case for subentities whose mutations are entirely standard. Verbs without a default factory (`list`, `form_new`) still require an explicit entry; supplying any explicit key overrides the factory default.
 
-**Top-level standard verbs follow the same auto-bind path as owned subentities.** When a top-level entity opts into `list` / `detail` / `create` / `update` / `delete` / `form_edit` and the matching key is *absent* from `handlers`, `mount_entity` builds the handler from `make_<verb>_handler(entity)` and stitches it onto the route file's module as `_handle_<verb>_<entity>` (e.g. `_handle_update_provider`, `_handle_list_post`). That's the path contract-test monkey-patches at `src.api.routes.<entity>._handle_<verb>_<entity>` resolve through; setting `__module__` on the built handler lets the mount layer's `_resolve_handler` find the patched version via `getattr(sys.modules[__module__], __name__)`. The target module is auto-detected from the `mount_entity` caller's frame, so route files don't pass `module=`. Bespoke verbs (e.g. `handle_delete_user`'s self-guard, `handle_create_provider`'s inline credentials append, `handle_list_users`'s self-exclude) stay explicit in the handlers dict and override the factory default. The only verb that has no default factory is `form_new` — its template-selection knob is too entity-specific to auto-bind (posts dispatches by `?kind=`).
+**Top-level standard verbs follow the same auto-bind path as owned subentities.** When a top-level entity opts into `list` / `detail` / `create` / `update` / `delete` / `form_edit` and the matching key is *absent* from `handlers`, `mount_entity` builds the handler from `make_<verb>_handler(entity)` and stitches it onto the route file's module as `_handle_<verb>_<entity>` (e.g. `_handle_update_provider`, `_handle_list_post`). That's the path contract-test monkey-patches at `src.api.routes.<entity>._handle_<verb>_<entity>` resolve through; setting `__module__` on the built handler lets the mount layer's `_resolve_handler` find the patched version via `getattr(sys.modules[__module__], __name__)`. The target module is auto-detected from the `mount_entity` caller's frame, so route files don't pass `module=`. Bespoke verbs (e.g. `handle_delete_user`'s self-guard, `handle_list_users`'s self-exclude) stay explicit in the handlers dict and override the factory default. The only verb that has no default factory is `form_new` — its template-selection knob is too entity-specific to auto-bind (posts dispatches by `?kind=`; providers needs the `ProviderCreate` schema class in context). Inline-child appends on create (providers' credential rows) come from the generic `handle_create` walking `spec.children`.
 
 `detail_extras=` / `detail_extra_repos=` and `list_extras=` / `list_extra_repos=` flow through to `make_detail_handler` / `make_list_handler` when auto-binding the respective handlers. They live on the `mount_entity` call site (route file) rather than on the spec because `provider_detail_extras` / `post_list_extras` themselves import their `<ENTITY>_ENTITY` — placing them on the spec would close the cycle. Validators raise at mount time if extras are set without the matching `routes.<verb>=True`, alongside an explicit `handlers[<verb>]`, or extras-repos without an extras-callable consumer.
 
@@ -266,21 +266,20 @@ And matching `make_<verb>_handler(spec)` factory functions (`make_create_handler
 ```python
 # in src/api/routes/providers.py
 from src.logic.providers.provider_processing import (
-    handle_create_provider,           # bespoke (inline credentials append)
     handle_get_provider_form,
-    handle_list_providers,
     provider_detail_extras,
 )
 from src.repositories.favorites.user_favorite_repository import UserFavoriteRepository
 
-# update / delete / form_edit auto-bound to make_<verb>_handler(PROVIDER_ENTITY)
-# via `mount_entity`; bespoke entries stay explicit in handlers.
+# list / detail / create / update / delete / form_edit auto-bind via
+# make_<verb>_handler(PROVIDER_ENTITY). Only form_new stays explicit
+# (the create-form template needs the ProviderCreate schema class in
+# its context). Owned credential subentities self-register on
+# PROVIDER_ENTITY.children and auto-bind their own CRUD.
 mount_entity(
     router,
     PROVIDER_ENTITY,
     handlers={
-        "list": handle_list_providers,
-        "create": handle_create_provider,           # bespoke (inline credentials append)
         "form_new": handle_get_provider_form,
     },
     detail_extras=provider_detail_extras,           # supplies `is_favorited` per (viewer, provider) pair
@@ -292,8 +291,10 @@ mount_entity(
 **When to use factory vs. bespoke handler.** Use the factory when the verb does the standard load → auth → mutate → audit ritual. Write a bespoke handler when the entity has rules that don't fit:
 
 - `handle_delete_user` is bespoke because of the self-guard (admin can't delete self).
-- `handle_create_provider` is bespoke because it appends initial credential sub-rows from the inline payload after the parent persists.
+- `handle_list_users` is bespoke because of the `exclude_user=requesting_user` filter (doesn't fit the "URL filter only" model).
 - `handle_add_favorite` / `handle_remove_favorite` are bespoke because they're M:N edge mutations, not CRUD.
+
+Inline-child append on create (providers' credential rows on parent-create) is handled by the generic `handle_create` walking `spec.children` — no entity needs a bespoke create handler just for nested writes.
 
 Bespoke handlers still use `mutate(...)` for audit + commit; they just own the orchestration their entity needs.
 

--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -489,9 +489,11 @@ class EntitySpec:
         order matches the children's construction order. Returned as a
         tuple so callers cannot mutate the underlying registry.
 
-        Consumers: ``handle_create_provider`` derives the inline-credential
-        loop from ``PROVIDER_ENTITY.children`` instead of restating
-        the (collection, model) pairs.
+        Consumers: the generic ``handle_create`` walks
+        ``spec.children`` so the standard top-level create path appends
+        inline-child rows automatically (providers' credential lists).
+        Adding a fourth credential is a one-file change (the new spec)
+        with no edit to the create handler.
         """
         return tuple(self._children)
 

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -9,7 +9,6 @@ from src.api.common.specs.provider_certification import CERTIFICATION_ENTITY
 from src.api.common.specs.provider_education import EDUCATION_ENTITY
 from src.api.common.specs.provider_licensure import LICENSURE_ENTITY
 from src.logic.providers.provider_processing import (
-    handle_create_provider,
     handle_get_provider_form,
     provider_detail_extras,
 )
@@ -20,22 +19,18 @@ router = BaseRouter(router=providers_api_router, default_tags=["providers"])
 logger = logging.getLogger(__name__)
 
 
-# Bespoke handlers (create — inline credentials append, form_new) stay
-# explicit. The detail handler takes a per-viewer `is_favorited` extras
-# callable; the list handler is now framework-built via
-# `make_list_handler(PROVIDER_ENTITY)` — `selected_<filter>` echoes
-# come from the generic context build. Update / delete / form_edit are
-# framework-built and stitched onto this module (auto-detected from the
-# caller frame) for contract-test patches at
-# `src.api.routes.providers._handle_<verb>_provider`. Owned credential
-# subentities (licensure, education, certification) auto-bind their own
-# create/update/delete factories — same path through `mount_entity`'s
-# owned-subentity branch.
+# Only `form_new` stays bespoke (the create-form template needs the
+# Pydantic class as a Jinja field-resolver). Every other verb auto-binds:
+# `create` reads `PROVIDER_ENTITY.children` to append inline credential
+# rows; `list` echoes filter selections; detail/update/delete/form_edit
+# go through the standard factories. Owned credential subentities
+# (licensure, education, certification) self-register on
+# `PROVIDER_ENTITY.children` and pick up the same auto-bind for their
+# create / update / delete factories.
 mount_entity(
     router,
     PROVIDER_ENTITY,
     handlers={
-        "create": handle_create_provider,
         "form_new": handle_get_provider_form,
     },
     detail_extras=provider_detail_extras,

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -157,8 +157,10 @@ async def handle_some_operation(
 For the standard CRUD verbs (create / update / delete), the default is to bind a factory-built handler from `_generic.py` (see [`api/common/README.md`](../api/common/README.md#generic-crud-handler-factories) for the route-file wiring). Write a bespoke handler in the entity's cluster only when the verb has rules that don't fit the standard ritual:
 
 - `handle_delete_user` is bespoke because of the self-guard ("admins can't delete their own account here").
-- `handle_create_provider` is bespoke because it appends initial credential sub-rows from the inline payload after the parent persists — a nested-write shape no other entity exercises.
+- `handle_list_users` is bespoke because the `exclude_user=requesting_user` filter doesn't fit the framework's "URL filter only" model.
 - `handle_add_favorite` / `handle_remove_favorite` are bespoke because they're M:N edge mutations with idempotent semantics + non-CRUD audit (`edge_audit` instead of `audit`).
+
+Nested-write creates (providers' inline credential rows) are handled by the generic `handle_create` walking `spec.children` — no entity needs a bespoke create handler just for that shape.
 
 Bespoke handlers still use the shared primitives — `mutate(...)` for CRUD-shaped mutations, `record_audit(...)` for non-CRUD audits, `assert_owner_or_admin` for the owner check, the spec's `audit` / `edge_audit` / `private_fields` declarations. They just orchestrate the entity-specific steps the framework can't subsume.
 

--- a/src/logic/_generic.py
+++ b/src/logic/_generic.py
@@ -187,10 +187,27 @@ async def handle_create(
         )
 
     else:
-        instance = spec.model(**payload.model_dump())
+        # Inline-child collections (e.g. provider's licensures /
+        # educations / certifications) come in on the payload alongside
+        # the parent's own fields. Exclude them from the parent
+        # constructor, persist the parent, then append each child via
+        # `repo.add_child` so the in-memory state stays coherent for
+        # the audit after-snapshot. Empty `spec.children` is the common
+        # case (most entities have no inline children) and the loop is
+        # a no-op.
+        inline_collections = tuple(c.url_collection for c in spec.children)
+        parent_fields = payload.model_dump(exclude=set(inline_collections))
+        instance = spec.model(**parent_fields)
         if spec.owner_attr is not None:
             setattr(instance, spec.owner_attr, requesting_user.id)
         created = await repo.create(instance)
+        for child_spec in spec.children:
+            for item in getattr(payload, child_spec.url_collection, []) or []:
+                await repo.add_child(
+                    created,
+                    child_spec.url_collection,
+                    child_spec.model(**item.model_dump()),
+                )
 
     async with mutate(
         repo,

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -21,20 +21,11 @@ from uuid import UUID
 
 from fastapi import Request
 
-# Importing the credential spec modules registers their `parent=PROVIDER_ENTITY`
-# children on `PROVIDER_ENTITY.children` via the EntitySpec post-init
-# registry — referenced by `handle_create_provider`'s inline-credential loop.
-import src.api.common.specs.provider_certification  # noqa: F401
-import src.api.common.specs.provider_education  # noqa: F401
-import src.api.common.specs.provider_licensure  # noqa: F401
 from src.api.common.exceptions import ForbiddenError, NotFoundError
-from src.api.common.specs.provider import PROVIDER_ENTITY
-from src.logic.audit import mutate
 from src.models import (
     Provider,
     User,
 )
-from src.repositories.audit_repository import AuditRepository
 from src.repositories.favorites.user_favorite_repository import UserFavoriteRepository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.repositories.users.user_repository import UserRepository
@@ -43,11 +34,6 @@ from src.schemas.providers.provider import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-# The audit binding lives on `PROVIDER_ENTITY.audit`; this re-export
-# keeps the handler body's `resource=PROVIDER` shape without churn.
-PROVIDER = PROVIDER_ENTITY.audit
 
 
 # --- Provider handlers ----------------------------------------------------
@@ -128,44 +114,3 @@ async def handle_get_provider_form(
         # (and core doesn't need to import schemas).
         "schema": ProviderCreate,
     }
-
-
-async def handle_create_provider(
-    payload: ProviderCreate,
-    repo: ProviderRepository,
-    audit_repo: AuditRepository,
-    requesting_user: User,
-) -> Provider:
-    """Creates a provider owned by the requesting user plus any inline
-    credential sub-rows. A user may own zero, one, or many providers —
-    nothing here rejects a second create. One `CREATE_PROVIDER`
-    audit row is written whose `after` snapshot includes the inline
-    sub-rows — the snapshot schema embeds the nested credential lists,
-    so a single row captures the full create.
-    """
-    # Inline-credential kinds derive from the parent → children registry
-    # on `PROVIDER_ENTITY`: each owned-credential spec registers itself
-    # when its module is imported. Adding a fourth credential is now a
-    # single new spec file — no edit here.
-    inline_collections = tuple(
-        child.url_collection for child in PROVIDER_ENTITY.children
-    )
-    provider_fields = payload.model_dump(exclude=set(inline_collections))
-    created = await repo.create_provider(user_id=requesting_user.id, **provider_fields)
-
-    for child in PROVIDER_ENTITY.children:
-        for item in getattr(payload, child.url_collection):
-            await repo.add_child(
-                created, child.url_collection, child.model(**item.model_dump())
-            )
-
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=created,
-        resource=PROVIDER,
-        verb="create",
-    ):
-        pass
-    return created

--- a/src/logic/providers/test_provider_processing.py
+++ b/src/logic/providers/test_provider_processing.py
@@ -15,10 +15,9 @@ from starlette.requests import Request
 
 from src.api.common.exceptions import ForbiddenError, NotFoundError
 from src.api.common.specs.provider import PROVIDER_ENTITY
-from src.logic._generic import handle_detail, handle_list
+from src.logic._generic import handle_create, handle_detail, handle_list
 from src.logic.audit import AuditAction
 from src.logic.providers.provider_processing import (
-    handle_create_provider,
     handle_list_user_providers,
     provider_detail_extras,
 )
@@ -393,11 +392,12 @@ async def test_list_user_providers_404_when_target_user_missing(
             )
 
 
-# --- handle_create_provider ----------------------------------------------
+# --- handle_create (provider, via the generic framework) -----------------
 
 
-# NOTE: `handle_create_provider` stays bespoke (inline credentials append);
-# the framework's `handle_create` doesn't cover this shape. Test stays.
+# Provider create goes through the framework's `handle_create`. The
+# inline-children loop now lives in `_generic.py`, driven by
+# `PROVIDER_ENTITY.children`.
 async def test_create_provider_persists_row_and_writes_audit(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
@@ -407,7 +407,13 @@ async def test_create_provider_persists_row_and_writes_audit(
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
         audit_repo = AuditRepository(session)
-        created = await handle_create_provider(payload, repo, audit_repo, user)
+        created = await handle_create(
+            PROVIDER_ENTITY,
+            payload=payload,
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=user,
+        )
 
     assert created.owner_id == user.id
     assert created.practice_name == "Acme Health"
@@ -447,7 +453,13 @@ async def test_create_provider_with_inline_children_captures_them_in_audit(
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
         audit_repo = AuditRepository(session)
-        created = await handle_create_provider(payload, repo, audit_repo, user)
+        created = await handle_create(
+            PROVIDER_ENTITY,
+            payload=payload,
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=user,
+        )
 
     rows = await _audit_rows_for(
         db_test_session_manager,
@@ -488,11 +500,12 @@ async def test_create_provider_allows_multiple_per_user(
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
         audit_repo = AuditRepository(session)
-        second = await handle_create_provider(
-            _provider_create_payload(practice_name="Second Practice"),
-            repo,
-            audit_repo,
-            user,
+        second = await handle_create(
+            PROVIDER_ENTITY,
+            payload=_provider_create_payload(practice_name="Second Practice"),
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=user,
         )
 
     assert second.id != first_id

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -210,7 +210,7 @@ async def handle_create_entity(data, user, repo: [Entity]Repository):
 When *not* to delegate:
 
 - `get_X_by_<field>` lookups that are not by primary key — write them out (e.g. `ProviderRepository.list_providers` filtering through `ProviderLicensure`).
-- Custom multi-step writes — e.g. `handle_create_provider` (the bespoke parent-create handler) appends initial credential sub-rows after the parent persists. Standard CRUD verbs go through the framework instead.
+- Custom multi-step writes that the generic framework can't subsume (edge add/remove for `UserFavorite`, idempotency rules). Inline-child append on parent-create *is* covered by the framework's `handle_create` walking `spec.children`.
 
 ```python
 # Typical resource repo today — only methods with custom query patterns:
@@ -235,7 +235,7 @@ async def list_providers(
     return await self._list(stmt.order_by(Provider.created_at.desc()))
 ```
 
-Per-entity `create_X` / `update_X` / `delete_X` wrapper methods have been removed for non-bespoke entities — the generic CRUD framework calls the public aliases above directly. Bespoke handlers (provider create with nested credentials, edge operations) drive their entity-specific writes through the same public aliases: `handle_create_provider` loops over a `(collection, Model)` table and calls `repo.add_child(parent, collection, Model(**fields))` for each inline credential row, so adding a fourth credential kind is a one-line table entry rather than a fourth `add_X` method on the repo.
+Per-entity `create_X` / `update_X` / `delete_X` wrapper methods have been removed — the generic CRUD framework calls `BaseRepository.create` / `patch` / `delete` directly. Bespoke handlers (edge add/remove) drive their entity-specific writes through the same public aliases. Inline-child append on parent-create (provider's credential lists) is the framework's job: `handle_create` walks `spec.children` and calls `repo.add_child(parent, collection, Model(**fields))` per child. Adding a fourth credential is a one-file change (the new spec), not an edit here.
 
 ## Common issues and solutions
 

--- a/src/repositories/providers/provider_repository.py
+++ b/src/repositories/providers/provider_repository.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import Sequence
 from uuid import UUID
 
 from sqlalchemy import select
@@ -62,6 +62,6 @@ class ProviderRepository(BaseRepository):
         return await self._list(stmt)
 
     # --- Provider mutations ----------------------------------------
-
-    async def create_provider(self, user_id: UUID, **fields: Any) -> Provider:
-        return await self._persist_new(Provider(owner_id=user_id, **fields))
+    # The framework's `handle_create` calls `repo.create(Provider(...))`
+    # (the public alias on `BaseRepository`) directly — no `create_provider`
+    # wrapper needed. Inline credential rows append via `repo.add_child`.

--- a/src/repositories/providers/test_provider_repository.py
+++ b/src/repositories/providers/test_provider_repository.py
@@ -57,14 +57,16 @@ async def test_create_provider_persists_row(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        created = await repo.create_provider(
-            user_id=user.id,
-            practice_name="Acme Health",
-            location_city="Springfield",
-            location_state="IL",
-            location_zip="62701",
-            in_person_sessions="yes",
-            virtual_sessions="no",
+        created = await repo.create(
+            Provider(
+                owner_id=user.id,
+                practice_name="Acme Health",
+                location_city="Springfield",
+                location_state="IL",
+                location_zip="62701",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+            )
         )
         await session.commit()
         provider_id = created.id
@@ -87,14 +89,16 @@ async def test_get_by_id_finds_created_provider(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        created = await repo.create_provider(
-            user_id=user.id,
-            practice_name="Acme",
-            location_city="Springfield",
-            location_state="IL",
-            location_zip="62701",
-            in_person_sessions="yes",
-            virtual_sessions="no",
+        created = await repo.create(
+            Provider(
+                owner_id=user.id,
+                practice_name="Acme",
+                location_city="Springfield",
+                location_state="IL",
+                location_zip="62701",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+            )
         )
         await session.commit()
         provider_id = created.id
@@ -113,14 +117,16 @@ async def test_get_by_user_id_finds_created_provider(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        await repo.create_provider(
-            user_id=user.id,
-            practice_name="Acme",
-            location_city="Springfield",
-            location_state="IL",
-            location_zip="62701",
-            in_person_sessions="yes",
-            virtual_sessions="no",
+        await repo.create(
+            Provider(
+                owner_id=user.id,
+                practice_name="Acme",
+                location_city="Springfield",
+                location_state="IL",
+                location_zip="62701",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+            )
         )
         await session.commit()
 
@@ -138,14 +144,16 @@ async def test_update_provider_changes_fields_visible_on_refetch(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        created = await repo.create_provider(
-            user_id=user.id,
-            practice_name="Original",
-            location_city="Springfield",
-            location_state="IL",
-            location_zip="62701",
-            in_person_sessions="yes",
-            virtual_sessions="no",
+        created = await repo.create(
+            Provider(
+                owner_id=user.id,
+                practice_name="Original",
+                location_city="Springfield",
+                location_state="IL",
+                location_zip="62701",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+            )
         )
         await session.commit()
         provider_id = created.id

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -150,18 +150,21 @@ class MockDataFactory:
 
     @classmethod
     def create_provider_create_dependency_config(cls) -> Dict[str, Any]:
-        """Mock for `handle_create_provider`.
+        """Mock for the factory-built `_handle_create_provider`.
 
         The route under test (`POST /providers`) reads `id` off
         the handler's return value to build the response body and the
         `Location` / `HX-Redirect` headers. A `SimpleNamespace` exposing
-        `id` is sufficient.
+        `id` is sufficient. The framework stitches the auto-bound
+        handler onto the route module, so contract patches target
+        `src.api.routes.providers._handle_create_provider` (not the
+        old bespoke handler in `provider_processing`).
         """
         stub_provider = SimpleNamespace(
             id=UUID("33333333-3333-3333-3333-333333333333"),
         )
         return {
-            "src.logic.providers.provider_processing.handle_create_provider": {
+            "src.api.routes.providers._handle_create_provider": {
                 "return_value_config": stub_provider
             }
         }


### PR DESCRIPTION
## Summary

- `handle_create` now walks `spec.children` in the standard top-level branch — excludes their `url_collection`s from the parent payload, persists the parent, then iterates each child collection and calls `repo.add_child`.
- Deletes `handle_create_provider` from `provider_processing.py`.
- Deletes `ProviderRepository.create_provider` — the generic framework calls `repo.create(Provider(...))` directly.
- Providers route auto-binds `create` via `make_create_handler`; only `form_new` stays explicit.
- Contract tests patch `src.api.routes.providers._handle_create_provider` (the framework-stitched handler) instead of the deleted bespoke handler.
- READMEs updated (`logic/`, `repositories/`, `api/common/`).

Closes #368. Final issue in the 8-PR per-entity repetition collapse series.

## Test plan

- [x] `dev test` — 780 passed
- [x] `dev test contract` — 16 passed
- [x] `dev lint` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)