### PR TITLE
PostKindSpec template paths default by convention

### DIFF
--- a/src/models/README.md
+++ b/src/models/README.md
@@ -78,7 +78,7 @@ Every cross-cutting site reads from `POST_KINDS`:
 
 - `Post.__table_args__` builds its `CheckConstraint` from `POST_KINDS.check_sql()` — the SQL is derived from `POST_KINDS.names`.
 - The route's `Literal[*POST_KIND_NAMES]` for `GET /posts/form?kind=…` is derived.
-- The form-template selection in `src/api/routes/posts.py` reads `spec.create_template` / `spec.edit_template`.
+- The form-template selection reads `spec.create_template` / `spec.edit_template`, which default to `posts/new_<name>.html` / `posts/edit_<name>.html` by convention — a new kind doesn't need to restate them.
 - `src/repositories/post_repository.py:_attach_detail` looks up by detail-class via `POST_KIND_BY_DETAIL_MODEL`; `update_post` writes to `spec.detail_relationship` for the post's kind.
 - `src/logic/post_processing.py:handle_create_post` and `handle_update_post` dispatch via `POST_KINDS[payload.kind]` instead of `isinstance` ladders.
 - `src/schemas/post.py:_flatten_post_to_dict` reads the relationship + field tuple from the registry (so `PostRead`, `PostAuditSnapshot` flatten through it).

--- a/src/models/posts/post_kinds.py
+++ b/src/models/posts/post_kinds.py
@@ -7,12 +7,16 @@ labels the route/template layers render for the kind.
 
 Adding a kind requires:
 
-1. A new entry in `POST_KINDS` here.
+1. A new entry in `POST_KINDS` here — only the identity tuple (name,
+   detail_model, detail_relationship, list_label) is required; template
+   paths default to ``posts/new_<name>.html`` / ``posts/edit_<name>.html``.
 2. A new detail model under `src/models/posts/<kind>_detail.py`, plus a
    `relationship(...)` line on `Post`.
 3. The four Pydantic variant classes in `src/schemas/post.py`
    (Read, Create, Update, AuditSnapshot).
-4. The `posts/new_<kind>.html` and `posts/edit_<kind>.html` templates.
+4. The `posts/new_<kind>.html` and `posts/edit_<kind>.html` templates
+   (the conventional names — declare an explicit `create_template=` /
+   `edit_template=` on the spec only when the file path diverges).
 5. An Alembic migration that creates the detail table and widens the
    `posts.kind` CHECK.
 
@@ -44,15 +48,29 @@ from .provider_availability_detail import ProviderAvailabilityDetail
 
 @dataclass(frozen=True)
 class PostKindSpec:
-    """Per-kind metadata. See module docstring for the registration contract."""
+    """Per-kind metadata. See module docstring for the registration contract.
+
+    Template paths default by convention: ``posts/new_<name>.html`` for
+    `create_template` and ``posts/edit_<name>.html`` for `edit_template`.
+    Specs only declare an explicit path when the file diverges from the
+    convention; today none does. The convention plus the directory listing
+    under `src/templates/posts/` is the single source of truth for what
+    templates a kind ships.
+    """
 
     name: str
     detail_model: type
     detail_relationship: str
     detail_fields: tuple[str, ...]
     list_label: str
-    create_template: str
-    edit_template: str
+    create_template: str | None = None
+    edit_template: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.create_template is None:
+            object.__setattr__(self, "create_template", f"posts/new_{self.name}.html")
+        if self.edit_template is None:
+            object.__setattr__(self, "edit_template", f"posts/edit_{self.name}.html")
 
 
 def _detail_fields(detail_model: type) -> tuple[str, ...]:
@@ -80,8 +98,6 @@ POST_KINDS: Final[DiscriminatorRegistry[PostKindSpec]] = DiscriminatorRegistry(
             detail_relationship="client_referral_detail",
             detail_fields=_detail_fields(ClientReferralDetail),
             list_label="client referral",
-            create_template="posts/new_client_referral.html",
-            edit_template="posts/edit_client_referral.html",
         ),
         "provider_availability": PostKindSpec(
             name="provider_availability",
@@ -89,8 +105,6 @@ POST_KINDS: Final[DiscriminatorRegistry[PostKindSpec]] = DiscriminatorRegistry(
             detail_relationship="provider_availability_detail",
             detail_fields=_detail_fields(ProviderAvailabilityDetail),
             list_label="provider availability",
-            create_template="posts/new_provider_availability.html",
-            edit_template="posts/edit_provider_availability.html",
         ),
     },
 )

--- a/src/models/posts/test_post_kinds.py
+++ b/src/models/posts/test_post_kinds.py
@@ -16,6 +16,8 @@ from src.models import (
     POST_KINDS,
     Post,
 )
+from src.models.posts.client_referral_detail import ClientReferralDetail
+from src.models.posts.post_kinds import PostKindSpec
 
 
 def test_kind_names_matches_registered_kinds():
@@ -74,6 +76,34 @@ def test_each_spec_detail_relationship_matches_kind_name():
     every kind agrees, asserting it catches typos."""
     for kind, spec in POST_KINDS.items():
         assert spec.detail_relationship == f"{kind}_detail"
+
+
+def test_template_paths_default_by_convention():
+    """`create_template` / `edit_template` are derived from the kind
+    name when not explicitly set, following
+    `posts/new_<name>.html` / `posts/edit_<name>.html`. Adding a kind
+    therefore only needs the identity tuple — the template paths
+    follow automatically (the templates themselves still need to exist
+    on disk, but the registry entry doesn't restate them)."""
+    for kind, spec in POST_KINDS.items():
+        assert spec.create_template == f"posts/new_{kind}.html"
+        assert spec.edit_template == f"posts/edit_{kind}.html"
+
+
+def test_explicit_template_paths_override_convention():
+    """A spec that needs a non-conventional path can still declare one
+    — passing `create_template="..."` skips the default."""
+    spec = PostKindSpec(
+        name="weird",
+        detail_model=ClientReferralDetail,
+        detail_relationship="weird_detail",
+        detail_fields=(),
+        list_label="weird",
+        create_template="posts/custom_create.html",
+    )
+    # Override sticks; the unset edit_template still defaults.
+    assert spec.create_template == "posts/custom_create.html"
+    assert spec.edit_template == "posts/edit_weird.html"
 
 
 def test_detail_fields_match_model_columns():


### PR DESCRIPTION
## Summary

`PostKindSpec.create_template` / `edit_template` now default to `posts/new_<name>.html` / `posts/edit_<name>.html` when not explicitly set. The two existing registry entries drop the redundant template strings — adding a new kind only needs the identity tuple.

Explicit overrides still work if a future kind's file diverges from the convention.

## Test plan

- [x] `dev test` — 871 passed (new tests pin the convention + explicit override)
- [x] `dev test contract` — 16 passed
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)