### PR TITLE
Auto-inject viewer flags + projection across handle_detail/handle_list

### DIFF
--- a/src/api/common/README.md
+++ b/src/api/common/README.md
@@ -242,7 +242,7 @@ Migrated route files compose the individual `mount_*` helpers through `mount_ent
 - `entity.read_user_dep` — `None` means public read; `mount_list` is called with `public=True`.
 - `owned_subentities` — a tuple of child `EntitySpec`s whose `parent` is `entity`. Each is mounted recursively via the same dispatcher; the handlers dict for an owned subentity is keyed `f"{owned.name}.{verb}"` (e.g. `"licensure.create"`). For verbs that match the standard CRUD-framework factories (`create`, `update`, `delete`, `detail`, `form_edit`), the explicit key is optional — `mount_entity` falls back to `make_<verb>_handler(owned)`, which is the common case for subentities whose mutations are entirely standard. Verbs without a default factory (`list`, `form_new`) still require an explicit entry; supplying any explicit key overrides the factory default.
 
-**Top-level standard verbs follow the same auto-bind path as owned subentities.** When a top-level entity opts into `list` / `detail` / `create` / `update` / `delete` / `form_edit` and the matching key is *absent* from `handlers`, `mount_entity` builds the handler from `make_<verb>_handler(entity)` and stitches it onto the route file's module as `_handle_<verb>_<entity>` (e.g. `_handle_update_provider`, `_handle_list_post`). That's the path contract-test monkey-patches at `src.api.routes.<entity>._handle_<verb>_<entity>` resolve through; setting `__module__` on the built handler lets the mount layer's `_resolve_handler` find the patched version via `getattr(sys.modules[__module__], __name__)`. The target module is auto-detected from the `mount_entity` caller's frame, so route files don't pass `module=`. Bespoke verbs (e.g. `handle_delete_user`'s self-guard, `handle_list_users`'s self-exclude) stay explicit in the handlers dict and override the factory default. The only verb that has no default factory is `form_new` — its template-selection knob is too entity-specific to auto-bind (posts dispatches by `?kind=`; providers needs the `ProviderCreate` schema class in context). Inline-child appends on create (providers' credential rows) come from the generic `handle_create` walking `spec.children`.
+**Top-level standard verbs follow the same auto-bind path as owned subentities.** When a top-level entity opts into `list` / `detail` / `create` / `update` / `delete` / `form_edit` and the matching key is *absent* from `handlers`, `mount_entity` builds the handler from `make_<verb>_handler(entity)` and stitches it onto the route file's module as `_handle_<verb>_<entity>` (e.g. `_handle_update_provider`, `_handle_list_post`). That's the path contract-test monkey-patches at `src.api.routes.<entity>._handle_<verb>_<entity>` resolve through; setting `__module__` on the built handler lets the mount layer's `_resolve_handler` find the patched version via `getattr(sys.modules[__module__], __name__)`. The target module is auto-detected from the `mount_entity` caller's frame, so route files don't pass `module=`. Bespoke verbs (e.g. `handle_delete_user`'s self-guard) stay explicit in the handlers dict and override the factory default. The only verb that has no default factory is `form_new` — its template-selection knob is too entity-specific to auto-bind (posts dispatches by `?kind=`; providers needs the `ProviderCreate` schema class in context). Inline-child appends on create (providers' credential rows) come from the generic `handle_create` walking `spec.children`.
 
 Per-viewer / per-list extras live on `EntitySpec` as `detail_extras_path` / `list_extras_path` — dotted import paths to the extras callable, resolved lazily at mount time via `importlib.import_module` + `getattr` (same machinery `StateAxis.handler_path` uses). The late-binding sidesteps the import cycle that previously forced the extras callables to live on the `mount_entity` call site: the logic module is only imported when `mount_entity` runs, which is after both the spec module and the logic module have finished initializing. Typed repo kwargs the extras callable receives are declared on the spec as `detail_extras_repos` / `list_extras_repos` (real classes — repositories live below specs in the import order, so the type-class import is cycle-safe). Spec construction validates the pairings: extras_path requires the matching `routes.<verb>=True`, extras_repos requires extras_path. `mount_entity` additionally rejects `detail_extras_path` alongside an explicit `handlers["detail"]` (the explicit handler would silently win).
 
@@ -257,8 +257,8 @@ For the standard CRUD verbs (create / update / delete) plus the detail and edit-
 - `handle_create(spec, *, payload, repo, audit_repo, requesting_user, parent_id=None)` — load (subentity case) / instantiate (standard case) / dispatch on `spec.discriminator` for polymorphic entities; persist; audit via `mutate(verb="create")`.
 - `handle_update(spec, *, target_id, payload, repo, audit_repo, requesting_user, parent_id=None)` — load → write_authz → polymorphic kind-invariant check → patch via `mutate(verb="update")`.
 - `handle_delete(spec, *, target_id, repo, audit_repo, requesting_user, parent_id=None)` — load → write_authz → audited delete via `mutate(verb="delete")`.
-- `handle_detail(spec, *, request, target_id, repo, requesting_user, extras=None, extra_kwargs=None)` — load → optional `can_edit` from `spec.can_write` → optional entity-specific extras callable for per-viewer / per-pair / related-collection state. The extras callable receives `target`, `request`, `requesting_user`, plus any `extra_kwargs`; its return dict merges into the context (last-write-wins, so extras can override the base `spec.name` binding — e.g. users binds under `target_user` for the projected view).
-- `handle_list(spec, *, request, repo, requesting_user, filter_values, extras=None, extra_kwargs=None)` — call `repo.list_<url_collection>(**filter_values)` by convention → base context binds items under `spec.url_collection` plus `selected_<filter>` echoes for the filter form → optional extras callable. Extras receives `items`, `request`, `requesting_user`, `filter_values`, plus any `extra_kwargs`.
+- `handle_detail(spec, *, request, target_id, repo, requesting_user, extras=None, extra_kwargs=None)` — load → optional `can_edit` from `spec.can_write` → auto-inject viewer-derived keys (`is_self`, `can_admin_actions`, plus `can_view_private` when `spec.private_field_predicate` is set and `target_<name>` projection when `spec.public_fields` is set) → optional entity-specific extras callable for per-viewer / per-pair / related-collection state. The extras callable receives `target`, `request`, `requesting_user`, plus any `extra_kwargs`; its return dict merges into the context (last-write-wins, so extras can override any framework-injected key). The auto-injection means an entity that just needs viewer flags + projection can leave `extras=None` entirely.
+- `handle_list(spec, *, request, repo, requesting_user, filter_values, extras=None, extra_kwargs=None)` — call `repo.list_<url_collection>(**filter_values)` by convention (threading `exclude_self=requesting_user` into the call when `spec.list_exclude_self=True`) → base context binds items under `spec.url_collection`, `can_admin_actions` from `is_admin(viewer)`, plus `selected_<filter>` echoes for the filter form → optional extras callable. Extras receives `items`, `request`, `requesting_user`, `filter_values`, plus any `extra_kwargs`.
 - `handle_get_edit_form(spec, *, request, target_id, repo, requesting_user)` — load → write_authz → context dict binding the entity under `spec.name`. For polymorphic entities, populates `template_name` from `spec.discriminator[kind].edit_template` so `mount_form`'s template-precedence renders the per-kind edit page.
 
 And matching `make_<verb>_handler(spec)` factory functions (`make_create_handler`, `make_update_handler`, `make_delete_handler`, `make_detail_handler`, `make_edit_form_handler`) that build callables with synthesized signatures so `mount_*` introspection (per #316) wires the right deps. `make_detail_handler` additionally accepts `extras=` (the pure-function hook) and `extra_repos=` (typed-repo params the synthesis adds to the signature so the registry resolves them). Route files don't call the factories directly today — `mount_entity` invokes them under the hood for any standard-CRUD verb the entity opts into without supplying an explicit handler (see [`mount_entity`](#mount_entity-dispatcher)). The built handlers are stitched onto the route module as `_handle_<verb>_<spec.name>` so contract tests can patch via the same path that worked before auto-binding landed:
@@ -288,8 +288,9 @@ mount_entity(
 **When to use factory vs. bespoke handler.** Use the factory when the verb does the standard load → auth → mutate → audit ritual. Write a bespoke handler when the entity has rules that don't fit:
 
 - `handle_delete_user` is bespoke because of the self-guard (admin can't delete self).
-- `handle_list_users` is bespoke because of the `exclude_user=requesting_user` filter (doesn't fit the "URL filter only" model).
 - `handle_add_favorite` / `handle_remove_favorite` are bespoke because they're M:N edge mutations, not CRUD.
+
+(`handle_list_users` *used to* be bespoke for its self-exclude filter; the framework now reads that off `spec.list_exclude_self` and threads `exclude_self=requesting_user` into the repo's list method, so the user-list path goes through the generic factory like every other entity.)
 
 Inline-child append on create (providers' credential rows on parent-create) is handled by the generic `handle_create` walking `spec.children` — no entity needs a bespoke create handler just for nested writes.
 
@@ -314,7 +315,8 @@ Per-entity instances at `src/api/common/specs/<entity>.py` carry:
 - **FastAPI deps** — `repo_dep`, `read_user_dep`, `write_user_dep`. `read_user_dep=None` declares a public read.
 - **Write authorization** — prefer `auth_policy=<AuthzPolicy>` over the hand-wired `write_authz` + `can_write` pair. `AuthzPolicy` carries the raising form (consumed by mutation handlers) and the predicate sibling (bound to detail-handler `can_edit` flags) as one declaration; the constructor expands the policy to populate both fields. The canonical sentinel `OWNER_OR_ADMIN` (defined in `entity_spec.py` alongside `AuthzPolicy`) pairs `assert_owner_or_admin` + `is_owner_or_admin` — used by provider, post, and the three credentials. The hand-wired form (`write_authz=` and/or `can_write=` directly) stays accepted for one-off rules but is mutually exclusive with `auth_policy`.
 - **Audit binding** — exactly one of: `audit_snapshot: type[BaseModel] | Callable` (+ optional `audit_action_stem`) for CRUD-shaped entities — the constructor calls `make_audited_resource(name, snapshot, action_stem=stem)` and stores the result on `audit`; or `edge_audit: EdgeAudit` for non-CRUD edges (favorites uses `edge_audit` with the `(add, remove)` verb map). Hand-built `audit=<AuditedResource>` is still accepted but mutually exclusive with `audit_snapshot`; specs should prefer the declarative form. Construction-time validation enforces all three exclusivity rules.
-- **Visibility** — `private_fields`, `private_field_predicate` (the projection rule from #304).
+- **Visibility** — `private_fields`, `private_field_predicate` (the projection rule from #304), plus `public_fields` (the always-visible shape on detail pages). When `public_fields` is set, `handle_detail` auto-binds `target_<name>` to a `project_view` dict gated by the predicate — entities no longer hand-roll the projection in their detail-extras callable.
+- **List-page viewer filtering** — `list_exclude_self: bool`. When True, `handle_list` threads `exclude_self=requesting_user` into the repo's list method so the viewer is dropped from the result set (anonymous viewers see the full list). Used by `user` (the user-list page is for *other* users).
 - **Route opt-ins** — `routes: RouteSet` flags: `list`, `detail`, `create`, `update`, `delete`, `form_new`, `form_edit`. Phase 1 reads these for documentation + spec-correctness tests; `mount_entity` (added in phase 2) consumes them at mount time.
 - **State axes** — `state_axes: tuple[StateAxis, ...]` (axis name, body schema, audit action, response projection).
 - **Related-list subresources** — `subresources: tuple[RelatedListSubresource, ...]` (child spec, template, optional `singleton_alias`).
@@ -327,30 +329,24 @@ Per-entity instances at `src/api/common/specs/<entity>.py` carry:
 ### How layers read from it
 
 ```python
