### PR TITLE
Replace client_referral.language_preferred with languages list (#428)

### DIFF
--- a/alembic/README.md
+++ b/alembic/README.md
@@ -22,6 +22,7 @@ Database migrations live here. Day-to-day operations go through the `dev migrate
 - **Schema only, not data.** Migrations change shape; data backfills go in separate scripts or in subsequent migrations explicitly authored to mutate data.
 - **Reversible by default.** A `downgrade()` that drops a column with data is data loss. For column removals or destructive changes, use a two-step migration: add-new + backfill, then a follow-up that removes-old after the backfill is verified.
 - **Descriptive messages.** `dev migrate generate "add user email_verified column"` beats `"changes"` — the message becomes the file name.
+- **Dropping a CHECK-constrained column on SQLite needs `batch_alter_table`.** A plain `op.drop_column(...)` against a column referenced by a named CHECK constraint will fail with `error in table … after drop column: no such column: <name>`. Wrap the drop in `with op.batch_alter_table(table) as batch_op:` and call `batch_op.drop_constraint("<ck_name>", type_="check")` + `batch_op.drop_column(...)` together — SQLite then rewrites the table cleanly. Examples: revisions `2bed07fb1d76`, `6e7b42cd3894`.
 
 ## Production deployment
 

--- a/alembic/versions/6e7b42cd3894_replace_cr_language_preferred_with_.py
+++ b/alembic/versions/6e7b42cd3894_replace_cr_language_preferred_with_.py
@@ -1,0 +1,87 @@
+"""replace_cr_language_preferred_with_languages
+
+Revision ID: 6e7b42cd3894
+Revises: 2bed07fb1d76
+Create Date: 2026-05-11 21:28:47.757667
+
+Sibling to revision `2bed07fb1d76`. `client_referral.language_preferred`
+was a yes/no enum signaling "referrer wants a non-English-speaking
+provider" without naming which language. Swap for a `languages` JSON
+list over a controlled vocabulary (#428).
+
+"""
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6e7b42cd3894"
+down_revision: Union[str, None] = "2bed07fb1d76"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Same SQLite gotcha as `2bed07fb1d76`: the old column carries a named
+    CHECK constraint, so a plain `DROP COLUMN` leaves a dangling
+    reference. Use `batch_alter_table` for the table-rewrite path.
+    """
+    conn = op.get_bind()
+    yes_rows = conn.execute(
+        sa.text(
+            "SELECT post_id FROM client_referral_details "
+            "WHERE language_preferred = 'yes'"
+        )
+    ).fetchall()
+    for (post_id,) in yes_rows:
+        logger.warning(
+            "Row post_id=%s had language_preferred='yes'; defaulted "
+            "languages to ['en'] — needs owner update to record the actual "
+            "preferred language.",
+            post_id,
+        )
+
+    with op.batch_alter_table("client_referral_details") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "languages",
+                sa.JSON(),
+                server_default=sa.text("'[\"en\"]'"),
+                nullable=False,
+            ),
+        )
+        batch_op.drop_constraint(
+            "ck_client_referral_details_language_preferred",
+            type_="check",
+        )
+        batch_op.drop_column("language_preferred")
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Lossy: the old yes/no flag is restored as "no" for every row,
+    regardless of what `languages` contained.
+    """
+    with op.batch_alter_table("client_referral_details") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "language_preferred",
+                sa.TEXT(),
+                server_default=sa.text("'no'"),
+                nullable=False,
+            ),
+        )
+        batch_op.create_check_constraint(
+            "ck_client_referral_details_language_preferred",
+            "language_preferred IN ('no', 'yes')",
+        )
+        batch_op.drop_column("languages")

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -50,7 +50,6 @@ from src.domain.models.enums import (
     CLIENT_REFERRAL_SERVICES,
     DESIRED_TIME_SLOTS,
     INSURANCE_OPTIONS,
-    LANGUAGE_PREFERRED_OPTIONS,
     LANGUAGES,
     LOCATION_AVAILABILITY_OPTIONS,
     TREATMENT_SETTINGS,
@@ -170,7 +169,7 @@ class ClientReferralRead(_PostReadBase):
     location_virtual: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     desired_times: DesiredTimesField = []
     client_dem_ages: Literal[*CLIENT_AGE_GROUPS]
-    language_preferred: Literal[*LANGUAGE_PREFERRED_OPTIONS]
+    languages: LanguagesField = []
     description: str
     services: ServicesField = []
     services_psychotherapy_modality: str | None = None
@@ -231,7 +230,10 @@ class ClientReferralCreate(WirePayload):
     location_virtual: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     desired_times: DesiredTimesField = []
     client_dem_ages: Literal[*CLIENT_AGE_GROUPS]
-    language_preferred: Literal[*LANGUAGE_PREFERRED_OPTIONS]
+    # Required min-1 on the wire — replaces the old yes/no
+    # `language_preferred` flag (#428). Defaults to `["en"]` so the
+    # form's "submit with defaults" case still validates.
+    languages: RequiredLanguagesField = ["en"]
     description: StrippedText
     services: ServicesField = []
     services_psychotherapy_modality: StrippedOptionalText = None
@@ -311,7 +313,9 @@ class ClientReferralUpdate(PartialUpdate):
     # add/remove is intentionally out of scope.
     desired_times: DesiredTimesField | None = None
     client_dem_ages: Literal[*CLIENT_AGE_GROUPS] | None = None
-    language_preferred: Literal[*LANGUAGE_PREFERRED_OPTIONS] | None = None
+    # `None` = leave unchanged. `min_length=1` rejects an explicit `[]`,
+    # mirroring PA's `languages` semantics.
+    languages: RequiredLanguagesField | None = None
     description: StrippedText | None = None
     services: ServicesField | None = None
     services_psychotherapy_modality: StrippedOptionalText = None
@@ -378,7 +382,7 @@ class ClientReferralAuditSnapshot(_PostAuditSnapshotBase):
     location_virtual: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     desired_times: DesiredTimesField = []
     client_dem_ages: Literal[*CLIENT_AGE_GROUPS]
-    language_preferred: Literal[*LANGUAGE_PREFERRED_OPTIONS]
+    languages: LanguagesField = []
     description: str
     services: ServicesField = []
     services_psychotherapy_modality: str | None = None

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -44,8 +44,6 @@ from src.domain.models.enums import (
     INSURANCE_LABELS,
     INSURANCE_OPTIONS,
     LANGUAGE_LABELS,
-    LANGUAGE_PREFERRED_LABELS,
-    LANGUAGE_PREFERRED_OPTIONS,
     LANGUAGES,
     LOCATION_AVAILABILITY_LABELS,
     LOCATION_AVAILABILITY_OPTIONS,
@@ -110,7 +108,6 @@ def test_post_create_client_referral_rejects_empty_description():
         "location_in_person",
         "location_virtual",
         "client_dem_ages",
-        "language_preferred",
         "description",
         "insurance",
     ],
@@ -125,6 +122,32 @@ def test_post_create_client_referral_requires_all_required_fields(missing_field)
 def test_post_create_client_referral_optional_fields_default_none():
     p = post_create_adapter.validate_python(client_referral_payload())
     assert p.services_psychotherapy_modality is None
+
+
+def test_post_create_client_referral_default_languages():
+    """`languages` defaults to ['en'] — keeps "submit with defaults" valid
+    even though the field is required min-1 (#428)."""
+    payload = client_referral_payload()
+    payload.pop("languages")
+    p = post_create_adapter.validate_python(payload)
+    assert p.languages == ["en"]
+
+
+def test_post_create_client_referral_accepts_multiple_languages():
+    p = post_create_adapter.validate_python(
+        client_referral_payload(languages=["en", "es"])
+    )
+    assert p.languages == ["en", "es"]
+
+
+def test_post_create_client_referral_rejects_empty_languages():
+    with pytest.raises(ValidationError):
+        post_create_adapter.validate_python(client_referral_payload(languages=[]))
+
+
+def test_post_create_client_referral_rejects_unknown_language_token():
+    with pytest.raises(ValidationError):
+        post_create_adapter.validate_python(client_referral_payload(languages=["xx"]))
 
 
 def test_post_create_client_referral_strips_optional_to_none():
@@ -533,7 +556,6 @@ def _literal_args(model_cls, field_name: str) -> tuple[str, ...]:
         (ClientReferralRead, "location_in_person", LOCATION_AVAILABILITY_OPTIONS),
         (ClientReferralRead, "location_virtual", LOCATION_AVAILABILITY_OPTIONS),
         (ClientReferralRead, "client_dem_ages", CLIENT_AGE_GROUPS),
-        (ClientReferralRead, "language_preferred", LANGUAGE_PREFERRED_OPTIONS),
         (ClientReferralRead, "insurance", INSURANCE_OPTIONS),
         (ProviderAvailabilityRead, "location_state", US_STATES),
         (ProviderAvailabilityRead, "in_person_sessions", LOCATION_AVAILABILITY_OPTIONS),
@@ -758,7 +780,6 @@ def test_post_update_services_rejects_unknown_token(kind):
     [
         (LOCATION_AVAILABILITY_OPTIONS, LOCATION_AVAILABILITY_LABELS),
         (CLIENT_AGE_GROUPS, CLIENT_AGE_GROUP_LABELS),
-        (LANGUAGE_PREFERRED_OPTIONS, LANGUAGE_PREFERRED_LABELS),
         (LANGUAGES, LANGUAGE_LABELS),
         (INSURANCE_OPTIONS, INSURANCE_LABELS),
         (DESIRED_TIME_SLOTS, DESIRED_TIME_SLOT_LABELS),

--- a/src/domain/models/__init__.py
+++ b/src/domain/models/__init__.py
@@ -4,7 +4,6 @@ from src.framework.persistence.base_model import Base, BaseModel, metadata
 from .enums import (
     CLIENT_AGE_GROUPS,
     INSURANCE_OPTIONS,
-    LANGUAGE_PREFERRED_OPTIONS,
     LOCATION_AVAILABILITY_OPTIONS,
     US_STATES,
 )
@@ -31,7 +30,6 @@ __all__ = [
     "CLIENT_AGE_GROUPS",
     "ClientReferralDetail",
     "INSURANCE_OPTIONS",
-    "LANGUAGE_PREFERRED_OPTIONS",
     "LOCATION_AVAILABILITY_OPTIONS",
     "POST_KIND_BY_DETAIL_MODEL",
     "POST_KIND_NAMES",

--- a/src/domain/models/enums.py
+++ b/src/domain/models/enums.py
@@ -69,11 +69,10 @@ CLIENT_AGE_GROUPS: Final[tuple[str, ...]] = (
     "adults_25_64",
     "older_adults_65_plus",
 )
-LANGUAGE_PREFERRED_OPTIONS: Final[tuple[str, ...]] = ("no", "yes")
 # Spoken-language tokens used by the multi-valued `languages` field on
-# `provider_availability`. Tokens are ISO-639 codes; labels are the
-# English display names. The tuple starts minimal — covers every seed
-# example today — and grows as real posts demand more entries.
+# both post kinds. Tokens are ISO-639 codes; labels are the English
+# display names. The tuple starts minimal — covers every seed example
+# today — and grows as real posts demand more entries.
 LANGUAGES: Final[tuple[str, ...]] = ("en", "es")
 INSURANCE_OPTIONS: Final[tuple[str, ...]] = (
     "in_network",
@@ -149,7 +148,6 @@ CLIENT_AGE_GROUP_LABELS: Final[dict[str, str]] = {
     "adults_25_64": "Adults 25–64",
     "older_adults_65_plus": "Older adults 65+",
 }
-LANGUAGE_PREFERRED_LABELS: Final[dict[str, str]] = {"no": "No", "yes": "Yes"}
 LANGUAGE_LABELS: Final[dict[str, str]] = {"en": "English", "es": "Spanish"}
 INSURANCE_LABELS: Final[dict[str, str]] = {
     "in_network": "In-network",

--- a/src/domain/models/posts/client_referral_detail.py
+++ b/src/domain/models/posts/client_referral_detail.py
@@ -8,7 +8,6 @@ from src.framework.persistence.base_model import Base
 from ..enums import (
     CLIENT_AGE_GROUPS,
     INSURANCE_OPTIONS,
-    LANGUAGE_PREFERRED_OPTIONS,
     LOCATION_AVAILABILITY_OPTIONS,
     US_STATES,
     named_check_in,
@@ -27,7 +26,6 @@ class ClientReferralDetail(Base):
         _ck("location_in_person", LOCATION_AVAILABILITY_OPTIONS),
         _ck("location_virtual", LOCATION_AVAILABILITY_OPTIONS),
         _ck("client_dem_ages", CLIENT_AGE_GROUPS),
-        _ck("language_preferred", LANGUAGE_PREFERRED_OPTIONS),
         _ck("insurance", INSURANCE_OPTIONS),
     )
 
@@ -49,7 +47,9 @@ class ClientReferralDetail(Base):
 
     # Section 2 — demographics
     client_dem_ages = Column(Text, nullable=False)
-    language_preferred = Column(Text, nullable=False)
+    languages = Column(
+        JSON, nullable=False, server_default=text("'[\"en\"]'"), default=lambda: ["en"]
+    )
 
     # Section 3 — description
     description = Column(Text, nullable=False)

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -503,6 +503,20 @@ async def test_get_client_referral_form_renders(
     assert kind_input.attributes.get("value") == "client_referral"
 
 
+async def test_client_referral_form_renders_languages_multi_select(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`languages` on CR renders via `field_for`'s multi_select arm (#428),
+    same shape as PA."""
+    response = await authenticated_client.get("/posts/form?kind=client_referral")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    boxes = tree.css('input[type="checkbox"][name="languages"]')
+    values = {b.attributes.get("value") for b in boxes}
+    assert values == {"en", "es"}
+
+
 async def test_get_post_form_default_kind_is_client_referral(
     authenticated_client: AsyncClient,
     logged_in_user: User,

--- a/src/domain/templates/posts/_client_referral_form.html
+++ b/src/domain/templates/posts/_client_referral_form.html
@@ -17,8 +17,8 @@ values for the same field name. The form naturally encodes multiple
 checkboxes as `desired_times=monday_morning&desired_times=friday_evening`,
 which FastAPI/Pydantic parses as a list.
 #}
-{%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, time_grid_field, multi_select_field -%}
-{%- macro client_referral_form(hx_method, action, submit_label, post=None) -%}
+{%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, time_grid_field, multi_select_field, field_for -%}
+{%- macro client_referral_form(hx_method, action, submit_label, post=None, schema=None) -%}
 {%- set d = post.client_referral_detail if post else None -%}
 <form hx-{{ hx_method }}="{{ action }}">
   <input type="hidden" name="kind" value="client_referral" />
@@ -36,7 +36,7 @@ which FastAPI/Pydantic parses as a list.
   <fieldset>
     <legend>Demographics</legend>
     {{ select_field("client_dem_ages", "Age group", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.client_dem_ages if d else None, placeholder=true) }}
-    {{ select_field("language_preferred", "Services preferred in language other than English?", LANGUAGE_PREFERRED_OPTIONS, labels=LANGUAGE_PREFERRED_LABELS, current=(d.language_preferred if d else "no")) }}
+    {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
   </fieldset>
 
   <fieldset>

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -25,8 +25,8 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
     {% endif %}
     <dt>Age group</dt>
     <dd>{{ CLIENT_AGE_GROUP_LABELS[d.client_dem_ages] }}</dd>
-    <dt>Language preferred (non-English)</dt>
-    <dd>{{ LANGUAGE_PREFERRED_LABELS[d.language_preferred] }}</dd>
+    <dt>Languages</dt>
+    <dd>{% for l in d.languages %}{{ LANGUAGE_LABELS[l] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     <dt>Description</dt>
     <dd>{{ d.description }}</dd>
     {% if d.services %}

--- a/src/domain/templates/posts/edit_client_referral.html
+++ b/src/domain/templates/posts/edit_client_referral.html
@@ -3,7 +3,7 @@
 {% block title %}Edit client referral{% endblock %}
 {% block content %}
 <h1>Edit client referral</h1>
-{{ client_referral_form("patch", "/posts/" ~ post.id, "Save changes", post=post) }}
+{{ client_referral_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=client_referral_create_schema) }}
 
 <hr />
 <a href="/posts/{{ post.id }}">Cancel</a>

--- a/src/domain/templates/posts/new_client_referral.html
+++ b/src/domain/templates/posts/new_client_referral.html
@@ -4,7 +4,7 @@
 {% block content %}
 <h1>New client referral</h1>
 <p>Per <code>notes/forms_spec.md</code>. No PII.</p>
-{{ client_referral_form("post", "/posts", "Create client referral") }}
+{{ client_referral_form("post", "/posts", "Create client referral", schema=client_referral_create_schema) }}
 
 <hr />
 <a href="/posts">Back to posts</a>

--- a/src/framework/rendering/templating.py
+++ b/src/framework/rendering/templating.py
@@ -1,7 +1,10 @@
 from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from src.domain.logic.posts.schema import ProviderAvailabilityCreate
+from src.domain.logic.posts.schema import (
+    ClientReferralCreate,
+    ProviderAvailabilityCreate,
+)
 from src.domain.models import enums
 from src.framework.config import settings
 from src.framework.rendering.form_fields import field_spec, register_choice_labels
@@ -30,8 +33,6 @@ _env.globals.update(
     LOCATION_AVAILABILITY_LABELS=enums.LOCATION_AVAILABILITY_LABELS,
     CLIENT_AGE_GROUPS=enums.CLIENT_AGE_GROUPS,
     CLIENT_AGE_GROUP_LABELS=enums.CLIENT_AGE_GROUP_LABELS,
-    LANGUAGE_PREFERRED_OPTIONS=enums.LANGUAGE_PREFERRED_OPTIONS,
-    LANGUAGE_PREFERRED_LABELS=enums.LANGUAGE_PREFERRED_LABELS,
     LANGUAGES=enums.LANGUAGES,
     LANGUAGE_LABELS=enums.LANGUAGE_LABELS,
     INSURANCE_OPTIONS=enums.INSURANCE_OPTIONS,
@@ -70,6 +71,7 @@ _env.globals.update(
     # pass the right schema to `field_for` without context-routing
     # changes. Per-kind form templates pick which to pass.
     provider_availability_create_schema=ProviderAvailabilityCreate,
+    client_referral_create_schema=ClientReferralCreate,
 )
 
 # Register the choice-tuple → labels-dict mapping that `field_spec`
@@ -82,9 +84,6 @@ register_choice_labels(
     enums.LOCATION_AVAILABILITY_OPTIONS, enums.LOCATION_AVAILABILITY_LABELS
 )
 register_choice_labels(enums.CLIENT_AGE_GROUPS, enums.CLIENT_AGE_GROUP_LABELS)
-register_choice_labels(
-    enums.LANGUAGE_PREFERRED_OPTIONS, enums.LANGUAGE_PREFERRED_LABELS
-)
 register_choice_labels(enums.LANGUAGES, enums.LANGUAGE_LABELS)
 register_choice_labels(enums.INSURANCE_OPTIONS, enums.INSURANCE_LABELS)
 register_choice_labels(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -55,7 +55,7 @@ _CLIENT_REFERRAL_DEFAULTS: dict[str, Any] = {
     "location_virtual": "no",
     "desired_times": [],
     "client_dem_ages": "adults_25_64",
-    "language_preferred": "no",
+    "languages": ["en"],
     "description": "needs placement",
     "services": [],
     "services_psychotherapy_modality": None,


### PR DESCRIPTION
## Summary
- Mirrors #425 for the other post kind. Swaps CR's yes/no `language_preferred` enum for `languages: list[Literal[*LANGUAGES]]`, defaulting to `[\"en\"]`. Reuses the `LANGUAGES` vocab, `LanguagesField` / `RequiredLanguagesField` aliases, and multi-select `field_spec` detection landed in #425.
- Single-PR (Path B) — framework was already in place from #425's phase A.
- Drops the now-unused `LANGUAGE_PREFERRED_OPTIONS` / `LANGUAGE_PREFERRED_LABELS` symbols entirely.
- Adds the SQLite-CHECK-drop note to `alembic/README.md` (flagged in #425's retro; second migration in a row to hit it).

Closes #428.

## Test plan
- [x] `dev test` — 905 passed, 52 skipped.
- [x] `dev test contract` — 16 passed.
- [x] `dev lint` — clean.
- [x] `dev migrate roundtrip` on rev `6e7b42cd3894` — clean upgrade/downgrade/upgrade.
- [x] New tests: default-of-`[\"en\"]`, multi-value, empty-list-422, unknown-token-422, form-renders-checkbox-group with English/Spanish.

## Framework/spec impact
None new. Reuses everything from #422 (Jinja-global schema injection — `client_referral_create_schema` joins `provider_availability_create_schema`) and #425 phase A (multi-select `field_for` arm).

## Per-PR retrospective
### Copy-paste worked, which is the right answer
**Friction:** None — the CR swap was a near-mechanical transcription of the PA swap. Same `batch_alter_table` shape, same Jinja-global wiring, same test pattern. Confirms #425's framework prep was sized correctly.
**Fix:** N/A.
**Why didn't existing patterns prevent this?** They DID — the pattern existed and was followed.
**Could this class recur elsewhere?** The Jinja-global schema wiring will get reused every time a polymorphic post kind needs `field_for`. If a third kind ever joins, the pattern is now well-trodden enough that a doc note in `src/domain/templates/posts/README.md` would help — not filing as a separate issue, just noting.
**Effort:** small.

### Dropping unused enum tuples mid-PR was tempting and correct
**Friction:** `LANGUAGE_PREFERRED_OPTIONS` had no consumers after this swap. Could have left it as dead code, but kept-around enum vocab is a slow poison — the next reader thinks it's still meaningful. Removed.
**Fix:** N/A — removal is itself the fix.
**Why didn't existing patterns prevent this?** No existing pattern about \"prune unused vocab when a feature lands\". Worth a one-line CLAUDE.md addition someday but not this PR.
**Could this class recur elsewhere?** Yes — every series-PR that retires a column should also remove the enum tuples that only fed it. The PR-author checklist isn't enforced, but the search is fast (`grep` for the removed symbol).
**Effort:** small.

### `alembic/README.md` finally got the SQLite-CHECK note
**Friction:** Two consecutive migrations (\`2bed07fb1d76\` and \`6e7b42cd3894\`) hit the same SQLite `DROP COLUMN` + named CHECK trap. The second one was instantly fixable by remembering the first. Documenting it in `alembic/README.md` makes the third occurrence (whoever it is) instantly fixable too.
**Fix:** Added to the conventions list with both revision IDs as examples.
**Why didn't existing patterns prevent this?** No prior migration had dropped a CHECK-constrained column, so there was no precedent — until #425 created one.
**Could this class recur elsewhere?** Yes — every later series issue that drops or replaces a CHECK-constrained column (#6 with `payment_situation`, end-of-series breaking removals) will hit it. Now documented.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)