### PR TITLE
docs: trim CLAUDE.md to load-bearing rules only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,16 @@
 # Working in this repo
 
-This file is the contract between you (the AI agent) and this codebase. Read it before any code change.
+The contract between you (the AI agent) and this codebase. Read it before any code change.
 
-## Architecture in one line
-
-The code under `src/` is organized into two top-level buckets: **`framework/`** (domain-agnostic library) and **`domain/`** (everything entity-specific, layered into `specs/`, `models/`, `logic/`, `routes/`, `templates/`). A new entity adds one file/cluster in each layer it uses. See [`src/README.md`](src/README.md) for how the buckets relate and the import discipline between them.
+The architecture, layer responsibilities, and per-directory grammar live in [`src/README.md`](src/README.md) and the layer READMEs it points at. This file documents only the rules that wouldn't be discovered by reading the code or the per-layer READMEs.
 
 ## Definition of done
 
 For any code change in `src/`, the change is **not done** until all four are true:
 
 1. The code change itself is in.
-2. The relevant README reflects new/changed/removed behavior — or you have explicitly verified it is still accurate. (Top-level: [`src/README.md`](src/README.md). Framework: [`src/framework/README.md`](src/framework/README.md). Per-layer under `src/domain/`: see [`src/domain/specs/`](src/domain/specs/), [`src/domain/models/README.md`](src/domain/models/README.md), [`src/domain/routes/README.md`](src/domain/routes/README.md), [`src/domain/templates/README.md`](src/domain/templates/README.md). Per-entity: `src/domain/logic/<entity>/README.md` when one exists.)
-3. The change has test coverage that pins what changed — colocated `test_*.py` in the same directory as the changed code (framework changes get `src/framework/test_*.py`; per-entity logic changes get `src/domain/logic/<entity>/test_*.py`; route-level smoke tests under `src/domain/routes/test_*.py` for thin pass-through.)
+2. The README closest to the changed code reflects new/changed/removed behavior — or you have explicitly verified it is still accurate.
+3. There is colocated `test_*.py` coverage that pins what changed.
 4. `dev test` passes and `dev lint` passes.
 
 If a relevant README or test file doesn't exist yet, **create it as part of the change**. Don't defer.
@@ -25,25 +23,17 @@ A Stop hook checks the diff at end-of-turn and surfaces a reminder when source f
 
 Each fact has exactly **one home**: the README closest to the code or config that the fact describes. Other docs link to it; they never restate it.
 
-- The CLI's command list is exposed by `dev --help` and `dev <command> --help`, generated from the argparse definitions in [`scripts/dev_cli.py`](scripts/dev_cli.py). Every other doc that wants to mention a command links to `dev --help`, not a hand-maintained restatement.
-- The two-bucket architecture (`framework/` vs `domain/`) lives in [`src/README.md`](src/README.md). Other READMEs link there, not duplicate it.
-- Framework behavior, conventions, and tests live in [`src/framework/README.md`](src/framework/README.md). Cross-references go upward via links.
-- Per-entity facts (cardinality decisions, polymorphism, audit quirks) live in `src/domain/logic/<entity>/README.md` when an entity has something non-obvious to say.
-- Migrations live in [`alembic/README.md`](alembic/README.md). Deployment in [`deployment/README.md`](deployment/README.md). Testing conventions in [`tests/README.md`](tests/README.md).
+The CLI's command list is generated from [`scripts/dev_cli.py`](scripts/dev_cli.py); link to `dev --help`, never restate. The architecture lives in [`src/README.md`](src/README.md); other READMEs link there. Per-entity facts live in `src/domain/logic/<entity>/README.md` when an entity has something non-obvious to say.
 
-If you find a fact stated in two places, **one of them is wrong** — even if both currently agree, they will drift. Pick the one closest to the code, leave it there, and replace the other with a link. The Stop hook only catches drift between code and its colocated README/test; cross-cutting drift (e.g. CLI commands documented in the root README) can only be prevented by not duplicating in the first place.
+If you find a fact stated in two places, **one of them is wrong** — even if both currently agree, they will drift. Pick the one closest to the code, leave it there, and replace the other with a link.
 
 ## Grammar, not alphabet
 
 A parent README expresses the **grammar** of what's in the directory below it — the shape, the rules, the contract every child must follow. It does not enumerate the **alphabet** — the specific entities, files, or counts that exist today.
 
