### PR TITLE
Add HtmlUrl marker for field_for url rendering (#446, phase A)

### DIFF
--- a/src/domain/templates/_shared/form_fields.html
+++ b/src/domain/templates/_shared/form_fields.html
@@ -35,6 +35,13 @@ canonical use.
 </label>
 {%- endmacro %}
 
+{% macro url_field(name, label, current=None, required=True) -%}
+<label for="{{ name }}">
+  {{ label }}
+  <input type="url" id="{{ name }}" name="{{ name }}"{% if current is not none %} value="{{ current }}"{% endif %}{% if required %} required{% endif %} />
+</label>
+{%- endmacro %}
+
 {% macro select_field(name, label, options, labels=None, current=None, required=True, placeholder=False) -%}
 <label for="{{ name }}">
   {{ label }}
@@ -117,6 +124,8 @@ posts an empty array. #}
 {{ multi_select_field(name, label, spec.choices, labels=spec.labels, current=current) }}
 {%- elif spec.kind == "textarea" -%}
 {{ textarea_field(name, label, current=current, required=is_required) }}
+{%- elif spec.kind == "url" -%}
+{{ url_field(name, label, current=current, required=is_required) }}
 {%- elif spec.kind == "text" -%}
 {{ text_field(name, label, current=current, required=is_required, pattern=spec.pattern, maxlength=spec.maxlength) }}
 {%- endif -%}

--- a/src/framework/rendering/form_fields.py
+++ b/src/framework/rendering/form_fields.py
@@ -34,6 +34,17 @@ class HtmlTextarea:
     """
 
 
+@dataclass(frozen=True)
+class HtmlUrl:
+    """Annotation marker that swaps `field_for`'s default `<input
+    type=text>` rendering for `<input type=url>` on a string field.
+    Browsers gate submission on URL syntax, switch mobile keyboards to
+    a URL layout, and surface autofill differently. Same no-payload
+    shape as `HtmlTextarea` — presence on the `Annotated[...]` metadata
+    is the signal.
+    """
+
+
 # Choice-tuple → label-dict registry, populated at startup by
 # `register_choice_labels()` from `src/framework/rendering/templating.py`. Lookup is
 # by tuple value (not identity) because `Literal[*TUPLE]` unpacks the
@@ -108,6 +119,7 @@ def field_spec(schema_cls: type[BaseModel], name: str) -> dict[str, Any]:
     pattern: str | None = None
     maxlength: int | None = None
     is_textarea = False
+    is_url = False
     for marker in field.metadata:
         if isinstance(marker, HtmlPattern):
             if marker.pattern is not None:
@@ -116,10 +128,19 @@ def field_spec(schema_cls: type[BaseModel], name: str) -> dict[str, Any]:
                 maxlength = marker.maxlength
         elif isinstance(marker, HtmlTextarea):
             is_textarea = True
+        elif isinstance(marker, HtmlUrl):
+            is_url = True
 
     if is_textarea:
         return {
             "kind": "textarea",
+            "name": name,
+            "required": not optional,
+        }
+
+    if is_url:
+        return {
+            "kind": "url",
             "name": name,
             "required": not optional,
         }

--- a/src/framework/rendering/test_form_fields.py
+++ b/src/framework/rendering/test_form_fields.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from src.framework.rendering.form_fields import (
     HtmlPattern,
     HtmlTextarea,
+    HtmlUrl,
     field_spec,
     register_choice_labels,
 )
@@ -27,6 +28,8 @@ register_choice_labels(_SIZES, None)
 _PatternedString = Annotated[str, HtmlPattern(pattern=r"\d{5}", maxlength=5)]
 _LongText = Annotated[str, HtmlTextarea()]
 _OptionalLongText = Annotated[str | None, HtmlTextarea()]
+_UrlText = Annotated[str, HtmlUrl()]
+_OptionalUrlText = Annotated[str | None, HtmlUrl()]
 
 
 class _Sample(BaseModel):
@@ -38,6 +41,8 @@ class _Sample(BaseModel):
     patterned: _PatternedString
     long_required: _LongText
     long_optional: _OptionalLongText = None
+    url_required: _UrlText
+    url_optional: _OptionalUrlText = None
     required_multi: list[Literal[*_COLORS]]
     optional_multi: list[Literal[*_COLORS]] | None = None
     unlabeled_multi: list[Literal[*_SIZES]]
@@ -103,6 +108,21 @@ def test_html_textarea_marker_switches_kind():
 def test_optional_html_textarea_drops_required():
     spec = field_spec(_Sample, "long_optional")
     assert spec["kind"] == "textarea"
+    assert spec["required"] is False
+
+
+def test_html_url_marker_switches_kind():
+    spec = field_spec(_Sample, "url_required")
+    assert spec == {
+        "kind": "url",
+        "name": "url_required",
+        "required": True,
+    }
+
+
+def test_optional_html_url_drops_required():
+    spec = field_spec(_Sample, "url_optional")
+    assert spec["kind"] == "url"
     assert spec["required"] is False
 
 


### PR DESCRIPTION
## Summary

Phase A of #446. Adds an `HtmlUrl` Annotated marker (mirroring `HtmlTextarea`) that swaps `field_for`'s default `<input type=text>` rendering for `<input type=url>` on a string field. Browser gates submission on URL syntax, mobile keyboards switch to URL layout, autofill semantics improve.

`field_spec` returns `kind="url"` when the marker is present. The Jinja `field_for` macro gains a new arm dispatching to a new `url_field` macro (same shape as `text_field`, `type="url"`).

No consumer change yet — phase B (the rest of #446) will swap PA's `website` field to use the marker and normalize seed URLs to include `https://` schemes.

## Test plan

- [x] New tests covering the marker on required + optional string fields.
- [x] All existing form_fields tests still pass.
- [x] `dev lint` passes.
- [x] Full `pytest` suite (926 pass, 52 skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)