-# Route file: a single mount_entity call consumes the spec.
+# Route file: a single mount_entity call consumes the spec. Standard CRUD
+# verbs auto-bind to the framework factories; only bespoke verbs (self-
+# guard on delete, state axes, related-list subresources) appear in
+# `handlers=`.
 mount_entity(
     router,
     USER_ENTITY,
-    handlers={
-        "list": handle_list_users,
-        "detail": handle_get_user_detail,
-        "delete": handle_delete_user,
-        "providers": handle_list_user_providers,
-        "activation": handle_set_user_activation,
-    },
+    handlers={"delete": handle_delete_user},
 )
 
 # Logic-layer handler: read audit + visibility primitives.
 async with mutate(repo, audit_repo, ..., resource=USER_ENTITY.audit, verb="delete"):
     await repo.delete(target)
 
-view = project_view(
-    target,
-    public_fields=("id", "username"),
-    actor=requesting_user,
-    private_fields=USER_ENTITY.private_fields,
-    private_field_predicate=USER_ENTITY.private_field_predicate,
-)
+# `target_user` projection is framework-injected by `handle_detail`
+# (see `public_fields` + `private_field_predicate` on USER_ENTITY).
+# Direct `project_view(...)` use survives where a handler needs an
+# ad-hoc shape; the spec-driven path is the default.
 
 # Polymorphic dispatch (posts): the discriminator is on the spec.
 spec = POST_ENTITY.discriminator[payload.kind]

--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -341,9 +341,26 @@ class EntitySpec:
     # Visibility ---------------------------------------------------------
     private_fields: tuple[str, ...] = ()
     private_field_predicate: Callable[..., bool] | None = None
+    # When set, `handle_detail` auto-binds `target_<name>` in the template
+    # context to a `project_view` dict using these as the public fields
+    # and the spec's `private_fields` / `private_field_predicate` for
+    # gating. The split between `public_fields` (per-view shape) and
+    # `private_fields` (gated-by-predicate) mirrors `project_view`'s own
+    # signature: spec declares *what is private*; `public_fields` declares
+    # *which view this is*. Requires `private_field_predicate` to be set.
+    public_fields: tuple[str, ...] = ()
 
     # Route opt-ins ------------------------------------------------------
     routes: RouteSet = field(default_factory=RouteSet)
