### PR TITLE
Replace client_referral.client_dem_ages with client_dem_age_groups list (#432)

### DIFF
--- a/alembic/versions/5b2d97b1860f_replace_cr_client_dem_ages_with_age_.py
+++ b/alembic/versions/5b2d97b1860f_replace_cr_client_dem_ages_with_age_.py
@@ -1,0 +1,81 @@
+"""replace_cr_client_dem_ages_with_age_groups
+
+Revision ID: 5b2d97b1860f
+Revises: 9cc643102347
+Create Date: 2026-05-11 22:02:30.776513
+
+Sibling to revision `9cc643102347`. CR's `client_dem_ages` was
+single-valued; rename + retype to `client_dem_age_groups` JSON list,
+mirroring PA's `age_groups` swap. Same `batch_alter_table` SQLite-CHECK
+trap documented in `alembic/README.md`.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5b2d97b1860f"
+down_revision: Union[str, None] = "9cc643102347"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "client_referral_details",
+        sa.Column(
+            "client_dem_age_groups",
+            sa.JSON(),
+            server_default=sa.text("'[]'"),
+            nullable=False,
+        ),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE client_referral_details "
+            "SET client_dem_age_groups = json_array(client_dem_ages)"
+        )
+    )
+    with op.batch_alter_table("client_referral_details") as batch_op:
+        batch_op.drop_constraint(
+            "ck_client_referral_details_client_dem_ages",
+            type_="check",
+        )
+        batch_op.drop_column("client_dem_ages")
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Lossy: restore the scalar column from the first list element;
+    `client_dem_age_groups[1:]` is discarded.
+    """
+    op.add_column(
+        "client_referral_details",
+        sa.Column(
+            "client_dem_ages",
+            sa.TEXT(),
+            server_default=sa.text("'adults_25_64'"),
+            nullable=False,
+        ),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE client_referral_details "
+            "SET client_dem_ages = json_extract(client_dem_age_groups, '$[0]') "
+            "WHERE json_array_length(client_dem_age_groups) > 0"
+        )
+    )
+    with op.batch_alter_table("client_referral_details") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_client_referral_details_client_dem_ages",
+            "client_dem_ages IN ('children_0_5', 'children_6_10', "
+            "'preteens_11_13', 'adolescents_14_18', 'young_adults_19_24', "
+            "'adults_25_64', 'older_adults_65_plus')",
+        )
+        batch_op.drop_column("client_dem_age_groups")

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -175,7 +175,7 @@ class ClientReferralRead(_PostReadBase):
     location_in_person: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     location_virtual: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     desired_times: DesiredTimesField = []
-    client_dem_ages: Literal[*CLIENT_AGE_GROUPS]
+    client_dem_age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     description: str
     services: ServicesField = []
@@ -236,7 +236,9 @@ class ClientReferralCreate(WirePayload):
     location_in_person: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     location_virtual: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     desired_times: DesiredTimesField = []
-    client_dem_ages: Literal[*CLIENT_AGE_GROUPS]
+    # Required min-1 on the wire — replaces the old single-valued
+    # `client_dem_ages` (#432). Mirrors PA's `age_groups` (#430).
+    client_dem_age_groups: RequiredAgeGroupsField
     # Required min-1 on the wire — replaces the old yes/no
     # `language_preferred` flag (#428). Defaults to `["en"]` so the
     # form's "submit with defaults" case still validates.
@@ -322,7 +324,7 @@ class ClientReferralUpdate(PartialUpdate):
     # selections. List-valued PATCH replaces the whole list — partial
     # add/remove is intentionally out of scope.
     desired_times: DesiredTimesField | None = None
-    client_dem_ages: Literal[*CLIENT_AGE_GROUPS] | None = None
+    client_dem_age_groups: RequiredAgeGroupsField | None = None
     # `None` = leave unchanged. `min_length=1` rejects an explicit `[]`,
     # mirroring PA's `languages` semantics.
     languages: RequiredLanguagesField | None = None
@@ -391,7 +393,7 @@ class ClientReferralAuditSnapshot(_PostAuditSnapshotBase):
     location_in_person: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     location_virtual: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     desired_times: DesiredTimesField = []
-    client_dem_ages: Literal[*CLIENT_AGE_GROUPS]
+    client_dem_age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     description: str
     services: ServicesField = []

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -107,7 +107,7 @@ def test_post_create_client_referral_rejects_empty_description():
         "location_zip",
         "location_in_person",
         "location_virtual",
-        "client_dem_ages",
+        "client_dem_age_groups",
         "description",
         "insurance",
     ],
@@ -150,6 +150,25 @@ def test_post_create_client_referral_rejects_unknown_language_token():
         post_create_adapter.validate_python(client_referral_payload(languages=["xx"]))
 
 
