### PR TITLE
Spec-declare self-target guards for state-axis and delete

### DIFF
--- a/src/api/common/entity_spec.py
+++ b/src/api/common/entity_spec.py
@@ -151,6 +151,15 @@ class StateAxis:
     # `make_snapshotter`. Handlers consume this directly to capture
     # before/after JSON for the audit row.
     audit_snapshot_fn: Callable[[Any], dict[str, Any]] | None = None
+    # When True, the framework rejects the request with 403 if the
+    # URL's target id equals the requesting user's id — preventing an
+    # admin from mutating their own state via this axis. Meaningful
+    # for user-shaped entities where the row IS the user; for owned
+    # resources the comparison never matches so the flag is a no-op.
+    # Wrapping happens in `mount_entity` before the handler is passed
+    # to `mount_state_axis`, so the per-entity handler stays free of
+    # the boilerplate.
+    forbid_self: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -362,6 +371,15 @@ class EntitySpec:
     # opt-in repo must accept.
     list_exclude_self: bool = False
 
+    # Delete-route self guard ------------------------------------------
+    # When True, `handle_delete` rejects the request with 403 if the
+    # URL's target id equals the requesting user's id — preventing an
+    # admin from deleting their own account. Symmetric to
+    # `StateAxis.forbid_self`. Meaningful for user-shaped entities; on
+    # owned resources the comparison never matches (target.id is a
+    # row UUID, not a user id) so the flag is a no-op.
+    delete_forbid_self: bool = False
+
     # List-page filters --------------------------------------------------
     filters: tuple[QueryParam, ...] = ()
 
@@ -470,6 +488,13 @@ class EntitySpec:
             raise ValueError(
                 f"EntitySpec({self.name!r}) sets list_exclude_self=True but "
                 "routes.list is False — the flag would never apply."
+            )
+        # `delete_forbid_self` is consumed only by `handle_delete`; if no
+        # delete route is opted in, the flag is dead.
+        if self.delete_forbid_self and not self.routes.delete:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) sets delete_forbid_self=True but "
+                "routes.delete is False — the flag would never apply."
             )
         # State-axis names must be unique; route mounting iterates by
         # name, so duplicates would shadow each other silently.

--- a/src/api/common/resource_routes.py
+++ b/src/api/common/resource_routes.py
@@ -44,6 +44,7 @@ from uuid import UUID
 from fastapi import Depends, Query, Request, status
 from pydantic import BaseModel, TypeAdapter
 