+
+    # List-page viewer filtering ----------------------------------------
+    # When True, `handle_list` passes `exclude_self=requesting_user` to
+    # the entity's `list_<collection>` repo method, dropping the viewer
+    # from the result set. Anonymous viewers see the full list. Only
+    # meaningful for entities whose rows are users (currently just
+    # `user`); the kwarg name `exclude_self` is the convention every
+    # opt-in repo must accept.
+    list_exclude_self: bool = False
 
     # List-page filters --------------------------------------------------
     filters: tuple[QueryParam, ...] = ()
@@ -423,6 +440,22 @@ class EntitySpec:
                 f"EntitySpec({self.name!r}) declares private_fields="
                 f"{self.private_fields!r} but no private_field_predicate — "
                 "private fields cannot be gated without a predicate."
+            )
+        # `public_fields` drives the `target_<name>` projection in
+        # `handle_detail`; without a predicate the gating step would
+        # silently allow every private field through.
+        if self.public_fields and self.private_field_predicate is None:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares public_fields="
+                f"{self.public_fields!r} but no private_field_predicate — "
+                "the projection cannot gate private fields without one."
+            )
+        # `list_exclude_self` is consumed only by `handle_list`; if no
+        # list route is opted in, the flag is dead.
+        if self.list_exclude_self and not self.routes.list:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) sets list_exclude_self=True but "
+                "routes.list is False — the flag would never apply."
             )
         # State-axis names must be unique; route mounting iterates by
         # name, so duplicates would shadow each other silently.

--- a/src/api/common/specs/test_user.py
+++ b/src/api/common/specs/test_user.py
@@ -38,6 +38,23 @@ def test_private_field_predicate_is_self_or_admin():
     assert USER_ENTITY.private_field_predicate is is_self_or_admin
 
 
+def test_public_fields_drive_detail_projection():
+    """`handle_detail` projects `target_user` from these fields, gated
+    by `private_field_predicate`. Changing this tuple changes what
+    unprivileged viewers see on the user detail page."""
+    assert USER_ENTITY.public_fields == ("id", "username")
+
+
+# --- List filtering ------------------------------------------------------
+
+
+def test_list_excludes_self():
+    """`/users` drops the viewer from the result set — the user-list
+    page is for *other* users. Threaded via the repo's `exclude_self`
+    kwarg by the generic `handle_list`."""
+    assert USER_ENTITY.list_exclude_self is True
+
+
 # --- Owner-attr semantics (user-specific) --------------------------------
 
 

--- a/src/api/common/specs/user.py
+++ b/src/api/common/specs/user.py
@@ -58,6 +58,8 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
     audit_snapshot=UserAuditSnapshot,
     private_fields=("email", "is_active", "is_verified"),
     private_field_predicate=is_self_or_admin,
