### PR TITLE
Move provider-only enum labels onto PROVIDER_ENTITY.static_context

### DIFF
--- a/src/api/common/specs/provider.py
+++ b/src/api/common/specs/provider.py
@@ -27,6 +27,14 @@ from src.api.common.entity_spec import (
 )
 from src.api.common.resource_routes import QueryParam
 from src.models import Provider
+from src.models.enums import (
+    CERTIFICATION_TYPES,
+    CERTIFICATION_TYPES_LABELS,
+    EDUCATION_TYPES,
+    EDUCATION_TYPES_LABELS,
+    LICENSE_TYPES,
+    LICENSE_TYPES_LABELS,
+)
 from src.repositories.dependencies import get_provider_repository
 from src.repositories.favorites.user_favorite_repository import UserFavoriteRepository
 from src.schemas.providers.provider import (
@@ -72,4 +80,18 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     # Per-viewer detail extras live on the spec — see `EntitySpec`.
     detail_extras_path="src.logic.providers.provider_processing.provider_detail_extras",
     detail_extras_repos=(("user_favorite_repo", UserFavoriteRepository),),
+    # Provider templates render credential-type display labels and the
+    # tuples behind the filter/select dropdowns. Tying them to the spec
+    # (instead of Jinja globals) means a new credential-type tuple
+    # doesn't need an edit in `core/templating.py`. The labels are
+    # provider-specific — posts and other entities don't read them —
+    # so they belong here, not in shared template-global infrastructure.
+    static_context={
+        "LICENSE_TYPES": LICENSE_TYPES,
+        "LICENSE_TYPES_LABELS": LICENSE_TYPES_LABELS,
+        "EDUCATION_TYPES": EDUCATION_TYPES,
+        "EDUCATION_TYPES_LABELS": EDUCATION_TYPES_LABELS,
+        "CERTIFICATION_TYPES": CERTIFICATION_TYPES,
+        "CERTIFICATION_TYPES_LABELS": CERTIFICATION_TYPES_LABELS,
+    },
 )

--- a/src/api/common/specs/test_provider.py
+++ b/src/api/common/specs/test_provider.py
@@ -58,3 +58,30 @@ def test_detail_extras_path_points_at_provider_detail_extras():
         PROVIDER_ENTITY.detail_extras_path
         == "src.logic.providers.provider_processing.provider_detail_extras"
     )
+
+
+# --- Static context (credential-type tuples + labels) -------------------
+
+
+def test_static_context_carries_credential_enums():
+    """Provider templates render credential-type display labels and
+    populate filter/select dropdowns from the matching tuples. Pinning
+    the keys here means a rename in `enums.py` surfaces in tests
+    before the page silently renders empty dropdowns."""
+    from src.models.enums import (
+        CERTIFICATION_TYPES,
+        CERTIFICATION_TYPES_LABELS,
+        EDUCATION_TYPES,
+        EDUCATION_TYPES_LABELS,
+        LICENSE_TYPES,
+        LICENSE_TYPES_LABELS,
+    )
+
+    assert PROVIDER_ENTITY.static_context == {
+        "LICENSE_TYPES": LICENSE_TYPES,
+        "LICENSE_TYPES_LABELS": LICENSE_TYPES_LABELS,
+        "EDUCATION_TYPES": EDUCATION_TYPES,
+        "EDUCATION_TYPES_LABELS": EDUCATION_TYPES_LABELS,
+        "CERTIFICATION_TYPES": CERTIFICATION_TYPES,
+        "CERTIFICATION_TYPES_LABELS": CERTIFICATION_TYPES_LABELS,
+    }

--- a/src/core/templating.py
+++ b/src/core/templating.py
@@ -43,12 +43,13 @@ _env.globals.update(
     CLIENT_REFERRAL_SERVICE_LABELS=enums.CLIENT_REFERRAL_SERVICE_LABELS,
     TREATMENT_SETTINGS=enums.TREATMENT_SETTINGS,
     TREATMENT_SETTINGS_LABELS=enums.TREATMENT_SETTINGS_LABELS,
-    LICENSE_TYPES=enums.LICENSE_TYPES,
-    LICENSE_TYPES_LABELS=enums.LICENSE_TYPES_LABELS,
-    EDUCATION_TYPES=enums.EDUCATION_TYPES,
-    EDUCATION_TYPES_LABELS=enums.EDUCATION_TYPES_LABELS,
-    CERTIFICATION_TYPES=enums.CERTIFICATION_TYPES,
-    CERTIFICATION_TYPES_LABELS=enums.CERTIFICATION_TYPES_LABELS,
+    # `LICENSE_TYPES`, `EDUCATION_TYPES`, `CERTIFICATION_TYPES` and
+    # their `_LABELS` are provider-only — they flow into the context
+    # via `PROVIDER_ENTITY.static_context` (merged by `handle_detail` /
+    # `handle_list` / `handle_get_edit_form`) so the spec is the single
+    # binding site. `register_choice_labels(...)` for those tuples
+    # stays below (the form-rendering macro looks up labels by tuple
+    # identity, not by Jinja global).
     # Pydantic-driven field rendering: `field_for(schema, name, label)`
     # in `_shared/form_fields.html` calls `field_spec(schema, name)` to
     # derive the form's HTML attributes (required, choices, pattern,

--- a/src/logic/_generic.py
+++ b/src/logic/_generic.py
@@ -554,6 +554,8 @@ async def handle_get_edit_form(
         the gate (matches the `handle_update`/`handle_delete` shape).
       - `spec.discriminator` — if set, populates `template_name` from
         the discriminator-registry entry's `edit_template` attribute.
+      - `spec.static_context` — merged in for entities that declare
+        constants the form template reads (e.g. provider enum labels).
     """
     target = await repo.get_by_model_id(spec.model, target_id)
     if target is None:
@@ -566,6 +568,10 @@ async def handle_get_edit_form(
         spec.name: target,
         "current_user": requesting_user,
     }
+    # Spec-declared constants (enum labels, schema classes the form
+    # references, etc.) — same merge precedence as detail/list.
+    if spec.static_context:
+        context.update(spec.static_context)
     if spec.discriminator is not None:
         kind = getattr(target, spec.discriminator.column)
         context["template_name"] = spec.discriminator[kind].edit_template


### PR DESCRIPTION
## Summary

The three credential-type tuples + labels (`LICENSE_TYPES`, `EDUCATION_TYPES`, `CERTIFICATION_TYPES` + `_LABELS`) are read only by provider templates. They've been Jinja globals in `core/templating.py`; this PR moves them onto `PROVIDER_ENTITY.static_context` so the spec is the single binding site for provider-specific template constants.

Shared labels (location, age groups, insurance, etc.) that posts and providers both read stay global — they're cross-entity by design.

`handle_get_edit_form` now merges `spec.static_context` (matching `handle_detail` / `handle_list`); without this the form-edit page would lose access to the labels.

`register_choice_labels(...)` for the three tuples stays in templating.py — the schema-driven `field_for` macro looks up labels by tuple identity, not Jinja global.

## Test plan

- [x] `dev test` — 873 passed (new test pins the static_context shape)
- [x] `dev test contract` — 16 passed
- [x] `dev lint`
- [ ] Manual: provider list/detail/form_edit render with the credential-type labels intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)