### PR TITLE
Drop set_user_activation wrapper, call repo.patch directly

### DIFF
--- a/src/domain/users/handlers.py
+++ b/src/domain/users/handlers.py
@@ -59,7 +59,7 @@ async def handle_set_user_activation(
     activation_axis = USER_ENTITY.state_axis("activation")
     snapshot = activation_axis.audit_snapshot_fn
     before = snapshot(target)
-    updated = await repo.set_user_activation(target, is_active=is_active)
+    updated = await repo.patch(target, is_active=is_active)
     await record_audit(
         audit_repo,
         actor_id=requesting_user.id,

--- a/src/domain/users/repository.py
+++ b/src/domain/users/repository.py
@@ -37,14 +37,6 @@ class UserRepository(BaseRepository):
         stmt = stmt.order_by(User.username)
         return await self._list(stmt)
 
-    async def set_user_activation(self, user: User, *, is_active: bool) -> User:
-        """Sets `is_active` on the user and flushes; the caller commits."""
-        user.is_active = is_active
-        self.session.add(user)
-        await self.session.flush()
-        await self.session.refresh(user)
-        return user
-
     async def delete_user(self, user: User) -> None:
         """Hard-deletes the user row; the caller commits."""
         await self._delete(user)


### PR DESCRIPTION
## Summary
`UserRepository.set_user_activation(user, is_active=...)` was a six-line wrapper that did exactly what `BaseRepository._patch` already does — set the attribute, flush, refresh. Delete it and have `handle_set_user_activation` call `repo.patch(target, is_active=is_active)` through the public alias instead.

## Test plan
- [x] `dev test` (879 passed, 52 skipped)
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)