### PR TITLE
Seed dev DB with 3 real-world provider-availability posts (#420)

### DIFF
--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -4,14 +4,16 @@ Seed the database with fixture data for development.
 
 Idempotent:
   - Users are matched by email; existing rows are skipped.
-  - Posts are matched by (title, owner_id); existing rows are skipped.
+  - Provider-availability posts are matched by
+    (kind='provider_availability', owner_id, practice_name); existing
+    rows are skipped.
 
 All fixture users share the password `password`.
 """
 
 import asyncio
 import sys
-from typing import TypedDict
+from typing import Any, TypedDict
 
 # Local import to avoid circulars at module import time
 from fastapi_users.db import SQLAlchemyUserDatabase
@@ -20,7 +22,7 @@ from sqlalchemy import select
 from src.auth_config import UserManager
 from src.db import async_session_maker
 from src.domain.logic.users.schema import UserCreate
-from src.domain.models import Post, User
+from src.domain.models import Post, ProviderAvailabilityDetail, User
 
 SHARED_PASSWORD = "password"
 
@@ -31,10 +33,9 @@ class FixtureUser(TypedDict):
     is_superuser: bool
 
 
-class FixturePost(TypedDict):
+class FixtureProviderAvailability(TypedDict):
     owner_email: str
-    title: str
-    body: str
+    detail: dict[str, Any]
 
 
 FIXTURE_USERS: list[FixtureUser] = [
@@ -44,26 +45,117 @@ FIXTURE_USERS: list[FixtureUser] = [
 ]
 
 
-FIXTURE_POSTS: list[FixturePost] = [
+# Real-world canonical examples that drive the schema-evolution work in
+# the issue series spawned by #420. Each `TODO(issue-N)` marker pins a
+# cell that doesn't fit today's schema and points at the follow-on PR
+# that will reshape both schema and seed together. Removing a marker
+# without that schema change is a regression — the markers are the
+# series' breadcrumb trail.
+FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
     {
         "owner_email": "alice@example.com",
-        "title": "Hello from Alice",
-        "body": "First post — just trying things out.",
+        "detail": {
+            "practice_name": "Katie Reeves, PhD",
+            "available_providers": "Katie Reeves, PhD",
+            # TODO(issue-5): telehealth-only — no city/zip. Required today; relax in #5.
+            "location_city": "(telehealth only)",
+            "location_state": "CA",
+            "location_zip": "00000",  # TODO(issue-5): placeholder; required today.
+            "in_person_sessions": "no",
+            "virtual_sessions": "yes",
+            "desired_times": [],
+            "services": ["psychotherapy", "medication_management"],
+            "settings": ["outpatient"],
+            "treatment_modality": "Psychodynamic, control-mastery",
+            # TODO(issue-2): the lead pitch ("immediate availability for new
+            # patients...") belongs in `description`, not `client_focus`. Folded
+            # for now.
+            "client_focus": (
+                "Older teens / TAY with ADHD, anxiety, depression, self-harm, "
+                "suicidality. Immediate availability for new patients; 25-min "
+                "(med management only) or 50-min sessions."
+            ),
+            # TODO(issue-4): spans adolescents + young_adults + adults. Single-valued today.
+            "age_group": "adolescents_14_18",
+            "non_english_services": "no",  # TODO(issue-3): replace with languages=["en"].
+            # TODO(issue-6): true value is self_pay_only; not in vocab today.
+            # Best-fit placeholder.
+            "payment_situation": "out_of_network",
+            "sliding_scale": False,
+            "cost": "$250 - $600 per session",
+            # TODO(issue-2): website=katiereevesphd.com
+            # TODO(issue-2): referral_instructions
+        },
     },
     {
         "owner_email": "alice@example.com",
-        "title": "On the joy of writing READMEs",
-        "body": "Documentation is a love letter to your future self.",
+        "detail": {
+            "practice_name": "Camp BooHoo",
+            # TODO(issue-9): may drop available_providers.
+            "available_providers": "Camp BooHoo staff",
+            "location_city": "Santa Clara",
+            "location_state": "CA",
+            # TODO(issue-5): venue (fairgrounds) has no zip; required today.
+            "location_zip": "95050",
+            "in_person_sessions": "yes",
+            "virtual_sessions": "no",
+            "desired_times": [],
+            # TODO(issue-7): "therapeutic camp" doesn't fit; allied_health is closest.
+            "services": ["allied_health"],
+            # TODO(issue-7): day_program token not in vocab yet. Outpatient is closest.
+            "settings": ["outpatient"],
+            "treatment_modality": "Social skills, emotion regulation",
+            # TODO(issue-2): the camp pitch belongs in description.
+            "client_focus": (
+                "Middle schoolers with ASD focused on social skills and "
+                "emotion regulation."
+            ),
+            # TODO(issue-4): middle school spans children_6_10 + preteens_11_13.
+            "age_group": "preteens_11_13",
+            "non_english_services": "yes",  # TODO(issue-3): replace with languages=["en", "es"].
+            "payment_situation": "out_of_network",  # TODO(issue-6): true value is self_pay_only.
+            "sliding_scale": True,
+            "cost": "$2,500 / session",
+            # TODO(issue-2): website=boohoocrybaby.com
+            # TODO(issue-2): referral_instructions
+            # TODO(issue-8): cohort dates ("May 25 & Jun 18, 2-week sessions, M-F 9-5")
+        },
     },
     {
-        "owner_email": "bob@example.com",
-        "title": "Bob's first post",
-        "body": "Hi, I'm Bob. I like long walks and short functions.",
-    },
-    {
-        "owner_email": "admin@example.com",
-        "title": "Welcome to Bedlam Connect",
-        "body": "Posting is in READ-only mode for now — write endpoints are coming.",
+        "owner_email": "alice@example.com",
+        "detail": {
+            "practice_name": "RISE IOP at CHC",
+            "available_providers": "RISE program staff",
+            "location_city": "Palo Alto",
+            "location_state": "CA",
+            "location_zip": "94304",
+            "in_person_sessions": "yes",
+            "virtual_sessions": "no",
+            "desired_times": [],
+            # TODO(issue-7): peer + family groups not in vocab yet
+            # (group_therapy, family_therapy).
+            "services": ["psychotherapy", "medication_management"],
+            "settings": ["iop"],
+            "treatment_modality": "Comprehensive DBT",
+            # TODO(issue-2): the IOP pitch belongs in description.
+            "client_focus": (
+                "High school students with high acuity, including "
+                "self-harm/suicidality with no immediate risk of harm to self "
+                "or others."
+            ),
+            # TODO(issue-4): "high school" spans adolescents_14_18 + possibly
+            # young_adults_19_24.
+            "age_group": "adolescents_14_18",
+            "non_english_services": "yes",  # TODO(issue-3): replace with languages=["en", "es"].
+            # TODO(issue-6): true value is please_contact
+            # ("Yes — no MediCal, please contact").
+            "payment_situation": "in_network",
+            "sliding_scale": True,
+            "cost": "$4k/week",
+            # TODO(issue-2): website=CHC.rise.org
+            # TODO(issue-2): referral_instructions
+            # TODO(issue-8): "M-F 8:30am-4:30pm, starts May 11"
+        },
     },
 ]
 
@@ -104,42 +196,51 @@ async def seed_users() -> tuple[int, int]:
     return created, skipped
 
 
-async def seed_posts() -> tuple[int, int]:
+async def seed_provider_availability() -> tuple[int, int]:
     created = 0
     skipped = 0
 
     async with async_session_maker() as session:
-        for fixture in FIXTURE_POSTS:
+        for fixture in FIXTURE_PROVIDER_AVAILABILITY:
+            practice_name = fixture["detail"]["practice_name"]
             owner_result = await session.execute(
                 select(User).where(User.email == fixture["owner_email"])
             )
             owner = owner_result.scalar_one_or_none()
             if owner is None:
                 print(
-                    f"⚠️  post '{fixture['title']}': owner {fixture['owner_email']} not found, skipping"
+                    f"⚠️  PA post '{practice_name}': "
+                    f"owner {fixture['owner_email']} not found, skipping"
                 )
                 skipped += 1
                 continue
 
             existing = await session.execute(
-                select(Post).where(
-                    Post.title == fixture["title"], Post.owner_id == owner.id
+                select(Post)
+                .join(
+                    ProviderAvailabilityDetail,
+                    ProviderAvailabilityDetail.post_id == Post.id,
+                )
+                .where(
+                    Post.kind == "provider_availability",
+                    Post.owner_id == owner.id,
+                    ProviderAvailabilityDetail.practice_name == practice_name,
                 )
             )
             if existing.scalar_one_or_none() is not None:
                 print(
-                    f"⏭️  post '{fixture['title']}' by {fixture['owner_email']} already exists, skipping"
+                    f"⏭️  PA post '{practice_name}' by {fixture['owner_email']} "
+                    f"already exists, skipping"
                 )
                 skipped += 1
                 continue
 
-            post = Post(
-                title=fixture["title"],
-                body=fixture["body"],
-                owner_id=owner.id,
+            post = Post(kind="provider_availability", owner_id=owner.id)
+            post.provider_availability_detail = ProviderAvailabilityDetail(
+                **fixture["detail"]
             )
             session.add(post)
-            print(f"✅ Created post '{fixture['title']}' by {fixture['owner_email']}")
+            print(f"✅ Created PA post '{practice_name}' by {fixture['owner_email']}")
             created += 1
 
         await session.commit()
@@ -149,12 +250,12 @@ async def seed_posts() -> tuple[int, int]:
 
 async def seed_all() -> int:
     users_created, users_skipped = await seed_users()
-    posts_created, posts_skipped = await seed_posts()
+    pa_created, pa_skipped = await seed_provider_availability()
 
     print(
         f"\n🌱 Seed complete:"
         f" {users_created} users created ({users_skipped} skipped),"
-        f" {posts_created} posts created ({posts_skipped} skipped)"
+        f" {pa_created} provider-availability posts created ({pa_skipped} skipped)"
     )
     if users_created > 0:
         print(f"   Password for all fixture users: {SHARED_PASSWORD}")

--- a/scripts/dev/test_seed.py
+++ b/scripts/dev/test_seed.py
@@ -1,0 +1,88 @@
+"""Tests for `scripts/dev/seed.py`.
+
+Two invariants matter beyond "the script ran":
+  - On a fresh DB, `seed_provider_availability` inserts the full fixture
+    set and populates each parent `Post` with its detail row in the
+    same flush. A regression where the parent is committed without the
+    detail would 500 every read view that joins the detail in.
+  - Re-running is a no-op. The idempotency key (kind, owner_id,
+    practice_name) keeps `dev seed` safe to run repeatedly during
+    development.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from scripts.dev import seed
+from src.domain.models import Post, ProviderAvailabilityDetail, User
+from tests.fixtures import async_test_sessionmaker
+from tests.helpers import create_test_user
+
+
+@pytest.fixture(autouse=True)
+def patch_session_maker(monkeypatch):
+    """Point the seed script at the in-memory test database."""
+    monkeypatch.setattr(seed, "async_session_maker", async_test_sessionmaker)
+
+
+async def _insert_alice() -> User:
+    user = create_test_user(email="alice@example.com", username="alice")
+    async with async_test_sessionmaker() as session:
+        async with session.begin():
+            session.add(user)
+    return user
+
+
+async def _all_pa_posts() -> list[Post]:
+    async with async_test_sessionmaker() as session:
+        result = await session.execute(
+            select(Post).where(Post.kind == "provider_availability")
+        )
+        return list(result.scalars().all())
+
+
+async def test_inserts_three_pa_posts_on_fresh_db(db_test_session_manager):
+    await _insert_alice()
+
+    created, skipped = await seed.seed_provider_availability()
+
+    assert (created, skipped) == (3, 0)
+    posts = await _all_pa_posts()
+    assert len(posts) == 3
+
+
+async def test_each_post_has_populated_detail_relationship(db_test_session_manager):
+    await _insert_alice()
+
+    await seed.seed_provider_availability()
+
+    async with async_test_sessionmaker() as session:
+        result = await session.execute(
+            select(ProviderAvailabilityDetail).join(
+                Post, Post.id == ProviderAvailabilityDetail.post_id
+            )
+        )
+        details = list(result.scalars().all())
+
+    practice_names = {d.practice_name for d in details}
+    assert practice_names == {"Katie Reeves, PhD", "Camp BooHoo", "RISE IOP at CHC"}
+
+
+async def test_rerun_is_idempotent(db_test_session_manager):
+    await _insert_alice()
+
+    first = await seed.seed_provider_availability()
+    second = await seed.seed_provider_availability()
+
+    assert first == (3, 0)
+    assert second == (0, 3)
+    assert len(await _all_pa_posts()) == 3
+
+
+async def test_skips_when_owner_missing(db_test_session_manager, capsys):
+    # No alice in this test — every fixture row should be skipped, nothing inserted.
+    created, skipped = await seed.seed_provider_availability()
+
+    assert created == 0
+    assert skipped == 3
+    assert await _all_pa_posts() == []


### PR DESCRIPTION
## Summary
- Replaces the stale `FIXTURE_POSTS` block in `scripts/dev/seed.py` (it constructed `Post(title=..., body=...)` after the polymorphic split removed those columns) with three canonical `provider_availability` posts: Katie Reeves, PhD; Camp BooHoo; RISE IOP at CHC. All three are owned by `alice@example.com` and seeded via the parent `Post` + `ProviderAvailabilityDetail` relationship in one flush.
- Idempotency key is now `(kind='provider_availability', owner_id, practice_name)`.
- Each fixture row carries `# TODO(issue-N)` markers on every cell that doesn't fit today's schema — these are the breadcrumb trail for the follow-on schema-evolution PRs (#2–#9).

Closes #420.

## Test plan
- [x] `dev test scripts/dev/test_seed.py` — 4 tests cover fresh-insert, idempotency, parent+detail invariant, and missing-owner skip.
- [x] `dev test` — 888 passed, 52 skipped.
- [x] `dev lint` — clean.

## Framework/spec impact
Per the issue's "proposed answer: no" — confirmed. The seed script uses ORM models + the existing detail-relationship pattern; no `EntitySpec` / `PostKindSpec` / `DiscriminatorRegistry` capability is needed for this issue. Deferring the optional `seed_data` hook until a second resource type wants seeded fixtures.

## README touches
None. `scripts/README.md` and the root README don't enumerate seed contents; `grep -rn` over `*.md` for `FIXTURE_POSTS`, `seed_posts`, etc. returned no hits.

## Per-PR retrospective
### Stale-fixture code wasn't caught by any guard
**Friction:** `FIXTURE_POSTS` had been broken since the polymorphic split — `Post(title=..., body=...)` would have crashed on construction. No test, lint check, or import-time validation caught it; only this issue's "verify the claim" step surfaced it.
**Fix:** A smoke-style colocated test that imports `seed.py` and asserts every fixture row can be constructed into an ORM instance (without committing) would have flagged this the moment `title`/`body` were dropped. Worth filing.
**Why didn't existing patterns prevent this?** The CLAUDE.md DoD requires colocated tests for changed code, but `seed.py` was untouched by the schema split that broke it — the contract surfaces a producer's test, not a consumer's. Cross-module contract drift is the class-of-bug.
**Could this class recur elsewhere?** Yes — anywhere a script constructs ORM models from a hand-written dict literal (other `scripts/dev/*` scripts, fixture loaders, ad-hoc tooling). One-shot audit: `grep -rn "Post\s*(" scripts/ deployment/ alembic/`.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)