### PR TITLE
Expand INSURANCE_OPTIONS vocab: self_pay_only + please_contact (#438)

### DIFF
--- a/alembic/versions/9131c572d8a1_expand_insurance_options_vocab.py
+++ b/alembic/versions/9131c572d8a1_expand_insurance_options_vocab.py
@@ -1,0 +1,73 @@
+"""expand_insurance_options_vocab
+
+Revision ID: 9131c572d8a1
+Revises: bf8725bca464
+Create Date: 2026-05-12 06:52:30.895867
+
+#438: widen the `INSURANCE_OPTIONS` controlled vocabulary from
+3 tokens (`in_network`, `out_of_network`, `in_and_out_of_network`) to
+5 (`+self_pay_only`, `+please_contact`). The CHECK constraint on each
+table referencing this vocab gets dropped and re-added.
+
+Two tables share the vocab: `provider_availability_details.payment_situation`
+and `client_referral_details.insurance`. Both CHECKs widen together so
+the dictionary remains in lockstep.
+
+Existing rows are unaffected — every previously-valid token remains
+valid. Downgrade narrows the CHECK back; if any row uses one of the
+two new tokens, the downgrade fails and the operator must backfill
+before retrying.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9131c572d8a1"
+down_revision: Union[str, None] = "bf8725bca464"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_WIDE_CK = (
+    "{column} IN ('in_network', 'out_of_network', 'in_and_out_of_network', "
+    "'self_pay_only', 'please_contact')"
+)
+_NARROW_CK = "{column} IN ('in_network', 'out_of_network', 'in_and_out_of_network')"
+
+
+def upgrade() -> None:
+    """Widen both CHECKs to admit the two new tokens."""
+    with op.batch_alter_table("provider_availability_details") as batch_op:
+        batch_op.drop_constraint(
+            "ck_provider_availability_details_payment_situation", type_="check"
+        )
+        batch_op.create_check_constraint(
+            "ck_provider_availability_details_payment_situation",
+            _WIDE_CK.format(column="payment_situation"),
+        )
+    with op.batch_alter_table("client_referral_details") as batch_op:
+        batch_op.drop_constraint("ck_client_referral_details_insurance", type_="check")
+        batch_op.create_check_constraint(
+            "ck_client_referral_details_insurance",
+            _WIDE_CK.format(column="insurance"),
+        )
+
+
+def downgrade() -> None:
+    """Narrow both CHECKs back. Fails if any row uses the new tokens."""
+    with op.batch_alter_table("client_referral_details") as batch_op:
+        batch_op.drop_constraint("ck_client_referral_details_insurance", type_="check")
+        batch_op.create_check_constraint(
+            "ck_client_referral_details_insurance",
+            _NARROW_CK.format(column="insurance"),
+        )
+    with op.batch_alter_table("provider_availability_details") as batch_op:
+        batch_op.drop_constraint(
+            "ck_provider_availability_details_payment_situation", type_="check"
+        )
+        batch_op.create_check_constraint(
+            "ck_provider_availability_details_payment_situation",
+            _NARROW_CK.format(column="payment_situation"),
+        )

--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -82,9 +82,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
                 "adults_25_64",
             ],
             "languages": ["en"],
-            # TODO(issue-6): true value is self_pay_only; not in vocab today.
-            # Best-fit placeholder.
-            "payment_situation": "out_of_network",
+            "payment_situation": "self_pay_only",
             "sliding_scale": False,
             "cost": "$250 - $600 per session",
         },
@@ -119,7 +117,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "client_focus": "Middle schoolers with ASD.",
             "age_groups": ["children_6_10", "preteens_11_13"],
             "languages": ["en", "es"],
-            "payment_situation": "out_of_network",  # TODO(issue-6): true value is self_pay_only.
+            "payment_situation": "self_pay_only",
             "sliding_scale": True,
             "cost": "$2,500 / session",
             # TODO(issue-8): cohort dates ("May 25 & Jun 18, 2-week sessions, M-F 9-5")
@@ -157,9 +155,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             ),
             "age_groups": ["adolescents_14_18"],
             "languages": ["en", "es"],
-            # TODO(issue-6): true value is please_contact
-            # ("Yes — no MediCal, please contact").
-            "payment_situation": "in_network",
+            "payment_situation": "please_contact",
             "sliding_scale": True,
             "cost": "$4k/week",
             # TODO(issue-8): "M-F 8:30am-4:30pm, starts May 11"

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -355,6 +355,42 @@ def test_post_create_dispatches_provider_availability():
     assert p.sliding_scale is False
 
 
+@pytest.mark.parametrize(
+    "token",
+    [
+        "in_network",
+        "out_of_network",
+        "in_and_out_of_network",
+        "self_pay_only",
+        "please_contact",
+    ],
+)
+def test_post_create_provider_availability_accepts_all_insurance_tokens(token):
+    """All five `INSURANCE_OPTIONS` tokens validate after #438's vocab
+    widening (`self_pay_only`, `please_contact` were added)."""
+    p = post_create_adapter.validate_python(
+        provider_availability_payload(payment_situation=token)
+    )
+    assert p.payment_situation == token
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "in_network",
+        "out_of_network",
+        "in_and_out_of_network",
+        "self_pay_only",
+        "please_contact",
+    ],
+)
+def test_post_create_client_referral_accepts_all_insurance_tokens(token):
+    """CR's `insurance` shares the `INSURANCE_OPTIONS` vocab with PA;
+    widening propagates to both."""
+    p = post_create_adapter.validate_python(client_referral_payload(insurance=token))
+    assert p.insurance == token
+
+
 def test_post_create_provider_availability_default_languages():
     """`languages` defaults to ['en'] — keeps the submit-with-defaults case
     valid even though the field is required min-1 (#425)."""

--- a/src/domain/models/enums.py
+++ b/src/domain/models/enums.py
@@ -78,6 +78,8 @@ INSURANCE_OPTIONS: Final[tuple[str, ...]] = (
     "in_network",
     "out_of_network",
     "in_and_out_of_network",
+    "self_pay_only",
+    "please_contact",
 )
 
 # Day × time-of-day grid for "when are you available". 21 tokens of the
@@ -153,6 +155,8 @@ INSURANCE_LABELS: Final[dict[str, str]] = {
     "in_network": "In-network",
     "out_of_network": "Out-of-network",
     "in_and_out_of_network": "In- and out-of-network",
+    "self_pay_only": "Self-pay only",
+    "please_contact": "Please contact",
 }
 # Per-axis labels for the desired-times grid. The form-render macro
 # uses these for the row (day) and column (slot) headers; per-cell


### PR DESCRIPTION
## Summary
- Adds `self_pay_only` and `please_contact` to `INSURANCE_OPTIONS` so real-world posts can describe their actual payment situation. Closes the gap that forced #420's seeds to wedge wrong tokens with `TODO(issue-6)` markers.
- Vocab is shared between PA's `payment_situation` and CR's `insurance` — both CHECK constraints widen together in revision `9131c572d8a1`.
- No framework changes; schema/form/detail pick up the new tokens automatically.

Closes #438.

## Test plan
- [x] `dev test` — 916 passed, 52 skipped.
- [x] `dev test contract` — 16 passed.
- [x] `dev lint` — clean.
- [x] `dev migrate roundtrip` on rev `9131c572d8a1` — clean.

## Per-PR retrospective
### Shared vocab → one migration, two CHECKs
**Friction:** Zero. The shared-vocab implication (`INSURANCE_OPTIONS` is referenced by both PA and CR detail tables) was obvious from the model files. Bundling both CHECK widenings in one migration kept the dictionary in lockstep — splitting would risk transient inconsistency. The migration template is now established for any future shared-vocab widening.
**Why didn't existing patterns prevent this?** It IS the pattern.
**Could this class recur elsewhere?** Yes — any future widening of `LOCATION_AVAILABILITY_OPTIONS`, `CLIENT_AGE_GROUPS`, `LANGUAGES`, or `CLIENT_REFERRAL_SERVICES` will face the same multi-table CHECK update. The pattern carries.
**Effort:** small.

### Batch-mode drop+re-add CHECK: third time, first-try clean
**Friction:** Zero. Same `batch_alter_table` idiom as the languages, age_groups, and nullability migrations earlier in this series. The `alembic/README.md` note is paying back.
**Why didn't existing patterns prevent this?** Pattern was the cure.
**Could this class recur elsewhere?** Already documented.
**Effort:** small.

### Reasonable-assumptions principle held
**Friction:** Zero. The 5-token vocab covers the patterns the seeds reveal without overfitting. Considered and rejected adjacents (`accepts_medicaid`, `sliding_scale_only`, `superbill_provided`) per the issue body. If future posts surface a missing case, file a follow-up; today's vocab is the right shape.
**Why didn't existing patterns prevent this?** N/A.
**Could this class recur elsewhere?** Every future vocab-widening issue (#7's `services`/`settings` additions) should be asked the same way: \"what's the minimum that covers the patterns without baking in current quirks?\"
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)