### PR TITLE
Generalize list_<collection> via framework default

### DIFF
--- a/src/domain/posts/repository.py
+++ b/src/domain/posts/repository.py
@@ -1,12 +1,11 @@
-from typing import Sequence
-
-from sqlalchemy import select
-
 from src.framework.base_repository import BaseRepository
-from src.models import Post
 
 
 class PostRepository(BaseRepository):
-    async def list_posts(self) -> Sequence[Post]:
-        """Lists all posts, newest first. Detail relationships are eager-loaded."""
-        return await self._list(select(Post).order_by(Post.created_at.desc()))
+    """Posts have no bespoke read/write methods today — listing falls
+    through to `BaseRepository.list_default(Post, order_by=Post.created_at.desc())`
+    via `handle_list` (`POST_ENTITY.list_order_by`), and create/update/
+    delete go through the public aliases on `BaseRepository`. The class
+    exists so dep injection can resolve a typed repo and per-test
+    fixtures can subclass it.
+    """

--- a/src/domain/users/repository.py
+++ b/src/domain/users/repository.py
@@ -1,5 +1,3 @@
-from typing import Sequence
-
 from sqlalchemy import select
 
 from src.framework.base_repository import BaseRepository
@@ -18,24 +16,6 @@ class UserRepository(BaseRepository):
         stmt = select(User).filter(User.email == email)
         result = await self.session.execute(stmt)
         return result.scalars().first()
-
-    async def list_users(
-        self,
-        *,
-        exclude_self: User | None = None,
-    ) -> Sequence[User]:
-        """Lists users, optionally excluding the requesting viewer.
-
-        The kwarg name `exclude_self` is the convention `handle_list`
-        passes for entities opting into `spec.list_exclude_self=True`.
-        """
-        stmt = select(User)
-
-        if exclude_self:
-            stmt = stmt.filter(User.id != exclude_self.id)
-
-        stmt = stmt.order_by(User.username)
-        return await self._list(stmt)
 
     async def delete_user(self, user: User) -> None:
         """Hard-deletes the user row; the caller commits."""

--- a/src/framework/base_repository.py
+++ b/src/framework/base_repository.py
@@ -160,6 +160,31 @@ class BaseRepository:
         non-`None` fields, flushes, refreshes."""
         return await self._patch(obj, **fields)
 
+    async def list_default(
+        self,
+        model: type[M],
+        *,
+        order_by: Any,
+        exclude_self: Any = None,
+    ) -> Sequence[M]:
+        """Framework fallback for `handle_list` when an entity has no
+        bespoke `list_<collection>` repo method.
+
+        `model` and `order_by` come from the entity's `EntitySpec`
+        (`spec.model`, `spec.list_order_by`). `exclude_self` is the
+        viewer threading `handle_list` passes when `spec.list_exclude_self`
+        is True — `None` skips the filter.
+
+        Entities whose listing needs joins, custom filters, or
+        ``.distinct()`` write a bespoke ``list_<collection>`` and the
+        framework picks that up instead.
+        """
+        stmt = select(model)
+        if exclude_self is not None:
+            stmt = stmt.filter(model.id != exclude_self.id)
+        stmt = stmt.order_by(order_by)
+        return await self._list(stmt)
+
     async def create_polymorphic(
         self, parent: Any, detail: Any, *, detail_relationship: str
     ) -> Any:

--- a/src/framework/entity_spec.py
+++ b/src/framework/entity_spec.py
@@ -378,6 +378,18 @@ class EntitySpec:
     # opt-in repo must accept.
     list_exclude_self: bool = False
 
+    # List default ordering --------------------------------------------
+    # SQLAlchemy column expression (e.g. `User.username` or
+    # `Post.created_at.desc()`) consumed by `BaseRepository.list_default`
+    # — the framework's fallback when an entity has no bespoke
+    # `list_<collection>` repo method. Required when `routes.list=True`
+    # AND no custom `list_<collection>` exists on the repo; either
+    # provide the ordering here or write the bespoke method. Specs whose
+    # repo defines `list_<collection>` (e.g. providers, with its
+    # licensure-join filter) leave this `None` and the bespoke method
+    # owns ordering inline.
+    list_order_by: Any = None
+
     # Delete-route self guard ------------------------------------------
     # When True, `handle_delete` rejects the request with 403 if the
     # URL's target id equals the requesting user's id — preventing an

--- a/src/framework/handlers.py
+++ b/src/framework/handlers.py
@@ -826,12 +826,34 @@ async def handle_list(
         context key for the items list.
       - ``spec.list_exclude_self`` — when True, drops the viewer from
         the result set via the repo method's ``exclude_self`` kwarg.
+      - ``spec.list_order_by`` — column expression for the framework
+        default (``BaseRepository.list_default``); used when the repo
+        has no bespoke ``list_<collection>`` method.
+
+    Dispatch: prefers ``repo.list_<collection>(**filter_values)`` when
+    that method exists on the repo (entities with joins / custom
+    filters like providers). Otherwise falls through to
+    ``repo.list_default(spec.model, order_by=spec.list_order_by, ...)``
+    so trivial list-by-creation-time / list-by-name entities don't
+    need a per-entity wrapper.
     """
