### PR TITLE
Replace provider_availability.age_group with age_groups list (#430)

### DIFF
--- a/alembic/versions/9cc643102347_replace_pa_age_group_with_age_groups.py
+++ b/alembic/versions/9cc643102347_replace_pa_age_group_with_age_groups.py
@@ -1,0 +1,93 @@
+"""replace_pa_age_group_with_age_groups
+
+Revision ID: 9cc643102347
+Revises: 6e7b42cd3894
+Create Date: 2026-05-11 21:39:17.603031
+
+Provider availability's `age_group` was single-valued — every real-world
+post in the seed set spans multiple buckets (#430). Swap for an
+`age_groups` JSON list, backfilling each row's prior scalar as a
+single-element list. Same `batch_alter_table` SQLite-CHECK trap as
+revisions `2bed07fb1d76` and `6e7b42cd3894`; see `alembic/README.md`.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9cc643102347"
+down_revision: Union[str, None] = "6e7b42cd3894"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Order matters: add `age_groups` first (with `[]` server_default so
+    NOT NULL holds), backfill from `age_group` while the old column
+    still exists, then `batch_alter_table` to drop the old column +
+    its named CHECK in one rewrite.
+    """
+    op.add_column(
+        "provider_availability_details",
+        sa.Column(
+            "age_groups",
+            sa.JSON(),
+            server_default=sa.text("'[]'"),
+            nullable=False,
+        ),
+    )
+
+    # SQLite's json_array(x) wraps a single value into a JSON array.
+    # Postgres has the same function under the same name — no dialect
+    # branching needed.
+    op.execute(
+        sa.text(
+            "UPDATE provider_availability_details "
+            "SET age_groups = json_array(age_group)"
+        )
+    )
+
+    with op.batch_alter_table("provider_availability_details") as batch_op:
+        batch_op.drop_constraint(
+            "ck_provider_availability_details_age_group",
+            type_="check",
+        )
+        batch_op.drop_column("age_group")
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Lossy: restore the scalar column from the first element of the list;
+    everything beyond `age_groups[0]` is discarded.
+    """
+    op.add_column(
+        "provider_availability_details",
+        sa.Column(
+            "age_group",
+            sa.TEXT(),
+            server_default=sa.text("'adults_25_64'"),
+            nullable=False,
+        ),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE provider_availability_details "
+            "SET age_group = json_extract(age_groups, '$[0]') "
+            "WHERE json_array_length(age_groups) > 0"
+        )
+    )
+    with op.batch_alter_table("provider_availability_details") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_provider_availability_details_age_group",
+            "age_group IN ('children_0_5', 'children_6_10', 'preteens_11_13', "
+            "'adolescents_14_18', 'young_adults_19_24', 'adults_25_64', "
+            "'older_adults_65_plus')",
+        )
+        batch_op.drop_column("age_groups")

--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -79,8 +79,11 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
                 "Older teens and TAY with ADHD, anxiety, depression, self-harm, "
                 "and suicidality."
             ),
-            # TODO(issue-4): spans adolescents + young_adults + adults. Single-valued today.
-            "age_group": "adolescents_14_18",
+            "age_groups": [
+                "adolescents_14_18",
+                "young_adults_19_24",
+                "adults_25_64",
+            ],
             "languages": ["en"],
             # TODO(issue-6): true value is self_pay_only; not in vocab today.
             # Best-fit placeholder.
@@ -119,8 +122,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "settings": ["outpatient"],
             "treatment_modality": "Social skills, emotion regulation",
             "client_focus": "Middle schoolers with ASD.",
-            # TODO(issue-4): middle school spans children_6_10 + preteens_11_13.
-            "age_group": "preteens_11_13",
+            "age_groups": ["children_6_10", "preteens_11_13"],
             "languages": ["en", "es"],
             "payment_situation": "out_of_network",  # TODO(issue-6): true value is self_pay_only.
             "sliding_scale": True,
@@ -158,9 +160,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
                 "self-harm/suicidality with no immediate risk of harm to self "
                 "or others."
             ),
-            # TODO(issue-4): "high school" spans adolescents_14_18 + possibly
-            # young_adults_19_24.
-            "age_group": "adolescents_14_18",
+            "age_groups": ["adolescents_14_18"],
             "languages": ["en", "es"],
             # TODO(issue-6): true value is please_contact
             # ("Yes — no MediCal, please contact").

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -111,6 +111,13 @@ LanguagesField = Annotated[list[Literal[*LANGUAGES]], BeforeValidator(_scalar_to
 # practice speaks at least one language, and the unfilterable "no
 # languages" state is meaningless. Mirrors services / settings.
 RequiredLanguagesField = Annotated[LanguagesField, Field(min_length=1)]
+AgeGroupsField = Annotated[
+    list[Literal[*CLIENT_AGE_GROUPS]], BeforeValidator(_scalar_to_list)
+]
+# `provider_availability.age_groups` is required-min-1 on the wire — every
+# practice serves at least one age bucket. Replaces the single-valued
+# `age_group` (#430).
+RequiredAgeGroupsField = Annotated[AgeGroupsField, Field(min_length=1)]
 
 
 # --- Shared flatten helper ----------------------------------------------
@@ -196,7 +203,7 @@ class ProviderAvailabilityRead(_PostReadBase):
     settings: SettingsField = []
     treatment_modality: str | None = None
     client_focus: str
-    age_group: Literal[*CLIENT_AGE_GROUPS]
+    age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     payment_situation: Literal[*INSURANCE_OPTIONS]
     sliding_scale: bool
@@ -264,7 +271,10 @@ class ProviderAvailabilityCreate(WirePayload):
     settings: RequiredSettingsField
     treatment_modality: StrippedOptionalText = None
     client_focus: StrippedText
-    age_group: Literal[*CLIENT_AGE_GROUPS]
+    # Required min-1 on the wire — replaces the old single-valued
+    # `age_group` (#430). No default; every PA post must declare at
+    # least one bucket explicitly.
+    age_groups: RequiredAgeGroupsField
     # Required min-1 on the wire — replaces the old yes/no
     # `non_english_services` flag (#425). Defaults to `["en"]` so the
     # form's "submit with defaults" case still validates.
@@ -344,7 +354,7 @@ class ProviderAvailabilityUpdate(PartialUpdate):
     settings: RequiredSettingsField | None = None
     treatment_modality: StrippedOptionalText = None
     client_focus: StrippedText | None = None
-    age_group: Literal[*CLIENT_AGE_GROUPS] | None = None
+    age_groups: RequiredAgeGroupsField | None = None
     # `None` = leave unchanged. `min_length=1` rejects an explicit `[]`,
     # mirroring `services`. Clearing the list is intentionally not
     # supported.
@@ -408,7 +418,7 @@ class ProviderAvailabilityAuditSnapshot(_PostAuditSnapshotBase):
     settings: SettingsField = []
     treatment_modality: str | None = None
     client_focus: str
-    age_group: Literal[*CLIENT_AGE_GROUPS]
+    age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     payment_situation: Literal[*INSURANCE_OPTIONS]
     sliding_scale: bool

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -365,6 +365,45 @@ def test_post_create_provider_availability_rejects_unknown_language_token():
         )
 
 
+def test_post_create_provider_availability_accepts_multiple_age_groups():
+    """`age_groups` accepts a multi-bucket list — Katie Reeves spans 3
+    buckets, that's the whole point of #430."""
+    p = post_create_adapter.validate_python(
+        provider_availability_payload(
+            age_groups=["adolescents_14_18", "young_adults_19_24", "adults_25_64"]
+        )
+    )
+    assert p.age_groups == [
+        "adolescents_14_18",
+        "young_adults_19_24",
+        "adults_25_64",
+    ]
+
+
+def test_post_create_provider_availability_rejects_empty_age_groups():
+    with pytest.raises(ValidationError):
+        post_create_adapter.validate_python(
+            provider_availability_payload(age_groups=[])
+        )
+
+
+def test_post_create_provider_availability_rejects_unknown_age_group_token():
+    with pytest.raises(ValidationError):
+        post_create_adapter.validate_python(
+            provider_availability_payload(age_groups=["not_a_bucket"])
+        )
+
+
+def test_post_update_provider_availability_accepts_age_groups_only():
+    p = post_update_adapter.validate_python(
+        {
+            "kind": "provider_availability",
+            "age_groups": ["young_adults_19_24", "adults_25_64"],
+        }
+    )
+    assert p.age_groups == ["young_adults_19_24", "adults_25_64"]
+
+
 def test_post_create_strips_surrounding_whitespace_provider_availability():
     p = post_create_adapter.validate_python(
         provider_availability_payload(practice_name="  Acme  ")
@@ -390,7 +429,7 @@ def test_post_create_provider_availability_rejects_empty_practice_name():
         "in_person_sessions",
         "virtual_sessions",
         "client_focus",
-        "age_group",
+        "age_groups",
         "payment_situation",
         "sliding_scale",
     ],
@@ -560,7 +599,6 @@ def _literal_args(model_cls, field_name: str) -> tuple[str, ...]:
         (ProviderAvailabilityRead, "location_state", US_STATES),
         (ProviderAvailabilityRead, "in_person_sessions", LOCATION_AVAILABILITY_OPTIONS),
         (ProviderAvailabilityRead, "virtual_sessions", LOCATION_AVAILABILITY_OPTIONS),
-        (ProviderAvailabilityRead, "age_group", CLIENT_AGE_GROUPS),
         (ProviderAvailabilityRead, "payment_situation", INSURANCE_OPTIONS),
         # Create variants
         (ClientReferralCreate, "location_state", US_STATES),
@@ -570,7 +608,6 @@ def _literal_args(model_cls, field_name: str) -> tuple[str, ...]:
         # Update variants (Optional[Literal[*TUPLE]])
         (ClientReferralUpdate, "location_state", US_STATES),
         (ClientReferralUpdate, "insurance", INSURANCE_OPTIONS),
-        (ProviderAvailabilityUpdate, "age_group", CLIENT_AGE_GROUPS),
     ],
 )
 def test_schema_literals_match_model_tuples(model_cls, field, expected):