+def test_post_create_client_referral_accepts_multiple_age_groups():
+    """CR's `client_dem_age_groups` accepts a multi-bucket list (#432) —
+    the original single-valued `client_dem_ages` forced referrers to
+    pick one when a child straddled buckets."""
+    p = post_create_adapter.validate_python(
+        client_referral_payload(
+            client_dem_age_groups=["children_6_10", "preteens_11_13"]
+        )
+    )
+    assert p.client_dem_age_groups == ["children_6_10", "preteens_11_13"]
+
+
+def test_post_create_client_referral_rejects_empty_age_groups():
+    with pytest.raises(ValidationError):
+        post_create_adapter.validate_python(
+            client_referral_payload(client_dem_age_groups=[])
+        )
+
+
 def test_post_create_client_referral_strips_optional_to_none():
     p = post_create_adapter.validate_python(
         client_referral_payload(services_psychotherapy_modality="   ")
@@ -176,7 +195,7 @@ def test_post_create_client_referral_rejects_unknown_state():
 def test_post_create_client_referral_rejects_unknown_age_group():
     with pytest.raises(ValidationError):
         post_create_adapter.validate_python(
-            client_referral_payload(client_dem_ages="too_old")
+            client_referral_payload(client_dem_age_groups=["too_old"])
         )
 
 
@@ -447,11 +466,11 @@ def test_post_create_rejects_unknown_fields_on_provider_availability():
 
 
 def test_post_create_rejects_cross_kind_field_bleed():
-    """Cross-kind field bleed must not validate. `client_dem_ages` is
-    a client-referral-only field; it has no place in a PA payload."""
+    """Cross-kind field bleed must not validate. `client_dem_age_groups`
+    is a client-referral-only field; it has no place in a PA payload."""
     with pytest.raises(ValidationError):
         post_create_adapter.validate_python(
-            provider_availability_payload(client_dem_ages="adults_25_64")
+            provider_availability_payload(client_dem_age_groups=["adults_25_64"])
         )
 
 
@@ -594,7 +613,6 @@ def _literal_args(model_cls, field_name: str) -> tuple[str, ...]:
         (ClientReferralRead, "location_state", US_STATES),
         (ClientReferralRead, "location_in_person", LOCATION_AVAILABILITY_OPTIONS),
         (ClientReferralRead, "location_virtual", LOCATION_AVAILABILITY_OPTIONS),
-        (ClientReferralRead, "client_dem_ages", CLIENT_AGE_GROUPS),
         (ClientReferralRead, "insurance", INSURANCE_OPTIONS),
         (ProviderAvailabilityRead, "location_state", US_STATES),
         (ProviderAvailabilityRead, "in_person_sessions", LOCATION_AVAILABILITY_OPTIONS),
@@ -602,7 +620,6 @@ def _literal_args(model_cls, field_name: str) -> tuple[str, ...]:
         (ProviderAvailabilityRead, "payment_situation", INSURANCE_OPTIONS),
         # Create variants
         (ClientReferralCreate, "location_state", US_STATES),
-        (ClientReferralCreate, "client_dem_ages", CLIENT_AGE_GROUPS),
         (ClientReferralCreate, "insurance", INSURANCE_OPTIONS),
         (ProviderAvailabilityCreate, "payment_situation", INSURANCE_OPTIONS),
         # Update variants (Optional[Literal[*TUPLE]])

--- a/src/domain/models/posts/client_referral_detail.py
+++ b/src/domain/models/posts/client_referral_detail.py
@@ -6,7 +6,6 @@ from sqlalchemy.types import Uuid
 from src.framework.persistence.base_model import Base
 
 from ..enums import (
-    CLIENT_AGE_GROUPS,
     INSURANCE_OPTIONS,
     LOCATION_AVAILABILITY_OPTIONS,
     US_STATES,
@@ -25,7 +24,6 @@ class ClientReferralDetail(Base):
         _ck("location_state", US_STATES),
         _ck("location_in_person", LOCATION_AVAILABILITY_OPTIONS),
         _ck("location_virtual", LOCATION_AVAILABILITY_OPTIONS),
-        _ck("client_dem_ages", CLIENT_AGE_GROUPS),
         _ck("insurance", INSURANCE_OPTIONS),
     )
 
@@ -46,7 +44,9 @@ class ClientReferralDetail(Base):
     )
 
     # Section 2 — demographics