+    public_fields=("id", "username"),
+    list_exclude_self=True,
     routes=RouteSet(list=True, detail=True, delete=True),
     state_axes=(
         StateAxis(

--- a/src/api/routes/README.md
+++ b/src/api/routes/README.md
@@ -30,27 +30,20 @@ For the standard CRUD verbs (create / update / delete), the route file binds han
 from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.user import USER_ENTITY
-from src.logic.providers.provider_processing import handle_list_user_providers
-from src.logic.users.user_processing import (
-    handle_delete_user,             # bespoke (self-guard)
-    handle_get_user_detail,
-    handle_list_users,
-    handle_set_user_activation,
-)
+from src.logic.users.user_processing import handle_delete_user
 
 router = make_entity_router(USER_ENTITY)
 users_api_router = router.router  # re-exported for `main.py`
 
+# Standard CRUD verbs (list/detail/delete) auto-bind to the framework
+# factories; state-axis (`activation`) and related-list (`providers`)
+# handlers are resolved at mount time via the spec's `handler_path`
+# strings. Only verbs whose orchestration falls outside the generic
+# ritual stay explicit — here, `delete` for its self-guard.
 mount_entity(
     router,
     USER_ENTITY,
-    handlers={
-        "list": handle_list_users,
-        "detail": handle_get_user_detail,
-        "delete": handle_delete_user,
-        "providers": handle_list_user_providers,        # related-list subresource
-        "activation": handle_set_user_activation,       # state-axis verb
-    },
+    handlers={"delete": handle_delete_user},
 )
 ```
 

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -1,10 +1,7 @@
 from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.user import USER_ENTITY
-from src.logic.users.user_processing import (
-    handle_delete_user,
-    handle_list_users,
-)
+from src.logic.users.user_processing import handle_delete_user
 
 router = make_entity_router(USER_ENTITY)
 # Re-export the underlying APIRouter under the historic name so
@@ -13,17 +10,13 @@ router = make_entity_router(USER_ENTITY)
 users_api_router = router.router
 
 
-# `handle_delete_user` and `handle_list_users` are bespoke (self-guard
-# on delete; per-viewer admin flag on list). Detail, state-axis
-# (`activation`), related-list subresource (`providers`), and per-viewer
-# detail extras (`user_detail_extras` + the provider repo it needs) all
-# live on `USER_ENTITY` — resolved at mount time via the spec's dotted
-# `*_path` strings so `specs/user.py` never imports `src.logic`.
+# `handle_delete_user` stays bespoke (self-guard on delete). List, detail,
+# state-axis (`activation`), related-list subresource (`providers`), and
+# per-viewer detail extras (`user_detail_extras` + the provider repo it
+# needs) all live on `USER_ENTITY` — resolved at mount time via the spec's
+# dotted `*_path` strings so `specs/user.py` never imports `src.logic`.
 mount_entity(
     router,
     USER_ENTITY,
-    handlers={
-        "list": handle_list_users,
-        "delete": handle_delete_user,
-    },
+    handlers={"delete": handle_delete_user},
 )

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -23,7 +23,7 @@ async def handle_list_users(
     requesting_user: User,
 ) -> dict:
     """Orchestrate user listing."""
-    users_list = await repo.list_users(exclude_user=requesting_user)
+    users_list = await repo.list_users(exclude_self=requesting_user)
     return {"users": users_list, "current_user": requesting_user}
 ```
 
@@ -52,7 +52,7 @@ async def handle_list_users(
     requesting_user: User,
 ):
     """Orchestrate user listing with filtering logic"""
-    users_list = await repo.list_users(exclude_user=requesting_user)
+    users_list = await repo.list_users(exclude_self=requesting_user)
     return {"users": users_list, "current_user": requesting_user}
 ```
 
@@ -157,14 +157,18 @@ async def handle_some_operation(
 For the standard CRUD verbs (create / update / delete), the default is to bind a factory-built handler from `_generic.py` (see [`api/common/README.md`](../api/common/README.md#generic-crud-handler-factories) for the route-file wiring). Write a bespoke handler in the entity's cluster only when the verb has rules that don't fit the standard ritual:
 
 - `handle_delete_user` is bespoke because of the self-guard ("admins can't delete their own account here").
-- `handle_list_users` is bespoke because the `exclude_user=requesting_user` filter doesn't fit the framework's "URL filter only" model.
 - `handle_add_favorite` / `handle_remove_favorite` are bespoke because they're M:N edge mutations with idempotent semantics + non-CRUD audit (`edge_audit` instead of `audit`).
 
 Nested-write creates (providers' inline credential rows) are handled by the generic `handle_create` walking `spec.children` — no entity needs a bespoke create handler just for that shape.
 
 Bespoke handlers still use the shared primitives — `mutate(...)` for CRUD-shaped mutations, `record_audit(...)` for non-CRUD audits, `assert_owner_or_admin` for the owner check, the spec's `audit` / `edge_audit` / `private_fields` declarations. They just orchestrate the entity-specific steps the framework can't subsume.
 
-Read handlers (`handle_list_*`, `handle_get_*_detail`, `handle_get_*_form`) stay bespoke today — each has enough per-page variation (cross-entity loads, per-viewer derived fields, filter forwarding, kind-based template selection) that generalization would add more spec axes than it would collapse.
+Read handlers go through the generic `handle_detail` / `handle_list` factories; entity-specific work — fetching related rows, computing per-page flags the framework doesn't derive — lives in a small `<entity>_detail_extras` / `<entity>_list_extras` callable bound via the spec's `*_extras_path`. The framework already injects:
+
+- **Detail**: `is_self` (viewer is the subject — comparison uses `spec.owner_attr or "id"`), `can_admin_actions` (`is_admin(viewer) and not is_self`), `can_view_private` (from `spec.private_field_predicate`), and `target_<name>` (a `project_view` dict gated by the predicate, present when `spec.public_fields` is set).
+- **List**: `can_admin_actions` (`is_admin(viewer)`). When `spec.list_exclude_self=True`, the viewer is dropped from results via the repo method's `exclude_self` kwarg (anonymous viewers see the full list).
+
+Extras callables therefore shrink to **only** the entity-specific fetches (e.g. `user_detail_extras` returns the providers the target owns; `provider_detail_extras` returns the `is_favorited` pair flag). Form handlers (`handle_get_*_form`) stay bespoke — kind-based template selection is too per-entity to generalize today.
 
 ### Error handling pattern
 
@@ -234,7 +238,7 @@ async def handle_get_users(request: Request) -> JSONResponse:
 
 # Good - return data for route to handle
 async def handle_get_users(repo: UserRepository, requesting_user: User):
-    users = await repo.list_users(exclude_user=requesting_user)
+    users = await repo.list_users(exclude_self=requesting_user)
     return {"users": users, "current_user": requesting_user}
 ```
 

--- a/src/logic/_generic.py
+++ b/src/logic/_generic.py
@@ -26,6 +26,8 @@ from pydantic import BaseModel
 
 from src.api.common.entity_spec import EntitySpec
 from src.api.common.exceptions import BadRequestError, NotFoundError
+from src.api.common.projections import project_view
+from src.logic._authz import is_admin
 from src.logic.audit import mutate
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
@@ -584,26 +586,39 @@ async def handle_detail(
     """Generic detail handler driven by `spec`.
 
     Performs: load target → 404 → compute `can_edit` from
-    `spec.can_write` (when set) → merge entity-specific extras via the
-    callable hook. The base context binds the entity under `spec.name`
-    (e.g. `"post"`, `"provider"`) so existing templates that read
-    `{{ post }}` / `{{ provider }}` keep working without per-entity
-    glue.
+    `spec.can_write` (when set) → inject viewer-derived flags +
+    `target_<name>` projection from spec metadata → merge
+    entity-specific extras via the callable hook. The base context binds
+    the entity under `spec.name` (e.g. `"post"`, `"provider"`) so
+    existing templates that read `{{ post }}` / `{{ provider }}` keep
+    working without per-entity glue.
+
+    Viewer-derived keys, always injected before extras run:
+      - `is_self` — viewer is the subject (`target.<owner_attr or 'id'>
+        == requesting_user.id`).
+      - `can_admin_actions` — `is_admin(viewer) and not is_self`.
+      - `can_view_private` — when `spec.private_field_predicate` is set,
+        the predicate evaluated against `(viewer, target)`.
+      - `target_<name>` — when `spec.public_fields` is set, a
+        `project_view` dict with private fields gated by the predicate.
 
     `extras` is the entity's per-detail customization callable. It
     receives the loaded target plus `request`, `requesting_user`, and
     any keyword args in `extra_kwargs` (the route layer passes typed
     repos this way — e.g. `user_favorite_repo` for provider detail).
     The dict it returns is merged into the base context with
-    last-write-wins semantics; entities can override the base
-    `spec.name` binding (e.g. users binds under `target_user` for the
-    projected view).
+    last-write-wins semantics; entities can override any framework-
+    injected key.
 
     Reads from the spec:
       - `spec.model` — class fetched via `repo.get_by_model_id`.
       - `spec.can_write` — when set, populates `can_edit` in context.
         Always accepts `User | None`; entities whose detail page is
         public (`read_user_dep=None`) pass `requesting_user=None`.
+      - `spec.owner_attr` — drives the `is_self` comparison.
+      - `spec.private_field_predicate` — drives `can_view_private` and
+        gates the `target_<name>` projection.
+      - `spec.public_fields` — declares the projection shape.
     """
     target = await repo.get_by_model_id(spec.model, target_id)
     if target is None:
@@ -616,6 +631,34 @@ async def handle_detail(
     }
     if spec.can_write is not None:
         context["can_edit"] = spec.can_write(target, requesting_user)
+
+    # Viewer-derived flags. `subject_attr` is the attribute on `target`
+    # whose value equals `requesting_user.id` when the viewer IS the
+    # subject — for `owner_attr=None` (users — the row IS the user), the
+    # rule reduces to `target.id == viewer.id`; for owned resources
+    # (provider, post), it uses the owner FK. The uniform rule lets every
+    # entity inherit `is_self` / `can_admin_actions` without per-entity glue.
+    subject_attr = spec.owner_attr or "id"
+    is_self = (
+        requesting_user is not None
+        and getattr(target, subject_attr) == requesting_user.id
+    )
+    context["is_self"] = is_self
+    context["can_admin_actions"] = is_admin(requesting_user) and not is_self
+
+    if spec.private_field_predicate is not None:
+        context["can_view_private"] = bool(
+            spec.private_field_predicate(requesting_user, target)
+        )
+
+    if spec.public_fields:
+        context[f"target_{spec.name}"] = project_view(
+            target,
+            public_fields=spec.public_fields,
+            actor=requesting_user,
+            private_fields=spec.private_fields,
+            private_field_predicate=spec.private_field_predicate,
+        )
 
     if extras is not None:
         extras_kwargs = {
@@ -668,24 +711,38 @@ async def handle_list(
     and a ``selected_<name>`` echo for each filter value so the filter
     form can preselect the active selection.
 
+    ``can_admin_actions`` is auto-injected from
+    ``is_admin(requesting_user)`` — list-level templates that show
+    admin-only actions read it without per-entity glue. When the spec
+    sets ``list_exclude_self=True``, the viewer is dropped from the
+    result set by passing ``exclude_self=requesting_user`` to the repo
+    method (the repo method must accept that kwarg; anonymous viewers
+    skip the filter and see the full list).
+
     ``extras`` is the per-entity post-fetch customization hook (matches
     ``handle_detail``'s ``extras`` shape). It receives ``items``,
     ``request``, ``requesting_user``, ``filter_values``, plus any
     ``extra_kwargs``. Its returned dict merges into the context with
-    last-write-wins semantics; entities can override the base bindings
-    (no current entity does).
+    last-write-wins semantics; entities can override any framework-
+    injected key.
 
     Reads from the spec:
       - ``spec.url_collection`` — picks the repo method name and the
         context key for the items list.
+      - ``spec.list_exclude_self`` — when True, drops the viewer from
+        the result set via the repo method's ``exclude_self`` kwarg.
     """
     list_method = getattr(repo, f"list_{spec.url_collection}")
-    items = await list_method(**filter_values)
+    list_kwargs: dict[str, Any] = dict(filter_values)
+    if spec.list_exclude_self and requesting_user is not None:
+        list_kwargs["exclude_self"] = requesting_user
+    items = await list_method(**list_kwargs)
 
     context: dict[str, Any] = {
         "request": request,
         spec.url_collection: items,
         "current_user": requesting_user,
+        "can_admin_actions": is_admin(requesting_user),
     }
     # Filter echo — the list page's filter form preselects the active
     # value by reading ``selected_<name>`` from the context.

--- a/src/logic/test__generic.py
+++ b/src/logic/test__generic.py
@@ -30,10 +30,15 @@ from src.logic.audit import AuditAction, AuditedResource
 
 @dataclass
 class _FixtureRow:
-    """Stand-in ORM row: just needs `id` plus optional parent FK column."""
+    """Stand-in ORM row: just needs `id` plus optional parent FK column.
+
+    `owner_id` defaults to None so tests that don't care about ownership
+    can ignore it; the spec's default `owner_attr="owner_id"` reads it
+    in `handle_detail`'s `is_self` derivation."""
 
     id: UUID
     parent_id: UUID | None = None
+    owner_id: UUID | None = None
     # Counters so tests can detect commit / delete / audit fired.
     _deleted: bool = False
 
@@ -117,6 +122,14 @@ class _ParentRow:
         self.id = id
 
 
+def _user(*, id_: UUID | None = None, is_superuser: bool = False) -> SimpleNamespace:
+    """User-stub factory that always carries `is_superuser`. Mirrors the
+    same-named helper in `test__authz.py`. The framework's auto-injection
+    of `can_admin_actions` reads `user.is_superuser`, so every stub the
+    detail/list handlers see needs the field present."""
+    return SimpleNamespace(id=id_ or uuid4(), is_superuser=is_superuser)
+
+
 # --- Fixture audit + write_authz ------------------------------------------
 
 
@@ -184,7 +197,7 @@ async def test_top_level_delete_happy_path():
     spec = _top_level_spec(write_authz=None)
     repo = _FakeRepo()
     audit_repo = _FakeAuditRepo()
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
     target_id = uuid4()
     repo.seed(_FixtureRow, _FixtureRow(id=target_id))
 
@@ -219,7 +232,7 @@ async def test_top_level_delete_invokes_write_authz_against_target():
     target_id = uuid4()
     target = _FixtureRow(id=target_id)
     repo.seed(_FixtureRow, target)
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
 
     await handle_delete(
         spec,
@@ -247,7 +260,7 @@ async def test_subentity_delete_happy_path():
     repo.seed(parent_spec.model, _ParentRow(id=parent_id))
     repo.seed(child_spec.model, _FixtureRow(id=child_id, parent_id=parent_id))
     audit_repo = _FakeAuditRepo()
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
 
     await handle_delete(
         child_spec,
@@ -287,7 +300,7 @@ async def test_subentity_write_authz_runs_against_parent():
         parent_id=parent_id,
         repo=repo,
         audit_repo=_FakeAuditRepo(),
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
     )
 
     assert len(seen) == 1
@@ -307,7 +320,7 @@ async def test_target_not_found_raises_not_found():
             target_id=uuid4(),
             repo=repo,
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
     assert repo.deleted == []
 
@@ -332,7 +345,7 @@ async def test_subentity_parent_fk_mismatch_raises_not_found():
             parent_id=other_parent_id,  # different parent
             repo=repo,
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -352,7 +365,7 @@ async def test_subentity_parent_not_found_raises_not_found():
             parent_id=parent_id,
             repo=repo,
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -372,7 +385,7 @@ async def test_subentity_without_parent_id_raises_value_error():
             parent_id=None,
             repo=repo,
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -396,7 +409,7 @@ async def test_write_authz_raises_propagates_no_audit_no_commit():
             target_id=target_id,
             repo=repo,
             audit_repo=audit_repo,
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
     assert repo.deleted == []
@@ -421,7 +434,7 @@ async def test_delete_raises_propagates_no_audit_no_commit():
             target_id=target_id,
             repo=repo,
             audit_repo=audit_repo,
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
     assert audit_repo.calls == []
@@ -448,7 +461,7 @@ async def test_no_audit_binding_raises_value_error():
             target_id=target_id,
             repo=repo,
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -468,7 +481,7 @@ async def test_no_write_authz_skips_auth_check():
         target_id=target_id,
         repo=repo,
         audit_repo=_FakeAuditRepo(),
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
     )
 
     assert len(repo.deleted) == 1
@@ -597,7 +610,7 @@ async def test_create_top_level_persists_and_audits():
     )
     repo = _create_fake_repo()
     audit_repo = _FakeAuditRepo()
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
 
     created = await handle_create(
         spec,
@@ -628,7 +641,7 @@ async def test_create_top_level_without_owner_attr():
         audit=_audit(),
     )
     repo = _create_fake_repo()
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
 
     created = await handle_create(
         spec,
@@ -668,7 +681,7 @@ async def test_create_subentity_appended_to_parent_and_audited():
     parent_obj = _ParentRow(id=parent_id)
     repo.seed(parent_spec.model, parent_obj)
     audit_repo = _FakeAuditRepo()
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
 
     created = await handle_create(
         spec,
@@ -709,7 +722,7 @@ async def test_create_subentity_parent_not_found():
             parent_id=uuid4(),
             repo=repo,
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -733,7 +746,7 @@ async def test_create_subentity_missing_parent_id_raises():
             parent_id=None,
             repo=_create_fake_repo(),
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -800,7 +813,7 @@ async def test_create_polymorphic_dispatches_via_discriminator():
         discriminator=registry,
     )
     repo = _create_fake_repo()
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
 
     created_red = await handle_create(
         spec,
@@ -848,7 +861,7 @@ async def test_create_no_audit_binding_raises():
             payload=_StandardPayload(),
             repo=_create_fake_repo(),
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -881,7 +894,7 @@ async def test_create_subentity_write_authz_raises_rolls_back():
             parent_id=parent_id,
             repo=repo,
             audit_repo=audit_repo,
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
     # Nothing added, no audit, no commit.
@@ -995,7 +1008,7 @@ async def test_update_top_level_partial_patch_via_exclude_unset():
         payload=_UpdatePayload(practice_name="New"),  # location_city unset
         repo=repo,
         audit_repo=audit_repo,
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
     )
 
     assert target.practice_name == "New"
@@ -1033,7 +1046,7 @@ async def test_update_invokes_write_authz_against_target():
         payload=_UpdatePayload(),
         repo=repo,
         audit_repo=_FakeAuditRepo(),
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
     )
 
     assert len(seen) == 1
@@ -1076,7 +1089,7 @@ async def test_update_subentity_happy_path():
         payload=_UpdatePayload(practice_name="New"),
         repo=repo,
         audit_repo=_FakeAuditRepo(),
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
     )
 
     assert seen_authz == [parent_obj]
@@ -1112,7 +1125,7 @@ async def test_update_subentity_parent_fk_mismatch_404():
             payload=_UpdatePayload(),
             repo=repo,
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -1169,7 +1182,7 @@ async def test_update_polymorphic_patches_detail_row():
         payload=_RedUpdatePayload(kind="red", redness=99),
         repo=repo,
         audit_repo=_FakeAuditRepo(),
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
     )
 
     assert detail.redness == 99
@@ -1215,7 +1228,7 @@ async def test_update_polymorphic_kind_mismatch_raises_bad_request():
             payload=_BlueUpdatePayload(kind="blue", blueness=5),
             repo=repo,
             audit_repo=audit_repo,
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
     # No audit, no commit on the kind-mismatch path.
@@ -1242,7 +1255,7 @@ async def test_update_target_not_found():
             payload=_UpdatePayload(),
             repo=_update_fake_repo(),
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -1271,7 +1284,7 @@ async def test_update_write_authz_raises_no_audit_no_commit():
             payload=_UpdatePayload(),
             repo=repo,
             audit_repo=audit_repo,
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
     assert repo.patched == []
@@ -1295,7 +1308,7 @@ async def test_update_no_audit_binding_raises():
             payload=_UpdatePayload(),
             repo=_update_fake_repo(),
             audit_repo=_FakeAuditRepo(),
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -1385,7 +1398,7 @@ async def test_edit_form_top_level_happy_path():
     target_id = uuid4()
     target = _FixtureRow(id=target_id)
     repo.seed(_FixtureRow, target)
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
     request = SimpleNamespace()
 
     context = await handle_get_edit_form(
@@ -1415,7 +1428,7 @@ async def test_edit_form_invokes_write_authz_against_target():
     target = _FixtureRow(id=target_id)
     repo = _FakeRepo()
     repo.seed(_FixtureRow, target)
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
 
     await handle_get_edit_form(
         spec,
@@ -1441,7 +1454,7 @@ async def test_edit_form_target_not_found_raises_not_found():
             request=SimpleNamespace(),
             target_id=uuid4(),
             repo=repo,
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -1460,7 +1473,7 @@ async def test_edit_form_write_authz_raises_propagates():
             request=SimpleNamespace(),
             target_id=target_id,
             repo=repo,
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -1493,7 +1506,7 @@ async def test_edit_form_polymorphic_returns_kind_template():
         request=SimpleNamespace(),
         target_id=target_id,
         repo=repo,
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
     )
 
     assert context["painting"] is target
@@ -1537,7 +1550,7 @@ async def test_make_edit_form_handler_delegates_to_handle_get_edit_form():
     target = _FixtureRow(id=target_id)
     repo = _FakeRepo()
     repo.seed(_FixtureRow, target)
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
     request = SimpleNamespace()
 
     handler = make_edit_form_handler(spec)
@@ -1571,7 +1584,7 @@ async def test_detail_top_level_happy_path():
     target = _FixtureRow(id=target_id)
     repo = _FakeRepo()
     repo.seed(_FixtureRow, target)
-    user = SimpleNamespace(id=uuid4())
+    user = _user()
 
     context = await handle_detail(
         spec,
@@ -1599,8 +1612,8 @@ async def test_detail_populates_can_edit_from_can_write():
     )
     target_id = uuid4()
     owner_id = uuid4()
-    owner = SimpleNamespace(id=owner_id)
-    stranger = SimpleNamespace(id=uuid4())
+    owner = _user(id_=owner_id)
+    stranger = _user()
 
     # _FixtureRow doesn't have owner_id; simulate by setattr.
     target = _FixtureRow(id=target_id)
@@ -1650,7 +1663,7 @@ async def test_detail_extras_merges_into_context():
         request=SimpleNamespace(),
         target_id=target_id,
         repo=repo,
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
         extras=extras,
     )
 
@@ -1680,7 +1693,7 @@ async def test_detail_extras_receives_extra_kwargs():
         request=SimpleNamespace(),
         target_id=target_id,
         repo=repo,
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
         extras=extras,
         extra_kwargs={"side_repo": side_repo},
     )
@@ -1699,7 +1712,7 @@ async def test_detail_target_not_found_raises_not_found():
             request=SimpleNamespace(),
             target_id=uuid4(),
             repo=repo,
-            requesting_user=SimpleNamespace(id=uuid4()),
+            requesting_user=_user(),
         )
 
 
@@ -1787,7 +1800,7 @@ async def test_make_detail_handler_delegates_to_handle_detail():
         request=SimpleNamespace(),
         widget_id=target_id,
         repo=repo,
-        requesting_user=SimpleNamespace(id=uuid4()),
+        requesting_user=_user(),
         side_repo=side_repo,
     )
 
