### PR TITLE
docs: remove grammar-not-alphabet violations from parent READMEs

### DIFF
--- a/src/domain/models/README.md
+++ b/src/domain/models/README.md
@@ -49,42 +49,17 @@ class User(BaseModel):
 
 Each model maps to a database table with explicit relationships managed by SQLAlchemy.
 
-## Domain entity matrix
+## Domain entities
 
-| Model        | Primary Purpose                                  | Key Fields                                                          | Unique Constraints |
-| ------------ | ------------------------------------------------ | ------------------------------------------------------------------- | ------------------ |
-| **User**     | Authentication and identity                      | username                                                            | username, email    |
-| **Post**     | User-authored content (parent of per-kind detail) | kind (CHECK `'client_referral', 'provider_availability'`), owner_id (FK) | —                  |
-| **ClientReferralDetail** | Per-kind detail for `kind='client_referral'` posts. Carries the full client-referral intake-form fields (location, demographics, description, services, insurance). Enum columns CHECK against tuples in [`enums.py`](enums.py); the `desired_times` and `services` multi-selects are JSON columns whose vocabularies are enforced by Pydantic on the wire (no SQL CHECK against array members). | post_id (PK + FK to posts, CASCADE), description, location_*, desired_times (JSON), client_dem_ages, language_preferred, services (JSON), services_psychotherapy_modality, insurance | — |
-| **ProviderAvailabilityDetail** | Per-kind detail for `kind='provider_availability'` posts. Carries the full provider-availability intake-form fields (provider info, location, availability, featured services, insurance). Enum columns CHECK against tuples in [`enums.py`](enums.py); the `desired_times`, `services`, and `settings` multi-selects are JSON columns whose vocabularies are enforced by Pydantic on the wire (no SQL CHECK against array members) — `services` and `settings` are required-min-1 on the wire here. | post_id (PK + FK to posts, CASCADE), practice_name, available_providers, location_*, in_person_sessions, virtual_sessions, desired_times (JSON), services (JSON), settings (JSON), treatment_modality, client_focus, age_group, non_english_services, payment_situation, sliding_scale, cost | — |
-| **Provider** | Long-lived directory entry for a provider — practice info, location, session-availability flags. Owns three credential lists (licensures, educations, certifications) via cascade. A user may own multiple `Provider` rows (`owner_id` is intentionally non-unique; see [`providers/README.md`](providers/README.md)). Distinct from `ProviderAvailabilityDetail` (which is per-`Post`); a `Provider` describes the provider themselves. Enum columns CHECK against `US_STATES` and `LOCATION_AVAILABILITY_OPTIONS` from [`enums.py`](enums.py). | owner_id (FK to users, CASCADE), practice_name, location_city, location_state, location_zip, in_person_sessions, virtual_sessions | — |
-| **ProviderLicensure** | One row per professional license held by a provider. CASCADE on the parent FK. `license_type` and `issuing_state` CHECK against `LICENSE_TYPES` and `US_STATES` from [`enums.py`](enums.py). See [`providers/README.md`](providers/README.md). | provider_id (FK to providers, CASCADE), license_type, license_number, issuing_state, expiration_date (Date, nullable) | — |
-| **ProviderEducation** | One row per educational credential held by a provider. CASCADE on the parent FK. `education_type` CHECKs against `EDUCATION_TYPES` from [`enums.py`](enums.py). `month_completed` is stored as a `"YYYY-MM"` string because the form captures month precision only. See [`providers/README.md`](providers/README.md). | provider_id (FK to providers, CASCADE), education_type, institution, month_completed (Text "YYYY-MM", nullable) | — |
-| **ProviderCertification** | One row per professional certification held by a provider. CASCADE on the parent FK. `certification_type` CHECKs against `CERTIFICATION_TYPES` from [`enums.py`](enums.py). See [`providers/README.md`](providers/README.md). | provider_id (FK to providers, CASCADE), certification_type, certifying_body, expiration_date (Date, nullable) | — |
-| **AuditLog** | Append-only mutation record (RESOURCE_GRAMMAR.md:135) | actor_id (FK, SET NULL), resource_type, resource_id, action, before/after (JSON) | —                  |
-| **UserFavorite** | Edge for the user→provider favorites M:N (a user may favorite many providers and a provider may be favorited by many users). Both FKs CASCADE so deleting either endpoint removes the edge. Surrogate `id` PK from `BaseModel` so audit rows reference a single UUID; the `(user_id, provider_id)` uniqueness pin lives in a named unique constraint. The `(user_id, created_at)` composite index supports the favorites listing query (newest-first per user). | user_id (FK to users, CASCADE), provider_id (FK to providers, CASCADE) | `(user_id, provider_id)` |
+The directory listing IS the registry: `ls .` shows every cluster + the shared parent-level files. Per-entity facts (fields, constraints, cascade behavior, parent/detail splits) live in each cluster's own README when there's something non-obvious to say.
 
