### PR TITLE
Rename CR fields for symmetry with PA (#450)

### DIFF
--- a/alembic/versions/5cecf02ed65d_rename_cr_fields_for_pa_symmetry.py
+++ b/alembic/versions/5cecf02ed65d_rename_cr_fields_for_pa_symmetry.py
@@ -1,0 +1,44 @@
+"""rename_cr_fields_for_pa_symmetry
+
+Revision ID: 5cecf02ed65d
+Revises: 69ff0615ad50
+Create Date: 2026-05-12 14:50:00.000000
+
+#450: rename two CR columns for symmetry with PA's already-canonical
+names. `client_dem_age_groups` → `age_groups` (the `client_dem_` prefix
+was redundant with the `kind` discriminator; CR's sibling `languages`
+field already has no such prefix). `services_psychotherapy_modality` →
+`treatment_modality` (PA's parallel name; CR's verbose name conflated
+"services" with "modality").
+
+Downgrade renames back. No data transform — just column renames.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5cecf02ed65d"
+down_revision: Union[str, None] = "69ff0615ad50"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Rename both CR columns inside batch_alter_table so SQLite
+    rewrites the table once for the pair instead of twice."""
+    with op.batch_alter_table("client_referral_details") as batch_op:
+        batch_op.alter_column("client_dem_age_groups", new_column_name="age_groups")
+        batch_op.alter_column(
+            "services_psychotherapy_modality", new_column_name="treatment_modality"
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("client_referral_details") as batch_op:
+        batch_op.alter_column("age_groups", new_column_name="client_dem_age_groups")
+        batch_op.alter_column(
+            "treatment_modality", new_column_name="services_psychotherapy_modality"
+        )

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -181,11 +181,11 @@ class ClientReferralRead(_PostReadBase):
     location_in_person: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     location_virtual: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     desired_times: DesiredTimesField = []
-    client_dem_age_groups: AgeGroupsField = []
+    age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     description: str
     services: ServicesField = []
-    services_psychotherapy_modality: str | None = None
+    treatment_modality: str | None = None
     insurance: Literal[*INSURANCE_OPTIONS]
 
 
@@ -240,14 +240,14 @@ class ClientReferralCreate(WirePayload):
     desired_times: DesiredTimesField = []
     # Required min-1 on the wire — replaces the old single-valued
     # `client_dem_ages` (#432). Mirrors PA's `age_groups` (#430).
-    client_dem_age_groups: RequiredAgeGroupsField
+    age_groups: RequiredAgeGroupsField
     # Required min-1 on the wire — replaces the old yes/no
     # `language_preferred` flag (#428). Defaults to `["en"]` so the
     # form's "submit with defaults" case still validates.
     languages: RequiredLanguagesField = ["en"]
     description: StrippedText
     services: ServicesField = []
-    services_psychotherapy_modality: StrippedOptionalText = None
+    treatment_modality: StrippedOptionalText = None
     insurance: Literal[*INSURANCE_OPTIONS]
 
 
@@ -330,13 +330,13 @@ class ClientReferralUpdate(PartialUpdate):
     # selections. List-valued PATCH replaces the whole list — partial
     # add/remove is intentionally out of scope.
     desired_times: DesiredTimesField | None = None
-    client_dem_age_groups: RequiredAgeGroupsField | None = None
+    age_groups: RequiredAgeGroupsField | None = None
     # `None` = leave unchanged. `min_length=1` rejects an explicit `[]`,
     # mirroring PA's `languages` semantics.
     languages: RequiredLanguagesField | None = None
     description: StrippedText | None = None
     services: ServicesField | None = None
-    services_psychotherapy_modality: StrippedOptionalText = None
+    treatment_modality: StrippedOptionalText = None
     insurance: Literal[*INSURANCE_OPTIONS] | None = None
 
 
@@ -398,11 +398,11 @@ class ClientReferralAuditSnapshot(_PostAuditSnapshotBase):
     location_in_person: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     location_virtual: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     desired_times: DesiredTimesField = []
-    client_dem_age_groups: AgeGroupsField = []
+    age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     description: str
     services: ServicesField = []
-    services_psychotherapy_modality: str | None = None
+    treatment_modality: str | None = None
     insurance: Literal[*INSURANCE_OPTIONS]
 
 

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -107,7 +107,7 @@ def test_post_create_client_referral_rejects_empty_description():
         "location_zip",
         "location_in_person",
         "location_virtual",
-        "client_dem_age_groups",
+        "age_groups",
         "description",
         "insurance",
     ],
@@ -121,7 +121,7 @@ def test_post_create_client_referral_requires_all_required_fields(missing_field)
 
 def test_post_create_client_referral_optional_fields_default_none():
     p = post_create_adapter.validate_python(client_referral_payload())
-    assert p.services_psychotherapy_modality is None
+    assert p.treatment_modality is None
 
 
 def test_post_create_client_referral_default_languages():
@@ -151,29 +151,25 @@ def test_post_create_client_referral_rejects_unknown_language_token():
 
 
 def test_post_create_client_referral_accepts_multiple_age_groups():
-    """CR's `client_dem_age_groups` accepts a multi-bucket list (#432) —
+    """CR's `age_groups` accepts a multi-bucket list (#432) —
     the original single-valued `client_dem_ages` forced referrers to
     pick one when a child straddled buckets."""
     p = post_create_adapter.validate_python(
-        client_referral_payload(
-            client_dem_age_groups=["children_6_10", "preteens_11_13"]
-        )
+        client_referral_payload(age_groups=["children_6_10", "preteens_11_13"])
     )
-    assert p.client_dem_age_groups == ["children_6_10", "preteens_11_13"]
+    assert p.age_groups == ["children_6_10", "preteens_11_13"]
 
 
 def test_post_create_client_referral_rejects_empty_age_groups():
     with pytest.raises(ValidationError):
-        post_create_adapter.validate_python(
-            client_referral_payload(client_dem_age_groups=[])
-        )
+        post_create_adapter.validate_python(client_referral_payload(age_groups=[]))
 
 
 def test_post_create_client_referral_strips_optional_to_none():
     p = post_create_adapter.validate_python(
-        client_referral_payload(services_psychotherapy_modality="   ")
+        client_referral_payload(treatment_modality="   ")
     )
-    assert p.services_psychotherapy_modality is None
+    assert p.treatment_modality is None
 
 
 def test_post_create_client_referral_rejects_invalid_zip():
@@ -195,7 +191,7 @@ def test_post_create_client_referral_rejects_unknown_state():
 def test_post_create_client_referral_rejects_unknown_age_group():
     with pytest.raises(ValidationError):
         post_create_adapter.validate_python(
-            client_referral_payload(client_dem_age_groups=["too_old"])
+            client_referral_payload(age_groups=["too_old"])
         )
 
 
@@ -550,11 +546,11 @@ def test_post_create_rejects_unknown_fields_on_provider_availability():
 
 
 def test_post_create_rejects_cross_kind_field_bleed():
-    """Cross-kind field bleed must not validate. `client_dem_age_groups`
+    """Cross-kind field bleed must not validate. `location_in_person`
     is a client-referral-only field; it has no place in a PA payload."""
     with pytest.raises(ValidationError):
         post_create_adapter.validate_python(
-            provider_availability_payload(client_dem_age_groups=["adults_25_64"])
+            provider_availability_payload(location_in_person="yes")
         )
 
 

--- a/src/domain/models/posts/client_referral_detail.py
+++ b/src/domain/models/posts/client_referral_detail.py
@@ -44,9 +44,7 @@ class ClientReferralDetail(Base):
     )
 
     # Section 2 — demographics