--- a/src/domain/models/posts/provider_availability_detail.py
+++ b/src/domain/models/posts/provider_availability_detail.py
@@ -6,7 +6,6 @@ from sqlalchemy.types import Uuid
 from src.framework.persistence.base_model import Base
 
 from ..enums import (
-    CLIENT_AGE_GROUPS,
     INSURANCE_OPTIONS,
     LOCATION_AVAILABILITY_OPTIONS,
     US_STATES,
@@ -25,7 +24,6 @@ class ProviderAvailabilityDetail(Base):
         _ck("location_state", US_STATES),
         _ck("in_person_sessions", LOCATION_AVAILABILITY_OPTIONS),
         _ck("virtual_sessions", LOCATION_AVAILABILITY_OPTIONS),
-        _ck("age_group", CLIENT_AGE_GROUPS),
         _ck("payment_situation", INSURANCE_OPTIONS),
     )
 
@@ -56,7 +54,7 @@ class ProviderAvailabilityDetail(Base):
     settings = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
     treatment_modality = Column(Text, nullable=True)
     client_focus = Column(Text, nullable=False)
-    age_group = Column(Text, nullable=False)
+    age_groups = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
     languages = Column(
         JSON, nullable=False, server_default=text("'[\"en\"]'"), default=lambda: ["en"]
     )

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -923,6 +923,29 @@ async def test_provider_availability_form_renders_languages_multi_select(
     assert "Spanish" in response.text
 
 
+async def test_provider_availability_form_renders_age_groups_multi_select(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`age_groups` renders as a 7-option multi-select checkbox group via
+    `field_for`'s `list[Literal[*T]]` arm (#430). First 7-option consumer
+    of the multi-select rails."""
+    response = await authenticated_client.get("/posts/form?kind=provider_availability")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    boxes = tree.css('input[type="checkbox"][name="age_groups"]')
+    values = {b.attributes.get("value") for b in boxes}
+    assert values == {
+        "children_0_5",
+        "children_6_10",
+        "preteens_11_13",
+        "adolescents_14_18",
+        "young_adults_19_24",
+        "adults_25_64",
+        "older_adults_65_plus",
+    }
+
+
 async def test_list_renders_provider_availability_row(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/posts/_provider_availability_form.html
+++ b/src/domain/templates/posts/_provider_availability_form.html
@@ -61,7 +61,7 @@ which FastAPI/Pydantic parses as a list.
     {{ multi_select_field("settings", "Treatment settings (select at least one)", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
     {{ text_field("treatment_modality", "Treatment modality (optional, e.g. DBT, EMDR)", current=d.treatment_modality if d else None, required=false) }}
     {{ textarea_field("client_focus", "Client focus (no PII)", current=d.client_focus if d else None) }}
-    {{ select_field("age_group", "Age group", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.age_group if d else None, placeholder=true) }}
+    {{ field_for(schema, "age_groups", "Age groups (select all that apply)", current=d.age_groups if d else None) }}
     {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
   </fieldset>
 

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -78,8 +78,8 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
     {% endif %}
     <dt>Client focus</dt>
     <dd>{{ d.client_focus }}</dd>
-    <dt>Age group</dt>
-    <dd>{{ CLIENT_AGE_GROUP_LABELS[d.age_group] }}</dd>
+    <dt>Age groups</dt>
+    <dd>{% for g in d.age_groups %}{{ CLIENT_AGE_GROUP_LABELS[g] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     <dt>Languages</dt>
     <dd>{% for l in d.languages %}{{ LANGUAGE_LABELS[l] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     <dt>Payment situation</dt>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -82,7 +82,7 @@ _PROVIDER_AVAILABILITY_DEFAULTS: dict[str, Any] = {
     "settings": ["outpatient"],
     "treatment_modality": None,
     "client_focus": "general adult outpatient",
-    "age_group": "adults_25_64",
+    "age_groups": ["adults_25_64"],
     "languages": ["en"],
     "payment_situation": "in_network",
     "sliding_scale": False,


### PR DESCRIPTION
## Summary
- Single-valued `age_group` forced real-world fixtures to lie (Katie Reeves spans 3 buckets; Camp BooHoo spans 2; only RISE fits in 1). Swap for `age_groups: list[Literal[*CLIENT_AGE_GROUPS]]` with required-min-1.
- Single-PR (Path B) — rides the multi-select rails from #426 directly. No framework prep.
- Migration backfills with `json_array(age_group)` — shared SQLite/Postgres function name, no dialect branching.

Closes #430.

## Test plan
- [x] `dev test` — 908 passed, 52 skipped.
- [x] `dev test contract` — 16 passed.
- [x] `dev lint` — clean.
- [x] `dev migrate roundtrip` on rev `9cc643102347` — clean.
- [x] New tests: multi-bucket accept, empty-list 422, unknown-token 422, PATCH-with-only-age_groups, 7-checkbox form render.

## Framework/spec impact
None. Existing multi-select rails held cleanly at 7 options — same dispatch path as the 2-option `languages` and 5-option `services`/`settings`. The retro covers this.

## Per-PR retrospective
### Multi-select rails held at 7 options
**Friction:** Zero. The 7-option group rendered identically to the 2-option `languages` group; no new edge cases. `field_for`'s `multi_select_field` arm is shape-stable across N.
**Fix:** N/A.
**Why didn't existing patterns prevent this?** The pattern was the solution.
**Could this class recur elsewhere?** Yes — every subsequent list-valued field over a controlled vocab gets it free. No audit needed.
**Effort:** small.

### `json_array(...)` backfill worked on SQLite without dialect branching
**Friction:** Zero. Postgres has the same function with the same semantics, so `op.execute(\"UPDATE … SET age_groups = json_array(age_group)\")` is dialect-portable. First time this codebase has needed a non-trivial in-migration data transform; future migrations doing column-shape changes can lean on the same idiom.
**Fix:** N/A.
**Why didn't existing patterns prevent this?** No prior migration needed an in-flight transform. The first one sets the precedent.
**Could this class recur elsewhere?** Yes — #6 (`payment_situation` vocab expansion) and the end-of-series breaking removals will likely need analogous transforms.
**Effort:** small.

### CR follow-up to file
Same shape problem on `client_referral.client_dem_ages` (single-valued). Will file as a follow-up issue when the loop wraps; intentionally not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)