-### Parent / per-kind-detail split
+### Polymorphic / per-kind detail (the post-shape)
 
-`Post` is the parent table for any post-shaped resource. It carries identity, ownership, timestamps, and a `kind` discriminator. Kind-specific fields live in their own detail table keyed by `post_id` (PK + FK with `ON DELETE CASCADE`).
+When an entity has multiple variants whose fields differ, the parent table carries identity + a discriminator column, and each variant's fields live in its own detail table keyed by `<parent>_id` (PK + FK with `ON DELETE CASCADE`). The registry of variants is a `DiscriminatorRegistry[<Spec>]` instance under the parent's cluster (e.g. [`posts/post_kinds.py`](posts/post_kinds.py) for `Post`). The framework's `handle_create` / `handle_update` dispatch through the registry; no `isinstance` ladders.
 
-Kinds today: `client_referral` (→ `client_referral_details`) and `provider_availability` (→ `provider_availability_details`). Both carry the scalar (single-value) fields from their respective intake forms plus the `desired_times` and `services` multi-selects (stored as JSON; vocabularies enforced on the wire by Pydantic; `services` is optional on CR, required-min-1 on PA). PA also carries the `settings` multi-select (required-min-1). The retired `note` kind (title + body) was removed once the two real kinds landed and the registry made the cleanup a one-line change. Detail rows have no `id` of their own — `post_id` is both PK and FK, enforcing 1:1.
+A new variant is: (1) a registry entry, (2) a new detail-model file in the cluster + a `relationship(...)` on the parent, (3) the matching Pydantic variants under `domain/logic/<entity>/schema.py`, (4) per-variant templates under `domain/templates/<entity>/`, (5) an Alembic migration. No edits in routes, repositories, or logic — those layers are registry-driven.
 
-### The `post_kinds` registry
-
-The set of allowed kinds — and the per-kind detail relationship + field metadata used across the codebase — lives in [`posts/post_kinds.py`](posts/post_kinds.py) as `POST_KINDS: DiscriminatorRegistry[PostKindSpec]`. The `DiscriminatorRegistry` machinery (names tuple, reverse-by-detail-model index, CHECK SQL generator) is the entity-agnostic infrastructure in [`src/framework/polymorphic.py`](../../framework/polymorphic.py); `PostKindSpec` is the post-specific Spec dataclass that the registry holds. Any future polymorphic entity gets its own Spec dataclass and its own `DiscriminatorRegistry[…]` instance, sharing the bookkeeping.
-
-Every cross-cutting site reads from `POST_KINDS`:
-
-- `Post.__table_args__` builds its `CheckConstraint` from `POST_KINDS.check_sql()` — the SQL is derived from `POST_KINDS.names`.
-- The route's `Literal[*POST_KIND_NAMES]` for `GET /posts/form?kind=…` is derived.
-- The form-template selection reads `spec.create_template` / `spec.edit_template`, which default to `posts/new_<name>.html` / `posts/edit_<name>.html` by convention — a new kind doesn't need to restate them.
-- `src/framework/base_repository.py:create_polymorphic` looks up by detail-class via `POST_KIND_BY_DETAIL_MODEL`; the framework's `handle_update` writes to `spec.detail_relationship` for the post's kind.
-- `src/framework/handlers.py:handle_create` and `handle_update` dispatch via `POST_KINDS[payload.kind]` instead of `isinstance` ladders.
-- `src/domain/logic/posts/schema.py:_flatten_post_to_dict` reads the relationship + field tuple from the registry (so `PostRead`, `PostAuditSnapshot` flatten through it).
-- `src/domain/templates/posts/list.html` receives `post_kinds` in its context and renders the per-kind "New X" links from it.
-
-Adding a kind is therefore: (1) a registry entry in `posts/post_kinds.py`, (2) a new detail model file under `posts/` + a `relationship(...)` line on `Post`, (3) the four Pydantic variant classes in `src/domain/logic/posts/schema.py`, (4) the per-kind templates under `src/domain/templates/posts/`, (5) an Alembic migration. Removing a kind is the inverse. No edits in routes, repositories, or logic — those layers are registry-driven. The consistency tests in [`posts/test_post_kinds.py`](posts/test_post_kinds.py) guard against re-encoding the kind set inline anywhere new.
+For the post-specific instance of the registry pattern (the full list of cross-cutting sites that read `POST_KINDS`, the discriminator-specific cleanup story), see [`posts/README.md`](posts/README.md).
 
 ## Layer organization
 

