### PR TITLE
Default audit_snapshot to read_schema when BaseModel

### DIFF
--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -390,6 +390,22 @@ class EntitySpec:
         # builds `audit` from name + schema (+ optional action_stem).
         # Declaring both forms is ambiguous; the user picked one and
         # forgot the other, almost certainly.
+        # Default `audit_snapshot` from `read_schema` when the read schema
+        # is a Pydantic class and no audit binding has been declared. The
+        # codebase convention is that audit snapshots are byte-identical
+        # to the read projection except for entities that explicitly
+        # diverge (posts: discriminated-union flatten; users: omits id).
+        # Those entities still set `audit_snapshot=` explicitly.
+        # `TypeAdapter` adapters are skipped — posts' read schema is a
+        # discriminated-union adapter whose audit snapshot is a distinct
+        # callable.
+        if (
+            self.audit_snapshot is None
+            and self.audit is None
+            and isinstance(self.read_schema, type)
+            and issubclass(self.read_schema, BaseModel)
+        ):
+            object.__setattr__(self, "audit_snapshot", self.read_schema)
         if self.audit_snapshot is not None and self.audit is not None:
             raise ValueError(
                 f"EntitySpec({self.name!r}) declares both `audit_snapshot` "

--- a/src/api/common/specs/_credential.py
+++ b/src/api/common/specs/_credential.py
@@ -26,7 +26,6 @@ def make_provider_credential_entity(
     id_param: str,
     model: type,
     audit_stem: str,
-    snapshot_schema: type[BaseModel],
     read_schema: type[BaseModel],
     create_adapter: type[BaseModel] | TypeAdapter,
     update_adapter: type[BaseModel] | TypeAdapter,
@@ -38,9 +37,10 @@ def make_provider_credential_entity(
     triple) — the credential enum stems diverge from the entity `name`
     (which is `"provider_licensure"`) so the stem is passed explicitly
     via the spec's `audit_action_stem`.
-    `snapshot_schema` is the Pydantic schema used for audit before/after
-    snapshots; `read_schema` is the response shape for `PATCH` (the
-    spec's constructor synthesizes `read_to_dict` from it).
+    `read_schema` is the response shape for `PATCH`; the spec
+    constructor synthesizes `read_to_dict` from it and defaults
+    `audit_snapshot` to it as well (credential audit snapshots are
+    byte-identical to their read projection).
     """
 
     return EntitySpec(
@@ -52,7 +52,6 @@ def make_provider_credential_entity(
         repo_dep=get_provider_repository,
         write_user_dep=current_active_user,
         auth_policy=OWNER_OR_ADMIN,
-        audit_snapshot=snapshot_schema,
         audit_action_stem=audit_stem,
         create_adapter=create_adapter,
         update_adapter=update_adapter,

--- a/src/api/common/specs/provider.py
+++ b/src/api/common/specs/provider.py
@@ -24,7 +24,6 @@ from src.auth_config import current_active_user
 from src.models import Provider
 from src.repositories.dependencies import get_provider_repository
 from src.schemas.providers.provider import (
-    ProviderAuditSnapshot,
     ProviderCreate,
     ProviderRead,
     ProviderUpdate,
@@ -47,7 +46,6 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     read_user_dep=current_active_user,
     write_user_dep=current_active_user,
     auth_policy=OWNER_OR_ADMIN,
-    audit_snapshot=ProviderAuditSnapshot,
     create_adapter=ProviderCreate,
     update_adapter=ProviderUpdate,
     read_schema=ProviderRead,

--- a/src/api/common/specs/provider_certification.py
+++ b/src/api/common/specs/provider_certification.py
@@ -10,7 +10,6 @@ from src.api.common.entity_spec import EntitySpec
 from src.api.common.specs._credential import make_provider_credential_entity
 from src.models import ProviderCertification
 from src.schemas.providers.provider import (
-    ProviderCertificationAuditSnapshot,
     ProviderCertificationCreate,
     ProviderCertificationRead,
     ProviderCertificationUpdate,
@@ -22,7 +21,6 @@ CERTIFICATION_ENTITY: Final[EntitySpec] = make_provider_credential_entity(
     id_param="certification_id",
     model=ProviderCertification,
     audit_stem="certification",
-    snapshot_schema=ProviderCertificationAuditSnapshot,
     read_schema=ProviderCertificationRead,
     create_adapter=ProviderCertificationCreate,
     update_adapter=ProviderCertificationUpdate,

--- a/src/api/common/specs/provider_education.py
+++ b/src/api/common/specs/provider_education.py
@@ -10,7 +10,6 @@ from src.api.common.entity_spec import EntitySpec
 from src.api.common.specs._credential import make_provider_credential_entity
 from src.models import ProviderEducation
 from src.schemas.providers.provider import (
-    ProviderEducationAuditSnapshot,
     ProviderEducationCreate,
     ProviderEducationRead,
     ProviderEducationUpdate,
@@ -22,7 +21,6 @@ EDUCATION_ENTITY: Final[EntitySpec] = make_provider_credential_entity(
     id_param="education_id",
     model=ProviderEducation,
     audit_stem="education",
-    snapshot_schema=ProviderEducationAuditSnapshot,
     read_schema=ProviderEducationRead,
     create_adapter=ProviderEducationCreate,
     update_adapter=ProviderEducationUpdate,

--- a/src/api/common/specs/provider_licensure.py
+++ b/src/api/common/specs/provider_licensure.py
@@ -16,7 +16,6 @@ from src.api.common.entity_spec import EntitySpec
 from src.api.common.specs._credential import make_provider_credential_entity
 from src.models import ProviderLicensure
 from src.schemas.providers.provider import (
-    ProviderLicensureAuditSnapshot,
     ProviderLicensureCreate,
     ProviderLicensureRead,
     ProviderLicensureUpdate,
@@ -28,7 +27,6 @@ LICENSURE_ENTITY: Final[EntitySpec] = make_provider_credential_entity(
     id_param="licensure_id",
     model=ProviderLicensure,
     audit_stem="licensure",
-    snapshot_schema=ProviderLicensureAuditSnapshot,
     read_schema=ProviderLicensureRead,
     create_adapter=ProviderLicensureCreate,
     update_adapter=ProviderLicensureUpdate,

--- a/src/api/common/test_entity_spec.py
+++ b/src/api/common/test_entity_spec.py
@@ -353,7 +353,10 @@ def test_audit_action_stem_overrides_name():
 def test_read_schema_builds_projection_from_basemodel():
     """`read_schema=<BaseModel>` synthesizes a callable that validates
     through the schema and dumps a JSON-mode dict."""
-    spec = _make_spec(read_schema=_DummyRead)
+    # `audit=` set explicitly so the spec doesn't try to default
+    # `audit_snapshot` from `read_schema` and fail on the synthetic
+    # `widget` name (no `CREATE_WIDGET` enum member).
+    spec = _make_spec(read_schema=_DummyRead, audit=_dummy_audit())
     assert spec.read_to_dict is not None
     projected = spec.read_to_dict(SimpleNamespace(flag=True))
     assert projected == {"flag": True}
@@ -371,7 +374,26 @@ def test_read_schema_builds_projection_from_type_adapter():
 
 def test_read_schema_and_read_to_dict_mutually_exclusive():
     with pytest.raises(ValueError, match="mutually exclusive"):
-        _make_spec(read_schema=_DummyRead, read_to_dict=lambda obj: {})
+        _make_spec(
+            read_schema=_DummyRead,
+            read_to_dict=lambda obj: {},
+            audit=_dummy_audit(),
+        )
+
+
+def test_audit_snapshot_defaults_to_read_schema_when_basemodel():
+    """If a spec provides `read_schema=<BaseModel>` and no explicit
+    `audit_snapshot`/`audit`, the constructor uses the read schema as
+    the audit snapshot. Mirrors the codebase convention: provider and
+    its credential sub-rows declare a `Read` schema that doubles as the
+    audit-row projection."""
+    spec = _make_spec(
+        name="provider_licensure",
+        read_schema=_DummyRead,
+        audit_action_stem="licensure",
+    )
+    assert spec.audit is not None
+    assert spec.audit.create == AuditAction.CREATE_LICENSURE
 
 
 def test_audit_action_stem_without_snapshot_raises():

--- a/src/schemas/providers/provider.py
+++ b/src/schemas/providers/provider.py
@@ -7,12 +7,13 @@ holds three credential lists —
 each managed via its own endpoints in later issues. The wire surface
 mirrors that shape: each entity has Read / Create / Update variants.
 
-`AuditSnapshot` variants are byte-identical to `Read` for every provider
-schema — same fields, same `from_attributes`. Rather than declare two
-classes per entity, the `*AuditSnapshot` symbols are aliases to the
-`*Read` siblings. Audit-row JSON shape is unchanged. Posts and users
-genuinely diverge between Read and AuditSnapshot (id omitted from the
-audit row) and keep distinct classes — see those modules.
+Audit snapshots for every provider entity are byte-identical to the
+matching `Read` schema, so each `EntitySpec` reads its audit shape
+through `read_schema` directly — `EntitySpec.__post_init__` defaults
+`audit_snapshot` to `read_schema` when the latter is a Pydantic class.
+This module therefore declares no `*AuditSnapshot` symbols; posts and
+users genuinely diverge (kind-discriminated flatten / omitted id) and
+keep distinct classes — see those modules.
 
 `ProviderRead` embeds the sub-entity Read lists. `ProviderUpdate` does
 **not** include nested lists — sub-entities are PATCHed via their own
@@ -55,9 +56,7 @@ from src.schemas._validators import (
 class _ProviderSubrowBase(ReadProjection):
     """Common fields for every provider sub-row Read schema (licensure /
     education / certification). Subclasses add entity-specific fields.
-
-    The credential AuditSnapshot variants are aliases to the matching
-    Read class (see module docstring); both surfaces share this base.
+    Also serves as the audit-snapshot shape (see module docstring).
     """
 
     id: uuid.UUID
@@ -90,13 +89,6 @@ class ProviderLicensureUpdate(PartialUpdate):
     expiration_date: date | None = None
 
 
-# The provider-credential AuditSnapshots are byte-identical to their
-# Read siblings — same base, same fields, same `from_attributes`. The
-# alias keeps the public symbol stable for spec imports while folding
-# the duplicated class into one declaration.
-ProviderLicensureAuditSnapshot = ProviderLicensureRead
-
-
 # --- ProviderEducation --------------------------------------------------
 
 
@@ -121,9 +113,6 @@ class ProviderEducationUpdate(PartialUpdate):
     month_completed: str | None = None
 
 
-ProviderEducationAuditSnapshot = ProviderEducationRead
-
-
 # --- ProviderCertification ----------------------------------------------
 
 
@@ -143,9 +132,6 @@ class ProviderCertificationUpdate(PartialUpdate):
     certification_type: Literal[*CERTIFICATION_TYPES] | None = None
     certifying_body: StrippedText | None = None
     expiration_date: date | None = None
-
-
-ProviderCertificationAuditSnapshot = ProviderCertificationRead
 
 
 # --- Provider ----------------------------------------------------
@@ -200,9 +186,3 @@ class ProviderUpdate(PartialUpdate):
     location_zip: ZipText | None = None
     in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
     virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
-
-
-# Provider's AuditSnapshot is byte-identical to ProviderRead once the
-# credential AuditSnapshot aliases land — the nested list types collapse
-# to the same classes. Alias keeps the symbol stable for the spec import.
-ProviderAuditSnapshot = ProviderRead


### PR DESCRIPTION
## Summary
- `EntitySpec.__post_init__` defaults `audit_snapshot` to `read_schema` when the latter is a Pydantic class and no explicit `audit`/`audit_snapshot` was declared.
- Drops the `*AuditSnapshot = *Read` aliases in `src/schemas/providers/provider.py` (4 of them) and the `audit_snapshot=` kwarg on the four provider specs + the `snapshot_schema` parameter on `make_provider_credential_entity`.
- Adds a positive test for the default.

Posts and users keep explicit `audit_snapshot=` because they diverge from the read shape.

Closes #374.

## Test plan
- [x] `dev test` (781 passed)
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)