### PR TITLE
Expand services + settings vocabularies for program-style posts (#440)

### DIFF
--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -109,10 +109,8 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "in_person_sessions": "yes",
             "virtual_sessions": "no",
             "desired_times": [],
-            # TODO(issue-7): "therapeutic camp" doesn't fit; allied_health is closest.
-            "services": ["allied_health"],
-            # TODO(issue-7): day_program token not in vocab yet. Outpatient is closest.
-            "settings": ["outpatient"],
+            "services": ["group_therapy"],
+            "settings": ["day_program"],
             "treatment_modality": "Social skills, emotion regulation",
             "client_focus": "Middle schoolers with ASD.",
             "age_groups": ["children_6_10", "preteens_11_13"],
@@ -143,9 +141,12 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "in_person_sessions": "yes",
             "virtual_sessions": "no",
             "desired_times": [],
-            # TODO(issue-7): peer + family groups not in vocab yet
-            # (group_therapy, family_therapy).
-            "services": ["psychotherapy", "medication_management"],
+            "services": [
+                "psychotherapy",
+                "medication_management",
+                "group_therapy",
+                "family_therapy",
+            ],
             "settings": ["iop"],
             "treatment_modality": "Comprehensive DBT",
             "client_focus": (

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -357,6 +357,37 @@ def test_post_create_dispatches_provider_availability():
 
 @pytest.mark.parametrize(
     "token",
+    ["group_therapy", "family_therapy", "couples_therapy"],
+)
+def test_post_create_provider_availability_accepts_new_services_tokens(token):
+    """The three service tokens added in #440 validate on PA Create."""
+    p = post_create_adapter.validate_python(
+        provider_availability_payload(services=[token])
+    )
+    assert p.services == [token]
+
+
+def test_post_create_provider_availability_accepts_day_program_setting():
+    """`day_program` setting added in #440 for program-style posts."""
+    p = post_create_adapter.validate_python(
+        provider_availability_payload(settings=["day_program"])
+    )
+    assert p.settings == ["day_program"]
+
+
+@pytest.mark.parametrize(
+    "token",
+    ["group_therapy", "family_therapy", "couples_therapy"],
+)
+def test_post_create_client_referral_accepts_new_services_tokens(token):
+    """CR shares the `CLIENT_REFERRAL_SERVICES` vocab with PA; widening
+    propagates to both (#440)."""
+    p = post_create_adapter.validate_python(client_referral_payload(services=[token]))
+    assert p.services == [token]
+
+
+@pytest.mark.parametrize(
+    "token",
     [
         "in_network",
         "out_of_network",

--- a/src/domain/models/enums.py
+++ b/src/domain/models/enums.py
@@ -112,6 +112,9 @@ CLIENT_REFERRAL_SERVICES: Final[tuple[str, ...]] = (
     "psychotherapy",
     "case_management",
     "allied_health",
+    "group_therapy",
+    "family_therapy",
+    "couples_therapy",
 )
 
 # Treatment settings categories. `provider_availability` only; required-min-1.
@@ -121,6 +124,7 @@ TREATMENT_SETTINGS: Final[tuple[str, ...]] = (
     "crisis_care",
     "php",
     "residential",
+    "day_program",
 )
 
 
@@ -189,6 +193,9 @@ CLIENT_REFERRAL_SERVICE_LABELS: Final[dict[str, str]] = {
     "psychotherapy": "Psychotherapy",
     "case_management": "Case management",
     "allied_health": "Allied health",
+    "group_therapy": "Group therapy",
+    "family_therapy": "Family therapy",
+    "couples_therapy": "Couples therapy",
 }
 TREATMENT_SETTINGS_LABELS: Final[dict[str, str]] = {
     "outpatient": "Outpatient",
@@ -196,6 +203,7 @@ TREATMENT_SETTINGS_LABELS: Final[dict[str, str]] = {
     "crisis_care": "Crisis care",
     "php": "PHP",
     "residential": "Residential",
+    "day_program": "Day program",
 }
 
 LICENSE_TYPES: Final[tuple[str, ...]] = (


### PR DESCRIPTION
## Summary
- Adds `group_therapy`, `family_therapy`, `couples_therapy` to `CLIENT_REFERRAL_SERVICES`; adds `day_program` to `TREATMENT_SETTINGS`. Includes the optional `couples_therapy` adjacent per the issue's judgment-call note.
- Closes the gap that forced Camp BooHoo's services/settings + RISE IOP's services into wrong placeholders. All three `TODO(issue-7)` markers in seed.py removed.
- No migration: `services` / `settings` are JSON columns without per-row CHECK constraints; validation happens at the Pydantic layer.

Closes #440.

## Test plan
- [x] `dev test` — 923 passed, 52 skipped.
- [x] `dev test contract` — 16 passed.
- [x] `dev lint` — clean.

## Per-PR retrospective
### Included `couples_therapy`
**Friction:** None. The issue signaled it as a judgment call; I included it because it's a well-understood common service line and adding it now is free. Deferring would create an awkward asymmetry with `family_therapy`.
**Why didn't existing patterns prevent this?** N/A — the issue explicitly delegated the call.
**Could this class recur elsewhere?** The reasonable-assumptions principle keeps coming up. Worth distilling into one sentence in CLAUDE.md someday: \"when an issue adjacent is free and symmetric, include it.\"
**Effort:** small.

### Shared `CLIENT_REFERRAL_SERVICES` widening covered both kinds
**Friction:** Zero. PA and CR both reach the tuple via `Literal[*CLIENT_REFERRAL_SERVICES]`, so widening fed both schemas automatically. Same pattern as #438's `INSURANCE_OPTIONS`.
**Could this class recur elsewhere?** Yes, anywhere a vocab is shared across kinds. Already grammar.
**Effort:** small.

### JSON columns: no migration headache
**Friction:** Zero. The `services` / `settings` JSON columns store list values; element-level validation lives at the Pydantic layer (`Literal[*VOCAB]`), not the DB. So a vocab widening is just a code change, not a schema change. Worth noting that this is the simplest possible vocab-expansion case (vs. #438 which needed CHECK widening).
**Could this class recur elsewhere?** Yes — every future widening of `DESIRED_TIME_SLOTS`, `LANGUAGES`, age-groups etc. that lives in JSON columns will skip the migration step. Worth mentioning in the model files' README sometime.
**Effort:** small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)