@@ -1920,3 +1933,404 @@ def test_make_list_handler_signature_includes_filters_and_repos():
     assert "requesting_user" in names
     assert "side_repo" in names
     assert handler.__name__ == "_handle_list_widget"
+
+
+# --- Viewer-flag + projection auto-injection (handle_detail) -------------
+
+
+def _is_self_or_admin(actor, target) -> bool:
+    """Stand-in `private_field_predicate`: viewer is self or admin."""
+    if actor is None:
+        return False
+    if getattr(actor, "is_superuser", False):
+        return True
+    subject_id = getattr(target, "owner_id", None) or getattr(target, "id", None)
+    return getattr(actor, "id", None) == subject_id
+
+
+@pytest.mark.asyncio
+async def test_detail_injects_is_self_for_owned_resource():
+    """`is_self` compares `target.<owner_attr>` to viewer.id when
+    `spec.owner_attr` is set (the owned-resource rule)."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        owner_attr="owner_id",
+        audit=_audit(),
+    )
+    target_id = uuid4()
+    owner_id = uuid4()
+    target = _FixtureRow(id=target_id)
+    target.owner_id = owner_id  # type: ignore[attr-defined]
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, target)
+
+    owner = SimpleNamespace(id=owner_id, is_superuser=False)
+    stranger = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    owner_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=owner,
+    )
+    stranger_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=stranger,
+    )
+    anon_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=None,
+    )
+
+    assert owner_ctx["is_self"] is True
+    assert stranger_ctx["is_self"] is False
+    assert anon_ctx["is_self"] is False
+
+
+@pytest.mark.asyncio
+async def test_detail_injects_is_self_for_user_like_resource():
+    """When `owner_attr=None` (the resource IS the user), `is_self`
+    reduces to `target.id == viewer.id`."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        owner_attr=None,
+        audit=_audit(),
+    )
+    target_id = uuid4()
+    target = _FixtureRow(id=target_id)
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, target)
+
+    self_viewer = SimpleNamespace(id=target_id, is_superuser=False)
+    other_viewer = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    self_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=self_viewer,
+    )
+    other_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=other_viewer,
+    )
+
+    assert self_ctx["is_self"] is True
+    assert other_ctx["is_self"] is False
+
+
+@pytest.mark.asyncio
+async def test_detail_injects_can_admin_actions_excludes_self():
+    """`can_admin_actions` is `is_admin(viewer) and not is_self` —
+    admins lose the flag on their own row so they can't act on themselves."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        owner_attr=None,
+        audit=_audit(),
+    )
+    target_id = uuid4()
+    target = _FixtureRow(id=target_id)
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, target)
+
+    admin = SimpleNamespace(id=uuid4(), is_superuser=True)
+    self_admin = SimpleNamespace(id=target_id, is_superuser=True)
+    plain = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    admin_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=admin,
+    )
+    self_admin_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=self_admin,
+    )
+    plain_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=plain,
+    )
+
+    assert admin_ctx["can_admin_actions"] is True
+    assert self_admin_ctx["can_admin_actions"] is False
+    assert plain_ctx["can_admin_actions"] is False
+
+
+@pytest.mark.asyncio
+async def test_detail_injects_can_view_private_when_predicate_set():
+    """`can_view_private` is the spec's `private_field_predicate`
+    evaluated against (viewer, target). Absent when no predicate."""
+    spec_with = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        private_fields=("secret",),
+        private_field_predicate=_is_self_or_admin,
+        audit=_audit(),
+    )
+    spec_without = _top_level_spec()  # no private_field_predicate
+    target_id = uuid4()
+    target = _FixtureRow(id=target_id)
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, target)
+
+    self_viewer = SimpleNamespace(id=target_id, is_superuser=False)
+    stranger = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    self_ctx = await handle_detail(
+        spec_with,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=self_viewer,
+    )
+    stranger_ctx = await handle_detail(
+        spec_with,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=stranger,
+    )
+    without_ctx = await handle_detail(
+        spec_without,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=stranger,
+    )
+
+    assert self_ctx["can_view_private"] is True
+    assert stranger_ctx["can_view_private"] is False
+    assert "can_view_private" not in without_ctx
+
+
+@pytest.mark.asyncio
+async def test_detail_injects_target_projection_when_public_fields_set():
+    """`target_<name>` is a `project_view` dict gated by the spec's
+    predicate. Omits private fields for non-privileged viewers."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        public_fields=("id",),
+        private_fields=("parent_id",),
+        private_field_predicate=_is_self_or_admin,
+        audit=_audit(),
+    )
+    target_id = uuid4()
+    parent_id = uuid4()
+    target = _FixtureRow(id=target_id, parent_id=parent_id)
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, target)
+
+    self_viewer = SimpleNamespace(id=target_id, is_superuser=False)
+    stranger = SimpleNamespace(id=uuid4(), is_superuser=False)
+
+    self_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=self_viewer,
+    )
+    stranger_ctx = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=stranger,
+    )
+
+    assert self_ctx["target_widget"] == {"id": target_id, "parent_id": parent_id}
+    assert stranger_ctx["target_widget"] == {"id": target_id}
+
+
+@pytest.mark.asyncio
+async def test_detail_no_projection_when_public_fields_unset():
+    """Without `public_fields`, no `target_<name>` key is injected."""
+    spec = _top_level_spec()
+    target_id = uuid4()
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, _FixtureRow(id=target_id))
+
+    context = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=SimpleNamespace(id=uuid4(), is_superuser=False),
+    )
+
+    assert "target_widget" not in context
+
+
+# --- Viewer-flag + exclude-self auto-injection (handle_list) -------------
+
+
+@pytest.mark.asyncio
+async def test_handle_list_injects_can_admin_actions():
+    """`can_admin_actions` is `is_admin(viewer)` on list pages (no
+    `is_self` semantics — every row is some other entity)."""
+    spec = _top_level_spec()
+
+    class _ListRepo:
+        async def list_widgets(self, **_):
+            return []
+
+    from src.logic._generic import handle_list
+
+    admin_ctx = await handle_list(
+        spec,
+        request=SimpleNamespace(),
+        repo=_ListRepo(),
+        requesting_user=SimpleNamespace(id=uuid4(), is_superuser=True),
+        filter_values={},
+    )
+    plain_ctx = await handle_list(
+        spec,
+        request=SimpleNamespace(),
+        repo=_ListRepo(),
+        requesting_user=SimpleNamespace(id=uuid4(), is_superuser=False),
+        filter_values={},
+    )
+    anon_ctx = await handle_list(
+        spec,
+        request=SimpleNamespace(),
+        repo=_ListRepo(),
+        requesting_user=None,
+        filter_values={},
+    )
+
+    assert admin_ctx["can_admin_actions"] is True
+    assert plain_ctx["can_admin_actions"] is False
+    assert anon_ctx["can_admin_actions"] is False
+
+
+@pytest.mark.asyncio
+async def test_handle_list_passes_exclude_self_when_spec_opts_in():
+    """`list_exclude_self=True` threads `exclude_self=requesting_user`
+    into the repo's list method. Anonymous viewers skip the kwarg."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        routes=RouteSet(list=True),
+        list_exclude_self=True,
+    )
+    captured: list[dict] = []
+
+    class _ListRepo:
+        async def list_widgets(self, **kwargs):
+            captured.append(kwargs)
+            return []
+
+    from src.logic._generic import handle_list
+
+    viewer = SimpleNamespace(id=uuid4(), is_superuser=False)
+    await handle_list(
+        spec,
+        request=SimpleNamespace(),
+        repo=_ListRepo(),
+        requesting_user=viewer,
+        filter_values={},
+    )
+    await handle_list(
+        spec,
+        request=SimpleNamespace(),
+        repo=_ListRepo(),
+        requesting_user=None,
+        filter_values={},
+    )
+
+    assert captured[0] == {"exclude_self": viewer}
+    assert captured[1] == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_list_omits_exclude_self_when_spec_opts_out():
+    """Without `list_exclude_self=True`, the repo call carries no
+    `exclude_self` kwarg — existing entities are unaffected."""
+    spec = _top_level_spec()
+    captured: list[dict] = []
+
+    class _ListRepo:
+        async def list_widgets(self, **kwargs):
+            captured.append(kwargs)
+            return []
+
+    from src.logic._generic import handle_list
+
+    await handle_list(
+        spec,
+        request=SimpleNamespace(),
+        repo=_ListRepo(),
+        requesting_user=SimpleNamespace(id=uuid4(), is_superuser=False),
+        filter_values={"kind": "alpha"},
+    )
+
+    assert captured[0] == {"kind": "alpha"}
+    assert "exclude_self" not in captured[0]
+
+
+# --- Spec construction-time validation -----------------------------------
+
+
+def test_public_fields_without_predicate_rejected():
+    """Declaring `public_fields` without a `private_field_predicate`
+    would let the projection silently pass every private field."""
+    with pytest.raises(ValueError, match="private_field_predicate"):
+        EntitySpec(
+            name="widget",
+            url_collection="widgets",
+            id_param="widget_id",
+            model=_FixtureRow,
+            public_fields=("id",),
+            audit=_audit(),
+        )
+
+
+def test_list_exclude_self_requires_list_route():
+    """`list_exclude_self` is only consumed by handle_list — without a
+    list route the flag would be dead."""
+    with pytest.raises(ValueError, match="routes.list"):
+        EntitySpec(
+            name="widget",
+            url_collection="widgets",
+            id_param="widget_id",
+            model=_FixtureRow,
+            audit=_audit(),
+            list_exclude_self=True,
+            routes=RouteSet(detail=True),
+        )

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -2,12 +2,9 @@ import logging
 from typing import Any
 from uuid import UUID
 
-from fastapi import Request
-
 from src.api.common.exceptions import NotFoundError
-from src.api.common.projections import project_view
 from src.api.common.specs.user import USER_ENTITY
-from src.logic._authz import forbid_self_action, is_admin
+from src.logic._authz import forbid_self_action
 from src.logic.audit import mutate, record_audit
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
@@ -18,73 +15,22 @@ from src.schemas.users.user import UserActivationUpdate
 logger = logging.getLogger(__name__)
 
 
-async def handle_list_users(
-    request: Request,
-    repo: UserRepository,
-    requesting_user: User,
-):
-    """
-    Handles the core logic for listing users.
-
-    Args:
-        request: The FastAPI request object.
-        repo: The user repository dependency.
-        requesting_user: The currently authenticated user.
-
-    Returns:
-        A dictionary containing the context for the template.
-
-    Raises:
-        Exception: Propagates exceptions from the repository layer.
-    """
-    users_list = await repo.list_users(exclude_user=requesting_user)
-
-    # `list_users` excludes the viewer, so every row is some other user;
-    # admin-actions visibility reduces to a single flag for the whole
-    # list rather than a per-row computation.
-    return {
-        "request": request,
-        "users": users_list,
-        "current_user": requesting_user,
-        "can_admin_actions": is_admin(requesting_user),
-    }
-
-
 async def user_detail_extras(
     *,
     target: User,
-    requesting_user: User | None,
     provider_repo: ProviderRepository,
     **_: Any,
 ) -> dict[str, Any]:
     """Per-viewer detail extras for `make_detail_handler(USER_ENTITY)`.
 
