### PR TITLE
Lift self-guard into _authz.forbid_self_action

### DIFF
--- a/src/logic/_authz.py
+++ b/src/logic/_authz.py
@@ -65,6 +65,21 @@ def is_self_or_admin(actor: User | None, target) -> bool:
     return actor.id == target.id or actor.is_superuser
 
 
+def forbid_self_action(target, actor: User, *, detail: str) -> None:
+    """Raise `ForbiddenError` if `actor` is operating on themselves.
+
+    For admin-only mutations whose target is a `User` row, the route's
+    `current_admin_user` dep already blocks non-admins — but an admin
+    could still aim the verb at their own account. The product rule is
+    that admins cannot self-mutate via these endpoints; this helper is
+    the single place that rule is expressed. `detail` is the full
+    error message so each call can phrase the action naturally
+    (activation, deletion, …).
+    """
+    if target.id == actor.id:
+        raise ForbiddenError(detail=detail)
+
+
 def assert_owner_or_admin(
     obj,
     user: User,

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -4,10 +4,10 @@ from uuid import UUID
 
 from fastapi import Request
 
-from src.api.common.exceptions import ForbiddenError, NotFoundError
+from src.api.common.exceptions import NotFoundError
 from src.api.common.projections import project_view
 from src.api.common.specs.user import USER_ENTITY
-from src.logic._authz import is_admin
+from src.logic._authz import forbid_self_action, is_admin
 from src.logic.audit import make_snapshotter, mutate, record_audit
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
@@ -108,10 +108,11 @@ async def handle_set_user_activation(
     target = await repo.get_user_by_id(user_id)
     if target is None:
         raise NotFoundError(detail="User not found")
-    if target.id == requesting_user.id:
-        raise ForbiddenError(
-            detail="Admins cannot change their own activation state here"
-        )
+    forbid_self_action(
+        target,
+        requesting_user,
+        detail="Admins cannot change their own activation state here",
+    )
 
     is_active = payload.state == "active"
     logger.info(
@@ -149,8 +150,11 @@ async def handle_delete_user(
     target = await repo.get_user_by_id(user_id)
     if target is None:
         raise NotFoundError(detail="User not found")
-    if target.id == requesting_user.id:
-        raise ForbiddenError(detail="Admins cannot delete their own account here")
+    forbid_self_action(
+        target,
+        requesting_user,
+        detail="Admins cannot delete their own account here",
+    )
 
     logger.info(f"Handler: admin {requesting_user.id} hard-deleting user {target.id}")
     async with mutate(


### PR DESCRIPTION
## Summary
- Adds `forbid_self_action(target, actor, *, detail: str)` to `src/logic/_authz.py`.
- Replaces the duplicate `if target.id == requesting_user.id: raise ForbiddenError(...)` in `handle_delete_user` and `handle_set_user_activation`.

Closes #372.

## Test plan
- [x] `dev test` (780 passed)
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)