### PR TITLE
Bind state-axis/subresource handlers via spec handler_path

### DIFF
--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -26,7 +26,7 @@ structurally.
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable
+from typing import Any, Callable
 
 from pydantic import BaseModel, TypeAdapter
 
@@ -85,17 +85,25 @@ class RouteSet:
 class StateAxis:
     """One state-axis subresource on an entity (e.g. `activation` on `user`).
 
-    `handler` and `response_to_dict` are intentionally optional in
-    phase 1: the route file passes the handler directly to
-    `mount_state_axis`, because importing logic handlers into the
-    spec module would invert the usual layer direction. Phase 2 will
-    populate `handler` once the import direction is sorted.
+    `handler_path` is the dotted import path of the handler the route
+    layer should bind to this axis (e.g.
+    ``"src.logic.users.user_processing.handle_set_user_activation"``).
+    `mount_entity` resolves it via `importlib.import_module` + `getattr`
+    at mount time, which is *after* both the spec module and the logic
+    module have been imported — so the spec module never imports from
+    `src.logic`, preserving the layer direction.
+
+    Carrying it as a string (not a callable) sidesteps the import
+    cycle that previously forced the route file to pass the handler
+    via `handlers={"activation": ...}`. Specs that pre-date this knob
+    can leave it unset and pass the handler explicitly; the explicit
+    handler wins.
     """
 
     name: str
     body_schema: type[BaseModel]
     action: AuditAction
-    handler: Callable[..., Awaitable[Any]] | None = None
+    handler_path: str | None = None
     response_to_dict: Callable[[Any], dict] | None = None
 
 
@@ -171,13 +179,17 @@ class RelatedListSubresource:
     either a hand-rolled inline `ResourceSpec(...)` or from
     ``<CHILD_ENTITY>.to_resource_spec()`` once the child is migrated.
 
