### PR TITLE
Add AuthDeps sentinels to collapse read/write_user_dep boilerplate

### DIFF
--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -31,9 +31,33 @@ from typing import Any, Callable
 from pydantic import BaseModel, TypeAdapter
 
 from src.api.common.resource_routes import QueryParam, ResourceSpec
+from src.auth_config import current_active_user, current_admin_user
 from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
 from src.logic.audit import AuditAction, AuditedResource, make_audited_resource
 from src.models._polymorphic import DiscriminatorRegistry
+
+
+@dataclass(frozen=True, slots=True)
+class AuthDeps:
+    """Paired FastAPI auth dependencies for read vs. write routes.
+
+    Every CRUD-shaped entity in the codebase picks from a small set of
+    auth-dep patterns:
+
+      - ``AUTHENTICATED`` — both reads and writes require any active
+        user (provider, post, the three provider credentials, favorites).
+      - ``ADMIN_FOR_WRITE`` — reads allow any active user, writes
+        require admin (users).
+
+    Hand-wired ``read_user_dep`` / ``write_user_dep`` still works for
+    one-off cases (none today). Mutually exclusive with ``AuthDeps``.
+
+    Mirrors the ``AuthzPolicy`` / ``OWNER_OR_ADMIN`` pattern that
+    collapsed the per-target authz pair onto one sentinel.
+    """
+
+    read: Callable[..., Any] | None
+    write: Callable[..., Any] | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -252,6 +276,12 @@ class EntitySpec:
     # matched callables. Mutually exclusive with the hand-wired form.
     can_write: Callable[..., bool] | None = None
     auth_policy: "AuthzPolicy | None" = None
+    # `auth_deps` is the declarative pair for `read_user_dep` /
+    # `write_user_dep` (FastAPI auth deps used at the *route* level —
+    # distinct from `auth_policy` which is the per-target check inside
+    # the handler). Mutually exclusive with hand-wired
+    # `read_user_dep`/`write_user_dep`.
+    auth_deps: "AuthDeps | None" = None
 
     # Audit --------------------------------------------------------------
     # `audit` and `edge_audit` are mutually exclusive — CRUD-shaped
@@ -487,6 +517,21 @@ class EntitySpec:
         if self.auth_policy is not None:
             object.__setattr__(self, "write_authz", self.auth_policy.write_authz)
             object.__setattr__(self, "can_write", self.auth_policy.can_write)
+        # `auth_deps` mirrors `auth_policy`: the constructor expands the
+        # paired declaration into the two slot fields. Mutually exclusive
+        # with hand-wired `read_user_dep` / `write_user_dep`.
+        if self.auth_deps is not None and (
+            self.read_user_dep is not None or self.write_user_dep is not None
+        ):
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares `auth_deps` plus "
+                "an explicit `read_user_dep` / `write_user_dep`; they "
+                "are mutually exclusive — pass the pair via `auth_deps` "
+                "or set the two deps explicitly."
+            )
+        if self.auth_deps is not None:
+            object.__setattr__(self, "read_user_dep", self.auth_deps.read)
+            object.__setattr__(self, "write_user_dep", self.auth_deps.write)
         # Validate extras bindings: a path requires an opted-in route
         # (otherwise the extras would never run); typed-repo kwargs
         # require a callable consumer (otherwise the kwargs are dead).
@@ -636,6 +681,20 @@ class EntitySpec:
 OWNER_OR_ADMIN: AuthzPolicy = AuthzPolicy(
     write_authz=assert_owner_or_admin,
     can_write=is_owner_or_admin,
+)
+
+
+# Canonical `AuthDeps` sentinels for the two route-level auth-dep
+# patterns the codebase uses. Specs that follow either pattern declare
+# `auth_deps=<sentinel>` and the constructor expands the pair onto
+# `read_user_dep` / `write_user_dep`.
+AUTHENTICATED: AuthDeps = AuthDeps(
+    read=current_active_user,
+    write=current_active_user,
+)
+ADMIN_FOR_WRITE: AuthDeps = AuthDeps(
+    read=current_active_user,
+    write=current_admin_user,
 )
 
 

--- a/src/api/common/specs/_credential.py
+++ b/src/api/common/specs/_credential.py
@@ -13,9 +13,13 @@ through it.
 
 from pydantic import BaseModel, TypeAdapter
 
-from src.api.common.entity_spec import OWNER_OR_ADMIN, EntitySpec, RouteSet
+from src.api.common.entity_spec import (
+    AUTHENTICATED,
+    OWNER_OR_ADMIN,
+    EntitySpec,
+    RouteSet,
+)
 from src.api.common.specs.provider import PROVIDER_ENTITY, _provider_form_redirect