-    client_dem_age_groups = Column(
-        JSON, nullable=False, server_default=text("'[]'"), default=list
-    )
+    age_groups = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
     languages = Column(
         JSON, nullable=False, server_default=text("'[\"en\"]'"), default=lambda: ["en"]
     )
@@ -56,7 +54,7 @@ class ClientReferralDetail(Base):
 
     # Section 4 — services
     services = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
-    services_psychotherapy_modality = Column(Text, nullable=True)
+    treatment_modality = Column(Text, nullable=True)
 
     # Section 5 — insurance
     insurance = Column(Text, nullable=False)

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -521,12 +521,12 @@ async def test_client_referral_form_renders_age_groups_multi_select(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """`client_dem_age_groups` on CR renders via the multi-select arm (#432),
+    """`age_groups` on CR renders via the multi-select arm (#432),
     mirroring PA's `age_groups` (#430)."""
     response = await authenticated_client.get("/posts/form?kind=client_referral")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    boxes = tree.css('input[type="checkbox"][name="client_dem_age_groups"]')
+    boxes = tree.css('input[type="checkbox"][name="age_groups"]')
     values = {b.attributes.get("value") for b in boxes}
     assert values == {
         "children_0_5",

--- a/src/domain/templates/posts/_client_referral_form.html
+++ b/src/domain/templates/posts/_client_referral_form.html
@@ -35,7 +35,7 @@ which FastAPI/Pydantic parses as a list.
 
   <fieldset>
     <legend>Demographics</legend>
-    {{ field_for(schema, "client_dem_age_groups", "Age groups (select all that apply)", current=d.client_dem_age_groups if d else None) }}
+    {{ field_for(schema, "age_groups", "Age groups (select all that apply)", current=d.age_groups if d else None) }}
     {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
   </fieldset>
 
@@ -47,7 +47,7 @@ which FastAPI/Pydantic parses as a list.
   <fieldset>
     <legend>Services</legend>
     {{ multi_select_field("services", "Services (optional)", CLIENT_REFERRAL_SERVICES, labels=CLIENT_REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
-    {{ text_field("services_psychotherapy_modality", "Psychotherapy modality (optional, e.g. DBT, EMDR)", current=d.services_psychotherapy_modality if d else None, required=false) }}
+    {{ text_field("treatment_modality", "Psychotherapy modality (optional, e.g. DBT, EMDR)", current=d.treatment_modality if d else None, required=false) }}
   </fieldset>
 
   <fieldset>

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -24,7 +24,7 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
     <dd>{% for slot in d.desired_times %}{{ DESIRED_TIME_SLOT_LABELS[slot] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     {% endif %}
     <dt>Age groups</dt>
-    <dd>{% for g in d.client_dem_age_groups %}{{ CLIENT_AGE_GROUP_LABELS[g] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
+    <dd>{% for g in d.age_groups %}{{ CLIENT_AGE_GROUP_LABELS[g] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     <dt>Languages</dt>
     <dd>{% for l in d.languages %}{{ LANGUAGE_LABELS[l] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     <dt>Description</dt>
@@ -33,9 +33,9 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
     <dt>Services</dt>
     <dd>{% for s in d.services %}{{ CLIENT_REFERRAL_SERVICE_LABELS[s] }}{% if not loop.last %}, {% endif %}{% endfor %}</dd>
     {% endif %}
-    {% if d.services_psychotherapy_modality %}
+    {% if d.treatment_modality %}
     <dt>Psychotherapy modality</dt>
-    <dd>{{ d.services_psychotherapy_modality }}</dd>
+    <dd>{{ d.treatment_modality }}</dd>
     {% endif %}
     <dt>Insurance</dt>
     <dd>{{ INSURANCE_LABELS[d.insurance] }}</dd>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -54,11 +54,11 @@ _CLIENT_REFERRAL_DEFAULTS: dict[str, Any] = {
     "location_in_person": "yes",
     "location_virtual": "no",
     "desired_times": [],
-    "client_dem_age_groups": ["adults_25_64"],
+    "age_groups": ["adults_25_64"],
     "languages": ["en"],
     "description": "needs placement",
     "services": [],
-    "services_psychotherapy_modality": None,
+    "treatment_modality": None,
     "insurance": "in_network",
 }
 


### PR DESCRIPTION
## Summary

Renames two CR detail-table columns + their Pydantic field counterparts:

- `client_dem_age_groups` → `age_groups`
- `services_psychotherapy_modality` → `treatment_modality`

The kind discriminator on \`Post\` already disambiguates "client referral vs provider availability," so the \`client_dem_\` prefix and the verbose modality name don't earn their existence. The new names match PA's already-canonical ones.

Migration uses \`batch_alter_table\` so SQLite rewrites the table once for the pair. Downgrade renames back. No data transform.

The \`test_post_create_rejects_cross_kind_field_bleed\` test had to pick a new CR-only field (\`age_groups\` is now shared); switched to \`location_in_person\`.

Closes #450.

## Test plan

- [x] \`dev migrate roundtrip\` green
- [x] Full \`pytest\` suite (924 pass, 52 skip)
- [x] \`dev lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)