+from src.api.common.exceptions import ForbiddenError
 from src.api.common.forms import parse_and_validate_form, parse_and_validate_json
 from src.api.common.responses import (
     APIResponse,
@@ -1244,6 +1245,10 @@ def mount_entity(
         handler = _resolve_spec_bound_handler(
             entity, effective_handlers, key=axis.name, handler_path=axis.handler_path
         )
+        if axis.forbid_self:
+            handler = _wrap_state_axis_with_self_guard(
+                handler, id_param=spec.id_param, axis_name=axis.name
+            )
         mount_state_axis(
             router,
             spec,
@@ -1379,6 +1384,47 @@ def _parent_path_param_pairs(spec: ResourceSpec) -> tuple[tuple[str, type], ...]
         s = s.parent
     out.reverse()
     return tuple(out)
+
+
+def _wrap_state_axis_with_self_guard(
+    handler: Callable[..., Awaitable[Any]],
+    *,
+    id_param: str,
+    axis_name: str,
+) -> Callable[..., Awaitable[Any]]:
+    """Wrap a state-axis handler so the framework rejects self-target
+    invocations with 403 before invoking the entity's mutation logic.
+
+    The comparison is `kwargs[id_param] == requesting_user.id`, which
+    only matches on user-shaped entities (where the URL's target id IS
+    a user id). For owned resources, target_id is a row UUID, so the
+    comparison is a no-op — the flag's documented scope.
+
+    The wrapper preserves the handler's signature via `__wrapped__` so
+    `inspect.signature` (used by `_synthesize_route_fn`) still sees the
+    real parameters.
+    """
+
+    async def _self_guard(*args: Any, **kwargs: Any) -> Any:
+        target_id = kwargs.get(id_param)
+        requesting_user = kwargs.get("requesting_user")
+        if (
+            target_id is not None
+            and requesting_user is not None
+            and target_id == requesting_user.id
+        ):
+            raise ForbiddenError(
+                detail=f"Cannot change your own {axis_name} via this endpoint"
+            )
+        # Resolve through `_resolve_handler` so contract-test monkey-
+        # patches against the inner handler's home module take effect
+        # — same mechanism `_call_handler_with` uses for the outer
+        # handler. Without this, the closure-captured reference would
+        # bypass the patch.
+        return await _resolve_handler(handler)(*args, **kwargs)
+
+    _self_guard.__wrapped__ = handler  # type: ignore[attr-defined]
+    return _self_guard
 
 
 def _resolve_spec_bound_handler(

--- a/src/api/common/specs/test_user.py
+++ b/src/api/common/specs/test_user.py
@@ -74,6 +74,8 @@ def test_activation_axis_shape():
     assert axis.action == AuditAction.SET_USER_ACTIVATION
     assert axis.audit_snapshot is UserActivationAuditSnapshot
     assert axis.audit_snapshot_fn is not None  # built by spec __post_init__
+    # Activation must self-guard: admins can't flip their own state.
+    assert axis.forbid_self is True
     sample = axis.response_to_dict(
         type(
             "Sample",
@@ -82,6 +84,12 @@ def test_activation_axis_shape():
         )()
     )
     assert sample == {"id": "abc-123", "username": "u", "is_active": True}
+
+
+def test_delete_forbid_self_is_true():
+    """`/users/{me}` deletion via DELETE is blocked at the framework
+    level — admins cannot delete their own account."""
+    assert USER_ENTITY.delete_forbid_self is True
 
 
 def test_state_axes_has_exactly_activation():

--- a/src/api/common/specs/user.py
+++ b/src/api/common/specs/user.py
@@ -61,6 +61,11 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
     public_fields=("id", "username"),
     list_exclude_self=True,
     routes=RouteSet(list=True, detail=True, delete=True),
+    # The user-list page is for *other* users; admins can't delete their
+    # own account via this endpoint, and the activation state-axis has
+    # the same self-target guard. Both are spec-declared so the user
+    # cluster doesn't carry hand-written self-target boilerplate.
+    delete_forbid_self=True,
     state_axes=(
         StateAxis(
             name="activation",
@@ -69,6 +74,7 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
             response_to_dict=_activation_response_to_dict,
             handler_path=("src.logic.users.user_processing.handle_set_user_activation"),
             audit_snapshot=UserActivationAuditSnapshot,
+            forbid_self=True,
         ),
     ),
     subresources=(

--- a/src/api/routes/users.py
+++ b/src/api/routes/users.py
@@ -1,7 +1,6 @@
 from src.api.common import make_entity_router
 from src.api.common.resource_routes import mount_entity
 from src.api.common.specs.user import USER_ENTITY
-from src.logic.users.user_processing import handle_delete_user
 
 router = make_entity_router(USER_ENTITY)
 # Re-export the underlying APIRouter under the historic name so
@@ -10,13 +9,14 @@ router = make_entity_router(USER_ENTITY)
 users_api_router = router.router
 
 
-# `handle_delete_user` stays bespoke (self-guard on delete). List, detail,
-# state-axis (`activation`), related-list subresource (`providers`), and
-# per-viewer detail extras (`user_detail_extras` + the provider repo it
-# needs) all live on `USER_ENTITY` — resolved at mount time via the spec's
-# dotted `*_path` strings so `specs/user.py` never imports `src.logic`.
-mount_entity(
-    router,
-    USER_ENTITY,
-    handlers={"delete": handle_delete_user},
-)
+# Every verb is factory-built or spec-resolved:
+#   - list / detail / delete — auto-bound from `make_<verb>_handler(USER_ENTITY)`.
+#     `delete` honors `USER_ENTITY.delete_forbid_self=True` for the
+#     "admin can't delete self" rule.
+#   - activation — state-axis handler resolved via the spec's
+#     `handler_path`; the framework wraps it with the `forbid_self`
+#     self-target guard declared on the axis.
+#   - providers — related-list subresource, same `handler_path` path.
+# Detail extras (`user_detail_extras` + the provider repo it needs)
+# live on the spec via `detail_extras_path`.
+mount_entity(router, USER_ENTITY, handlers={})

--- a/src/logic/_generic.py
+++ b/src/logic/_generic.py
@@ -25,7 +25,7 @@ from fastapi import Request
 from pydantic import BaseModel
 
 from src.api.common.entity_spec import EntitySpec
-from src.api.common.exceptions import BadRequestError, NotFoundError
+from src.api.common.exceptions import BadRequestError, ForbiddenError, NotFoundError
 from src.api.common.projections import project_view
 from src.logic._authz import is_admin
 from src.logic.audit import mutate
@@ -75,6 +75,15 @@ async def handle_delete(
     target = await repo.get_by_model_id(spec.model, target_id)
     if target is None:
         raise NotFoundError(detail=f"{spec.name.capitalize()} not found")
+
+    # Self-target guard for user-shaped entities — the comparison only
+    # matches when `target.id` IS the requesting user's id (i.e. the row
+    # is a user). For owned resources, target.id is a row UUID, so the
+    # comparison is harmless. See `EntitySpec.delete_forbid_self`.
+    if spec.delete_forbid_self and target.id == requesting_user.id:
+        raise ForbiddenError(
+            detail=f"Cannot delete your own {spec.name} via this endpoint"
+        )
 
     if spec.parent is not None:
         if parent_id is None:

--- a/src/logic/test__generic.py
+++ b/src/logic/test__generic.py
@@ -2431,3 +2431,133 @@ def test_static_context_default_is_empty_dict():
     """Default is empty; absent declaration means no extra keys land."""
     spec = _top_level_spec()
     assert spec.static_context == {}
+
+
+# --- delete_forbid_self ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_delete_rejects_self_when_flag_set():
+    """`delete_forbid_self=True` blocks the request with 403 if the URL
+    target id equals the requesting user's id. Same logic that used to
+    live in `handle_delete_user` (bespoke), now framework-driven."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        routes=RouteSet(delete=True),
+        delete_forbid_self=True,
+    )
+    actor_id = uuid4()
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, _FixtureRow(id=actor_id))
+    audit_repo = _FakeAuditRepo()
+    actor = _user(id_=actor_id, is_superuser=True)
+
+    with pytest.raises(ForbiddenError):
+        await handle_delete(
+            spec,
+            target_id=actor_id,
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=actor,
+        )
+    # Nothing deleted, no audit row written.
+    assert repo.deleted == []
+    assert audit_repo.calls == []
+
+
+@pytest.mark.asyncio
+async def test_handle_delete_allows_non_self_when_flag_set():
+    """The flag fires only on self-target — admins can still delete
+    other users' rows."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        routes=RouteSet(delete=True),
+        delete_forbid_self=True,
+    )
+    target_id = uuid4()
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, _FixtureRow(id=target_id))
+
+    await handle_delete(
+        spec,
+        target_id=target_id,
+        repo=repo,
+        audit_repo=_FakeAuditRepo(),
+        requesting_user=_user(is_superuser=True),
+    )
+    assert len(repo.deleted) == 1
+
+
+def test_delete_forbid_self_requires_delete_route():
+    """`delete_forbid_self` is consumed only by handle_delete — without
+    a delete route the flag would be dead."""
+    with pytest.raises(ValueError, match="routes.delete"):
+        EntitySpec(
+            name="widget",
+            url_collection="widgets",
+            id_param="widget_id",
+            model=_FixtureRow,
+            audit=_audit(),
+            delete_forbid_self=True,
+            routes=RouteSet(detail=True),
+        )
+
+
+# --- StateAxis.forbid_self (mount-time wrapper) --------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_axis_forbid_self_wrapper_rejects_self_target():
+    """The `forbid_self` axis flag wraps the resolved handler so a
+    self-target invocation raises 403 before the inner handler runs."""
+    from src.api.common.resource_routes import _wrap_state_axis_with_self_guard
+
+    inner_called = False
+
+    async def inner(*, widget_id, requesting_user, payload):
+        nonlocal inner_called
+        inner_called = True
+        return None
+
+    wrapped = _wrap_state_axis_with_self_guard(
+        inner, id_param="widget_id", axis_name="activation"
+    )
+    actor_id = uuid4()
+    actor = _user(id_=actor_id)
+
+    with pytest.raises(ForbiddenError, match="activation"):
+        await wrapped(widget_id=actor_id, requesting_user=actor, payload=None)
+    assert inner_called is False
+
+
+@pytest.mark.asyncio
+async def test_state_axis_forbid_self_wrapper_lets_other_targets_through():
+    """The wrapper is a no-op when target_id != requesting_user.id."""
+    from src.api.common.resource_routes import _wrap_state_axis_with_self_guard
+
+    inner_called = False
+
+    async def inner(*, widget_id, requesting_user, payload):
+        nonlocal inner_called
+        inner_called = True
+        return "ok"
+
+    wrapped = _wrap_state_axis_with_self_guard(
+        inner, id_param="widget_id", axis_name="activation"
+    )
+
+    result = await wrapped(
+        widget_id=uuid4(),
+        requesting_user=_user(),
+        payload=None,
+    )
+    assert result == "ok"
+    assert inner_called is True

--- a/src/logic/users/test_user_processing.py
+++ b/src/logic/users/test_user_processing.py
@@ -2,14 +2,14 @@
 
 The user-detail projection is a security claim — `target_view` must omit
 `email`, `is_active`, `is_verified` from any viewer who isn't the user
-themselves or an admin. The `user_detail_extras` callable carries this
-guarantee: a forgotten template guard can re-leak; a missing dict key
-can't. These tests pin that invariant so the dict shape is the
-load-bearing surface, independent of any template.
+themselves or an admin. The auto-injected `target_user` projection on
+`handle_detail` carries this guarantee from `USER_ENTITY.public_fields`
+/ `private_fields` / `private_field_predicate`; the extras callable
+just adds the owned-providers list. These tests pin the dict shape so
+the security invariant holds independent of any template.
 
-Self-target guards on `handle_set_user_activation` and `handle_delete_user`
-are pinned here too — direct API callers can't bypass the template's
-`{% if %}` hide.
+Self-target guards (delete + activation) are spec-declared and
+framework-enforced — pinned in `src/logic/test__generic.py`.
 """
 
 import uuid
@@ -18,19 +18,12 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.requests import Request
 
-from src.api.common.exceptions import ForbiddenError
 from src.api.common.specs.user import USER_ENTITY
 from src.logic._generic import handle_detail
-from src.logic.users.user_processing import (
-    handle_delete_user,
-    handle_set_user_activation,
-    user_detail_extras,
-)
+from src.logic.users.user_processing import user_detail_extras
 from src.models import User
-from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
 from src.repositories.users.user_repository import UserRepository
-from src.schemas.users.user import UserActivationUpdate
 from tests.helpers import create_test_user
 
 pytestmark = pytest.mark.asyncio
@@ -130,39 +123,10 @@ async def test_get_user_detail_includes_private_fields_for_admin(
     assert context["can_view_private"] is True
 
 
-# --- Self-target guards on activation / delete ---------------------------
-
-
-async def test_set_user_activation_rejects_self_target(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-):
-    """An admin cannot flip their own activation via this handler — the
-    self-guard lives in logic so direct API calls can't bypass the
-    template's `{% if %}` hide."""
-    admin = await _seed_user(db_test_session_manager, is_superuser=True)
-
-    async with db_test_session_manager() as session:
-        with pytest.raises(ForbiddenError):
-            await handle_set_user_activation(
-                user_id=admin.id,
-                payload=UserActivationUpdate(state="deactivated"),
-                repo=UserRepository(session),
-                audit_repo=AuditRepository(session),
-                requesting_user=admin,
-            )
-
-
-async def test_delete_user_rejects_self_target(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-):
-    """An admin cannot hard-delete themselves via this handler."""
-    admin = await _seed_user(db_test_session_manager, is_superuser=True)
-
-    async with db_test_session_manager() as session:
-        with pytest.raises(ForbiddenError):
-            await handle_delete_user(
-                user_id=admin.id,
-                repo=UserRepository(session),
-                audit_repo=AuditRepository(session),
-                requesting_user=admin,
-            )
+# Self-target guards on `delete` and the `activation` state-axis are
+# spec-declared (`USER_ENTITY.delete_forbid_self=True`,
+# `state_axis("activation").forbid_self=True`); the framework enforces
+# them, so the rejection behavior is pinned in `src/logic/test__generic.py`
+# (for `handle_delete`) and the framework-wrapper test for state-axis
+# self-guards. No user-level direct-handler tests needed — the handler
+# itself no longer has the boilerplate to test.

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -4,8 +4,7 @@ from uuid import UUID
 
 from src.api.common.exceptions import NotFoundError
 from src.api.common.specs.user import USER_ENTITY
-from src.logic._authz import forbid_self_action
-from src.logic.audit import mutate, record_audit
+from src.logic.audit import record_audit
 from src.models import User
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.providers.provider_repository import ProviderRepository
@@ -43,17 +42,15 @@ async def handle_set_user_activation(
     """Admin-only: set a user's activation state. Writes an audit row in the
     same transaction.
 
-    Self-guard lives here so direct API calls can't bypass the template's
-    `{% if %}` hide. The route's `current_admin_user` dep blocks non-admins.
+    The self-target guard is spec-driven — `USER_ENTITY.state_axis(
+    "activation").forbid_self=True` makes the framework wrap this
+    handler with the 403 check before invoking it, so this handler is
+    free of self-target boilerplate. The route's `current_admin_user`
+    dep blocks non-admins.
     """
     target = await repo.get_user_by_id(user_id)
     if target is None:
         raise NotFoundError(detail="User not found")
-    forbid_self_action(
-        target,
-        requesting_user,
-        detail="Admins cannot change their own activation state here",
-    )
 
     is_active = payload.state == "active"
     logger.info(
@@ -74,37 +71,3 @@ async def handle_set_user_activation(
     )
     await repo.session.commit()
     return updated
-
-
-async def handle_delete_user(
-    user_id: UUID,
-    repo: UserRepository,
-    audit_repo: AuditRepository,
-    requesting_user: User,
-) -> None:
-    """Admin-only: hard-delete a user row. Writes an audit row in the same
-    transaction; `before` captures the soon-to-be-gone state, `after` is None.
-
-    Self-delete is forbidden (the actor is never the target), so writing the
-    audit row after the delete fires is safe — the actor row stays around
-    for the FK and `mutate()` captures `target.id` up front.
-    """
-    target = await repo.get_user_by_id(user_id)
-    if target is None:
-        raise NotFoundError(detail="User not found")
-    forbid_self_action(
-        target,
-        requesting_user,
-        detail="Admins cannot delete their own account here",
-    )
-
-    logger.info(f"Handler: admin {requesting_user.id} hard-deleting user {target.id}")
-    async with mutate(
-        repo,
-        audit_repo,
-        actor=requesting_user,
-        target=target,
-        resource=USER_ENTITY.audit,
-        verb="delete",
-    ):
-        await repo.delete_user(target)


### PR DESCRIPTION
## Summary

`StateAxis.forbid_self: bool` and `EntitySpec.delete_forbid_self: bool` move the "admin can't operate on their own account" rule from hand-written boilerplate in user-side handlers onto the spec.

- `mount_entity` wraps any axis handler whose spec sets `forbid_self=True` with a 403 check before invoking the inner handler. Wrapper preserves the handler's signature via `__wrapped__` and re-resolves through `_resolve_handler` so contract-test monkey-patches still take effect.
- `handle_delete` raises `ForbiddenError` when `spec.delete_forbid_self` is set and `target.id == requesting_user.id`.

## Net effect on the user cluster

- `handle_delete_user` deleted — `handle_delete` carries the ritual including self-guard.
- `handle_set_user_activation` drops the manual `forbid_self_action` call.
- `users.py` is now `make_entity_router + mount_entity(USER_ENTITY, handlers={})` — every verb is framework-resolved.

For owned resources the `target.id == viewer.id` comparison never matches, so the flag is harmless when unset.

## Test plan

- [x] `dev test` — 872 passed
- [x] `dev test contract` — 16 passed (the user-admin-actions monkey-patch still resolves through the framework wrapper)
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)