-    `handler` is omitted for the same reason as `StateAxis.handler`:
-    the route file binds it at mount time.
+    `handler_path` is the dotted import path of the handler bound to
+    this related-list (same shape as `StateAxis.handler_path`).
+    `mount_entity` resolves it via `importlib.import_module` +
+    `getattr` at mount time — strings preserve the layer direction
+    (`specs` never imports `logic`). Specs that don't set it can pass
+    the handler explicitly via `mount_entity(..., handlers={...})`.
     """
 
     child_spec: ResourceSpec
     template: str
-    handler: Callable[..., Awaitable[Any]] | None = None
+    handler_path: str | None = None
     singleton_alias: tuple[str, Callable[..., Any]] | None = None
 
 

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -1076,10 +1076,13 @@ def mount_entity(
         consumed.add("delete")
 
     for axis in entity.state_axes:
+        handler = _resolve_spec_bound_handler(
+            entity, effective_handlers, key=axis.name, handler_path=axis.handler_path
+        )
         mount_state_axis(
             router,
             spec,
-            handler=effective_handlers[axis.name],
+            handler=handler,
             axis_name=axis.name,
             body_schema=axis.body_schema,
             response_to_dict=axis.response_to_dict,
@@ -1088,11 +1091,14 @@ def mount_entity(
 
     for sub in entity.subresources:
         key = sub.child_spec.collection
+        handler = _resolve_spec_bound_handler(
+            entity, effective_handlers, key=key, handler_path=sub.handler_path
+        )
         mount_related_list(
             router,
             parent_spec=spec,
             child_spec=sub.child_spec,
-            handler=effective_handlers[key],
+            handler=handler,
             template=sub.template,
             singleton_alias=sub.singleton_alias,
         )
@@ -1208,6 +1214,60 @@ def _parent_path_param_pairs(spec: ResourceSpec) -> tuple[tuple[str, type], ...]
         s = s.parent
     out.reverse()
     return tuple(out)
+
+
+def _resolve_spec_bound_handler(
+    entity: Any,
+    effective_handlers: dict[str, Callable[..., Any]],
+    *,
+    key: str,
+    handler_path: str | None,
+) -> Callable[..., Any]:
+    """Pick the handler for a state-axis or related-list subresource.
+
+    Precedence:
+
+    1. Explicit handler in `mount_entity(handlers=...)` — overrides
+       anything declared on the spec (covers tests, hand-rolled cases,
+       and entities that haven't been migrated to `handler_path`).
+    2. `handler_path` declared on the spec — resolved lazily via
+       `importlib.import_module` + `getattr`. Keeps the layer
+       direction intact (`specs` never statically imports `logic`).
+    3. Neither → raise a clear error naming the entity and the key.
+    """
+    if key in effective_handlers:
+        return effective_handlers[key]
+    if handler_path is not None:
+        import importlib
+
+        module_path, _, attr = handler_path.rpartition(".")
+        if not module_path:
+            raise ValueError(
+                f"mount_entity({entity.name!r}): handler_path "
+                f"{handler_path!r} for {key!r} is not a dotted path "
+                "(expected `pkg.module.attr`)."
+            )
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as exc:
+            raise ImportError(
+                f"mount_entity({entity.name!r}): could not import "
+                f"{module_path!r} to resolve handler_path "
+                f"{handler_path!r} for {key!r}: {exc}"
+            ) from exc
+        try:
+            return getattr(module, attr)
+        except AttributeError as exc:
+            raise AttributeError(
+                f"mount_entity({entity.name!r}): module "
+                f"{module_path!r} has no attribute {attr!r} "
+                f"(handler_path {handler_path!r} for {key!r})."
+            ) from exc
+    raise KeyError(
+        f"mount_entity({entity.name!r}): no handler for {key!r} — "
+        f"supply it in `handlers={{{key!r}: ...}}` or set "
+        "`handler_path=` on the spec entry."
+    )
 
 
 def _resolve_handler(fn: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/api/common/specs/user.py
+++ b/src/api/common/specs/user.py
@@ -60,6 +60,7 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
             body_schema=UserActivationUpdate,
             action=AuditAction.SET_USER_ACTIVATION,
             response_to_dict=_activation_response_to_dict,
+            handler_path=("src.logic.users.user_processing.handle_set_user_activation"),
         ),
     ),
     subresources=(
@@ -67,6 +68,9 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
             child_spec=PROVIDER_ENTITY.to_resource_spec(),
             template="users/providers_list.html",
             singleton_alias=("me", current_active_user),
+            handler_path=(
+                "src.logic.providers.provider_processing.handle_list_user_providers"
+            ),
         ),
     ),
     # `/users/me` — detail page id sourced from the session.

--- a/src/api/common/test_resource_routes.py
+++ b/src/api/common/test_resource_routes.py
@@ -1106,6 +1106,12 @@ from src.logic.audit import AuditAction as _AuditAction  # noqa: E402
 from src.logic.audit import AuditedResource as _AuditedResource  # noqa: E402
 
 
+def _stub_axis_handler():
+    """Module-level callable that `test_mount_entity_state_axis_resolves_handler_path`
+    targets via `handler_path` to exercise the importlib resolver."""
+    return None
+
+
 def _stub_audit() -> _AuditedResource:
     return _AuditedResource(
         type="thing",
@@ -1283,6 +1289,94 @@ def test_mount_entity_dispatches_related_list_subresources():
         rr.mount_related_list = orig
     assert len(calls) == 1
     assert calls[0]["template"] == "x/list.html"
+
+
+def test_mount_entity_state_axis_resolves_handler_path():
+    """When a state axis declares `handler_path` and `handlers` omits the
+    key, `mount_entity` resolves the dotted path via importlib."""
+    calls = []
+    import src.api.common.resource_routes as rr
+
+    orig = rr.mount_state_axis
+    rr.mount_state_axis = lambda *a, **k: calls.append(k)
+    try:
+        spec = _EntitySpec(
+            name="thing",
+            url_collection="things",
+            id_param="thing_id",
+            model=SimpleNamespace,
+            audit=_stub_audit(),
+            state_axes=(
+                _StateAxis(
+                    name="activation",
+                    body_schema=_AxisBody,
+                    action=_AuditAction.SET_USER_ACTIVATION,
+                    handler_path=(
+                        "src.api.common.test_resource_routes._stub_axis_handler"
+                    ),
+                ),
+            ),
+        )
+        mount_entity(None, spec, handlers={})
+    finally:
+        rr.mount_state_axis = orig
+    assert len(calls) == 1
+    assert calls[0]["handler"] is _stub_axis_handler
+
+
+def test_mount_entity_state_axis_explicit_handler_wins_over_path():
+    """An explicit handler in `handlers={}` overrides the spec's path."""
+    calls = []
+    import src.api.common.resource_routes as rr
+
+    orig = rr.mount_state_axis
+    rr.mount_state_axis = lambda *a, **k: calls.append(k)
+
+    def explicit():
+        return None
+
+    try:
+        spec = _EntitySpec(
+            name="thing",
+            url_collection="things",
+            id_param="thing_id",
+            model=SimpleNamespace,
+            audit=_stub_audit(),
+            state_axes=(
+                _StateAxis(
+                    name="activation",
+                    body_schema=_AxisBody,
+                    action=_AuditAction.SET_USER_ACTIVATION,
+                    handler_path=(
+                        "src.api.common.test_resource_routes._stub_axis_handler"
+                    ),
+                ),
+            ),
+        )
+        mount_entity(None, spec, handlers={"activation": explicit})
+    finally:
+        rr.mount_state_axis = orig
+    assert calls[0]["handler"] is explicit
+
+
+def test_mount_entity_handler_path_missing_attr_raises_clear_error():
+    spec = _EntitySpec(
+        name="thing",
+        url_collection="things",
+        id_param="thing_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+        state_axes=(
+            _StateAxis(
+                name="activation",
+                body_schema=_AxisBody,
+                action=_AuditAction.SET_USER_ACTIVATION,
+                handler_path=("src.api.common.test_resource_routes._missing_handler"),
+            ),
+        ),
+    )
+    with pytest.raises(AttributeError, match="_missing_handler"):
+        mount_entity(None, spec, handlers={})
 
 
 def test_mount_entity_missing_handler_raises_key_error():

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -5,11 +5,9 @@ from fastapi import APIRouter
 from src.api.common import BaseRouter
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.user import USER_ENTITY
-from src.logic.providers.provider_processing import handle_list_user_providers
 from src.logic.users.user_processing import (
     handle_delete_user,
     handle_list_users,
-    handle_set_user_activation,
     user_detail_extras,
 )
 from src.repositories.providers.provider_repository import ProviderRepository
