### PR TITLE
Add static_context spec field for constants like post_kinds

### DIFF
--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -423,6 +423,20 @@ class EntitySpec:
     list_extras_path: str | None = None
     list_extras_repos: tuple[tuple[str, type], ...] = ()
 
+    # Static context bindings -------------------------------------------
+    # Constant key→value pairs that `handle_detail` / `handle_list` merge
+    # into the template context after the framework's auto-injected keys
+    # and before the entity's extras callable runs. Use this for values
+    # that are computed once at spec-construction time (registry tuples,
+    # enum lists, feature flags) — anything dynamic stays on the extras
+    # callable. Posts uses this for `post_kinds` so its list page renders
+    # per-kind "New X" links without a dedicated extras callable.
+    #
+    # The dict is shared by reference, so values should be immutable
+    # (tuples / frozen lists / plain enums). Spec consumers read from
+    # `entity.static_context` but never mutate.
+    static_context: dict[str, Any] = field(default_factory=dict)
+
     # Owned-subentity registry. Populated in __post_init__: when a spec
     # is constructed with `parent=<P>`, the child appends itself to
     # `P._children` (in-place mutation; the frozen dataclass guarantees

--- a/src/api/common/specs/post.py
+++ b/src/api/common/specs/post.py
@@ -60,5 +60,8 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
     ),
     update_redirect=Redirects.to_detail("posts", "post_id"),
     discriminator=POST_KINDS,
-    list_extras_path="src.logic.posts.post_processing.post_list_extras",
+    # The list page renders per-kind "New X" links from this tuple —
+    # consumed by `src/templates/posts/list.html`. Computed once at
+    # spec-construction time; the registry is immutable after import.
+    static_context={"post_kinds": list(POST_KINDS.values())},
 )

--- a/src/api/common/specs/test_post.py
+++ b/src/api/common/specs/test_post.py
@@ -64,11 +64,17 @@ def test_discriminator_names_match_registry():
     assert POST_ENTITY.discriminator.names == POST_KINDS.names
 
 
-# --- Extras binding ------------------------------------------------------
+# --- Static context ------------------------------------------------------
 
 
-def test_list_extras_path_points_at_post_list_extras():
-    assert (
-        POST_ENTITY.list_extras_path
-        == "src.logic.posts.post_processing.post_list_extras"
-    )
+def test_static_context_carries_post_kinds():
+    """The list page reads `post_kinds` from context to render the
+    per-kind 'New X' links. Sourcing it from the spec means a registry
+    edit doesn't require a code edit anywhere else."""
+    assert POST_ENTITY.static_context == {"post_kinds": list(POST_KINDS.values())}
+
+
+def test_list_extras_path_unset():
+    """Posts no longer needs a list_extras callable — `post_kinds` lives
+    on `static_context` and the framework merges it directly."""
+    assert POST_ENTITY.list_extras_path is None

--- a/src/api/routes/posts.py
+++ b/src/api/routes/posts.py
@@ -8,11 +8,11 @@ posts_api_router = router.router
 
 
 # Every standard verb (list, detail, create, update, delete, form_edit)