--- a/src/domain/routes/README.md
+++ b/src/domain/routes/README.md
@@ -10,9 +10,9 @@ Routes are **ultra-thin HTTP adapters** that handle request parsing, delegate to
 
 CRUD-shaped routes use the **`EntitySpec` declaration + `mount_entity` dispatcher**. Each entity declares its identity once in [`src/domain/specs/<entity>.py`](../../framework/README.md#entityspec) (carries `routes` opt-in flags, audit binding, state axes, subresources, filters, discriminator, templates, etc.) and the route file calls `mount_entity(router, ENTITY, handlers={...})`. The dispatcher reads the spec and fires the right underlying `mount_*` helper for each opted-in verb. Sub-resources nest via the child entity's `parent=PARENT_ENTITY` field and are passed through `owned_subentities=` on the dispatcher. Routes that don't fit the grammar (auth flows, `/me/*` singletons, M:N edge add/remove, utility endpoints) stay hand-written — see [Bespoke routes](#bespoke-routes) below.
 
-The underlying `mount_*` helpers (`mount_list`, `mount_detail`, `mount_create`, `mount_update`, `mount_delete`, `mount_form`, `mount_state_axis`, `mount_related_list`) remain available for entities whose URL shape `mount_entity` can't handle — favorites' M:N edge POST/DELETE is the only current example. Every other entity (users, providers + 3 credential subentities, posts) composes through `mount_entity`.
+The underlying `mount_*` helpers (`mount_list`, `mount_detail`, `mount_create`, `mount_update`, `mount_delete`, `mount_form`, `mount_state_axis`, `mount_related_list`) remain available for entities whose URL shape `mount_entity` can't handle — M:N edge add/remove is the canonical example. Otherwise an entity composes through `mount_entity`.
 
-For the standard CRUD verbs (create / update / delete), the route file binds handlers built by `make_<verb>_handler(ENTITY)` from [`src/framework/handlers.py`](../../framework/handlers.py). Bespoke handlers are written only when the entity has rules that don't fit the standard load → auth → mutate → audit ritual (current examples: users' delete self-guard, providers' create with nested credential append, favorites' edge ops).
+For the standard CRUD verbs (create / update / delete), the route file binds handlers built by `make_<verb>_handler(ENTITY)` from [`src/framework/handlers.py`](../../framework/handlers.py). Bespoke handlers are written only when the entity has rules that don't fit the standard load → auth → mutate → audit ritual.
 
 ### What we do
 
