### PR TITLE
Move state-axis audit-snapshot schema onto the spec

### DIFF
--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -33,7 +33,12 @@ from pydantic import BaseModel, TypeAdapter
 from src.api.common.resource_routes import QueryParam, ResourceSpec
 from src.auth_config import current_active_user, current_admin_user
 from src.logic._authz import assert_owner_or_admin, is_owner_or_admin
-from src.logic.audit import AuditAction, AuditedResource, make_audited_resource
+from src.logic.audit import (
+    AuditAction,
+    AuditedResource,
+    make_audited_resource,
+    make_snapshotter,
+)
 from src.models._polymorphic import DiscriminatorRegistry
 
 
@@ -122,6 +127,17 @@ class StateAxis:
     via `handlers={"activation": ...}`. Specs that pre-date this knob
     can leave it unset and pass the handler explicitly; the explicit
     handler wins.
+
+    `audit_snapshot` is the Pydantic class used to project a row into
+    the audit log's `before`/`after` JSON for this axis. The spec's
+    `__post_init__` builds the snapshotter once via
+    :func:`src.logic.audit.make_snapshotter` and stores it on
+    ``audit_snapshot_fn`` so the handler reads
+    ``axis.audit_snapshot_fn(target)`` instead of building its own
+    module-level snapshotter. Matches the CRUD-side
+    ``audit_snapshot → audit`` flow on ``EntitySpec`` — state axes are
+    now declaratively complete (body shape + audit action + audit
+    snapshot all live on the axis).
     """
 
     name: str
@@ -129,6 +145,12 @@ class StateAxis:
     action: AuditAction
     handler_path: str | None = None
     response_to_dict: Callable[[Any], dict] | None = None
+    audit_snapshot: type[BaseModel] | None = None
+    # Derived: populated by `EntitySpec.__post_init__` via
+    # `object.__setattr__` after wrapping `audit_snapshot` in
+    # `make_snapshotter`. Handlers consume this directly to capture
+    # before/after JSON for the audit row.
+    audit_snapshot_fn: Callable[[Any], dict[str, Any]] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -410,6 +432,28 @@ class EntitySpec:
                 f"EntitySpec({self.name!r}) declares duplicate state-axis "
                 f"names: {axis_names}"
             )
+        # Build the audit snapshotter for each axis that declares an
+        # `audit_snapshot` schema. Mirrors the CRUD-side
+        # `audit_snapshot → audit` flow above: the schema lives on the
+        # declarative pair (axis), the constructor wraps it once via
+        # `make_snapshotter`, and handlers read `axis.audit_snapshot_fn`
+        # instead of binding their own module-level snapshotter.
+        # Declaring `audit_snapshot_fn` directly alongside `audit_snapshot`
+        # is ambiguous — pick one.
+        for axis in self.state_axes:
+            if axis.audit_snapshot is not None and axis.audit_snapshot_fn is not None:
+                raise ValueError(
+                    f"EntitySpec({self.name!r}) state-axis {axis.name!r} "
+                    "declares both `audit_snapshot` and `audit_snapshot_fn`; "
+                    "they are mutually exclusive — pass the schema via "
+                    "`audit_snapshot` and let the spec build the callable."
+                )
+            if axis.audit_snapshot is not None:
+                object.__setattr__(
+                    axis,
+                    "audit_snapshot_fn",
+                    make_snapshotter(axis.audit_snapshot),
+                )
         # Wrap a plain Pydantic class in `TypeAdapter(...)` so the
         # downstream mounts (which expect an adapter) get one regardless
         # of which form the spec was constructed with. Discriminated-union

--- a/src/api/common/specs/test_user.py
+++ b/src/api/common/specs/test_user.py
@@ -12,7 +12,7 @@ from src.api.common.entity_spec import ADMIN_FOR_WRITE, RelatedListSubresource
 from src.api.common.specs.user import USER_ENTITY
 from src.logic._authz import is_self_or_admin
 from src.logic.audit import AuditAction
-from src.schemas.users.user import UserActivationUpdate
+from src.schemas.users.user import UserActivationAuditSnapshot, UserActivationUpdate
 
 # --- Auth deps (security-visible) ----------------------------------------
 
@@ -55,6 +55,8 @@ def test_activation_axis_shape():
     axis = USER_ENTITY.state_axis("activation")
     assert axis.body_schema is UserActivationUpdate
     assert axis.action == AuditAction.SET_USER_ACTIVATION
+    assert axis.audit_snapshot is UserActivationAuditSnapshot
+    assert axis.audit_snapshot_fn is not None  # built by spec __post_init__
     sample = axis.response_to_dict(
         type(
             "Sample",

--- a/src/api/common/specs/user.py
+++ b/src/api/common/specs/user.py
@@ -32,7 +32,11 @@ from src.logic.audit import AuditAction
 from src.models import User
 from src.repositories.dependencies import get_user_repository
 from src.repositories.providers.provider_repository import ProviderRepository
-from src.schemas.users.user import UserActivationUpdate, UserAuditSnapshot
+from src.schemas.users.user import (
+    UserActivationAuditSnapshot,
+    UserActivationUpdate,
+    UserAuditSnapshot,
+)
 
 
 def _activation_response_to_dict(user: User) -> dict:
@@ -62,6 +66,7 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
             action=AuditAction.SET_USER_ACTIVATION,
             response_to_dict=_activation_response_to_dict,
             handler_path=("src.logic.users.user_processing.handle_set_user_activation"),
+            audit_snapshot=UserActivationAuditSnapshot,
         ),
     ),
     subresources=(

--- a/src/api/common/test_entity_spec.py
+++ b/src/api/common/test_entity_spec.py
@@ -90,6 +90,56 @@ def test_no_private_fields_no_predicate_constructs():
     assert spec.private_field_predicate is None
 
 
+def test_state_axis_audit_snapshot_builds_fn():
+    """`StateAxis.audit_snapshot` is the schema; the spec's
+    `__post_init__` wraps it in `make_snapshotter` once and stores the
+    result on `audit_snapshot_fn`. Mirrors the CRUD-side flow."""
+    spec = _make_spec(
+        state_axes=(
+            StateAxis(
+                name="flip",
+                body_schema=_DummyBody,
+                action=AuditAction.SET_USER_ACTIVATION,
+                audit_snapshot=_DummyRead,
+            ),
+        )
+    )
+    axis = spec.state_axis("flip")
+    assert axis.audit_snapshot_fn is not None
+    # Snapshot validates an attribute-bag through `_DummyRead` and
+    # returns a JSON-mode dict.
+    sample = SimpleNamespace(flag=True)
+    assert axis.audit_snapshot_fn(sample) == {"flag": True}
+
+
+def test_state_axis_audit_snapshot_and_fn_mutually_exclusive():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _make_spec(
+            state_axes=(
+                StateAxis(
+                    name="flip",
+                    body_schema=_DummyBody,
+                    action=AuditAction.SET_USER_ACTIVATION,
+                    audit_snapshot=_DummyRead,
+                    audit_snapshot_fn=lambda _obj: {},
+                ),
+            )
+        )
+
+
+def test_state_axis_without_audit_snapshot_leaves_fn_none():
+    spec = _make_spec(
+        state_axes=(
+            StateAxis(
+                name="flip",
+                body_schema=_DummyBody,
+                action=AuditAction.SET_USER_ACTIVATION,
+            ),
+        )
+    )
+    assert spec.state_axis("flip").audit_snapshot_fn is None
+
+
 def test_duplicate_state_axis_names_raises():
     """Two axes with the same name would shadow each other at mount time."""
     axis_a = StateAxis(

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -8,19 +8,14 @@ from src.api.common.exceptions import NotFoundError
 from src.api.common.projections import project_view
 from src.api.common.specs.user import USER_ENTITY
 from src.logic._authz import forbid_self_action, is_admin
-from src.logic.audit import make_snapshotter, mutate, record_audit
+from src.logic.audit import mutate, record_audit
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.repositories.users.user_repository import UserRepository
-from src.schemas.users.user import (
-    UserActivationAuditSnapshot,
-    UserActivationUpdate,
-)
+from src.schemas.users.user import UserActivationUpdate
 
 logger = logging.getLogger(__name__)
-
-_snapshot_user_activation = make_snapshotter(UserActivationAuditSnapshot)
 
 
 async def handle_list_users(
@@ -118,9 +113,10 @@ async def handle_set_user_activation(
     logger.info(
         f"Handler: admin {requesting_user.id} setting activation={payload.state} on user {target.id}"
     )
-    before = _snapshot_user_activation(target)
-    updated = await repo.set_user_activation(target, is_active=is_active)
     activation_axis = USER_ENTITY.state_axis("activation")
+    snapshot = activation_axis.audit_snapshot_fn
+    before = snapshot(target)
+    updated = await repo.set_user_activation(target, is_active=is_active)
     await record_audit(
         audit_repo,
         actor_id=requesting_user.id,
@@ -128,7 +124,7 @@ async def handle_set_user_activation(
         resource_id=updated.id,
         action=activation_axis.action,
         before=before,
-        after=_snapshot_user_activation(updated),
+        after=snapshot(updated),
     )
     await repo.session.commit()
     return updated


### PR DESCRIPTION
## Summary

- `StateAxis` gains `audit_snapshot: type[BaseModel] | None`; `EntitySpec.__post_init__` wraps it once via `make_snapshotter` and stores the result on `audit_snapshot_fn` (matching the CRUD-side `audit_snapshot → audit` flow).
- `USER_ENTITY.activation` declares the schema; `_snapshot_user_activation` module-level binding in `user_processing.py` is gone — the handler reads `axis.audit_snapshot_fn` directly.
- Mutually-exclusive validation: declaring both `audit_snapshot` and `audit_snapshot_fn` raises at construction time.

Closes #388.

## Test plan
- [x] `dev test` — 853 passed, 51 skipped.
- [x] `dev lint` — clean.
- [x] New tests cover snapshot-fn build, mutual-exclusion, and the no-snapshot path.
- [x] `test_user.py` pins the new field is populated on the user spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)