### PR TITLE
Drop client_focus and available_providers from provider_availability (#444)

### DIFF
--- a/alembic/versions/69ff0615ad50_drop_pa_client_focus_and_available_.py
+++ b/alembic/versions/69ff0615ad50_drop_pa_client_focus_and_available_.py
@@ -1,0 +1,58 @@
+"""drop_pa_client_focus_and_available_providers
+
+Revision ID: 69ff0615ad50
+Revises: 6dfcb644a327
+Create Date: 2026-05-12 07:32:13.844200
+
+#444: drop two now-redundant PA columns. `client_focus`'s role is fully
+covered by `description` (#422) post-content-merge. `available_providers`
+doesn't fit program-style posts and duplicates `practice_name` for solo
+practices.
+
+Downgrade restores both as `NOT NULL` with empty-string `server_default`
+— lossy on any row inserted post-drop (the previous values are gone),
+but structurally reversible.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "69ff0615ad50"
+down_revision: Union[str, None] = "6dfcb644a327"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Drop both columns inside batch_alter_table — SQLite rewrites the
+    table once for the pair instead of twice."""
+    with op.batch_alter_table("provider_availability_details") as batch_op:
+        batch_op.drop_column("client_focus")
+        batch_op.drop_column("available_providers")
+
+
+def downgrade() -> None:
+    """Restore both columns as NOT NULL with empty-string defaults.
+    Lossy — prior values are gone."""
+    with op.batch_alter_table("provider_availability_details") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "available_providers",
+                sa.TEXT(),
+                server_default=sa.text("('')"),
+                nullable=False,
+            ),
+        )
+        batch_op.add_column(
+            sa.Column(
+                "client_focus",
+                sa.TEXT(),
+                server_default=sa.text("('')"),
+                nullable=False,
+            ),
+        )

