### PR TITLE
Rename UserRepository.get_user_by_id → get_by_id

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -236,7 +236,7 @@ async def get_user(
     user_id: UUID,
     user_repo: UserRepository = Depends(get_user_repository),
 ):
-    return await user_repo.get_user_by_id(user_id)
+    return await user_repo.get_by_id(user_id)
 ```
 
 ## Related documentation

--- a/src/logic/README.md
+++ b/src/logic/README.md
@@ -70,7 +70,7 @@ There is no separate service layer — see [`../README.md`](../README.md) for th
 
 ```python
 async def handle_set_user_activation(user_id, payload, repo, requesting_user):
-    target = await repo.get_user_by_id(user_id)
+    target = await repo.get_by_id(user_id)
     ...
     updated = await repo.set_user_activation(target, is_active=...)
     await repo.session.commit()   # logic owns the commit

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -77,7 +77,7 @@ async def handle_list_user_providers(
         raise ForbiddenError(
             detail="Only the target user or an admin may view their providers"
         )
-    target_user = await user_repo.get_user_by_id(user_id)
+    target_user = await user_repo.get_by_id(user_id)
     if target_user is None:
         raise NotFoundError(detail=f"User {user_id} not found")
     providers = await repo.list_for_user(user_id)

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -48,7 +48,7 @@ async def handle_set_user_activation(
     free of self-target boilerplate. The route's `current_admin_user`
     dep blocks non-admins.
     """
-    target = await repo.get_user_by_id(user_id)
+    target = await repo.get_by_id(user_id)
     if target is None:
         raise NotFoundError(detail="User not found")
 

--- a/src/repositories/users/user_repository.py
+++ b/src/repositories/users/user_repository.py
@@ -9,7 +9,7 @@ from ..base import BaseRepository
 
 
 class UserRepository(BaseRepository):
-    async def get_user_by_id(self, user_id: UUID) -> User | None:
+    async def get_by_id(self, user_id: UUID) -> User | None:
         """Retrieves a user by their ID."""
         return await self._get_by_id(User, user_id)
 


### PR DESCRIPTION
## Summary
- Aligns naming with \`ProviderRepository.get_by_id\` — the class context already says "user", so the prefix is redundant.
- Pure mechanical rename: one method definition, two call sites (\`user_processing.handle_set_user_activation\`, \`provider_processing.handle_list_user_providers\`), two README examples.

## Test plan
- [x] \`dev test\` (879 passed, 52 skipped)
- [x] \`dev lint\` (all checks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)