### PR TITLE
fix: convert UUID to hex for raw-SQL bind in pa_provider_fk migration (#448)

### DIFF
--- a/alembic/versions/537ba27726f9_pa_provider_fk.py
+++ b/alembic/versions/537ba27726f9_pa_provider_fk.py
@@ -122,7 +122,12 @@ def upgrade() -> None:
             if existing:
                 provider_id = existing.id
             else:
-                provider_id = uuid.uuid4()
+                # SQLite stores Uuid as CHAR(32) hex — the stdlib sqlite3
+                # driver can't bind a uuid.UUID object directly, so we
+                # produce the hex form ourselves. Using sa.text() bypasses
+                # SQLAlchemy's type adapter; values go straight to the
+                # DBAPI driver.
+                provider_id = uuid.uuid4().hex
                 bind.execute(
                     sa.text("""
                         INSERT INTO providers (


### PR DESCRIPTION
## Summary

Production migration crashed on:

\`\`\`
sqlite3.ProgrammingError: Error binding parameter 1: type 'UUID' is not supported
\`\`\`

The backfill INSERT in \`537ba27726f9_pa_provider_fk.py\` uses \`sa.text(...)\` (raw SQL), which bypasses SQLAlchemy's \`Uuid\` type adapter — bound params go straight to the stdlib \`sqlite3\` driver, which can't bind a \`uuid.UUID\` object.

\`dev migrate roundtrip\` didn't catch it locally because the test DB has no pre-existing PA rows when #448 first runs, so the backfill loop is empty. The droplet has seeded PA posts → backfill runs → INSERT chokes on the UUID.

One-line fix: produce the hex form (\`uuid.uuid4().hex\`) which matches the \`CHAR(32)\` storage shape SQLAlchemy already uses for the column.

## Test plan

- [x] \`dev migrate roundtrip\` still green
- [x] Full \`pytest\` (948 pass, 52 skip)
- [ ] Production deploy completes against the droplet's partial-state DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)