### PR TITLE
ci: run the full default test suite, not just the route layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   ACCESS_TOKEN_EXPIRE_MINUTES: 60
 
 jobs:
-  api-tests:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   ACCESS_TOKEN_EXPIRE_MINUTES: 60
 
 jobs:
-  tests:
+  api-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   ACCESS_TOKEN_EXPIRE_MINUTES: 60
 
 jobs:
-  api-tests:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -42,15 +42,15 @@ jobs:
           echo "💡 To reproduce this locally, run: alembic -c config/alembic.ini upgrade head"
           echo "   Or use the development CLI: dev migrate up"
 
-      - name: Run API tests
-        run: dev test src/domain/routes --tb short -v
+      - name: Run tests
+        run: dev test --tb short -v
 
-      - name: Show API test failure help
+      - name: Show test failure help
         if: failure()
         run: |
-          echo "❌ API tests failed!"
-          echo "💡 To reproduce this locally, run: dev test src/domain/routes --tb short -v"
-          echo "   API tests are colocated under src/domain/routes/ (see tests/README.md)"
+          echo "❌ Tests failed!"
+          echo "💡 To reproduce this locally, run: dev test --tb short -v"
+          echo "   This runs the full default test suite (excludes contract tests; those run in the contract-tests job)."
 
   contract-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   PYTHON_VERSION: '3.11'
   DATABASE_URL: sqlite+aiosqlite:///./test.db
-  SECRET: test-secret-key-for-ci-only
+  # Padded to >=32 chars; PyJWT warns on shorter HMAC keys for SHA256.
+  SECRET: test-secret-key-for-ci-only-padded-to-32-bytes
   ALGORITHM: HS256
   ACCESS_TOKEN_EXPIRE_MINUTES: 60
 

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -201,6 +201,10 @@ class DevCommands:
 class TestCommands:
     """Test-related commands."""
 
+    # Tell pytest not to try collecting this class — the `Test` prefix
+    # makes it look like a test class, but it's the CLI command handler.
+    __test__ = False
+
     # Shortcut aliases for test paths. `dev test contract` expands to the full
     # path because `tests/test_contract` is excluded from default `pytest`
     # collection (`addopts` in `pyproject.toml`) and a regression in #100

--- a/src/framework/test_audit.py
+++ b/src/framework/test_audit.py
@@ -24,7 +24,10 @@ from src.framework.audit_repository import AuditRepository
 from src.framework.base_repository import BaseRepository
 from tests.helpers import create_test_user
 
-pytestmark = pytest.mark.asyncio
+# No module-level `pytestmark = pytest.mark.asyncio` — `asyncio_mode =
+# "auto"` in pyproject.toml already auto-marks async test functions,
+# and applying the mark to the module triggers a warning on every sync
+# test in this file.
 
 
 class _ExampleSnapshot(BaseModel):


### PR DESCRIPTION
Followup to PR #413. The pre-reorg \`api-tests\` job ran \`dev test src/api\` and only gated ~130 of the codebase's 884 tests. The other ~750 tests (framework, specs, models, per-entity handlers/repos/schemas, scripts) weren't enforced by any CI job — locally \`dev test\` would catch a regression but a green CI on a PR was no guarantee the suite was actually passing.

This PR swaps the test invocation to \`dev test --tb short -v\` (no path), letting pytest use the default \`testpaths\` from \`pyproject.toml\` (\`tests\`, \`src\`, \`scripts\`; \`tests/test_contract\` excluded via \`addopts\`). Job renamed from \`api-tests\` to \`tests\` to reflect the broader scope.

## Risk

This may surface pre-existing failures that have been hidden by the narrow CI scope. If anything fails on this PR, the right move is generally:
- If it's a real bug the suite caught: fix it.
- If it's a CI-environment-only flake: investigate and either fix or skip-with-reason.

## Test plan
- [x] \`dev test\` passes locally (884 passed, 52 skipped)
- [ ] CI passes here

🤖 Generated with [Claude Code](https://claude.com/claude-code)