-# is factory-built. `list` auto-binds via `make_list_handler(POST_ENTITY)`
-# with `post_list_extras` (declared on the spec via `list_extras_path`)
-# adding the registered `post_kinds` to the context so the list page
-# can render its per-kind 'New X' links. `form_new` stays bespoke for
-# the `?kind=` template dispatch.
+# is factory-built. `list` auto-binds via `make_list_handler(POST_ENTITY)`;
+# the `post_kinds` tuple the list page reads for its per-kind 'New X'
+# links comes from `POST_ENTITY.static_context`, merged into the context
+# by the generic `handle_list`. `form_new` stays bespoke for the
+# `?kind=` template dispatch.
 mount_entity(
     router,
     POST_ENTITY,

--- a/src/logic/_generic.py
+++ b/src/logic/_generic.py
@@ -601,6 +601,9 @@ async def handle_detail(
         the predicate evaluated against `(viewer, target)`.
       - `target_<name>` — when `spec.public_fields` is set, a
         `project_view` dict with private fields gated by the predicate.
+      - Entries from `spec.static_context` — spec-declared constants
+        (registry tuples, enum lists) merged before extras so the
+        callable can still override.
 
     `extras` is the entity's per-detail customization callable. It
     receives the loaded target plus `request`, `requesting_user`, and
@@ -660,6 +663,12 @@ async def handle_detail(
             private_field_predicate=spec.private_field_predicate,
         )
 
+    # Spec-declared constants — merged before extras so an extras
+    # callable can still override (last-write-wins, matching the
+    # framework's existing precedence rule).
+    if spec.static_context:
+        context.update(spec.static_context)
+
     if extras is not None:
         extras_kwargs = {
             "target": target,
@@ -717,7 +726,9 @@ async def handle_list(
     sets ``list_exclude_self=True``, the viewer is dropped from the
     result set by passing ``exclude_self=requesting_user`` to the repo
     method (the repo method must accept that kwarg; anonymous viewers
-    skip the filter and see the full list).
+    skip the filter and see the full list). Entries from
+    ``spec.static_context`` (constants like posts' ``post_kinds`` tuple)
+    merge into the context after the filter echo and before extras.
 
     ``extras`` is the per-entity post-fetch customization hook (matches
     ``handle_detail``'s ``extras`` shape). It receives ``items``,
@@ -748,6 +759,10 @@ async def handle_list(
     # value by reading ``selected_<name>`` from the context.
     for fname, fvalue in filter_values.items():
         context[f"selected_{fname}"] = fvalue
+
+    # Spec-declared constants — same merge precedence as handle_detail.
+    if spec.static_context:
+        context.update(spec.static_context)
 
     if extras is not None:
         extras_kwargs: dict[str, Any] = {

--- a/src/logic/posts/post_processing.py
+++ b/src/logic/posts/post_processing.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any
 
 from fastapi import Request
 
@@ -22,13 +21,6 @@ PostUpdatePayload = ClientReferralUpdate | ProviderAvailabilityUpdate
 # Audit binding lives on the spec (single declaration). Re-exported as
 # `POST` so handler bodies can keep their `resource=POST` shape.
 POST = POST_ENTITY.audit
-
-
-async def post_list_extras(**_: Any) -> dict[str, Any]:
-    """Per-list extras for `make_list_handler(POST_ENTITY)`. Includes the
-    registered post kinds in the context so the list page can render its
-    per-kind 'New X' links from a single source of truth."""
-    return {"post_kinds": list(POST_KINDS.values())}
 
 
 async def handle_get_post_form(

--- a/src/logic/test__generic.py
+++ b/src/logic/test__generic.py
@@ -2334,3 +2334,100 @@ def test_list_exclude_self_requires_list_route():
             list_exclude_self=True,
             routes=RouteSet(detail=True),
         )
+
+
+# --- static_context spec field --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_detail_merges_static_context():
+    """`spec.static_context` entries land in the detail context, after
+    auto-injected viewer keys and before extras run."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        static_context={"widget_kinds": ("alpha", "beta")},
+    )
+    target_id = uuid4()
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, _FixtureRow(id=target_id))
+
+    context = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=_user(),
+    )
+
+    assert context["widget_kinds"] == ("alpha", "beta")
+
+
+@pytest.mark.asyncio
+async def test_handle_list_merges_static_context():
+    """`spec.static_context` entries land in the list context, after the
+    base context and `selected_<filter>` echoes."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        static_context={"widget_kinds": ("alpha", "beta")},
+    )
+
+    class _ListRepo:
+        async def list_widgets(self, **_):
+            return []
+
+    from src.logic._generic import handle_list
+
+    context = await handle_list(
+        spec,
+        request=SimpleNamespace(),
+        repo=_ListRepo(),
+        requesting_user=None,
+        filter_values={},
+    )
+
+    assert context["widget_kinds"] == ("alpha", "beta")
+
+
+@pytest.mark.asyncio
+async def test_extras_can_override_static_context():
+    """Extras runs after static_context merges in; last-write-wins lets
+    an entity-specific extras override a static value if needed."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        static_context={"flag": "from-static"},
+    )
+    target_id = uuid4()
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, _FixtureRow(id=target_id))
+
+    async def extras(**_):
+        return {"flag": "from-extras"}
+
+    context = await handle_detail(
+        spec,
+        request=SimpleNamespace(),
+        target_id=target_id,
+        repo=repo,
+        requesting_user=_user(),
+        extras=extras,
+    )
+
+    assert context["flag"] == "from-extras"
+
+
+def test_static_context_default_is_empty_dict():
+    """Default is empty; absent declaration means no extra keys land."""
+    spec = _top_level_spec()
+    assert spec.static_context == {}


### PR DESCRIPTION
## Summary

`EntitySpec` gains `static_context: dict[str, Any]` for constants the template context needs (registry tuples, enum lists, etc). `handle_detail` / `handle_list` merge it after the auto-injected keys and before extras, so an extras callable can still override.

Posts switches to it: `POST_ENTITY.static_context={"post_kinds": list(POST_KINDS.values())}` replaces the one-line `post_list_extras` callable + its `list_extras_path` binding. `post_processing.py` is now just the bespoke `handle_get_post_form`.

## Test plan

- [x] `dev test` — 869 passed
- [x] `dev test contract` — 16 passed
- [x] `dev lint`
- [x] Spec-conformance: `POST_ENTITY.static_context["post_kinds"] == list(POST_KINDS.values())`; `POST_ENTITY.list_extras_path is None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)