### PR TITLE
Delete no-op __init__ overrides on repositories

### DIFF
--- a/src/repositories/README.md
+++ b/src/repositories/README.md
@@ -79,16 +79,12 @@ A repository does not import from a peer cluster's repository; if logic needs to
 from typing import Sequence
 from uuid import UUID
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.models import [Entity]
 from ..base import BaseRepository
 
 class [Entity]Repository(BaseRepository):
-    def __init__(self, session: AsyncSession):
-        super().__init__(session)
-
     async def get_[entity]_by_id(self, [entity]_id: UUID) -> [Entity] | None:
         """Retrieves a [entity] by its ID."""
         stmt = select([Entity]).filter([Entity].id == [entity]_id)

--- a/src/repositories/audit_repository.py
+++ b/src/repositories/audit_repository.py
@@ -8,7 +8,6 @@ from typing import Any, Sequence
 from uuid import UUID
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import AuditLog
 
@@ -16,9 +15,6 @@ from .base import BaseRepository
 
 
 class AuditRepository(BaseRepository):
-    def __init__(self, session: AsyncSession):
-        super().__init__(session)
-
     async def record(
         self,
         *,

--- a/src/repositories/favorites/user_favorite_repository.py
+++ b/src/repositories/favorites/user_favorite_repository.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import Provider, UserFavorite
 
@@ -10,9 +9,6 @@ from ..base import BaseRepository
 
 
 class UserFavoriteRepository(BaseRepository):
-    def __init__(self, session: AsyncSession):
-        super().__init__(session)
-
     async def get_by_pair(
         self, *, user_id: UUID, provider_id: UUID
     ) -> UserFavorite | None:

--- a/src/repositories/posts/post_repository.py
+++ b/src/repositories/posts/post_repository.py
@@ -1,7 +1,6 @@
 from typing import Sequence
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import Post
 
@@ -9,9 +8,6 @@ from ..base import BaseRepository
 
 
 class PostRepository(BaseRepository):
-    def __init__(self, session: AsyncSession):
-        super().__init__(session)
-
     async def list_posts(self) -> Sequence[Post]:
         """Lists all posts, newest first. Detail relationships are eager-loaded."""
         return await self._list(select(Post).order_by(Post.created_at.desc()))

--- a/src/repositories/providers/provider_repository.py
+++ b/src/repositories/providers/provider_repository.py
@@ -2,7 +2,6 @@ from typing import Sequence
 from uuid import UUID
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import Provider, ProviderLicensure
 
@@ -10,9 +9,6 @@ from ..base import BaseRepository
 
 
 class ProviderRepository(BaseRepository):
-    def __init__(self, session: AsyncSession):
-        super().__init__(session)
-
     # --- Provider reads --------------------------------------------
 
     async def get_by_id(self, provider_id: UUID) -> Provider | None:

--- a/src/repositories/users/user_repository.py
+++ b/src/repositories/users/user_repository.py
@@ -2,7 +2,6 @@ from typing import Sequence
 from uuid import UUID
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models import User
 
@@ -10,9 +9,6 @@ from ..base import BaseRepository
 
 
 class UserRepository(BaseRepository):
-    def __init__(self, session: AsyncSession):
-        super().__init__(session)
-
     async def get_user_by_id(self, user_id: UUID) -> User | None:
         """Retrieves a user by their ID."""
         return await self._get_by_id(User, user_id)


### PR DESCRIPTION
## Summary
- Every repository was redeclaring `def __init__(self, session): super().__init__(session)` — pure copy-paste boilerplate. `BaseRepository.__init__` is inherited for free; removing the override is a strict subtraction.
- Also drops the now-unused `AsyncSession` import from each repo file.
- Updates the "Creating a new repository" template in `src/repositories/README.md` to match (no `__init__`, no `AsyncSession` import).

## Test plan
- [x] \`dev test\` (875 passed, 52 skipped)
- [x] \`dev lint\` (all checks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)