-from src.auth_config import current_active_user
 from src.repositories.dependencies import get_provider_repository
 
 
@@ -50,7 +54,7 @@ def make_provider_credential_entity(
         model=model,
         parent=PROVIDER_ENTITY,
         repo_dep=get_provider_repository,
-        write_user_dep=current_active_user,
+        auth_deps=AUTHENTICATED,
         auth_policy=OWNER_OR_ADMIN,
         audit_action_stem=audit_stem,
         create_adapter=create_adapter,

--- a/src/api/common/specs/post.py
+++ b/src/api/common/specs/post.py
@@ -20,8 +20,13 @@ Read by:
 
 from typing import Final
 
-from src.api.common.entity_spec import OWNER_OR_ADMIN, EntitySpec, Redirects, RouteSet
-from src.auth_config import current_active_user
+from src.api.common.entity_spec import (
+    AUTHENTICATED,
+    OWNER_OR_ADMIN,
+    EntitySpec,
+    Redirects,
+    RouteSet,
+)
 from src.models import POST_KINDS, Post
 from src.repositories.dependencies import get_post_repository
 from src.schemas.posts.post import (
@@ -38,8 +43,7 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
     model=Post,
     # `owner_attr` defaults to "owner_id" — posts track their owner via Post.owner_id.
     repo_dep=get_post_repository,
-    read_user_dep=current_active_user,
-    write_user_dep=current_active_user,
+    auth_deps=AUTHENTICATED,
     auth_policy=OWNER_OR_ADMIN,
     audit_snapshot=post_audit_snapshot,
     create_adapter=post_create_adapter,

--- a/src/api/common/specs/provider.py
+++ b/src/api/common/specs/provider.py
@@ -18,9 +18,14 @@ Read by:
 
 from typing import Final
 
-from src.api.common.entity_spec import OWNER_OR_ADMIN, EntitySpec, Redirects, RouteSet
+from src.api.common.entity_spec import (
+    AUTHENTICATED,
+    OWNER_OR_ADMIN,
+    EntitySpec,
+    Redirects,
+    RouteSet,
+)
 from src.api.common.resource_routes import QueryParam
-from src.auth_config import current_active_user
 from src.models import Provider
 from src.repositories.dependencies import get_provider_repository
 from src.repositories.favorites.user_favorite_repository import UserFavoriteRepository
@@ -44,8 +49,7 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     # `owner_attr` defaults to "owner_id" — providers track their
     # owning user via Provider.owner_id.
     repo_dep=get_provider_repository,
-    read_user_dep=current_active_user,
-    write_user_dep=current_active_user,
+    auth_deps=AUTHENTICATED,
     auth_policy=OWNER_OR_ADMIN,
     create_adapter=ProviderCreate,
     update_adapter=ProviderUpdate,

--- a/src/api/common/specs/test_post.py
+++ b/src/api/common/specs/test_post.py
@@ -6,12 +6,16 @@ posts: the discriminator binding (polymorphic registry), the update
 redirect to the detail page, and the list-extras binding.
 """
 
-from src.api.common.entity_spec import OWNER_OR_ADMIN
+from src.api.common.entity_spec import AUTHENTICATED, OWNER_OR_ADMIN
 from src.api.common.specs.post import POST_ENTITY
 from src.models import POST_KINDS
 from src.schemas.posts.post import post_create_adapter, post_update_adapter
 
-# --- Authorization (post-specific) ---------------------------------------
+# --- Auth deps + authorization (post-specific) ---------------------------
+
+
+def test_auth_deps_is_authenticated():
+    assert POST_ENTITY.auth_deps is AUTHENTICATED
 
 
 def test_auth_policy_is_owner_or_admin():

--- a/src/api/common/specs/test_provider.py
+++ b/src/api/common/specs/test_provider.py
@@ -6,17 +6,23 @@ what's unique to providers: list filters, the post-mutation redirects,
 the auth_policy expansion, and the per-viewer extras binding.
 """
 
-from src.api.common.entity_spec import OWNER_OR_ADMIN
+from src.api.common.entity_spec import AUTHENTICATED, OWNER_OR_ADMIN
 from src.api.common.specs.provider import PROVIDER_ENTITY
 
-# --- Authorization (provider-specific) -----------------------------------
+# --- Auth deps + authorization (provider-specific) -----------------------
+
+
+def test_auth_deps_is_authenticated():
+    """Providers expose CRUD to any active user; per-target write rules
+    live in `auth_policy`."""
+    assert PROVIDER_ENTITY.auth_deps is AUTHENTICATED
 
 
 def test_auth_policy_is_owner_or_admin():
-    """Pinned identity of the sentinel — `OWNER_OR_ADMIN` is the
-    `AuthzPolicy(assert_owner_or_admin, is_owner_or_admin)` pair and
-    a future spec mistakenly setting `auth_policy=AUTHENTICATED` (when
-    AuthDeps lands) would silently widen mutation access."""
+    """Pinned identity of the sentinel. The pair-of-callables in
+    `OWNER_OR_ADMIN` is the only `AuthzPolicy` instance that enforces
+    "owner-or-admin"; a future refactor swapping it would silently
+    change the mutation rule."""
     assert PROVIDER_ENTITY.auth_policy is OWNER_OR_ADMIN
 
 

--- a/src/api/common/specs/test_spec_conformance.py
+++ b/src/api/common/specs/test_spec_conformance.py
@@ -219,6 +219,19 @@ def test_auth_policy_expands_to_write_authz_and_can_write(
     assert spec.can_write is spec.auth_policy.can_write
 
 
+@_PARAM_ALL
+def test_auth_deps_expands_to_read_and_write_user_dep(
+    spec: EntitySpec,
+) -> None:
+    """When ``auth_deps`` is set, the constructor populates
+    ``read_user_dep`` and ``write_user_dep`` from it. Sibling rule to
+    ``auth_policy``'s expansion."""
+    if spec.auth_deps is None:
+        pytest.skip(f"{spec.name!r} uses no AuthDeps sentinel")
+    assert spec.read_user_dep is spec.auth_deps.read
+    assert spec.write_user_dep is spec.auth_deps.write
+
+
 # --- Parent / children registry ------------------------------------------
 
 

--- a/src/api/common/specs/test_user.py
+++ b/src/api/common/specs/test_user.py
@@ -8,11 +8,21 @@ axis, the providers related-list, the private-fields tuple, the
 `/users/me` singleton alias, and the per-viewer detail extras binding.
 """
 
-from src.api.common.entity_spec import RelatedListSubresource
+from src.api.common.entity_spec import ADMIN_FOR_WRITE, RelatedListSubresource
 from src.api.common.specs.user import USER_ENTITY
 from src.logic._authz import is_self_or_admin
 from src.logic.audit import AuditAction
 from src.schemas.users.user import UserActivationUpdate
+
+# --- Auth deps (security-visible) ----------------------------------------
+
+
+def test_auth_deps_is_admin_for_write():
+    """Pinned identity — `ADMIN_FOR_WRITE` is the only sentinel where
+    writes require admin. A future spec accidentally setting
+    `auth_deps=AUTHENTICATED` would silently widen mutation access."""
+    assert USER_ENTITY.auth_deps is ADMIN_FOR_WRITE
+
 
 # --- Visibility (security-visible) ---------------------------------------
 

--- a/src/api/common/specs/user.py
+++ b/src/api/common/specs/user.py
@@ -19,13 +19,14 @@ A1 documented (`api/common -> api/routes`) is resolved.
 from typing import Final
 
 from src.api.common.entity_spec import (
+    ADMIN_FOR_WRITE,
     EntitySpec,
     RelatedListSubresource,
     RouteSet,
     StateAxis,
 )
 from src.api.common.specs.provider import PROVIDER_ENTITY
-from src.auth_config import current_active_user, current_admin_user
+from src.auth_config import current_active_user
 from src.logic._authz import is_self_or_admin
 from src.logic.audit import AuditAction
 from src.models import User
@@ -49,8 +50,7 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
     model=User,
     owner_attr=None,  # the resource *is* the user; not owned by another user
     repo_dep=get_user_repository,
-    read_user_dep=current_active_user,
-    write_user_dep=current_admin_user,
+    auth_deps=ADMIN_FOR_WRITE,
     audit_snapshot=UserAuditSnapshot,
     private_fields=("email", "is_active", "is_verified"),
     private_field_predicate=is_self_or_admin,

--- a/src/api/common/specs/user_favorite.py
+++ b/src/api/common/specs/user_favorite.py
@@ -25,6 +25,7 @@ mount helpers later; A4 doesn't.
 from typing import Final
 
 from src.api.common.entity_spec import (
+    AUTHENTICATED,
     EdgeAudit,
     EntitySpec,
     M2NRelation,
@@ -33,7 +34,6 @@ from src.api.common.entity_spec import (
 )
 from src.api.common.specs.provider import PROVIDER_ENTITY
 from src.api.common.specs.user import USER_ENTITY
-from src.auth_config import current_active_user
 from src.logic.audit import AuditAction, make_snapshotter
 from src.models import UserFavorite
 from src.repositories.dependencies import get_user_favorite_repository
@@ -59,8 +59,7 @@ FAVORITE_ENTITY: Final[EntitySpec] = EntitySpec(
     id_param="favorite_id",
     model=UserFavorite,
     repo_dep=get_user_favorite_repository,
-    read_user_dep=current_active_user,
-    write_user_dep=current_active_user,
+    auth_deps=AUTHENTICATED,
     edge_audit=FAVORITE_EDGE_AUDIT,
     relation=M2NRelation(
         from_entity=USER_ENTITY,

--- a/src/api/common/test_entity_spec.py
+++ b/src/api/common/test_entity_spec.py
@@ -11,7 +11,10 @@ import pytest
 from pydantic import BaseModel, ConfigDict, TypeAdapter
 
 from src.api.common.entity_spec import (
+    ADMIN_FOR_WRITE,
+    AUTHENTICATED,
     OWNER_OR_ADMIN,
+    AuthDeps,
     AuthzPolicy,
     EdgeAudit,
     EntitySpec,
@@ -21,6 +24,7 @@ from src.api.common.entity_spec import (
     StateAxis,
     Templates,
 )
+from src.auth_config import current_active_user, current_admin_user
 from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
 from src.logic.audit import AuditAction, AuditedResource, make_snapshotter
 
@@ -506,6 +510,47 @@ def test_auth_policy_and_can_write_mutually_exclusive():
             auth_policy=OWNER_OR_ADMIN,
             can_write=is_owner_or_admin,
         )
+
+
+def test_authenticated_sentinel_expands_to_both_deps():
+    """`auth_deps=AUTHENTICATED` populates both fields with
+    `current_active_user`. Mirrors the `auth_policy` shape."""
+    spec = _make_spec(auth_deps=AUTHENTICATED)
+    assert spec.read_user_dep is current_active_user
+    assert spec.write_user_dep is current_active_user
+
+
+def test_admin_for_write_sentinel_expands():
+    """`auth_deps=ADMIN_FOR_WRITE` keeps reads open to any active user
+    but elevates writes to admin-only — the user-entity pattern."""
+    spec = _make_spec(auth_deps=ADMIN_FOR_WRITE)
+    assert spec.read_user_dep is current_active_user
+    assert spec.write_user_dep is current_admin_user
+
+
+def test_auth_deps_and_read_user_dep_mutually_exclusive():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _make_spec(
+            auth_deps=AUTHENTICATED,
+            read_user_dep=current_active_user,
+        )
+
+
+def test_auth_deps_and_write_user_dep_mutually_exclusive():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _make_spec(
+            auth_deps=AUTHENTICATED,
+            write_user_dep=current_active_user,
+        )
+
+
+def test_custom_auth_deps_can_be_declared():
+    """`AuthDeps` is a public dataclass — future patterns (e.g. an
+    `ANONYMOUS_READ` variant) just bind a new instance."""
+    deps = AuthDeps(read=None, write=current_admin_user)
+    spec = _make_spec(auth_deps=deps)
+    assert spec.read_user_dep is None
+    assert spec.write_user_dep is current_admin_user
 
 
 def test_custom_authz_policy_can_be_declared():


### PR DESCRIPTION
## Summary

- New `AuthDeps(read, write)` dataclass + `AUTHENTICATED` / `ADMIN_FOR_WRITE` sentinels next to `AuthzPolicy` / `OWNER_OR_ADMIN`.
- `EntitySpec.auth_deps` expands to `read_user_dep`/`write_user_dep` in `__post_init__`. Mutually exclusive with hand-wired form.
- 7 specs migrate to `auth_deps=<SENTINEL>`; `current_active_user` / `current_admin_user` imports collapse from 6 files to 1.
- Conformance suite gains an `auth_deps` invariant; per-entity tests pin the sentinel identity (security-visible).

Closes #386.

## Test plan
- [x] `dev test` — 846 passed, 51 skipped.
- [x] `dev lint` — clean.
- [x] Pre-existing `auth_policy` tests pass unchanged.
- [x] New tests cover both sentinels' expansion, both exclusivity rules, and a custom `AuthDeps` instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)