### PR TITLE
Delete unused UserFavoriteRead schema

### DIFF
--- a/src/schemas/favorites/user_favorite.py
+++ b/src/schemas/favorites/user_favorite.py
@@ -3,21 +3,16 @@
 A favorite is an immutable binary edge: a user either has favorited a
 provider or they haven't. The wire surface is therefore minimal — no
 Create / Update schemas (POST takes both ids from URL+session; favorites
-are never updated). The Read shape powers the favorites listing; the
-AuditSnapshot is structurally identical and used for audit before/after.
+are never updated), no Read schema (the favorites listing renders ORM
+rows directly via the template). The only schema needed is
+`UserFavoriteAuditSnapshot`, consumed by `FAVORITE_ENTITY.edge_audit`'s
+snapshotter for audit before/after captures.
 """
 
 import uuid
 from datetime import datetime
 
 from src.schemas._validators import ReadProjection
-
-
-class UserFavoriteRead(ReadProjection):
-    id: uuid.UUID
-    user_id: uuid.UUID
-    provider_id: uuid.UUID
-    created_at: datetime
 
 
 class UserFavoriteAuditSnapshot(ReadProjection):


### PR DESCRIPTION
## Summary

`UserFavoriteRead` was byte-identical to `UserFavoriteAuditSnapshot` and never imported — the favorites listing renders ORM rows directly via the template, so the Read projection has no consumer. Drop the dead class and correct the module docstring to match.

## Test plan

- [x] `dev test` — 865 passed
- [x] `dev lint`
- [x] Grep audit: `grep -rn "UserFavoriteRead" .` returns no consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)