-    Adds the providers the target owns, viewer-derived flags
-    (`is_self`, `can_admin_actions`, `can_view_private`), and a
-    private-field projection bound under `target_user`. Templates read
-    `target_user`, not the raw `user` key the framework base context
-    binds — the projection is what carries the omit-private-fields
-    guarantee, so binding it under the template-facing name is
-    defense-in-depth: a forgotten template guard can re-leak; a
-    missing dict key can't.
+    Fetches the providers the target owns. Viewer-derived flags
+    (`is_self`, `can_admin_actions`, `can_view_private`) and the
+    `target_user` projection are framework-injected by `handle_detail`
+    from `USER_ENTITY.public_fields` / `private_fields` /
+    `private_field_predicate` — defense-in-depth (a forgotten template
+    guard can re-leak; a missing dict key can't) is preserved.
     """
-    providers = await provider_repo.list_for_user(target.id)
-    is_self = requesting_user is not None and target.id == requesting_user.id
-    return {
-        "providers": providers,
-        "is_self": is_self,
-        "can_admin_actions": is_admin(requesting_user) and not is_self,
-        "can_view_private": USER_ENTITY.private_field_predicate(
-            requesting_user, target
-        ),
-        "target_user": project_view(
-            target,
-            public_fields=("id", "username"),
-            actor=requesting_user,
-            private_fields=USER_ENTITY.private_fields,
-            private_field_predicate=USER_ENTITY.private_field_predicate,
-        ),
-    }
+    return {"providers": await provider_repo.list_for_user(target.id)}
 
 
 async def handle_set_user_activation(

--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -127,7 +127,7 @@ async def handle_list_[entity](
     repo: [Entity]Repository,
     requesting_user: User,
 ):
-    items = await repo.list_[entity](exclude_user=requesting_user)
+    items = await repo.list_[entity](exclude_self=requesting_user)
     return {"items": items, "current_user": requesting_user}
 ```
 

--- a/src/repositories/users/user_repository.py
+++ b/src/repositories/users/user_repository.py
@@ -32,13 +32,17 @@ class UserRepository(BaseRepository):
     async def list_users(
         self,
         *,
-        exclude_user: User | None = None,
+        exclude_self: User | None = None,
     ) -> Sequence[User]:
-        """Lists users, optionally excluding a user."""
+        """Lists users, optionally excluding the requesting viewer.
+
+        The kwarg name `exclude_self` is the convention `handle_list`
+        passes for entities opting into `spec.list_exclude_self=True`.
+        """
         stmt = select(User)
 
-        if exclude_user:
-            stmt = stmt.filter(User.id != exclude_user.id)
+        if exclude_self:
+            stmt = stmt.filter(User.id != exclude_self.id)
 
         stmt = stmt.order_by(User.username)
         return await self._list(stmt)


### PR DESCRIPTION
## Summary

- Spec gains `public_fields` (drives the `target_<name>` projection) and `list_exclude_self` (drops the viewer from list results via a uniform `exclude_self=` repo kwarg).
- `handle_detail` now injects `is_self` / `can_admin_actions` / `can_view_private` / `target_<name>` from spec metadata; `handle_list` injects `can_admin_actions` and plumbs `exclude_self`.
- `handle_list_users` deleted, `user_detail_extras` shrunk to one line, `users.py` collapses to the same shape as `posts.py` / `providers.py` (just `make_entity_router` + `mount_entity(handlers={"delete": handle_delete_user})`).
- `UserRepository.list_users` kwarg renamed `exclude_user` → `exclude_self` for naming consistency with the framework convention.

## Why

The viewer-flag composition (`is_self`, `can_admin_actions`, `can_view_private`, the `project_view` projection) is mechanically derivable from spec data (`owner_attr`, `private_field_predicate`, `public_fields`) — there's no entity-specific judgment involved. Moving it onto the framework removes the last reason `handle_list_users` was bespoke, drops the duplicate composition between `user_detail_extras` and any future entity that wants the same flags, and means new entities inherit the visibility primitives by setting two fields instead of writing an extras callable.

## Test plan

- [x] `dev test` — 865 passed (existing user-detail tests are the load-bearing pins for projection behavior; framework tests in `test__generic.py` pin the auto-injection against fixture specs)
- [x] `dev test contract` — 16 passed
- [x] `dev lint`
- [ ] Manual: hit `/users` (admin sees actions, non-admin doesn't, viewer absent from list) and `/users/{id}` as stranger / self / admin (private fields gated correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)