@@ -110,7 +110,7 @@ If a future case suggests the grammar should grow to fit one of these (e.g. a se
 
 ### Adding a CRUD-shaped resource (the common case)
 
-1. **Declare the spec** at `src/domain/specs/<entity>.py`. The spec carries every per-entity declaration (identity, audit binding, route opt-ins, write_authz, body adapters, redirects, filters, templates, etc.). See existing examples in `specs/` — `user.py` (simplest), `provider.py` (with filters + form pages), `post.py` (with discriminator), `user_favorite.py` (edge / M:N).
+1. **Declare the spec** at `src/domain/specs/<entity>.py`. The spec carries every per-entity declaration (identity, audit binding, route opt-ins, write_authz, body adapters, redirects, filters, templates, etc.). Browse [`../specs/`](../specs/) for working examples covering the common shapes: simple CRUD, CRUD with filters and form pages, polymorphic (`discriminator=`), and M:N edge (`relation=`).
 
 2. **Add a spec-correctness test** at `src/domain/specs/test_<entity>.py` asserting the spec declares the right values (audit type, owner_attr, route flags, etc.).
 

--- a/src/framework/README.md
+++ b/src/framework/README.md
@@ -83,7 +83,7 @@ Common utilities handle concerns that span multiple routes and domains.
 - `decorators.py` - Error handling and logging decorators applied to all routes
 - `exceptions.py` - `APIException` subclasses (`NotFoundError`, `ForbiddenError`, ...) raised by logic, plus the fastapi-users → HTTP translator
 - `forms.py` - HTTP-adapter primitives for request bodies: `parse_form_to_payload(request)` (form → dict, lists for repeated keys), `validate_or_422(adapter, payload_dict)` (run a `TypeAdapter`, translate `ValidationError` to 422 with `[{"loc","msg","type"}]`), and the back-to-back wrappers `parse_and_validate_form` / `parse_and_validate_json` (form-encoded vs. JSON body — state-axis subresources use the JSON variant). Home for any HTTP-adapter primitive that two or more route modules would otherwise import from each other.
-- `projections.py` - `project_view(obj, *, public_fields, actor, private_fields=(), private_field_predicate=None)` builds a dict of `public_fields` from `obj` and conditionally appends `private_fields` when `private_field_predicate(actor, obj)` is true. Used by handlers that gate fields per viewer (today: user detail, where `email` / `is_active` / `is_verified` are visible only to the user themselves or an admin). Defense in depth alongside template-level guards: omitting keys at projection time means a forgotten `{% if %}` cannot re-leak. `ResourceSpec.private_fields` / `private_field_predicate` store the same primitives as declarative metadata so future cross-layer readers (JSON endpoint, audit snapshot, OpenAPI doc) can read the rule without rediscovering it.
+- `projections.py` - `project_view(obj, *, public_fields, actor, private_fields=(), private_field_predicate=None)` builds a dict of `public_fields` from `obj` and conditionally appends `private_fields` when `private_field_predicate(actor, obj)` is true. Used by handlers that need to gate fields per viewer. Defense in depth alongside template-level guards: omitting keys at projection time means a forgotten `{% if %}` cannot re-leak. `EntitySpec.public_fields` / `private_fields` / `private_field_predicate` store the same primitives as declarative metadata so future cross-layer readers (JSON endpoint, audit snapshot, OpenAPI doc) can read the rule without rediscovering it.
 - `resource_routes.py` - Unified `ResourceSpec` + opt-in `mount_*` grammar (covers top-level *and* sub-resource CRUD via `parent=`). See [Unified resource grammar](#unified-resource-grammar) below.
 - `entity_spec.py` - `EntitySpec` dataclass: single declaration of a domain entity's identity (CRUD audit via `AuditedResource`, non-CRUD audit via `EdgeAudit`, private-field visibility, route opt-ins, state-axis shape, related-list subresources, templates, owned-subentity `parent` chain, write_authz, body adapters, list filters, HX-Redirects, `discriminator` binding for polymorphic entities, `M2NRelation` for M:N edges). Per-entity instances live under [`../domain/specs/<entity>.py`](../domain/specs/) and are read by route files (via `to_resource_spec()` for the mount helpers) and per-entity handlers (for audit and visibility primitives). See [`EntitySpec`](#entityspec) below.
 
@@ -151,18 +151,7 @@ Synthesis recognizes:
 
 Forgetting to register a new repo type in `_REPO_TYPE_RESOLVERS` raises `MountError` at app startup with a message naming the unresolved type — the failure mode is loud and immediate.
 
-### What's mounted today
-
-| Mount helper | Used by (post-`mount_entity`) |
-| --- | --- |
-| `mount_list` / `mount_detail` | every migrated entity (users, providers, posts) |
-| `mount_create` / `mount_update` | providers, posts, the three provider-owned credential subentities |
-| `mount_delete` | users (bespoke handler), providers, posts, credential subentities (factory-built handlers) |
-| `mount_form` | providers (new + edit), posts (new + edit; posts derive the `?kind=` Literal from `entity.discriminator.names`) |
-| `mount_related_list` | users (GET `/{id}/providers`) |
-| `mount_state_axis` | users (PUT `/{id}/activation`) |
-| Sub-resource via `parent=` on the spec | credential subentities (mounted via `mount_entity(..., owned_subentities=(...))`) |
-| Hand-rolled (no mount helper fits) | favorites' POST/DELETE on `/users/me/favorites/{provider_id}` — M:N edge add/remove |
+Which mount helpers an entity opts into is declared on its `EntitySpec` (the `RouteSet` flags, `state_axes`, `subresources`, and `relation` fields). To see the full set currently mounted across all entities, run `dev routes`.
 
 ### Multi-repo handlers
 
@@ -302,7 +291,7 @@ Per-mount docstrings in `resource_routes.py` are the canonical reference for req
 
 ## `EntitySpec`
 
-`entity_spec.py` defines `EntitySpec`, the **upstream declaration** of a domain entity. Where `ResourceSpec` (above) is what the mount helpers consume, `EntitySpec` is the single declaration the rest of the codebase reads from. Phase 1 of #317 is complete — every entity in the codebase (`users`, `providers` + its three credential subentities, `posts`, `user_favorite`) is load-bearing on its spec.
+`entity_spec.py` defines `EntitySpec`, the **upstream declaration** of a domain entity. Where `ResourceSpec` (above) is what the mount helpers consume, `EntitySpec` is the single declaration the rest of the codebase reads from. Every entity in [`../domain/specs/`](../domain/specs/) is load-bearing on its spec.
 
 ### What it captures
 


### PR DESCRIPTION
Follow-up to the README audit. CLAUDE.md's "grammar, not alphabet" rule says parent READMEs should describe the shape/rules of what's below them, not enumerate the specific entities or files that exist today. Sweeping the three parent READMEs surfaced eight violators; this PR fixes them.

## What changed

### \`src/framework/README.md\`
1. **\`projections.py\` line** — dropped the \"today: user detail, where email/is_active/is_verified...\" alphabet; described the rule instead.
2. **\"What's mounted today\" table** — was a roster of every entity per mount helper. Replaced with a one-line pointer: spec flags + \`dev routes\` is the registry.
3. **\"Phase 1 of #317 is complete — every entity in the codebase (users, providers + ...)\"** — dropped the roster and the phase-tracking detritus.

### \`src/domain/routes/README.md\`
4. **\"favorites' M:N edge ... Every other entity (users, providers + 3 credential subentities, posts)...\"** — replaced with the rule.
5. **\"See existing examples in \`specs/\` — \`user.py\` (simplest), \`provider.py\` (with filters + form pages), ...\"** — point at the directory and name the patterns, not the files.

### \`src/domain/models/README.md\`
6. **\"Domain entity matrix\"** — the biggest violator. A full table listing every model with its key fields and unique constraints, which the per-cluster READMEs already cover. Deleted; replaced with a grammar paragraph (\"the directory listing IS the registry\") and a brief polymorphic-shape subsection.
7. **\"Kinds today: client_referral ... provider_availability ...\"** — alphabet.
8. **\"Every cross-cutting site reads from POST_KINDS:\" + 6 bullets of file paths** — same content already lives in \`posts/README.md\`; replaced with a pointer.

## Test plan
- [x] \`dev lint\`
- [x] \`dev test\` (884 passed, 52 skipped)
- [x] All markdown links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)