### PR TITLE
Relax required fields on provider_availability (#433)

### DIFF
--- a/alembic/versions/bf8725bca464_relax_pa_required_fields.py
+++ b/alembic/versions/bf8725bca464_relax_pa_required_fields.py
@@ -1,0 +1,61 @@
+"""relax_pa_required_fields
+
+Revision ID: bf8725bca464
+Revises: 5b2d97b1860f
+Create Date: 2026-05-11 22:11:44.350836
+
+#433: relax four `provider_availability_details` columns from
+`NOT NULL` to nullable. Telehealth-only practices (Katie Reeves) have
+no usable city/ZIP; some posts will plausibly want to leave
+in_person/virtual session-format unspecified.
+
+`services` and `settings` columns stay `NOT NULL DEFAULT '[]'` — only
+the wire validator drops `min_length=1`.
+
+Downgrade caveat: if any row has NULL in any of the four columns when
+this revision is reversed, the back-to-NOT-NULL alter will fail.
+Backfill before downgrading.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "bf8725bca464"
+down_revision: Union[str, None] = "5b2d97b1860f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema. Nullability flips for four columns; SQLite needs
+    batch mode (table rewrite) to alter column constraints."""
+    with op.batch_alter_table("provider_availability_details") as batch_op:
+        batch_op.alter_column("location_city", existing_type=sa.TEXT(), nullable=True)
+        batch_op.alter_column("location_zip", existing_type=sa.TEXT(), nullable=True)
+        batch_op.alter_column(
+            "in_person_sessions", existing_type=sa.TEXT(), nullable=True
+        )
+        batch_op.alter_column(
+            "virtual_sessions", existing_type=sa.TEXT(), nullable=True
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Fails if any row has NULL in the affected columns. Backfill first.
+    """
+    with op.batch_alter_table("provider_availability_details") as batch_op:
+        batch_op.alter_column("location_city", existing_type=sa.TEXT(), nullable=False)
+        batch_op.alter_column("location_zip", existing_type=sa.TEXT(), nullable=False)
+        batch_op.alter_column(
+            "in_person_sessions", existing_type=sa.TEXT(), nullable=False
+        )
+        batch_op.alter_column(
+            "virtual_sessions", existing_type=sa.TEXT(), nullable=False
+        )

--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -65,10 +65,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             ),
             "referral_instructions": "Contact via website to schedule an intake call.",
             "website": "katiereevesphd.com",
-            # TODO(issue-5): telehealth-only — no city/zip. Required today; relax in #5.
-            "location_city": "(telehealth only)",
             "location_state": "CA",
-            "location_zip": "00000",  # TODO(issue-5): placeholder; required today.
             "in_person_sessions": "no",
             "virtual_sessions": "yes",
             "desired_times": [],
@@ -111,8 +108,6 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "website": "boohoocrybaby.com",
             "location_city": "Santa Clara",
             "location_state": "CA",
-            # TODO(issue-5): venue (fairgrounds) has no zip; required today.
-            "location_zip": "95050",
             "in_person_sessions": "yes",
             "virtual_sessions": "no",
             "desired_times": [],

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -190,15 +190,12 @@ class ProviderAvailabilityRead(_PostReadBase):
     website: str | None = None
     practice_name: str
     available_providers: str
-    location_city: str
+    location_city: str | None = None
     location_state: Literal[*US_STATES]
-    location_zip: str
-    in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
-    virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
+    location_zip: str | None = None
+    in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
+    virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
     desired_times: DesiredTimesField = []
-    # Read does not enforce min-1 — pre-services PA rows backfilled to
-    # `[]` by the migration would otherwise be unreadable. Min-1 lives
-    # on Create/Update only, where it actually prevents new violations.
     services: ServicesField = []
     settings: SettingsField = []
     treatment_modality: str | None = None
@@ -261,16 +258,19 @@ class ProviderAvailabilityCreate(WirePayload):
     website: StrippedOptionalText = None
     practice_name: StrippedText
     available_providers: StrippedText
-    location_city: StrippedText
+    # `location_state` stays required — only usable geographic filter axis.
+    # City / ZIP / session-format / services / settings all relax to
+    # optional here (#433): telehealth-only practices (Katie Reeves) have
+    # no city/ZIP; venue posts (Camp BooHoo) have placeholder ZIPs;
+    # services/settings vocabularies don't yet cover every post kind.
+    location_city: StrippedOptionalText = None
     location_state: Literal[*US_STATES]
-    location_zip: ZipText
-    in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
-    virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
+    location_zip: ZipText | None = None
+    in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
+    virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
     desired_times: DesiredTimesField = []
-    # Required min-1 on PA per spec — divergence from CR's optional
-    # `services`. No default: an absent field 422s, an empty list 422s.
-    services: RequiredServicesField
-    settings: RequiredSettingsField
+    services: ServicesField = []
+    settings: SettingsField = []
     treatment_modality: StrippedOptionalText = None
     client_focus: StrippedText
     # Required min-1 on the wire — replaces the old single-valued
@@ -408,14 +408,12 @@ class ProviderAvailabilityAuditSnapshot(_PostAuditSnapshotBase):
     website: str | None = None
     practice_name: str
     available_providers: str
-    location_city: str
+    location_city: str | None = None
     location_state: Literal[*US_STATES]
-    location_zip: str
-    in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
-    virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
+    location_zip: str | None = None
+    in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
+    virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
     desired_times: DesiredTimesField = []
-    # AuditSnapshot mirrors Read — no min-1 enforcement, so historic /
-    # backfilled rows can be projected without 422-ing the audit pipeline.
     services: ServicesField = []
     settings: SettingsField = []
     treatment_modality: str | None = None

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -442,11 +442,7 @@ def test_post_create_provider_availability_rejects_empty_practice_name():
     [
         "practice_name",
         "available_providers",
-        "location_city",
         "location_state",
-        "location_zip",
-        "in_person_sessions",
-        "virtual_sessions",
         "client_focus",
         "age_groups",
         "payment_situation",
@@ -771,18 +767,41 @@ def test_post_create_services_rejects_unknown_token(payload_factory):
         post_create_adapter.validate_python(payload_factory(services=["telekinesis"]))
 
 
-def test_post_create_provider_availability_services_rejects_empty_list():
-    """PA's `services` is required-min-1; an explicit `[]` 422s."""
-    with pytest.raises(ValidationError):
-        post_create_adapter.validate_python(provider_availability_payload(services=[]))
+def test_post_create_provider_availability_services_accepts_empty_list():
+    """PA's `services` was required-min-1; #433 relaxed to optional. An
+    explicit `[]` validates."""
+    p = post_create_adapter.validate_python(provider_availability_payload(services=[]))
+    assert p.services == []
 
 
-def test_post_create_provider_availability_services_required():
-    """Omitting `services` entirely on PA also 422s — no default fallback."""
+def test_post_create_provider_availability_services_absent_defaults_empty():
+    """Omitting `services` entirely on PA falls back to `[]` per #433."""
     payload = provider_availability_payload()
     payload.pop("services")
-    with pytest.raises(ValidationError):
-        post_create_adapter.validate_python(payload)
+    p = post_create_adapter.validate_python(payload)
+    assert p.services == []
+
+
+def test_post_create_provider_availability_accepts_omitted_optional_fields():
+    """City, ZIP, sessions, services, settings are all optional after
+    #433 — telehealth-only and venue-based posts must be expressible."""
+    payload = provider_availability_payload()
+    for field in (
+        "location_city",
+        "location_zip",
+        "in_person_sessions",
+        "virtual_sessions",
+        "services",
+        "settings",
+    ):
+        payload.pop(field, None)
+    p = post_create_adapter.validate_python(payload)
+    assert p.location_city is None
+    assert p.location_zip is None
+    assert p.in_person_sessions is None
+    assert p.virtual_sessions is None
+    assert p.services == []
+    assert p.settings == []
 
 
 @pytest.mark.parametrize(

--- a/src/domain/models/posts/provider_availability_detail.py
+++ b/src/domain/models/posts/provider_availability_detail.py
@@ -38,13 +38,13 @@ class ProviderAvailabilityDetail(Base):
     available_providers = Column(Text, nullable=False)
 
     # Section 2 — location
-    location_city = Column(Text, nullable=False)
+    location_city = Column(Text, nullable=True)
     location_state = Column(Text, nullable=False)
-    location_zip = Column(Text, nullable=False)
+    location_zip = Column(Text, nullable=True)
 
     # Section 3 — availability
-    in_person_sessions = Column(Text, nullable=False)
-    virtual_sessions = Column(Text, nullable=False)
+    in_person_sessions = Column(Text, nullable=True)
+    virtual_sessions = Column(Text, nullable=True)
     desired_times = Column(
         JSON, nullable=False, server_default=text("'[]'"), default=list
     )

--- a/src/domain/templates/posts/_provider_availability_form.html
+++ b/src/domain/templates/posts/_provider_availability_form.html
@@ -43,22 +43,22 @@ which FastAPI/Pydantic parses as a list.
 
   <fieldset>
     <legend>Location</legend>
-    {{ text_field("location_city", "City", current=d.location_city if d else None) }}
+    {{ text_field("location_city", "City (leave blank for telehealth-only)", current=d.location_city if d else None, required=false) }}
     {{ select_field("location_state", "State", US_STATES, current=d.location_state if d else None, placeholder=true) }}
-    {{ text_field("location_zip", "ZIP", current=d.location_zip if d else None, pattern="\\d{5}", maxlength=5) }}
+    {{ text_field("location_zip", "ZIP (optional)", current=d.location_zip if d else None, pattern="\\d{5}", maxlength=5, required=false) }}
   </fieldset>
 
   <fieldset>
     <legend>Availability</legend>
-    {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.in_person_sessions if d else None, placeholder=true) }}
-    {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.virtual_sessions if d else None, placeholder=true) }}
+    {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.in_person_sessions if d else None, placeholder=true, required=false) }}
+    {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.virtual_sessions if d else None, placeholder=true, required=false) }}
     {{ time_grid_field("desired_times", "Desired times (optional)", current=d.desired_times if d else None) }}
   </fieldset>
 
   <fieldset>
     <legend>Featured services</legend>
