### PR TITLE
Add HtmlTextarea marker for schema-driven textarea rendering (#422, phase A)

### DIFF
--- a/src/domain/templates/_shared/form_fields.html
+++ b/src/domain/templates/_shared/form_fields.html
@@ -104,6 +104,8 @@ posts an empty array. #}
 {%- set is_required = spec.required if required is none else required -%}
 {%- if spec.kind == "select" -%}
 {{ select_field(name, label, spec.choices, labels=spec.labels, current=current, required=is_required, placeholder=true) }}
+{%- elif spec.kind == "textarea" -%}
+{{ textarea_field(name, label, current=current, required=is_required) }}
 {%- elif spec.kind == "text" -%}
 {{ text_field(name, label, current=current, required=is_required, pattern=spec.pattern, maxlength=spec.maxlength) }}
 {%- endif -%}

--- a/src/framework/rendering/README.md
+++ b/src/framework/rendering/README.md
@@ -5,12 +5,12 @@ Jinja templating engine + form-rendering glue + per-viewer response projections.
 ## Files
 
 - `templating.py` — Jinja `Environment` setup with `FileSystemLoader("src/domain/templates")`, the controlled-vocabulary tuples from `../../domain/models/enums.py` exposed as Jinja globals, and `register_choice_labels(...)` populating the choice-tuple → label-dict registry that `field_spec(...)` consumes. The `templates` `Jinja2Templates` instance + `get_template_context()` helper are the public interface.
-- `form_fields.py` — `HtmlPattern` (Pydantic annotation marker carrying HTML pattern/maxlength hints) and `field_spec(schema_cls, name)` (introspects a Pydantic schema's `FieldInfo` and returns a normalized dict the `field_for` Jinja macro dispatches on). Lets templates derive their `<input>` attributes from the same Pydantic field that validates the request.
+- `form_fields.py` — `HtmlPattern` / `HtmlTextarea` (Pydantic annotation markers — the former carries HTML pattern/maxlength hints, the latter swaps `<input type=text>` for `<textarea>`) and `field_spec(schema_cls, name)` (introspects a Pydantic schema's `FieldInfo` and returns a normalized dict the `field_for` Jinja macro dispatches on). Lets templates derive their `<input>` attributes from the same Pydantic field that validates the request.
 - `projections.py` — `project_view(obj, *, public_fields, actor, private_fields=(), private_field_predicate=None)` builds a dict of `public_fields` from `obj` and conditionally appends `private_fields` when the predicate is true. Defense-in-depth alongside template `{% if %}` guards: omitting keys at projection time means a forgotten template guard can't re-leak.
 
 ## Schema-driven form rendering
 
-`field_for(schema, name, label, current=None, required=None)` (in `domain/templates/_shared/form_fields.html`) calls the `field_spec` Jinja global at render time to derive the form's HTML attributes from the schema. The schema's `Literal[*TUPLE]` becomes a `<select>`; an `Annotated[T, HtmlPattern(...)]` becomes `pattern` / `maxlength` on the `<input>`. Adding a value to a controlled-vocabulary tuple flows automatically to every form using these macros — no per-template edits.
+`field_for(schema, name, label, current=None, required=None)` (in `domain/templates/_shared/form_fields.html`) calls the `field_spec` Jinja global at render time to derive the form's HTML attributes from the schema. The schema's `Literal[*TUPLE]` becomes a `<select>`; an `Annotated[T, HtmlPattern(...)]` becomes `pattern` / `maxlength` on the `<input>`; an `Annotated[T, HtmlTextarea()]` becomes a `<textarea>`. Adding a value to a controlled-vocabulary tuple flows automatically to every form using these macros — no per-template edits.
 
 ## Tests
 

--- a/src/framework/rendering/form_fields.py
+++ b/src/framework/rendering/form_fields.py
@@ -23,6 +23,17 @@ class HtmlPattern:
     maxlength: int | None = None
 
 
+@dataclass(frozen=True)
+class HtmlTextarea:
+    """Annotation marker that swaps `field_for`'s default `<input
+    type=text>` rendering for `<textarea>` on a string field. Free-text
+    fields long enough to want a multi-line control (descriptions,
+    instructions) reach for this; everything else stays text by default.
+    No payload — presence on the field's `Annotated[...]` metadata is
+    the signal.
+    """
+
+
 # Choice-tuple → label-dict registry, populated at startup by
 # `register_choice_labels()` from `src/framework/rendering/templating.py`. Lookup is
 # by tuple value (not identity) because `Literal[*TUPLE]` unpacks the
@@ -80,12 +91,22 @@ def field_spec(schema_cls: type[BaseModel], name: str) -> dict[str, Any]:
 
     pattern: str | None = None
     maxlength: int | None = None
+    is_textarea = False
     for marker in field.metadata:
         if isinstance(marker, HtmlPattern):
             if marker.pattern is not None:
                 pattern = marker.pattern
             if marker.maxlength is not None:
                 maxlength = marker.maxlength
+        elif isinstance(marker, HtmlTextarea):
+            is_textarea = True
+
+    if is_textarea:
+        return {
+            "kind": "textarea",
+            "name": name,
+            "required": not optional,
+        }
 
     return {
         "kind": "text",

--- a/src/framework/rendering/test_form_fields.py
+++ b/src/framework/rendering/test_form_fields.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from src.framework.rendering.form_fields import (
     HtmlPattern,
+    HtmlTextarea,
     field_spec,
     register_choice_labels,
 )
@@ -24,6 +25,8 @@ _SIZES = ("s", "m", "l")
 register_choice_labels(_SIZES, None)
 
 _PatternedString = Annotated[str, HtmlPattern(pattern=r"\d{5}", maxlength=5)]
+_LongText = Annotated[str, HtmlTextarea()]
+_OptionalLongText = Annotated[str | None, HtmlTextarea()]
 
 
 class _Sample(BaseModel):
@@ -33,6 +36,8 @@ class _Sample(BaseModel):
     optional_choice: Literal[*_COLORS] | None = None
     unlabeled_choice: Literal[*_SIZES]
     patterned: _PatternedString
+    long_required: _LongText
+    long_optional: _OptionalLongText = None
 
 
 def test_required_text_field():
@@ -81,6 +86,21 @@ def test_html_pattern_marker_propagates():
     assert spec["kind"] == "text"
     assert spec["pattern"] == r"\d{5}"
     assert spec["maxlength"] == 5
+
+
+def test_html_textarea_marker_switches_kind():
+    spec = field_spec(_Sample, "long_required")
+    assert spec == {
+        "kind": "textarea",
+        "name": "long_required",
+        "required": True,
+    }
+
+
+def test_optional_html_textarea_drops_required():
+    spec = field_spec(_Sample, "long_optional")
+    assert spec["kind"] == "textarea"
+    assert spec["required"] is False
 
 
 def test_zip_text_alias_carries_pattern_in_real_schema():


### PR DESCRIPTION
## Summary
- Framework prep PR for #422 (Path A from the issue's recommendation — split into two PRs so the framework change can land and be reviewed independently of the consumer change).
- Adds `HtmlTextarea` Annotated metadata marker in `src/framework/rendering/form_fields.py`, mirroring the existing `HtmlPattern`.
- `field_spec` now returns `kind=\"textarea\"` when the marker is present; `field_for` macro dispatches to the existing `textarea_field` macro for that kind.
- No consumer change in this PR. Phase B (separate PR) will add `description` / `referral_instructions` / `website` to `provider_availability` and render them via `field_for`.

Refs #422.

## Test plan
- [x] `dev test src/framework/rendering/` — 17 tests pass, including two new ones for the marker.
- [x] `dev test` — 890 passed, 52 skipped (up from 888 — two new tests).
- [x] `dev lint` — clean.

## Framework/spec impact
This **is** the framework/spec change for #422. Pure additive — adds a new marker class + a new `field_spec` branch + a new `field_for` template arm. Existing `HtmlPattern`-marked and unmarked fields are untouched. README updated to reflect the new marker.

## Per-PR retrospective
### Path A split paid off
**Friction:** None worth filing — the split is small, self-contained, and trivially verifiable in isolation.
**Fix:** N/A.
**Why didn't existing patterns prevent this?** The existing `HtmlPattern` pattern was the template for this change; following it kept scope tight.
**Could this class recur elsewhere?** \`kind=\"multi_select\"\` will eventually be needed for issues #3/#4 (list-valued fields like languages and multi-valued age groups). The dispatch structure here is ready for it — one more `elif` arm in `field_for` plus one more spec branch. Worth noting as a heads-up; no audit needed today.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)