--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -56,10 +56,10 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
         "owner_email": "alice@example.com",
         "detail": {
             "practice_name": "Katie Reeves, PhD",
-            "available_providers": "Katie Reeves, PhD",
             "description": (
                 "Solo private practice offering psychotherapy and medication "
-                "management for older teens and transitional-age youth. "
+                "management for older teens and transitional-age youth with "
+                "ADHD, anxiety, depression, self-harm, and suicidality. "
                 "Immediate availability for new patients. 25-minute med-"
                 "management visits and 50-minute therapy sessions."
             ),
@@ -72,10 +72,6 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "services": ["psychotherapy", "medication_management"],
             "settings": ["outpatient"],
             "treatment_modality": "Psychodynamic, control-mastery",
-            "client_focus": (
-                "Older teens and TAY with ADHD, anxiety, depression, self-harm, "
-                "and suicidality."
-            ),
             "age_groups": [
                 "adolescents_14_18",
                 "young_adults_19_24",
@@ -91,8 +87,6 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
         "owner_email": "alice@example.com",
         "detail": {
             "practice_name": "Camp BooHoo",
-            # TODO(issue-9): may drop available_providers.
-            "available_providers": "Camp BooHoo staff",
             "description": (
                 "Therapeutic summer camp focused on social skills and emotion "
                 "regulation for middle schoolers with ASD. Two 2-week cohorts "
@@ -113,7 +107,6 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "services": ["group_therapy"],
             "settings": ["day_program"],
             "treatment_modality": "Social skills, emotion regulation",
-            "client_focus": "Middle schoolers with ASD.",
             "age_groups": ["children_6_10", "preteens_11_13"],
             "languages": ["en", "es"],
             "payment_situation": "self_pay_only",
@@ -125,11 +118,12 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
         "owner_email": "alice@example.com",
         "detail": {
             "practice_name": "RISE IOP at CHC",
-            "available_providers": "RISE program staff",
             "description": (
                 "RISE is a Comprehensive DBT intensive outpatient program for "
-                "high school students with high acuity. Two last-minute "
-                "openings; new cohort starts May 11. M-F 8:30am-4:30pm."
+                "high school students with high acuity, including those with "
+                "self-harm or suicidality at no immediate risk of harm to self "
+                "or others. Two last-minute openings; new cohort starts May 11. "
+                "M-F 8:30am-4:30pm."
             ),
             "referral_instructions": (
                 "Please contact the program coordinator for intake details."
@@ -150,11 +144,6 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             ],
             "settings": ["iop"],
             "treatment_modality": "Comprehensive DBT",
-            "client_focus": (
-                "High school students with high acuity, including "
-                "self-harm/suicidality with no immediate risk of harm to self "
-                "or others."
-            ),
             "age_groups": ["adolescents_14_18"],
             "languages": ["en", "es"],
             "payment_situation": "please_contact",

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -189,7 +189,6 @@ class ProviderAvailabilityRead(_PostReadBase):
     referral_instructions: str | None = None
     website: str | None = None
     practice_name: str
-    available_providers: str
     location_city: str | None = None
     location_state: Literal[*US_STATES]
     location_zip: str | None = None
@@ -200,7 +199,6 @@ class ProviderAvailabilityRead(_PostReadBase):
     services: ServicesField = []
     settings: SettingsField = []
     treatment_modality: str | None = None
-    client_focus: str
     age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     payment_situation: Literal[*INSURANCE_OPTIONS]
@@ -258,7 +256,6 @@ class ProviderAvailabilityCreate(WirePayload):
     referral_instructions: TextareaOptional = None
     website: StrippedOptionalText = None
     practice_name: StrippedText
-    available_providers: StrippedText
     # `location_state` stays required — only usable geographic filter axis.
     # City / ZIP / session-format / services / settings all relax to
     # optional here (#433): telehealth-only practices (Katie Reeves) have
@@ -276,7 +273,6 @@ class ProviderAvailabilityCreate(WirePayload):
     services: ServicesField = []
     settings: SettingsField = []
     treatment_modality: StrippedOptionalText = None
-    client_focus: StrippedText
     # Required min-1 on the wire — replaces the old single-valued
     # `age_group` (#430). No default; every PA post must declare at
     # least one bucket explicitly.
@@ -346,7 +342,6 @@ class ProviderAvailabilityUpdate(PartialUpdate):
     referral_instructions: TextareaOptional = None
     website: StrippedOptionalText = None
     practice_name: StrippedText | None = None
-    available_providers: StrippedText | None = None
     location_city: StrippedText | None = None
     location_state: Literal[*US_STATES] | None = None
     location_zip: ZipText | None = None
@@ -360,7 +355,6 @@ class ProviderAvailabilityUpdate(PartialUpdate):
     services: RequiredServicesField | None = None
     settings: RequiredSettingsField | None = None
     treatment_modality: StrippedOptionalText = None
-    client_focus: StrippedText | None = None
     age_groups: RequiredAgeGroupsField | None = None
     # `None` = leave unchanged. `min_length=1` rejects an explicit `[]`,
     # mirroring `services`. Clearing the list is intentionally not
@@ -412,7 +406,6 @@ class ProviderAvailabilityAuditSnapshot(_PostAuditSnapshotBase):
     referral_instructions: str | None = None
     website: str | None = None
     practice_name: str
-    available_providers: str
     location_city: str | None = None
     location_state: Literal[*US_STATES]
     location_zip: str | None = None
@@ -423,7 +416,6 @@ class ProviderAvailabilityAuditSnapshot(_PostAuditSnapshotBase):
     services: ServicesField = []
     settings: SettingsField = []
     treatment_modality: str | None = None
-    client_focus: str
     age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     payment_situation: Literal[*INSURANCE_OPTIONS]

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -531,9 +531,7 @@ def test_post_create_provider_availability_rejects_empty_practice_name():
     "missing_field",
     [
         "practice_name",
-        "available_providers",
         "location_state",
-        "client_focus",
         "age_groups",
         "payment_situation",
         "sliding_scale",

--- a/src/domain/models/posts/provider_availability_detail.py
+++ b/src/domain/models/posts/provider_availability_detail.py
@@ -35,7 +35,6 @@ class ProviderAvailabilityDetail(Base):
 
     # Section 1 — provider information
     practice_name = Column(Text, nullable=False)
-    available_providers = Column(Text, nullable=False)
 
     # Section 2 — location
     location_city = Column(Text, nullable=True)
@@ -57,7 +56,6 @@ class ProviderAvailabilityDetail(Base):
     services = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
     settings = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
     treatment_modality = Column(Text, nullable=True)
-    client_focus = Column(Text, nullable=False)
     age_groups = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
     languages = Column(
         JSON, nullable=False, server_default=text("'[\"en\"]'"), default=lambda: ["en"]

--- a/src/domain/templates/posts/_provider_availability_form.html
+++ b/src/domain/templates/posts/_provider_availability_form.html
@@ -38,7 +38,6 @@ which FastAPI/Pydantic parses as a list.
   <fieldset>
     <legend>Provider information</legend>
     {{ text_field("practice_name", "Practice name", current=d.practice_name if d else None) }}
-    {{ text_field("available_providers", "Available providers", current=d.available_providers if d else None) }}
   </fieldset>
 
   <fieldset>
@@ -61,7 +60,6 @@ which FastAPI/Pydantic parses as a list.
     {{ multi_select_field("services", "Services (optional)", CLIENT_REFERRAL_SERVICES, labels=CLIENT_REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
     {{ multi_select_field("settings", "Treatment settings (optional)", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
     {{ text_field("treatment_modality", "Treatment modality (optional, e.g. DBT, EMDR)", current=d.treatment_modality if d else None, required=false) }}
-    {{ textarea_field("client_focus", "Client focus (no PII)", current=d.client_focus if d else None) }}
     {{ field_for(schema, "age_groups", "Age groups (select all that apply)", current=d.age_groups if d else None) }}
     {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
   </fieldset>

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -52,8 +52,6 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
   <dl>
     <dt>Practice name</dt>
     <dd>{{ d.practice_name }}</dd>
-    <dt>Available providers</dt>
-    <dd>{{ d.available_providers }}</dd>
     {% if d.website %}
     <dt>Website</dt>
     <dd>{{ d.website }}</dd>
@@ -84,8 +82,6 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
     <dt>Treatment modality</dt>
     <dd>{{ d.treatment_modality }}</dd>
     {% endif %}
-    <dt>Client focus</dt>
-    <dd>{{ d.client_focus }}</dd>
     <dt>Age groups</dt>
     <dd>{% for g in d.age_groups %}{{ CLIENT_AGE_GROUP_LABELS[g] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     <dt>Languages</dt>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -67,7 +67,6 @@ _PROVIDER_AVAILABILITY_DEFAULTS: dict[str, Any] = {
     "referral_instructions": None,
     "website": None,
     "practice_name": "Acme Health",
-    "available_providers": "Dr. Doe; Dr. Roe",
     "location_city": "Springfield",
     "location_state": "IL",
     "location_zip": "62701",
@@ -82,7 +81,6 @@ _PROVIDER_AVAILABILITY_DEFAULTS: dict[str, Any] = {
     # tests overriding `settings` can assume isn't already in the list.
     "settings": ["outpatient"],
     "treatment_modality": None,
-    "client_focus": "general adult outpatient",
     "age_groups": ["adults_25_64"],
     "languages": ["en"],
     "payment_situation": "in_network",


### PR DESCRIPTION
## Summary
- Breaking removal of two PA fields whose roles are now covered (or were never well-fit):
  - `client_focus` → its content lives in `description` (added in #422). Seeds' content was folded into `description` so no information is lost.
  - `available_providers` → doesn't fit program-style posts; duplicates `practice_name` for solo practices.
- Single-PR (Path B); no framework changes. Migration: `batch_alter_table` drop of both columns. Downgrade restores them as NOT NULL with empty defaults (lossy).
- Closes #444 — the last issue in the schema-evolution series.

Closes #444.

## Test plan
- [x] `dev test` — 924 passed, 52 skipped.
- [x] `dev test contract` — 16 passed.
- [x] `dev lint` — clean.
- [x] `dev migrate roundtrip` on rev `69ff0615ad50` — clean.

## Series-level retrospective

Ten issues shipped — the planned nine plus the two CR-sibling follow-ups (#428, #432).

**What worked unexpectedly well**

- Path A splits (#422 → #423/#424, #425 → #426/#427) consistently. The framework prep PR shipped in under 90s of CI; the consumer PR rode the rebased main. The pattern is robust enough to be the default for any framework + consumer change.
- The Jinja-global schema injection workaround (`provider_availability_create_schema`, then `client_referral_create_schema`) held across both kinds and four `field_for` consumers without modification. The underlying import-cycle issue with `PostKindSpec` is still a latent problem, but the workaround is good enough that the structural fix can wait.
- `alembic/README.md`'s SQLite-CHECK-drop note (added in #428's PR) prevented every subsequent migration from re-discovering the same trap. Three migrations after the note all worked first try.

**Biggest time sinks (none catastrophic)**

- Initial misdiagnosis of `op.alter_column` nullability flips needing batch mode in #433 — solved by reading `alembic/README.md`'s note and broadening its scope. The README note now covers any constraint flip, not just CHECK drops.
- Cross-kind field-bleed test (`test_post_create_rejects_cross_kind_field_bleed`) needed its example field swapped twice during the series as different fields became shared. Naming the test by behavior, not example, would have made the swaps free.

**Retro entries that mattered most**

- The Path A pattern from #422 has prevented at least three other "should I bundle?" forks in this series.
- The seed-doubles-as-canary idea from #420 paid off every single PR: removing `TODO(issue-N)` markers is a cheap, visible signal that the schema change actually fits the source material.

**Latent issues worth filing**

- `PostKindSpec` import cycle (workaround used 4× now; structural fix is medium effort).
- `services` / `settings` Update path is still `RequiredServicesField | None = None` from before #433 — a PATCH with `services=[]` 422s even though `services=[]` is now valid on Create. Asymmetric. Worth a small follow-up.
- The hand-wired form fields that haven't migrated to `field_for` (e.g. `cost`, `treatment_modality`, `radio_bool_field`, multi-`select_field`s) keep accumulating noise. The cleanup issue mentioned in earlier retros is overdue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)