### PR TITLE
Drop <br> tags from form macros and auth forms

### DIFF
--- a/src/domain/templates/_shared/form_fields.html
+++ b/src/domain/templates/_shared/form_fields.html
@@ -1,7 +1,8 @@
 {# Form-field render macros.
 
-Each macro emits one labelled field (label + control + line breaks) so
-per-kind form partials read as a flat field list rather than HTML
+Each macro emits one labelled field — Pico CSS styles `<label>` and
+its nested control as a block, so no `<br>` between fields is needed.
+Per-kind form partials read as a flat field list rather than HTML
 boilerplate. The `<select>` and bool-radio macros iterate over a
 controlled-vocabulary tuple from `src/models/enums.py` (registered
 as Jinja globals in `src/core/templating.py`) and look display labels up
@@ -21,25 +22,31 @@ canonical use.
 #}
 
 {% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None) -%}
-<label for="{{ name }}">{{ label }}:</label><br />
-<input type="text" id="{{ name }}" name="{{ name }}"{% if current is not none %} value="{{ current }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}{% if maxlength %} maxlength="{{ maxlength }}"{% endif %}{% if required %} required{% endif %} /><br /><br />
+<label for="{{ name }}">
+  {{ label }}
+  <input type="text" id="{{ name }}" name="{{ name }}"{% if current is not none %} value="{{ current }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}{% if maxlength %} maxlength="{{ maxlength }}"{% endif %}{% if required %} required{% endif %} />
+</label>
 {%- endmacro %}
 
 {% macro textarea_field(name, label, current=None, required=True) -%}
-<label for="{{ name }}">{{ label }}:</label><br />
-<textarea id="{{ name }}" name="{{ name }}"{% if required %} required{% endif %}>{{ current or "" }}</textarea><br /><br />
+<label for="{{ name }}">
+  {{ label }}
+  <textarea id="{{ name }}" name="{{ name }}"{% if required %} required{% endif %}>{{ current or "" }}</textarea>
+</label>
 {%- endmacro %}
 
 {% macro select_field(name, label, options, labels=None, current=None, required=True, placeholder=False) -%}
-<label for="{{ name }}">{{ label }}:</label><br />
-<select id="{{ name }}" name="{{ name }}"{% if required %} required{% endif %}>
-  {%- if placeholder and not current %}
-  <option value="" disabled selected>--</option>
-  {%- endif %}
-  {%- for v in options %}
-  <option value="{{ v }}"{% if current == v %} selected{% endif %}>{{ labels[v] if labels else v }}</option>
-  {%- endfor %}
-</select><br /><br />
+<label for="{{ name }}">
+  {{ label }}
+  <select id="{{ name }}" name="{{ name }}"{% if required %} required{% endif %}>
+    {%- if placeholder and not current %}
+    <option value="" disabled selected>--</option>
+    {%- endif %}
+    {%- for v in options %}
+    <option value="{{ v }}"{% if current == v %} selected{% endif %}>{{ labels[v] if labels else v }}</option>
+    {%- endfor %}
+  </select>
+</label>
 {%- endmacro %}
 
 {# Filter-form variant of `select_field`. Two differences from the
@@ -50,13 +57,15 @@ canonical use.
    filter is applied); the matching option is preselected, otherwise
    the "any" option is. #}
 {% macro filter_select_field(name, label, options, labels=None, current=None, any_label="Any") -%}
-<label for="{{ name }}">{{ label }}:</label><br />
-<select id="{{ name }}" name="{{ name }}">
-  <option value=""{% if not current %} selected{% endif %}>{{ any_label }}</option>
-  {%- for v in options %}
-  <option value="{{ v }}"{% if current == v %} selected{% endif %}>{{ labels[v] if labels else v }}</option>
-  {%- endfor %}
-</select><br /><br />
+<label for="{{ name }}">
+  {{ label }}
+  <select id="{{ name }}" name="{{ name }}">
+    <option value=""{% if not current %} selected{% endif %}>{{ any_label }}</option>
+    {%- for v in options %}
+    <option value="{{ v }}"{% if current == v %} selected{% endif %}>{{ labels[v] if labels else v }}</option>
+    {%- endfor %}
+  </select>
+</label>
 {%- endmacro %}
 
 {% macro radio_bool_field(name, label, current=None, required=True) -%}
@@ -64,7 +73,7 @@ canonical use.
   <legend>{{ label }}</legend>
   <label><input type="radio" name="{{ name }}" value="true"{% if current is sameas true %} checked{% endif %}{% if required %} required{% endif %} /> Yes</label>
   <label><input type="radio" name="{{ name }}" value="false"{% if current is sameas false %} checked{% endif %}{% if required %} required{% endif %} /> No</label>