-    client_dem_ages = Column(Text, nullable=False)
+    client_dem_age_groups = Column(
+        JSON, nullable=False, server_default=text("'[]'"), default=list
+    )
     languages = Column(
         JSON, nullable=False, server_default=text("'[\"en\"]'"), default=lambda: ["en"]
     )

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -517,6 +517,28 @@ async def test_client_referral_form_renders_languages_multi_select(
     assert values == {"en", "es"}
 
 
+async def test_client_referral_form_renders_age_groups_multi_select(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`client_dem_age_groups` on CR renders via the multi-select arm (#432),
+    mirroring PA's `age_groups` (#430)."""
+    response = await authenticated_client.get("/posts/form?kind=client_referral")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    boxes = tree.css('input[type="checkbox"][name="client_dem_age_groups"]')
+    values = {b.attributes.get("value") for b in boxes}
+    assert values == {
+        "children_0_5",
+        "children_6_10",
+        "preteens_11_13",
+        "adolescents_14_18",
+        "young_adults_19_24",
+        "adults_25_64",
+        "older_adults_65_plus",
+    }
+
+
 async def test_get_post_form_default_kind_is_client_referral(
     authenticated_client: AsyncClient,
     logged_in_user: User,

--- a/src/domain/templates/posts/_client_referral_form.html
+++ b/src/domain/templates/posts/_client_referral_form.html
@@ -35,7 +35,7 @@ which FastAPI/Pydantic parses as a list.
 
   <fieldset>
     <legend>Demographics</legend>
-    {{ select_field("client_dem_ages", "Age group", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.client_dem_ages if d else None, placeholder=true) }}
+    {{ field_for(schema, "client_dem_age_groups", "Age groups (select all that apply)", current=d.client_dem_age_groups if d else None) }}
     {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
   </fieldset>
 

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -23,8 +23,8 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
     <dt>Desired times</dt>
     <dd>{% for slot in d.desired_times %}{{ DESIRED_TIME_SLOT_LABELS[slot] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     {% endif %}
-    <dt>Age group</dt>
-    <dd>{{ CLIENT_AGE_GROUP_LABELS[d.client_dem_ages] }}</dd>
+    <dt>Age groups</dt>
+    <dd>{% for g in d.client_dem_age_groups %}{{ CLIENT_AGE_GROUP_LABELS[g] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     <dt>Languages</dt>
     <dd>{% for l in d.languages %}{{ LANGUAGE_LABELS[l] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     <dt>Description</dt>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -54,7 +54,7 @@ _CLIENT_REFERRAL_DEFAULTS: dict[str, Any] = {
     "location_in_person": "yes",
     "location_virtual": "no",
     "desired_times": [],
-    "client_dem_ages": "adults_25_64",
+    "client_dem_age_groups": ["adults_25_64"],
     "languages": ["en"],
     "description": "needs placement",
     "services": [],


### PR DESCRIPTION
## Summary
- CR sibling to #430. Renames `client_dem_ages` → `client_dem_age_groups` and retypes Literal → `list[Literal[*CLIENT_AGE_GROUPS]]` with required-min-1.
- Closes the age-group multi-select work across both post kinds (paired with PA's #430).
- Single-PR (Path B); reuses #430's `AgeGroupsField` / `RequiredAgeGroupsField` aliases — no framework prep.

Closes #432.

## Test plan
- [x] `dev test` — 909 passed, 52 skipped.
- [x] `dev test contract` — 16 passed.
- [x] `dev lint` — clean.
- [x] `dev migrate roundtrip` on rev `5b2d97b1860f` — clean.

## Framework/spec impact
None. `AgeGroupsField` already lived in `posts/schema.py` from #430; importable by CR variants without hoisting.

## Per-PR retrospective
### `AgeGroupsField` reuse: zero friction
**Friction:** None. The alias was defined at module scope in `posts/schema.py` next to `LanguagesField`, so both CR and PA Pydantic classes reach it without hoisting. The issue retro question (\"was hoisting needed?\") answers itself: no.
**Why didn't existing patterns prevent this?** It IS the pattern — module-scope aliases co-located with their consumers' schemas.
**Could this class recur elsewhere?** Every future multi-select that's used by both kinds (e.g. if `services` ever needs to be on CR with the PA min-1 constraint relaxed) will reuse this pattern. Already grammar.
**Effort:** small.

### Rename `client_dem_ages` → `client_dem_age_groups` was worth it
**Friction:** The retro question asked whether the rename churn was worth it vs. keeping the name and just changing the type. Tradeoff: keeping `client_dem_ages` is shorter and the original name was technically already plural — but it would diverge from PA's `age_groups` and make grep-driven code reading harder (\"are these the same concept or different?\"). The rename keeps the parallel structure visible across kinds.
**Fix:** Renamed.
**Why didn't existing patterns prevent this?** No prior pattern about \"keep cross-kind concept names parallel.\" Worth a CLAUDE.md note someday but not this PR.
**Could this class recur elsewhere?** Yes — issue #6 will likely face the same fork (`payment_situation` on PA vs. `insurance` on CR — different names today, similar concept). Anyone touching them will need to pick.
**Effort:** medium (touched 8 files).

### SQLite CHECK-drop pattern: third migration in a row, first-try clean
**Friction:** Zero. The `alembic/README.md` note from #428 made this instant. Future-self payoff confirmed.
**Fix:** N/A.
**Why didn't existing patterns prevent this?** The pattern DID prevent it — that was the whole point of the doc note.
**Could this class recur elsewhere?** Already documented; no new audit needed.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)