### PR TITLE
Render provider_availability.website as <input type=url> (#446, phase B)

### DIFF
--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -64,7 +64,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
                 "management visits and 50-minute therapy sessions."
             ),
             "referral_instructions": "Contact via website to schedule an intake call.",
-            "website": "katiereevesphd.com",
+            "website": "https://katiereevesphd.com",
             "location_state": "CA",
             "in_person_sessions": "no",
             "virtual_sessions": "yes",
@@ -97,7 +97,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
                 "Visit our website to download the intake packet, then email "
                 "campbooohoo@example.com to reserve a cohort spot."
             ),
-            "website": "boohoocrybaby.com",
+            "website": "https://boohoocrybaby.com",
             "location_city": "Santa Clara",
             "location_state": "CA",
             "in_person_sessions": "yes",
@@ -128,7 +128,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "referral_instructions": (
                 "Please contact the program coordinator for intake details."
             ),
-            "website": "CHC.rise.org",
+            "website": "https://chc.rise.org",
             "location_city": "Palo Alto",
             "location_state": "CA",
             "location_zip": "94304",

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -55,7 +55,7 @@ from src.domain.models.enums import (
     TREATMENT_SETTINGS,
     US_STATES,
 )
-from src.framework.rendering.form_fields import HtmlTextarea
+from src.framework.rendering.form_fields import HtmlTextarea, HtmlUrl
 from src.framework.schema_validators import (
     PartialUpdate,
     ReadProjection,
@@ -70,6 +70,12 @@ from src.framework.schema_validators import (
 # only affects form rendering (`field_for` picks `<textarea>` over
 # `<input>`); the validator chain is identical to `StrippedOptionalText`.
 TextareaOptional = Annotated[StrippedOptionalText, HtmlTextarea()]
+
+# `website` is a URL with the same `Stripped` cleaning chain — the
+# marker only swaps form rendering from `<input type=text>` to
+# `<input type=url>`. Schema-side validation stays the same; browser
+# gates submission on URL syntax client-side.
+UrlOptional = Annotated[StrippedOptionalText, HtmlUrl()]
 
 
 def _scalar_to_list(v):
@@ -254,7 +260,7 @@ class ProviderAvailabilityCreate(WirePayload):
     # seed posts confirm the shape works (#422).
     description: TextareaOptional = None
     referral_instructions: TextareaOptional = None
-    website: StrippedOptionalText = None
+    website: UrlOptional = None
     practice_name: StrippedText
     # `location_state` stays required — only usable geographic filter axis.
     # City / ZIP / session-format / services / settings all relax to
@@ -340,7 +346,7 @@ class ProviderAvailabilityUpdate(PartialUpdate):
     kind: Literal["provider_availability"]
     description: TextareaOptional = None
     referral_instructions: TextareaOptional = None
-    website: StrippedOptionalText = None
+    website: UrlOptional = None
     practice_name: StrippedText | None = None
     location_city: StrippedText | None = None
     location_state: Literal[*US_STATES] | None = None

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -915,9 +915,9 @@ async def test_provider_availability_form_renders_free_text_fields(
 ):
     """The three free-text fields render through `field_for` — `description`
     and `referral_instructions` as `<textarea>` (driven by the `HtmlTextarea`
-    marker on the schema), `website` as `<input type=text>`. A regression
-    where `HtmlTextarea` stops being picked up would render the first two as
-    `<input>` and silently break the form."""
+    marker on the schema), `website` as `<input type="url">` (driven by
+    `HtmlUrl` — #446). A regression where either marker stops being picked
+    up would render fields as the wrong control and silently break the form."""
     response = await authenticated_client.get("/posts/form?kind=provider_availability")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
@@ -925,7 +925,7 @@ async def test_provider_availability_form_renders_free_text_fields(
     assert tree.css_first("textarea#referral_instructions") is not None
     website = tree.css_first("input#website")
     assert website is not None
-    assert website.attributes.get("type", "text") == "text"
+    assert website.attributes.get("type") == "url"
 
 
 async def test_provider_availability_form_renders_languages_multi_select(

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -54,7 +54,7 @@ Provider availability: {{ post.provider_availability_detail.practice_name }}
     <dd>{{ d.practice_name }}</dd>
     {% if d.website %}
     <dt>Website</dt>
-    <dd>{{ d.website }}</dd>
+    <dd><a href="{{ d.website }}" target="_blank" rel="noopener noreferrer">{{ d.website }}</a></dd>
     {% endif %}
     <dt>Location</dt>
     <dd>{% if d.location_city %}{{ d.location_city }}, {% endif %}{{ d.location_state }}{% if d.location_zip %} {{ d.location_zip }}{% endif %}</dd>


### PR DESCRIPTION
## Summary

Phase B of #446. Swaps PA's \`website\` schema field from \`StrippedOptionalText\` to a new \`UrlOptional = Annotated[StrippedOptionalText, HtmlUrl()]\` alias. \`field_for\`'s \`url\` arm from phase A picks it up and emits \`<input type="url">\`, giving browser URL validation, mobile keyboard hints, and richer autofill semantics for free.

Seed values normalized to include \`https://\` schemes (and lowercased host where appropriate) — the scheme-less source-example phrasing was illustrative, not prescriptive.

Detail page wraps \`d.website\` in an \`<a>\` now that schemes are reliable.

Closes #446.

## Test plan

- [x] Updated form-render test asserts \`<input type="url">\` for website
- [x] Full \`pytest\` suite (926 pass, 52 skip)
- [x] \`dev lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)