-A grammar is stable across churn: "every `domain/logic/<entity>/` directory holds the per-entity helpers (handlers + repository + schema) for one domain entity; specs and the framework read from but do not depend on per-entity code." An alphabet drifts every time you add or rename an entity: "currently we have posts, providers, users, auth, favorites." The directory listing IS the alphabet — `ls src/domain/specs/` and `ls src/domain/logic/` are the source of truth for what entities exist.
-
 A useful tell: when you write "currently X" in a parent README, you're describing alphabet. Replace with the grammar (what role X plays for *any* entity) and a pointer to the directory. When you write "always", "must", or "may", you're describing grammar — keep it.
 
-The same rule applies recursively. An entity's own README (`domain/logic/<entity>/README.md`) is the right home for facts about that specific entity — there, the entity *is* the subject, not part of an alphabet. The parent points down to entities; entities describe themselves; the parent doesn't restate them.
-
-This complements the [single-source-of-truth rule](#one-source-of-truth--link-dont-copy): that rule says facts have one home; this rule says parent READMEs prefer rules over rosters.
+The same rule applies recursively. An entity's own README is the right home for facts about that specific entity — there, the entity *is* the subject. The parent points down to entities; entities describe themselves; the parent doesn't restate them.
 
 **Default to not creating a new README.** A README earns its existence by documenting something `ls` and the code can't:
 
@@ -53,35 +43,13 @@ This complements the [single-source-of-truth rule](#one-source-of-truth--link-do
 
 If the only thing a candidate README would say is enumerate-what-`ls`-shows or restate-the-bucket-rules, don't write it. Empty or aspirational READMEs are net-negative — they tell the next reader to expect content that isn't load-bearing.
 
-## Where to look
-
-| Topic | Where it lives |
-| --- | --- |
-| Architecture, two-bucket layout, import discipline | [`src/README.md`](src/README.md) |
-| Framework behavior (EntitySpec, mount helpers, generic handlers) | [`src/framework/README.md`](src/framework/README.md) |
-| Resource URL grammar, lifecycle, subresource conventions | [`src/domain/routes/RESOURCE_GRAMMAR.md`](src/domain/routes/RESOURCE_GRAMMAR.md) |
-| CLI commands (`dev ...`) | `dev --help` (source: [`scripts/dev_cli.py`](scripts/dev_cli.py)) |
-| Testing conventions, fixtures | [`tests/README.md`](tests/README.md) |
-| Database migrations | [`alembic/README.md`](alembic/README.md) |
-| Deployment | [`deployment/README.md`](deployment/README.md) |
-| Per-entity quirks | `src/domain/<entity>/README.md` when one exists |
-
 Pre-commit hooks run lint automatically — don't bypass with `--no-verify`.
-
-## When in doubt
-
-1. Read [`src/README.md`](src/README.md) for the two-bucket layout and what may import what.
-2. Read [`src/framework/README.md`](src/framework/README.md) if you're touching the dispatch helpers, generic handlers, or audit framework.
-3. If a single change adds a new entity, follow the entity checklist in [`src/README.md`](src/README.md#adding-a-new-domain-entity) — one spec file + one domain cluster + one route file.
-4. **Before adding or modifying a resource type**, read [`src/domain/routes/RESOURCE_GRAMMAR.md`](src/domain/routes/RESOURCE_GRAMMAR.md) first. It's the prescriptive contract for URL shape, lifecycle states, and subresource conventions.
-5. **Before adding or moving a route**, run `dev routes [prefix]` to see every handler currently mounted. Catches router shadowing before tests do. Full CLI list: `dev --help` (source: [`scripts/dev_cli.py`](scripts/dev_cli.py)).
-6. **Before changing a wire or storage contract**, do the contract-surface check below.
 
 ## Before implementing a multi-layer change: contract-surface check
 
-Bucket-by-bucket planning catches "did I update every file?" — it does *not* catch "did I just break every existing client?" That second question is what this section is for.
+Layer-by-layer planning catches "did I update every file?" — it does *not* catch "did I just break every existing client?" That second question is what this section is for.
 
-Before writing code on any change that modifies a schema, route, template, or persisted format, write a short pre-implementation note that answers three questions. Five minutes; no plan-mode session needed.
+Before writing code on any change that modifies a schema, route, template, or persisted format, write a short pre-implementation note that answers four questions. Five minutes; no plan-mode session needed.
 
 1. **Which contract surfaces does this touch?** For each, classify as **compatible** (existing producers/consumers keep working) or **breaking** (someone has to change). Surfaces include:
    - HTTP request body shape (route schemas)
@@ -94,7 +62,7 @@ Before writing code on any change that modifies a schema, route, template, or pe
 
 3. **For each breaking surface, who decides?** If the breakage is scoped (only internal callers, only your tests) you can absorb it. If it leaks past your boundary (HTML forms, external API consumers, persisted data already in production) **surface the choice to the user explicitly** before implementing — *"this changes X for existing clients; OK, or do you want me to prep first?"* Don't decide silently inside the implementation.
 
-4. **Which other READMEs reference symbols, files, or paths I'm renaming, deleting, or changing?** Bucket-by-bucket planning catches *which buckets a change touches*; it doesn't catch *which other READMEs reference the symbols being changed*. For each renamed or removed identifier, run:
+4. **Which other READMEs reference symbols, files, or paths I'm renaming, deleting, or changing?** For each renamed or removed identifier, run:
 
    ```bash
    grep -rn "<old-name>" $(find . -name README.md -not -path './.claude/*' -not -path './.pytest_cache/*')
@@ -102,11 +70,11 @@ Before writing code on any change that modifies a schema, route, template, or pe
 
    Update or delete any matches as part of the same PR — neighbor-README drift is otherwise invisible until the next reader hits a stale claim.
 
-The cost of skipping this check is one end-of-PR realization that you took the wrong shape — by which point unwinding is more work than the prep PR would have been.
+Also, before adding or moving a route, run `dev routes [prefix]` to see every handler currently mounted — catches router shadowing before tests do. And before adding or modifying a resource type, read [`src/domain/routes/RESOURCE_GRAMMAR.md`](src/domain/routes/RESOURCE_GRAMMAR.md) — it's the prescriptive contract for URL shape, lifecycle states, and subresource conventions.
 
 ## Plan mode
 
-Use `/plan` when a change touches multiple buckets or introduces new resources/routes — the Explore + Plan overhead pays off when a wrong direction is expensive. Skip it for typo fixes, single-file refactors, README polish, and anything you can describe in one sentence.
+Use `/plan` when a change touches multiple layers or introduces new resources/routes — the Explore + Plan overhead pays off when a wrong direction is expensive. Skip it for typo fixes, single-file refactors, README polish, and anything you can describe in one sentence.
 
 ## Per-PR retrospective
 


### PR DESCRIPTION
CLAUDE.md had accumulated duplication of content already documented in \`src/README.md\` and the per-layer READMEs. Every restated fact is drift bait. This PR strips it back to rules that wouldn't be discovered by reading the code or the per-layer READMEs.

**128 → 96 lines (-25%).**

## What got removed

- **\"Architecture in one line\"** — duplicated \`src/README.md\`.
- **\"Where to look\" table** — eight rows pointing at READMEs that document themselves. The new opening line points at \`src/README.md\` as the entry point.
- **\"When in doubt\" steps 1-3** — restated the \"Where to look\" table.
- **Definition-of-done point 2's per-layer README enumeration** — collapsed to \"the README closest to the changed code.\"
- **Definition-of-done point 3's three test-location examples** — collapsed to \"colocated \`test_*.py\` coverage.\"
- **Stale path \`src/domain/<entity>/README.md\`** (umbrella-reorg leftover; should have been \`src/domain/logic/<entity>/\`) — removed with the table.

## What stays (the load-bearing rules)

- Definition of done (the 4-point rule).
- One-source-of-truth principle.
- Grammar-not-alphabet rule.
- Default-no-new-READMEs rule.
- Contract-surface check (the 4-question pre-implementation note).
- Plan-mode rule.
- Per-PR retrospective format.

The pointers to RESOURCE_GRAMMAR.md and \`dev routes\` got folded into the contract-surface section since they're prescriptive disciplines, not navigation.

## Test plan
- [x] \`dev lint\`
- [x] \`dev test\` (884 passed, 52 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)