@@ -19,26 +17,23 @@ router = BaseRouter(router=users_api_router, default_tags=["users"])
 logger = logging.getLogger(__name__)
 
 
-# `handle_delete_user` is bespoke (self-guard); the detail handler is
+# `handle_delete_user` and `handle_list_users` are bespoke (self-guard
+# on delete; per-viewer admin flag on list); the detail handler is
 # factory-built but takes a per-viewer `user_detail_extras` callable
 # (loads owned providers + projects `target_user` via
 # `USER_ENTITY.private_fields`). The extras live at the call site
 # rather than on the spec because `user_detail_extras` itself imports
 # `USER_ENTITY` — putting the extras on the spec would close the cycle.
-# Other framework verbs (none active for users today) and the state-axis
-# / related-list dispatchers are spec-driven.
+# The state-axis (`activation`) and related-list subresource
+# (`providers`) handlers are bound via `handler_path` strings on the
+# spec — `mount_entity` resolves them at mount time without forcing
+# `specs/user.py` to import `src.logic`.
 mount_entity(
     router,
     USER_ENTITY,
     handlers={
         "list": handle_list_users,
         "delete": handle_delete_user,
-        # State axis (activation): action + body schema + response
-        # projection all declared on `USER_ENTITY.state_axes[0]`.
-        "activation": handle_set_user_activation,
-        # Related-list subresource (providers); singleton-alias
-        # `/users/me/providers` declared on the spec.
-        "providers": handle_list_user_providers,
     },
     detail_extras=user_detail_extras,
     detail_extra_repos=(("provider_repo", ProviderRepository),),


### PR DESCRIPTION
## Summary
- Adds `handler_path: str | None` to `StateAxis` and `RelatedListSubresource`.
- `mount_entity` resolves it via `importlib.import_module` + `getattr` when an explicit `handlers[<key>]` isn't provided. Strings carry the binding without forcing the spec module to import from `src.logic`.
- User spec now declares `handler_path` for the activation axis and the providers subresource; `routes/users.py` drops both from its handlers dict.
- Adds three resolver tests (resolves from path, explicit wins, missing attribute raises clear error).

Existing `mount_entity` tests pass unmodified; the only field rename (`StateAxis.handler` → `StateAxis.handler_path`) had no callers.

Closes #380.

## Test plan
- [x] `dev test` (785 passed)
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)