-    list_method = getattr(repo, f"list_{spec.url_collection}")
     list_kwargs: dict[str, Any] = dict(filter_values)
     if spec.list_exclude_self and requesting_user is not None:
         list_kwargs["exclude_self"] = requesting_user
-    items = await list_method(**list_kwargs)
+    list_method = getattr(repo, f"list_{spec.url_collection}", None)
+    if list_method is not None:
+        items = await list_method(**list_kwargs)
+    else:
+        if spec.list_order_by is None:
+            raise ValueError(
+                f"handle_list: spec {spec.name!r} has no list_order_by and "
+                f"no bespoke list_{spec.url_collection!s} method on the "
+                "repo — either declare list_order_by on the spec or add a "
+                f"list_{spec.url_collection!s}() method to the repo."
+            )
+        items = await repo.list_default(
+            spec.model, order_by=spec.list_order_by, **list_kwargs
+        )
 
     context: dict[str, Any] = {
         "request": request,

--- a/src/framework/test_base_repository.py
+++ b/src/framework/test_base_repository.py
@@ -210,3 +210,53 @@ async def test_count_respects_distinct_with_join(
 
     assert total == 1
     assert len(rows) == 1
+
+
+# --- list_default ---------------------------------------------------------
+
+
+async def test_list_default_orders_by_column(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`list_default` honors the `order_by` argument exactly. Specs pass
+    `User.username` / `Post.created_at.desc()` / etc. — whatever the
+    entity needs."""
+    await _seed_users(db_test_session_manager, ["c", "a", "b"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo.list_default(User, order_by=User.username)
+
+    assert [u.username for u in rows] == ["a", "b", "c"]
+
+
+async def test_list_default_exclude_self_filters_target_user(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`exclude_self` drops the row whose id matches `exclude_self.id`.
+    The viewer-filtering pattern `handle_list` uses for entities with
+    `spec.list_exclude_self=True`."""
+    users = await _seed_users(db_test_session_manager, ["a", "b", "c"])
+    viewer = users[0]
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo.list_default(
+            User, order_by=User.username, exclude_self=viewer
+        )
+
+    assert [u.username for u in rows] == ["b", "c"]
+
+
+async def test_list_default_none_exclude_self_returns_everyone(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`exclude_self=None` (the default) skips the filter — anonymous
+    viewers see every row."""
+    await _seed_users(db_test_session_manager, ["a", "b"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo.list_default(User, order_by=User.username)
+
+    assert len(rows) == 2

--- a/src/framework/test_handlers.py
+++ b/src/framework/test_handlers.py
@@ -2499,6 +2499,75 @@ async def test_handle_list_omits_exclude_self_when_spec_opts_out():
     assert "exclude_self" not in captured[0]
 
 
+@pytest.mark.asyncio
+async def test_handle_list_falls_back_to_list_default_when_no_bespoke_method():
+    """When the repo has no `list_<collection>` method, `handle_list`
+    falls through to `BaseRepository.list_default(spec.model,
+    order_by=spec.list_order_by, **kwargs)` — the framework default
+    for trivial listings."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        routes=RouteSet(list=True),
+        list_order_by="ORDER_BY_SENTINEL",
+    )
+    captured: dict = {}
+
+    class _DefaultOnlyRepo:
+        async def list_default(self, model, *, order_by, **kwargs):
+            captured["model"] = model
+            captured["order_by"] = order_by
+            captured["kwargs"] = kwargs
+            return []
+
+    from src.framework.handlers import handle_list
+
+    await handle_list(
+        spec,
+        request=SimpleNamespace(),
+        repo=_DefaultOnlyRepo(),
+        requesting_user=None,
+        filter_values={},
+    )
+
+    assert captured["model"] is _FixtureRow
+    assert captured["order_by"] == "ORDER_BY_SENTINEL"
+    assert captured["kwargs"] == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_list_fallback_raises_when_no_order_by():
+    """No bespoke list method AND no `list_order_by` is a misconfiguration.
+    The framework can't pick an ordering for the caller, so it raises a
+    clear error instead of executing a random-order list."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        routes=RouteSet(list=True),
+    )
+
+    class _DefaultOnlyRepo:
+        async def list_default(self, model, *, order_by, **kwargs):  # pragma: no cover
+            return []
+
+    from src.framework.handlers import handle_list
+
+    with pytest.raises(ValueError, match="list_order_by"):
+        await handle_list(
+            spec,
+            request=SimpleNamespace(),
+            repo=_DefaultOnlyRepo(),
+            requesting_user=None,
+            filter_values={},
+        )
+
+
 # --- Spec construction-time validation -----------------------------------
 
 

--- a/src/specs/post.py
+++ b/src/specs/post.py
@@ -49,6 +49,7 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
     create_adapter=post_create_adapter,
     update_adapter=post_update_adapter,
     read_schema=post_read_adapter,
+    list_order_by=Post.created_at.desc(),
     routes=RouteSet(
         list=True,
         detail=True,

--- a/src/specs/user.py
+++ b/src/specs/user.py
@@ -60,6 +60,7 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
     private_field_predicate=is_self_or_admin,
     public_fields=("id", "username"),
     list_exclude_self=True,
+    list_order_by=User.username,
     routes=RouteSet(list=True, detail=True, delete=True),
     # The user-list page is for *other* users; admins can't delete their
     # own account via this endpoint, and the activation state-axis has


### PR DESCRIPTION
## Summary
The four entities split into two camps for list queries: providers needs a bespoke method (joins through `provider_licensures` with a `.distinct()` de-dup); users and posts each had a trivial `select(Model).order_by(...)` wrapper. Move the trivial case into the framework.

- Add `list_order_by: Any = None` to `EntitySpec`. Specs that opt into `routes.list=True` AND have no bespoke `list_<collection>` method on the repo declare the column expression here.
- Add `BaseRepository.list_default(model, *, order_by, exclude_self=None)`. The framework fallback — owns the select, the `exclude_self` filter, and the `order_by`.
- `handle_list` dispatches: if the repo has `list_<collection>`, call that (providers); otherwise fall through to `repo.list_default(spec.model, order_by=spec.list_order_by, ...)` (users, posts).
- Remove `UserRepository.list_users` and `PostRepository.list_posts` — both were 1:1 with the new default. `USER_ENTITY` and `POST_ENTITY` declare `list_order_by`.

Providers' `list_providers` stays bespoke (its filter is a join through `provider_licensures`, not expressible without a query DSL — that's the line we explicitly committed not to cross).

## Test plan
- [x] `dev test` (884 passed, 52 skipped — 5 new tests covering `list_default` + the `handle_list` fallback path + the no-`order_by` misconfiguration error)
- [x] `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)