### PR TITLE
Detect list[Literal[*T]] as multi_select in field_spec (#425, phase A)

### DIFF
--- a/src/domain/templates/_shared/form_fields.html
+++ b/src/domain/templates/_shared/form_fields.html
@@ -104,6 +104,8 @@ posts an empty array. #}
 {%- set is_required = spec.required if required is none else required -%}
 {%- if spec.kind == "select" -%}
 {{ select_field(name, label, spec.choices, labels=spec.labels, current=current, required=is_required, placeholder=true) }}
+{%- elif spec.kind == "multi_select" -%}
+{{ multi_select_field(name, label, spec.choices, labels=spec.labels, current=current) }}
 {%- elif spec.kind == "textarea" -%}
 {{ textarea_field(name, label, current=current, required=is_required) }}
 {%- elif spec.kind == "text" -%}

--- a/src/framework/rendering/README.md
+++ b/src/framework/rendering/README.md
@@ -10,7 +10,7 @@ Jinja templating engine + form-rendering glue + per-viewer response projections.
 
 ## Schema-driven form rendering
 
-`field_for(schema, name, label, current=None, required=None)` (in `domain/templates/_shared/form_fields.html`) calls the `field_spec` Jinja global at render time to derive the form's HTML attributes from the schema. The schema's `Literal[*TUPLE]` becomes a `<select>`; an `Annotated[T, HtmlPattern(...)]` becomes `pattern` / `maxlength` on the `<input>`; an `Annotated[T, HtmlTextarea()]` becomes a `<textarea>`. Adding a value to a controlled-vocabulary tuple flows automatically to every form using these macros — no per-template edits.
+`field_for(schema, name, label, current=None, required=None)` (in `domain/templates/_shared/form_fields.html`) calls the `field_spec` Jinja global at render time to derive the form's HTML attributes from the schema. The schema's `Literal[*TUPLE]` becomes a `<select>`; `list[Literal[*TUPLE]]` becomes a multi-select checkbox group; an `Annotated[T, HtmlPattern(...)]` becomes `pattern` / `maxlength` on the `<input>`; an `Annotated[T, HtmlTextarea()]` becomes a `<textarea>`. Adding a value to a controlled-vocabulary tuple flows automatically to every form using these macros — no per-template edits.
 
 ## Tests
 

--- a/src/framework/rendering/form_fields.py
+++ b/src/framework/rendering/form_fields.py
@@ -78,6 +78,22 @@ def field_spec(schema_cls: type[BaseModel], name: str) -> dict[str, Any]:
     optional = _is_optional(annotation)
     inner = _strip_optional(annotation) if optional else annotation
 
+    # `list[Literal[*T]]` (with or without `| None`) is unambiguous —
+    # it IS a multi-select. No marker needed to disambiguate, unlike
+    # the `str` vs `str-as-textarea` case (`HtmlTextarea`).
+    if get_origin(inner) is list:
+        list_args = get_args(inner)
+        if len(list_args) == 1 and get_origin(list_args[0]) is Literal:
+            choices = list(get_args(list_args[0]))
+            labels = _CHOICE_LABELS.get(tuple(choices))
+            return {
+                "kind": "multi_select",
+                "name": name,
+                "required": not optional,
+                "choices": choices,
+                "labels": labels,
+            }
+
     if get_origin(inner) is Literal:
         choices = list(get_args(inner))
         labels = _CHOICE_LABELS.get(tuple(choices))

--- a/src/framework/rendering/test_form_fields.py
+++ b/src/framework/rendering/test_form_fields.py
@@ -38,6 +38,9 @@ class _Sample(BaseModel):
     patterned: _PatternedString
     long_required: _LongText
     long_optional: _OptionalLongText = None
+    required_multi: list[Literal[*_COLORS]]
+    optional_multi: list[Literal[*_COLORS]] | None = None
+    unlabeled_multi: list[Literal[*_SIZES]]
 
 
 def test_required_text_field():
@@ -101,6 +104,32 @@ def test_optional_html_textarea_drops_required():
     spec = field_spec(_Sample, "long_optional")
     assert spec["kind"] == "textarea"
     assert spec["required"] is False
+
+
+def test_list_literal_field_renders_as_multi_select_with_labels():
+    spec = field_spec(_Sample, "required_multi")
+    assert spec == {
+        "kind": "multi_select",
+        "name": "required_multi",
+        "required": True,
+        "choices": list(_COLORS),
+        "labels": _COLOR_LABELS,
+    }
+
+
+def test_optional_list_literal_field_drops_required():
+    spec = field_spec(_Sample, "optional_multi")
+    assert spec["kind"] == "multi_select"
+    assert spec["required"] is False
+    assert spec["choices"] == list(_COLORS)
+
+
+def test_unlabeled_multi_select_returns_none_labels():
+    """Multi-select over a tuple registered without labels surfaces
+    `labels=None`, same fallback path as the single-select case."""
+    spec = field_spec(_Sample, "unlabeled_multi")
+    assert spec["kind"] == "multi_select"
+    assert spec["labels"] is None
 
 
 def test_zip_text_alias_carries_pattern_in_real_schema():


### PR DESCRIPTION
## Summary
- Framework prep PR for #425 (Path A from the issue). Extends the schema-driven dispatch ladder with a third arm: `field_spec` returns `kind=\"multi_select\"` for `list[Literal[*T]]` annotations (with and without `| None`).
- `field_for` dispatches the new kind to the existing `multi_select_field` macro.
- No new annotation marker needed — `list[Literal[...]]` is unambiguous, unlike the `str` vs `str-as-textarea` split that needed `HtmlTextarea`.
- No consumer change. Phase B will swap PA's `non_english_services` for a `languages` field rendered through `field_for`.

Refs #425.

## Test plan
- [x] `dev test src/framework/rendering/` — 20 tests (3 new ones for multi_select).
- [x] `dev test` — 900 passed, 52 skipped.
- [x] `dev lint` — clean.

## Framework/spec impact
This **is** the framework change for #425. Same shape as #423 — a single new `field_spec` branch + a new `field_for` arm + tests. Existing single-select, textarea, and text paths are untouched.

## Per-PR retrospective
### Detection from type alone — no marker needed
**Friction:** None — confirmed the issue's prediction. `list[Literal[*T]]` is a single shape, and Pydantic exposes `get_origin(inner) is list` + `get_args(list_args[0])` cleanly.
**Fix:** N/A.
**Why didn't existing patterns prevent this?** The existing `HtmlTextarea` marker pattern was a guide but not a constraint — for shapes that already disambiguate themselves, skipping the marker is the right call.
**Could this class recur elsewhere?** A future `tuple[Literal[*T], ...]` or `frozenset[Literal[*T]]` would need the same detection but a different `get_origin` arm. Not anticipated, but if it happens the existing structure absorbs it as another `elif` clause.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)