### PR TITLE
Extract duplicated _ck helper into models.enums

### DIFF
--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -303,3 +303,20 @@ def check_in_tuple_sql(column: str, values: tuple[str, ...]) -> str:
     so it's not safe for arbitrary future values."""
     quoted = ", ".join("'" + v.replace("'", "''") + "'" for v in values)
     return f"{column} IN ({quoted})"
+
+
+def named_check_in(
+    table: str, column: str, values: tuple[str, ...]
+) -> "CheckConstraint":
+    """`column IN (values)` CHECK named `ck_<table>_<column>`.
+
+    Centralizes the per-model `_ck` boilerplate every entity using a
+    controlled-vocabulary column was restating. Models import this
+    directly instead of redeclaring a local closure over `_TABLE`.
+    """
+    from sqlalchemy import CheckConstraint
+
+    return CheckConstraint(
+        check_in_tuple_sql(column, values),
+        name=f"ck_{table}_{column}",
+    )

--- a/src/models/posts/client_referral_detail.py
+++ b/src/models/posts/client_referral_detail.py
@@ -1,4 +1,6 @@
-from sqlalchemy import JSON, CheckConstraint, Column, ForeignKey, Text, text
+from functools import partial
+
+from sqlalchemy import JSON, Column, ForeignKey, Text, text
 from sqlalchemy.types import Uuid
 
 from ..base import Base
@@ -8,18 +10,11 @@ from ..enums import (
     LANGUAGE_PREFERRED_OPTIONS,
     LOCATION_AVAILABILITY_OPTIONS,
     US_STATES,
-    check_in_tuple_sql,
+    named_check_in,
 )
 
 _TABLE = "client_referral_details"
-
-
-def _ck(column: str, values: tuple[str, ...]) -> CheckConstraint:
-    """`column IN (values)` CHECK named `ck_<table>_<column>`."""
-    return CheckConstraint(
-        check_in_tuple_sql(column, values),
-        name=f"ck_{_TABLE}_{column}",
-    )
+_ck = partial(named_check_in, _TABLE)
 
 
 class ClientReferralDetail(Base):

--- a/src/models/posts/provider_availability_detail.py
+++ b/src/models/posts/provider_availability_detail.py
@@ -1,4 +1,6 @@
-from sqlalchemy import JSON, Boolean, CheckConstraint, Column, ForeignKey, Text, text
+from functools import partial
+
+from sqlalchemy import JSON, Boolean, Column, ForeignKey, Text, text
 from sqlalchemy.types import Uuid
 
 from ..base import Base
@@ -8,18 +10,11 @@ from ..enums import (
     LANGUAGE_PREFERRED_OPTIONS,
     LOCATION_AVAILABILITY_OPTIONS,
     US_STATES,
-    check_in_tuple_sql,
+    named_check_in,
 )
 
 _TABLE = "provider_availability_details"
-
-
-def _ck(column: str, values: tuple[str, ...]) -> CheckConstraint:
-    """`column IN (values)` CHECK named `ck_<table>_<column>`."""
-    return CheckConstraint(
-        check_in_tuple_sql(column, values),
-        name=f"ck_{_TABLE}_{column}",
-    )
+_ck = partial(named_check_in, _TABLE)
 
 
 class ProviderAvailabilityDetail(Base):

--- a/src/models/providers/provider.py
+++ b/src/models/providers/provider.py
@@ -1,19 +1,14 @@
-from sqlalchemy import CheckConstraint, Column, ForeignKey, Text
+from functools import partial
+
+from sqlalchemy import Column, ForeignKey, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import Uuid
 
 from ..base import BaseModel
-from ..enums import LOCATION_AVAILABILITY_OPTIONS, US_STATES, check_in_tuple_sql
+from ..enums import LOCATION_AVAILABILITY_OPTIONS, US_STATES, named_check_in
 
 _TABLE = "providers"
-
-
-def _ck(column: str, values: tuple[str, ...]) -> CheckConstraint:
-    """`column IN (values)` CHECK named `ck_<table>_<column>`."""
-    return CheckConstraint(
-        check_in_tuple_sql(column, values),
-        name=f"ck_{_TABLE}_{column}",
-    )
+_ck = partial(named_check_in, _TABLE)
 
 
 class Provider(BaseModel):

--- a/src/models/providers/provider_certification.py
+++ b/src/models/providers/provider_certification.py
@@ -1,18 +1,13 @@
-from sqlalchemy import CheckConstraint, Column, Date, ForeignKey, Text
+from functools import partial
+
+from sqlalchemy import Column, Date, ForeignKey, Text
 from sqlalchemy.types import Uuid
 
 from ..base import BaseModel
-from ..enums import CERTIFICATION_TYPES, check_in_tuple_sql
+from ..enums import CERTIFICATION_TYPES, named_check_in
 
 _TABLE = "provider_certifications"
-
-
-def _ck(column: str, values: tuple[str, ...]) -> CheckConstraint:
-    """`column IN (values)` CHECK named `ck_<table>_<column>`."""
-    return CheckConstraint(
-        check_in_tuple_sql(column, values),
-        name=f"ck_{_TABLE}_{column}",
-    )
+_ck = partial(named_check_in, _TABLE)
 
 
 class ProviderCertification(BaseModel):

--- a/src/models/providers/provider_education.py
+++ b/src/models/providers/provider_education.py
@@ -1,18 +1,13 @@
-from sqlalchemy import CheckConstraint, Column, ForeignKey, Text
+from functools import partial
+
+from sqlalchemy import Column, ForeignKey, Text
 from sqlalchemy.types import Uuid
 
 from ..base import BaseModel
-from ..enums import EDUCATION_TYPES, check_in_tuple_sql
+from ..enums import EDUCATION_TYPES, named_check_in
 
 _TABLE = "provider_educations"
-
-
-def _ck(column: str, values: tuple[str, ...]) -> CheckConstraint:
-    """`column IN (values)` CHECK named `ck_<table>_<column>`."""
-    return CheckConstraint(
-        check_in_tuple_sql(column, values),
-        name=f"ck_{_TABLE}_{column}",
-    )
+_ck = partial(named_check_in, _TABLE)
 
 
 class ProviderEducation(BaseModel):

--- a/src/models/providers/provider_licensure.py
+++ b/src/models/providers/provider_licensure.py
@@ -1,18 +1,13 @@
-from sqlalchemy import CheckConstraint, Column, Date, ForeignKey, Text
+from functools import partial
+
+from sqlalchemy import Column, Date, ForeignKey, Text
 from sqlalchemy.types import Uuid
 
 from ..base import BaseModel
-from ..enums import LICENSE_TYPES, US_STATES, check_in_tuple_sql
+from ..enums import LICENSE_TYPES, US_STATES, named_check_in
 
 _TABLE = "provider_licensures"
-
-
-def _ck(column: str, values: tuple[str, ...]) -> CheckConstraint:
-    """`column IN (values)` CHECK named `ck_<table>_<column>`."""
-    return CheckConstraint(
-        check_in_tuple_sql(column, values),
-        name=f"ck_{_TABLE}_{column}",
-    )
+_ck = partial(named_check_in, _TABLE)
 
 
 class ProviderLicensure(BaseModel):


### PR DESCRIPTION
## Summary
- Lifts the verbatim-duplicated `_ck` helper out of 6 model files into a single `named_check_in(table, column, values)` function next to `check_in_tuple_sql` in `src/models/enums.py`.
- Each model now expresses the local `_ck` alias as `functools.partial(named_check_in, _TABLE)` — one line instead of a six-line closure.

Closes #370.

## Test plan
- [x] `dev test` (780 passed, 1 skipped)
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)