### PR TITLE
Fold favorites.py into mount_entity via mount_edge_routes

### DIFF
--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -704,6 +704,170 @@ def mount_state_axis(
     router.put(path)(route_fn)
 
 
+def mount_edge_routes(
+    router: Any,
+    entity: Any,  # `EntitySpec` for an M:N edge with `relation` set
+    *,
+    list_handler: Callable[..., Awaitable[dict]],
+    add_handler: Callable[..., Awaitable[Any]],
+    remove_handler: Callable[..., Awaitable[None]],
+) -> None:
+    """Mount the three self-only routes for an M:N edge entity.
+
+    Routes:
+      - ``GET ""`` → renders ``entity.templates.list`` with the
+        context returned by ``list_handler``.
+      - ``POST /{<to_attr>}`` → calls ``add_handler`` and returns
+        ``201 Created`` (new edge: `Location` + `HX-Redirect` to the
+        target's detail page) or ``200 OK`` (idempotent re-add:
+        `HX-Refresh: true`). Existence check runs in the helper so
+        the wire-shape semantics live in one place.
+      - ``DELETE /{<to_attr>}`` → calls ``remove_handler`` and
+        returns ``204 No Content`` + `HX-Redirect`. Idempotent —
+        the handler is expected to no-op if the edge doesn't exist.
+
+    Reads from the spec:
+      - ``entity.relation.to_attr`` — path-param name (e.g.
+        ``"provider_id"``).
+      - ``entity.relation.to_entity.url_collection`` — used for the
+        HX-Redirect target (``"/{to_collection}/{id}"``).
+      - ``entity.relation.to_entity.repo_dep`` — Depends for the
+        opposite-end repo (e.g. the provider repo on a favorite).
+      - ``entity.repo_dep`` — Depends for the edge repo.
+      - ``entity.read_user_dep`` — auth dep for the requesting actor.
+      - ``entity.templates.list`` — Jinja path for the list page.
+
+    The actor's id is sourced from ``entity.read_user_dep``, not from
+    the URL — these routes are self-only (the codebase has no
+    parametric ``/users/{user_id}/<collection>/...`` form for edges
+    today; admin views of others' edges are not exposed in v1).
+    """
+    if entity.relation is None:
+        raise ValueError(
+            f"mount_edge_routes({entity.name!r}): entity has no `relation`; "
+            "edge mounts require an M2NRelation declaration on the spec."
+        )
+    if entity.templates.list is None:
+        raise ValueError(
+            f"mount_edge_routes({entity.name!r}): entity.templates.list is "
+            "required for the list endpoint."
+        )
+    to_attr = entity.relation.to_attr
+    to_entity = entity.relation.to_entity
+    to_collection = to_entity.url_collection
+    # Handler kwarg name for the opposite-end repo follows the spec
+    # name convention: `provider_repo` for the provider entity, etc.
+    to_repo_kwarg = f"{to_entity.name}_repo"
+    list_template = entity.templates.list
+    user_dep = entity.read_user_dep
+    repo_dep = entity.repo_dep
+    to_repo_dep = to_entity.repo_dep
+
+    # Audit repo isn't on the spec — it's the universal audit-log dep
+    # every mutation handler takes. Imported lazily to avoid a cycle
+    # with repositories.dependencies (which imports from this module's
+    # cluster mate `entity_spec`).
+    from src.repositories.dependencies import get_audit_repository
+
+    @router.get("", name=f"{entity.name}:list")
+    async def _list_route(  # noqa: F811 — closure, not re-exported
+        request: Request,
+        user: Any = Depends(user_dep),
+        repo: Any = Depends(repo_dep),
+    ):
+        context = await list_handler(request=request, repo=repo, requesting_user=user)
+        return APIResponse.html_response(
+            template_name=list_template,
+            context=context,
+            request=request,
+            current_user=user,
+        )
+
+    add_route_path = f"/{{{to_attr}}}"
+
+    @router.post(
+        add_route_path,
+        status_code=status.HTTP_201_CREATED,
+        name=f"{entity.name}:add",
+    )
+    async def _add_route(
+        user: Any = Depends(user_dep),
+        repo: Any = Depends(repo_dep),
+        to_repo: Any = Depends(to_repo_dep),
+        audit_repo: Any = Depends(get_audit_repository),
+        **path_kwargs: UUID,
+    ):
+        target_id = path_kwargs[to_attr]
+        # Existence-check before delegating so the wire shape can
+        # distinguish first-add (201) from idempotent re-add (200 +
+        # HX-Refresh). The handler also no-ops on duplicates, so this
+        # second query is the cheapest path to keep the wire contract.
+        existing = await repo.get_by_pair(user_id=user.id, **{to_attr: target_id})
+        edge = await add_handler(
+            **{
+                to_attr: target_id,
+                "repo": repo,
+                to_repo_kwarg: to_repo,
+                "audit_repo": audit_repo,
+                "requesting_user": user,
+            }
+        )
+        redirect = f"/{to_collection}/{target_id}"
+        if existing is not None:
+            return updated_response(body={"id": str(edge.id)}, hx_refresh=True)
+        return created_response(id=edge.id, location=redirect, hx_redirect=redirect)
+
+    # FastAPI's path-param introspection runs against the declared
+    # function signature. `**path_kwargs` doesn't expose `provider_id`
+    # to FastAPI — fix by attaching an `inspect.Signature` that names
+    # the to_attr explicitly. Same trick `_synthesize_route_fn` uses.
+    _add_route.__signature__ = _edge_route_signature(  # type: ignore[attr-defined]
+        _add_route, to_attr=to_attr
+    )
+
+    @router.delete(
+        add_route_path,
+        status_code=status.HTTP_204_NO_CONTENT,
+        name=f"{entity.name}:remove",
+    )
+    async def _remove_route(
+        user: Any = Depends(user_dep),
+        repo: Any = Depends(repo_dep),
+        audit_repo: Any = Depends(get_audit_repository),
+        **path_kwargs: UUID,
+    ):
+        target_id = path_kwargs[to_attr]
+        await remove_handler(
+            **{to_attr: target_id},
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=user,
+        )
+        return deleted_response(hx_redirect=f"/{to_collection}/{target_id}")
+
+    _remove_route.__signature__ = _edge_route_signature(  # type: ignore[attr-defined]
+        _remove_route, to_attr=to_attr
+    )
+
+
+def _edge_route_signature(fn: Callable, *, to_attr: str) -> inspect.Signature:
+    """Rewrite `fn`'s signature so its `**path_kwargs` becomes an
+    explicit typed `to_attr: UUID` parameter that FastAPI binds from
+    the URL. The wrapper still receives the value via `**path_kwargs`
+    in its body — only the FastAPI-visible signature changes."""
+    orig = inspect.signature(fn)
+    params: list[inspect.Parameter] = [
+        inspect.Parameter(
+            to_attr, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=UUID
+        )
+    ]
+    for p in orig.parameters.values():
+        if p.kind == inspect.Parameter.VAR_KEYWORD:
+            continue
+        params.append(p)
+    return inspect.Signature(parameters=params)
+
+
 def mount_related_list(
     router: Any,
     parent_spec: ResourceSpec,

--- a/src/api/routes/favorites.py
+++ b/src/api/routes/favorites.py
@@ -1,113 +1,41 @@
-"""User favorites routes — hand-rolled because the codebase has no
-mount helper for M:N edge add/remove. The three routes are intentionally
-self-only: the path prefix is fixed at `/users/me/favorites`, the actor
-id is sourced from `current_active_user`, and there is no
-`/users/{user_id}/favorites/...` parametric form. Admins do not see
-other users' favorites in v1.
+"""User-favorites routes — driven by `mount_edge_routes` against the
+M:N edge spec. The three routes (list / add / remove) are synthesized
+from `FAVORITE_ENTITY.relation`, `FAVORITE_ENTITY.templates.list`, and
+the repo/user deps the spec declares; the route file no longer
+restates path strings, status codes, or HX-Redirect targets.
 
-Status-code shape:
+Status-code shape (preserved across the refactor):
 - POST returns 201 on first creation (with `Location` + `HX-Redirect`),
-  200 on idempotent re-favorite (no relocation; the desired state already
-  holds).
-- DELETE returns 204 always — actual removal and no-op land at the same
-  end state from the user's perspective.
+  200 on idempotent re-favorite (`HX-Refresh: true`; no relocation).
+- DELETE returns 204 always — actual removal and no-op land at the
+  same end state from the user's perspective.
 
-Audit and commit are owned by the logic-layer handlers, not these route
-shells.
+Audit and commit are owned by the logic-layer handlers, not the mount
+helper.
 """
 
 import logging
-from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter
 
-from src.api.common import APIResponse, BaseRouter
-from src.api.common.responses import (
-    created_response,
-    deleted_response,
-    updated_response,
-)
-from src.auth_config import current_active_user
+from src.api.common import BaseRouter
+from src.api.common.resource_routes import mount_edge_routes
+from src.api.common.specs.user_favorite import FAVORITE_ENTITY
 from src.logic.favorites.favorite_processing import (
     handle_add_favorite,
     handle_list_my_favorites,
     handle_remove_favorite,
 )
-from src.models import User
-from src.repositories.audit_repository import AuditRepository
-from src.repositories.dependencies import (
-    get_audit_repository,
-    get_provider_repository,
-    get_user_favorite_repository,
-)
-from src.repositories.favorites.user_favorite_repository import UserFavoriteRepository
-from src.repositories.providers.provider_repository import ProviderRepository
 
 favorites_api_router = APIRouter(prefix="/users/me/favorites")
 router = BaseRouter(router=favorites_api_router, default_tags=["favorites"])
 logger = logging.getLogger(__name__)
 
 
-@router.get("", name="favorites:list_my_favorites")
-async def list_my_favorites(
-    request: Request,
-    user: User = Depends(current_active_user),
-    repo: UserFavoriteRepository = Depends(get_user_favorite_repository),
-):
-    """Render the requesting user's favorites listing. Self-only; the
-    /me path is the only entry point."""
-    context = await handle_list_my_favorites(
-        request=request, repo=repo, requesting_user=user
-    )
-    return APIResponse.html_response(
-        template_name="favorites/list.html",
-        context=context,
-        request=request,
-        current_user=user,
-    )
-
-
-@router.post("/{provider_id}", name="favorites:add_favorite")
-async def add_favorite(
-    provider_id: UUID,
-    user: User = Depends(current_active_user),
-    repo: UserFavoriteRepository = Depends(get_user_favorite_repository),
-    provider_repo: ProviderRepository = Depends(get_provider_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-):
-    """Add a favorite edge. Idempotent: a duplicate POST returns 200
-    with `HX-Refresh`, signalling the toggle UI to re-render. First
-    creation returns 201 with the new edge id."""
-    existing = await repo.get_by_pair(user_id=user.id, provider_id=provider_id)
-    favorite = await handle_add_favorite(
-        provider_id=provider_id,
-        repo=repo,
-        provider_repo=provider_repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    if existing is not None:
-        return updated_response(body={"id": str(favorite.id)}, hx_refresh=True)
-    return created_response(
-        id=favorite.id,
-        location=f"/providers/{provider_id}",
-        hx_redirect=f"/providers/{provider_id}",
-    )
-
-
-@router.delete("/{provider_id}", name="favorites:remove_favorite")
-async def remove_favorite(
-    provider_id: UUID,
-    user: User = Depends(current_active_user),
-    repo: UserFavoriteRepository = Depends(get_user_favorite_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-):
-    """Remove a favorite edge. Idempotent: 204 either way — the end
-    state matches the user's intent regardless of prior edge state."""
-    await handle_remove_favorite(
-        provider_id=provider_id,
-        repo=repo,
-        audit_repo=audit_repo,
-        requesting_user=user,
-    )
-    return deleted_response(hx_redirect=f"/providers/{provider_id}")
+mount_edge_routes(
+    router,
+    FAVORITE_ENTITY,
+    list_handler=handle_list_my_favorites,
+    add_handler=handle_add_favorite,
+    remove_handler=handle_remove_favorite,
+)


### PR DESCRIPTION
## Summary
- Adds `mount_edge_routes(router, entity, *, list_handler, add_handler, remove_handler)` to `src/api/common/resource_routes.py`.
- The helper reads every URL / template / repo / HX-Redirect knob from `FAVORITE_ENTITY.relation` + spec deps; the existence-check that picks 201 vs 200+HX-Refresh lives in the helper.
- `favorites.py` shrinks from 60 lines to a single `mount_edge_routes(...)` call.
- All 9 existing `test_favorites.py` wire tests pass unmodified.

Closes #382.

## Test plan
- [x] `dev test` (785 passed)
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)