-</fieldset><br />
+</fieldset>
 {%- endmacro %}
 
 {# Flat checkbox list driven by a controlled-vocabulary tuple. All
@@ -82,9 +91,9 @@ the upcoming `settings` field on `provider_availability` reuses it. #}
   <label>
     <input type="checkbox" name="{{ name }}" value="{{ v }}"{% if v in selected %} checked{% endif %} />
     {{ labels[v] if labels else v }}
-  </label><br />
+  </label>
   {%- endfor %}
-</fieldset><br />
+</fieldset>
 {%- endmacro %}
 
 {# Day × time-of-day checkbox grid. Renders one checkbox per
@@ -143,5 +152,5 @@ posts an empty array. #}
       {%- endfor %}
     </tbody>
   </table>
-</fieldset><br />
+</fieldset>
 {%- endmacro %}

--- a/src/domain/templates/auth/forgot_password.html
+++ b/src/domain/templates/auth/forgot_password.html
@@ -7,8 +7,10 @@ block content %}
 </p>
 <!-- Assuming the POST action is the default FastAPI Users endpoint -->
 <form method="post" action="/auth/forgot-password">
-  <label for="email">Email:</label><br />
-  <input type="email" id="email" name="email" required /><br /><br />
+  <label for="email">
+    Email
+    <input type="email" id="email" name="email" required />
+  </label>
   <input type="submit" value="Send Reset Link" />
 </form>
 <hr />

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -6,10 +6,14 @@
 <form
   method="post"
   action="/auth/jwt/login{% if next_url %}?next={{ next_url }}{% endif %}">
-  <label for="username">Email:</label><br />
-  <input type="email" id="username" name="username" /><br />
-  <label for="Password">Password:</label><br />
-  <input type="password" id="password" name="password" /><br /><br />
+  <label for="username">
+    Email
+    <input type="email" id="username" name="username" />
+  </label>
+  <label for="password">
+    Password
+    <input type="password" id="password" name="password" />
+  </label>
   <input type="submit" value="Login" />
 </form>
 <hr />

--- a/src/domain/templates/auth/register.html
+++ b/src/domain/templates/auth/register.html
@@ -2,12 +2,18 @@
 content %}
 <h1>Register</h1>
 <form hx-post="/auth/register" hx-ext="json-enc">
-  <label for="email">Email:</label><br />
-  <input type="email" id="email" name="email" required /><br />
-  <label for="username">Username:</label><br />
-  <input type="text" id="username" name="username" required /><br />
-  <label for="password">Password:</label><br />
-  <input type="password" id="password" name="password" required /><br /><br />
+  <label for="email">
+    Email
+    <input type="email" id="email" name="email" required />
+  </label>
+  <label for="username">
+    Username
+    <input type="text" id="username" name="username" required />
+  </label>
+  <label for="password">
+    Password
+    <input type="password" id="password" name="password" required />
+  </label>
   <input type="submit" value="Register" />
 </form>
 <hr />

--- a/src/domain/templates/auth/reset_password.html
+++ b/src/domain/templates/auth/reset_password.html
@@ -8,8 +8,10 @@ content %}
 <form method="post" action="/auth/reset-password">
   <input type="hidden" name="token" value="{{ token }}" />
   <!-- Token passed from route context -->
-  <label for="password">Enter new password:</label><br />
-  <input type="password" id="password" name="password" required /><br /><br />
+  <label for="password">
+    Enter new password
+    <input type="password" id="password" name="password" required />
+  </label>
   <input type="submit" value="Reset Password" />
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
Follow-up to #435. Pico styles `<label>` and its nested control as a block, so per-field `<br>`s aren't needed for vertical stacking.

- `_shared/form_fields.html` — `text_field` / `textarea_field` / `select_field` / `filter_select_field` now use Pico's nested-label pattern (`<label>{label}<input/></label>`). Trailing `<br>`s on the fieldset-based macros (`radio_bool_field`, `multi_select_field`, `time_grid_field`) dropped — Pico already spaces fieldsets.
- `auth/login.html`, `auth/register.html`, `auth/forgot_password.html`, `auth/reset_password.html` — same nested-label shape, no `<br>`s.
- Macro docstring updated to reflect the new shape.

## Test plan
- [x] `dev test` (909 passed, 52 skipped)
- [x] `dev lint`
- [ ] Manually verify forms still render with consistent spacing under Pico

🤖 Generated with [Claude Code](https://claude.com/claude-code)