-    {{ multi_select_field("services", "Services (select at least one)", CLIENT_REFERRAL_SERVICES, labels=CLIENT_REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
-    {{ multi_select_field("settings", "Treatment settings (select at least one)", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
+    {{ multi_select_field("services", "Services (optional)", CLIENT_REFERRAL_SERVICES, labels=CLIENT_REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
+    {{ multi_select_field("settings", "Treatment settings (optional)", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
     {{ text_field("treatment_modality", "Treatment modality (optional, e.g. DBT, EMDR)", current=d.treatment_modality if d else None, required=false) }}
     {{ textarea_field("client_focus", "Client focus (no PII)", current=d.client_focus if d else None) }}
     {{ field_for(schema, "age_groups", "Age groups (select all that apply)", current=d.age_groups if d else None) }}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -59,11 +59,15 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
     <dd>{{ d.website }}</dd>
     {% endif %}
     <dt>Location</dt>
-    <dd>{{ d.location_city }}, {{ d.location_state }} {{ d.location_zip }}</dd>
+    <dd>{% if d.location_city %}{{ d.location_city }}, {% endif %}{{ d.location_state }}{% if d.location_zip %} {{ d.location_zip }}{% endif %}</dd>
+    {% if d.in_person_sessions %}
     <dt>In-person sessions</dt>
     <dd>{{ LOCATION_AVAILABILITY_LABELS[d.in_person_sessions] }}</dd>
+    {% endif %}
+    {% if d.virtual_sessions %}
     <dt>Virtual sessions</dt>
     <dd>{{ LOCATION_AVAILABILITY_LABELS[d.virtual_sessions] }}</dd>
+    {% endif %}
     {% if d.desired_times %}
     <dt>Desired times</dt>
     <dd>{% for slot in d.desired_times %}{{ DESIRED_TIME_SLOT_LABELS[slot] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>


### PR DESCRIPTION
## Summary
- Six PA fields flip from required to optional: `location_city`, `location_zip`, `in_person_sessions`, `virtual_sessions`, `services`, `settings`.
- `location_state` stays required — only usable geographic filter axis.
- Pure constraint relaxation; no framework changes.
- Migration: `batch_alter_table` nullability flips (third migration to use batch mode this series, first to flip nullability rather than add/drop columns).

Closes #433.

## Test plan
- [x] `dev test` — 906 passed, 52 skipped.
- [x] `dev test contract` — 16 passed.
- [x] `dev lint` — clean.
- [x] `dev migrate roundtrip` on rev `bf8725bca464` — clean.

## Framework/spec impact
None.

## Per-PR retrospective
### Batch-mode `ALTER COLUMN nullable=True` worked cleanly on SQLite
**Friction:** First migration to flip nullability (earlier migrations added or dropped columns). The autogen produced direct `op.alter_column(...)` calls without batch mode; needed to wrap in `batch_alter_table` manually to be safe under SQLite. Worked first try.
**Fix:** N/A — wrap is the documented pattern.
**Why didn't existing patterns prevent this?** The `alembic/README.md` note from #428 specifically covers CHECK-drop; nullability flips aren't mentioned but the same batch-mode advice applies. Worth a one-line broadening of that note.
**Could this class recur elsewhere?** Yes — any future migration that flips column constraints (NULL, type, default) will need batch mode on SQLite. Filing as a doc-note tweak in a small follow-up.
**Effort:** small.

### `required=false` flips on the form template revealed migration opportunity
**Friction:** None directly. But noticed during the diff: every flip is on a `text_field` / `select_field` / `multi_select_field` call where the field already has a corresponding Pydantic schema entry. If those calls migrated to `field_for(schema, ...)`, the required-ness would derive from the schema automatically and these manual flips wouldn't be needed — same lesson as #422 / #425 noted.
**Fix:** Not in this PR (out of scope per issue's \"don't migrate hand-wired fields\" note). The cleanup issue from earlier retros still stands.
**Why didn't existing patterns prevent this?** It IS the pattern (\"defer the migration\"); just adding evidence to the pile.
**Could this class recur elsewhere?** Yes — every later schema-relax in the series will repeat this pattern.
**Effort:** medium (for the deferred migration, when filed).

### Detail-page guard for null trailing-comma in location line
**Friction:** The location render concatenated `{{ city }}, {{ state }} {{ zip }}` — when city or zip is null, this renders extra commas/spaces. Guarded inline with `{% if %}`. Five-second fix once spotted, but worth flagging for future relax-PRs in the series: every render-time concatenation needs to handle the null arm.
**Fix:** Inline guards in the detail template.
**Why didn't existing patterns prevent this?** Earlier-series PRs (description / website / referral_instructions) guarded whole `<dt>/<dd>` rows; this was the first case where multiple fields concatenated into a single rendered string. The two patterns coexist cleanly.
**Could this class recur elsewhere?** Yes — any composite render (\"M-F 9-5\", \"$300 / hour\", etc.) added in later issues should default to null-aware concatenation.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)