### PR TITLE
Make get_by_model_id generic, delete get_by_id wrappers

### DIFF
--- a/src/logic/favorites/favorite_processing.py
+++ b/src/logic/favorites/favorite_processing.py
@@ -21,7 +21,7 @@ from fastapi import Request
 from src.api.common.exceptions import NotFoundError
 from src.api.common.specs.user_favorite import FAVORITE_ENTITY
 from src.logic.audit import record_audit
-from src.models import User, UserFavorite
+from src.models import Provider, User, UserFavorite
 from src.repositories.audit_repository import AuditRepository
 from src.repositories.favorites.user_favorite_repository import UserFavoriteRepository
 from src.repositories.providers.provider_repository import ProviderRepository
@@ -49,7 +49,7 @@ async def handle_add_favorite(
     404 if the target provider does not exist — keeps the existence of a
     deleted provider opaque to the favorites endpoint.
     """
-    provider = await provider_repo.get_by_id(provider_id)
+    provider = await provider_repo.get_by_model_id(Provider, provider_id)
     if provider is None:
         raise NotFoundError(detail="Provider not found")
 

--- a/src/logic/providers/provider_processing.py
+++ b/src/logic/providers/provider_processing.py
@@ -77,7 +77,7 @@ async def handle_list_user_providers(
         raise ForbiddenError(
             detail="Only the target user or an admin may view their providers"
         )
-    target_user = await user_repo.get_by_id(user_id)
+    target_user = await user_repo.get_by_model_id(User, user_id)
     if target_user is None:
         raise NotFoundError(detail=f"User {user_id} not found")
     providers = await repo.list_for_user(user_id)

--- a/src/logic/users/user_processing.py
+++ b/src/logic/users/user_processing.py
@@ -48,7 +48,7 @@ async def handle_set_user_activation(
     free of self-target boilerplate. The route's `current_admin_user`
     dep blocks non-admins.
     """
-    target = await repo.get_by_id(user_id)
+    target = await repo.get_by_model_id(User, user_id)
     if target is None:
         raise NotFoundError(detail="User not found")
 

--- a/src/repositories/base.py
+++ b/src/repositories/base.py
@@ -20,14 +20,19 @@ from sqlalchemy import Select, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 T = TypeVar("T")
+M = TypeVar("M")
 
 
 class BaseRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def _get_by_id(self, model: type[Any], obj_id: UUID) -> Any | None:
-        """Fetch a single row by primary key. Returns `None` if missing."""
+    async def _get_by_id(self, model: type[M], obj_id: UUID) -> M | None:
+        """Fetch a single row by primary key. Returns `None` if missing.
+
+        Generic over the model class: `_get_by_id(User, id)` returns
+        `User | None`, verified by the type checker via `M`.
+        """
         stmt = select(model).filter(model.id == obj_id)
         result = await self.session.execute(stmt)
         return result.scalars().first()
@@ -127,9 +132,11 @@ class BaseRepository:
     # aliases below — same behavior, the underscore convention stays
     # intact for intra-cluster usage.
 
-    async def get_by_model_id(self, model: type[Any], obj_id: UUID) -> Any | None:
+    async def get_by_model_id(self, model: type[M], obj_id: UUID) -> M | None:
         """Public alias for `_get_by_id`. Used by generic framework
-        handlers that need to fetch any model by primary key."""
+        handlers and per-entity call sites that need a typed fetch by
+        primary key — `get_by_model_id(User, id)` returns `User | None`.
+        """
         return await self._get_by_id(model, obj_id)
 
     async def delete(self, obj: Any) -> None:

--- a/src/repositories/providers/provider_repository.py
+++ b/src/repositories/providers/provider_repository.py
@@ -11,11 +11,6 @@ from ..base import BaseRepository
 class ProviderRepository(BaseRepository):
     # --- Provider reads --------------------------------------------
 
-    async def get_by_id(self, provider_id: UUID) -> Provider | None:
-        """Retrieves a provider by id. Sub-table relationships are
-        eager-loaded via `lazy="selectin"` on the model."""
-        return await self._get_by_id(Provider, provider_id)
-
     async def get_by_user_id(self, user_id: UUID) -> Provider | None:
         """Retrieves a provider owned by the given user. A user may own
         multiple providers; this returns whichever the DB hands back first

--- a/src/repositories/providers/test_provider_repository.py
+++ b/src/repositories/providers/test_provider_repository.py
@@ -105,7 +105,7 @@ async def test_get_by_id_finds_created_provider(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        found = await repo.get_by_id(provider_id)
+        found = await repo.get_by_model_id(Provider, provider_id)
         assert found is not None
         assert found.id == provider_id
 
@@ -160,7 +160,7 @@ async def test_update_provider_changes_fields_visible_on_refetch(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        provider = await repo.get_by_id(provider_id)
+        provider = await repo.get_by_model_id(Provider, provider_id)
         assert provider is not None
         await repo.patch(provider, practice_name="Renamed", location_city="Chicago")
         await session.commit()
@@ -203,7 +203,7 @@ async def test_delete_provider_cascades_licensures(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        provider = await repo.get_by_id(provider_id)
+        provider = await repo.get_by_model_id(Provider, provider_id)
         assert provider is not None
         await repo.delete(provider)
         await session.commit()
@@ -425,7 +425,7 @@ async def test_licensure_crud_round_trip(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        provider = await repo.get_by_id(provider_id)
+        provider = await repo.get_by_model_id(Provider, provider_id)
         licensure = await repo.add_child(
             provider,
             "licensures",
@@ -471,7 +471,7 @@ async def test_education_crud_round_trip(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        provider = await repo.get_by_id(provider_id)
+        provider = await repo.get_by_model_id(Provider, provider_id)
         education = await repo.add_child(
             provider,
             "educations",
@@ -516,7 +516,7 @@ async def test_certification_crud_round_trip(
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
-        provider = await repo.get_by_id(provider_id)
+        provider = await repo.get_by_model_id(Provider, provider_id)
         cert = await repo.add_child(
             provider,
             "certifications",

--- a/src/repositories/users/user_repository.py
+++ b/src/repositories/users/user_repository.py
@@ -1,5 +1,4 @@
 from typing import Sequence
-from uuid import UUID
 
 from sqlalchemy import select
 
@@ -9,10 +8,6 @@ from ..base import BaseRepository
 
 
 class UserRepository(BaseRepository):
-    async def get_by_id(self, user_id: UUID) -> User | None:
-        """Retrieves a user by their ID."""
-        return await self._get_by_id(User, user_id)
-
     async def get_user_by_username(self, username: str) -> User | None:
         """Retrieves a user by their username."""
         stmt = select(User).filter(User.username == username)


### PR DESCRIPTION
## Summary
- `BaseRepository.get_by_model_id(Model, id)` now returns `Model | None` via a `TypeVar`, so call sites get full typing without per-repository wrappers.
- Drop `UserRepository.get_by_id` and `ProviderRepository.get_by_id`; the wrappers added no value beyond what the typed base method offers.
- Logic call sites (`user_processing`, `provider_processing`, `favorite_processing`) and the provider repo tests go through `get_by_model_id(Model, id)` directly.

## Test plan
- [x] `dev test`
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)