### PR TITLE
Add make_entity_router helper; drop per-route-file APIRouter scaffolding

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -110,8 +110,8 @@ from src.logic.users.user_processing import (
     handle_set_user_activation,
 )
 
-users_api_router = APIRouter(prefix="/users")
-router = BaseRouter(router=users_api_router, default_tags=["users"])
+router = make_entity_router(USER_ENTITY)
+users_api_router = router.router  # re-exported so `main.py` keeps resolving
 
 mount_entity(
     router,

--- a/src/api/common/__init__.py
+++ b/src/api/common/__init__.py
@@ -1,6 +1,6 @@
 # This file makes src/api/common a Python package
 
-from .base_router import BaseRouter
+from .base_router import BaseRouter, make_entity_router
 from .decorators import handle_route_errors
 from .exceptions import (
     APIException,
@@ -27,6 +27,7 @@ __all__ = [
     "ForbiddenError",
     "handle_fastapi_users_error",
     "BaseRouter",
+    "make_entity_router",
     "created_response",
     "deleted_response",
     "parse_and_validate_form",

--- a/src/api/common/base_router.py
+++ b/src/api/common/base_router.py
@@ -1,8 +1,11 @@
-from typing import Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 from fastapi import APIRouter, Depends
 
 from src.api.common.decorators import handle_route_errors, log_route_call
+
+if TYPE_CHECKING:
+    from src.api.common.entity_spec import EntitySpec
 
 
 class BaseRouter:
@@ -98,6 +101,34 @@ class BaseRouter:
             return endpoint
 
         return decorator
+
+
+def make_entity_router(entity: "EntitySpec") -> BaseRouter:
+    """Build a `BaseRouter` for `entity` with prefix + tags derived from the spec.
+
+    The prefix is ``f"/{entity.url_collection}"`` by default; entities
+    whose URL doesn't fit the convention (favorites lives under
+    ``/users/me/favorites``) set ``prefix_override`` on the spec.
+    Default tags are ``[entity.url_collection]``.
+
+    Replaces the 4-line scaffold that every route file used to repeat:
+
+        users_api_router = APIRouter(prefix="/users")
+        router = BaseRouter(router=users_api_router, default_tags=["users"])
+
+    Route files now do ``router = make_entity_router(USER_ENTITY)``; the
+    underlying ``APIRouter`` is accessible as ``router.router`` for
+    ``app.include_router(...)`` in ``main.py``.
+    """
+    prefix = (
+        entity.prefix_override
+        if entity.prefix_override is not None
+        else f"/{entity.url_collection}"
+    )
+    return BaseRouter(
+        router=APIRouter(prefix=prefix),
+        default_tags=[entity.url_collection],
+    )
 
 
 # Example of how to use this BaseRouter:

--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -349,6 +349,14 @@ class EntitySpec:
     # Templates ----------------------------------------------------------
     templates: Templates = field(default_factory=Templates)
 
+    # Route-prefix override --------------------------------------------
+    # Default route prefix is ``f"/{url_collection}"`` (e.g. ``/users``).
+    # Favorites is the only entity whose URL doesn't fit the convention
+    # — its routes live under ``/users/me/favorites`` — so it sets this
+    # field. Other entities leave it ``None`` and the default applies.
+    # Consumed by ``make_entity_router(entity)`` in ``base_router.py``.
+    prefix_override: str | None = None
+
     # Detail singleton alias (e.g. `/users/me`) -------------------------
     # `mount_detail`'s `singleton_alias=` kwarg — additionally mounts
     # `GET /<collection>/<alias>` whose id is sourced from a session

--- a/src/api/common/specs/user_favorite.py
+++ b/src/api/common/specs/user_favorite.py
@@ -73,4 +73,9 @@ FAVORITE_ENTITY: Final[EntitySpec] = EntitySpec(
     # introduce edge-specific flags + mount helpers.
     routes=RouteSet(),
     templates=Templates(list="favorites/list.html"),
+    # Favorites' URLs nest under the requesting user: the edge is
+    # self-only and routes live at `/users/me/favorites/...` rather than
+    # `/<url_collection>/...`. Every other entity leaves `prefix_override`
+    # unset; the default is `f"/{url_collection}"`.
+    prefix_override="/users/me/favorites",
 )

--- a/src/api/common/test_base_router.py
+++ b/src/api/common/test_base_router.py
@@ -1,0 +1,71 @@
+"""Tests for `make_entity_router` — the helper that collapses the
+APIRouter + BaseRouter scaffolding per route file.
+
+`BaseRouter` itself has implicit coverage via every route test that
+goes through a real route; this module isolates the construction
+helper.
+"""
+
+from types import SimpleNamespace
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from src.api.common.base_router import BaseRouter, make_entity_router
+from src.api.common.entity_spec import AUTHENTICATED, EntitySpec, RouteSet
+from src.logic.audit import AuditAction, AuditedResource, make_snapshotter
+
+
+class _DummyBody(BaseModel):
+    flag: bool
+
+
+def _audit() -> AuditedResource:
+    return AuditedResource(
+        type="widget",
+        snapshot=make_snapshotter(_DummyBody),
+        create=AuditAction.CREATE_USER,
+        update=AuditAction.UPDATE_USER,
+        delete=AuditAction.DELETE_USER,
+    )
+
+
+def _spec(**overrides) -> EntitySpec:
+    defaults = dict(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=SimpleNamespace,
+        audit=_audit(),
+        auth_deps=AUTHENTICATED,
+        routes=RouteSet(),
+    )
+    defaults.update(overrides)
+    return EntitySpec(**defaults)
+
+
+def test_default_prefix_derives_from_url_collection():
+    """No `prefix_override` → prefix is `/<url_collection>`."""
+    router = make_entity_router(_spec())
+    assert isinstance(router, BaseRouter)
+    assert isinstance(router.router, APIRouter)
+    assert router.router.prefix == "/widgets"
+
+
+def test_default_tags_are_url_collection():
+    router = make_entity_router(_spec())
+    assert router.default_tags == ["widgets"]
+
+
+def test_prefix_override_wins_over_default():
+    """Favorites' edge entity uses `/users/me/favorites` — the helper
+    honors the override and skips the `/url_collection` derivation."""
+    router = make_entity_router(_spec(prefix_override="/users/me/favorites"))
+    assert router.router.prefix == "/users/me/favorites"
+
+
+def test_prefix_override_does_not_affect_tags():
+    """Tags stay tied to `url_collection` regardless of prefix override;
+    the override is purely about URL shape."""
+    router = make_entity_router(_spec(prefix_override="/users/me/favorites"))
+    assert router.default_tags == ["widgets"]

--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -27,7 +27,7 @@ For the standard CRUD verbs (create / update / delete), the route file binds han
 **Example**: a typical route file with the unified grammar (users):
 
 ```python
-from src.api.common import BaseRouter
+from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.user import USER_ENTITY
 from src.logic.providers.provider_processing import handle_list_user_providers
@@ -38,8 +38,8 @@ from src.logic.users.user_processing import (
     handle_set_user_activation,
 )
 
-users_api_router = APIRouter(prefix="/users")
-router = BaseRouter(router=users_api_router, default_tags=["users"])
+router = make_entity_router(USER_ENTITY)
+users_api_router = router.router  # re-exported for `main.py`
 
 mount_entity(
     router,
@@ -124,7 +124,7 @@ If a future case suggests the grammar should grow to fit one of these (e.g. a se
 3. **Create the route file** `<resource>.py`. Call `mount_entity`; framework verbs auto-bind to `make_<verb>_handler(<ENTITY>_ENTITY)` and get stitched onto the route module as `_handle_<verb>_<entity>` (target module auto-detected from the caller frame) for contract-test patches. Only bespoke handlers (and `list` / `form_new`, which have no factory defaults) need explicit `handlers` entries.
 
 ```python
-from src.api.common import BaseRouter
+from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.<entity> import <ENTITY>_ENTITY
 from src.logic.<entity>.<entity>_processing import (
@@ -135,8 +135,8 @@ from src.logic.<entity>.<entity>_processing import (
     # mount time.
 )
 
-<entity>_api_router = APIRouter(prefix="/<entities>")
-router = BaseRouter(router=<entity>_api_router, default_tags=["<entities>"])
+router = make_entity_router(<ENTITY>_ENTITY)
+<entity>_api_router = router.router  # re-exported for `main.py`
 
 mount_entity(
     router,

--- a/src/api/routes/favorites.py
+++ b/src/api/routes/favorites.py
@@ -14,11 +14,7 @@ Audit and commit are owned by the logic-layer handlers, not the mount
 helper.
 """
 
-import logging
-
-from fastapi import APIRouter
-
-from src.api.common import BaseRouter
+from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_edge_routes
 from src.api.common.specs.user_favorite import FAVORITE_ENTITY
 from src.logic.favorites.favorite_processing import (
@@ -27,9 +23,8 @@ from src.logic.favorites.favorite_processing import (
     handle_remove_favorite,
 )
 
-favorites_api_router = APIRouter(prefix="/users/me/favorites")
-router = BaseRouter(router=favorites_api_router, default_tags=["favorites"])
-logger = logging.getLogger(__name__)
+router = make_entity_router(FAVORITE_ENTITY)
+favorites_api_router = router.router
 
 
 mount_edge_routes(

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -1,15 +1,10 @@
-import logging
-
-from fastapi import APIRouter
-
-from src.api.common import BaseRouter
+from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.post import POST_ENTITY
 from src.logic.posts.post_processing import handle_get_post_form
 
-posts_api_router = APIRouter(prefix="/posts")
-router = BaseRouter(router=posts_api_router, default_tags=["posts"])
-logger = logging.getLogger(__name__)
+router = make_entity_router(POST_ENTITY)
+posts_api_router = router.router
 
 
 # Every standard verb (list, detail, create, update, delete, form_edit)

--- a/src/api/routes/providers.py
+++ b/src/api/routes/providers.py
@@ -1,8 +1,4 @@
-import logging
-
-from fastapi import APIRouter
-
-from src.api.common import BaseRouter
+from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.provider import PROVIDER_ENTITY
 from src.api.common.specs.provider_certification import CERTIFICATION_ENTITY
@@ -10,9 +6,8 @@ from src.api.common.specs.provider_education import EDUCATION_ENTITY
 from src.api.common.specs.provider_licensure import LICENSURE_ENTITY
 from src.logic.providers.provider_processing import handle_get_provider_form
 
-providers_api_router = APIRouter(prefix="/providers")
-router = BaseRouter(router=providers_api_router, default_tags=["providers"])
-logger = logging.getLogger(__name__)
+router = make_entity_router(PROVIDER_ENTITY)
+providers_api_router = router.router
 
 
 # Only `form_new` stays bespoke (the create-form template needs the

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -1,8 +1,4 @@
-import logging
-
-from fastapi import APIRouter
-
-from src.api.common import BaseRouter
+from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.user import USER_ENTITY
 from src.logic.users.user_processing import (
@@ -10,9 +6,11 @@ from src.logic.users.user_processing import (
     handle_list_users,
 )
 
-users_api_router = APIRouter(prefix="/users")
-router = BaseRouter(router=users_api_router, default_tags=["users"])
-logger = logging.getLogger(__name__)
+router = make_entity_router(USER_ENTITY)
+# Re-export the underlying APIRouter under the historic name so
+# `main.py`'s `app.include_router(users.users_api_router, ...)` keeps
+# resolving without churn.
+users_api_router = router.router
 
 
 # `handle_delete_user` and `handle_list_users` are bespoke (self-guard


### PR DESCRIPTION
## Summary

- New `make_entity_router(entity)` helper derives `APIRouter(prefix=...)` + `BaseRouter(default_tags=...)` from the spec.
- `EntitySpec.prefix_override` carries favorites' non-derivable `/users/me/favorites` prefix; other entities use the `/<url_collection>` default.
- All 4 route files migrate; underlying APIRouters re-export under their historic `<entity>_api_router` names so `main.py` resolves unchanged.
- Dead `logger = logging.getLogger(__name__)` lines (unused in every route file) get dropped.

Closes #387.

## Test plan
- [x] `dev test` — 850 passed, 51 skipped.
- [x] `dev lint` — clean.
- [x] New `test_base_router.py` covers prefix + tags derivation and prefix_override behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)