### PR TITLE
Clarify licensure-state filter + show licensure states on provider list

### DIFF
--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -218,6 +218,43 @@ async def test_list_providers_renders_html(
     assert "Open House" in response.text
 
 
+async def test_list_providers_shows_licensure_states(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Each list row surfaces the provider's licensure issuing states so
+    matches against `?issuing_state=` are visually obvious — a CT-located
+    provider holding a CA license shows `Licensed in: CA, CT` and the
+    user can see why they appeared in a CA filter (#458 follow-up)."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+    provider_id = await _seed_provider_for(
+        db_test_session_manager,
+        user_id=other.id,
+        practice_name="Multi-state Care",
+        location_state="CT",
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                make_provider_licensure(
+                    provider_id=provider_id, license_type="lcsw", issuing_state="CA"
+                )
+            )
+            session.add(
+                make_provider_licensure(
+                    provider_id=provider_id, license_type="lpc", issuing_state="CT"
+                )
+            )
+
+    response = await authenticated_client.get("/providers")
+
+    assert response.status_code == 200
+    assert "Licensed in: CA, CT" in response.text
+
+
 async def test_list_providers_renders_empty_state(
     authenticated_client: AsyncClient,
 ):

--- a/src/domain/templates/providers/list.html
+++ b/src/domain/templates/providers/list.html
@@ -8,7 +8,7 @@
   <fieldset>
     <legend>Filter</legend>
     {{ filter_select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, current=selected_license_type) }}
-    {{ filter_select_field("issuing_state", "Issuing state", US_STATES, current=selected_issuing_state) }}
+    {{ filter_select_field("issuing_state", "Licensed in state", US_STATES, current=selected_issuing_state) }}
     <input type="submit" value="Apply" />
     <a href="/providers">Clear</a>
   </fieldset>
@@ -17,9 +17,13 @@
 {% if providers %}
 <ul class="providers-list">
   {%- for provider in providers %}
+  {%- set issuing_states = provider.licensures | map(attribute='issuing_state') | unique | sort | list -%}
   <li>
     <a href="/providers/{{ provider.id }}">{{ provider.practice_name }}</a>
     &mdash; {{ provider.location_city }}, {{ provider.location_state }}
+    {%- if issuing_states %}
+    <br /><small>Licensed in: {{ issuing_states | join(', ') }}</small>
+    {%- endif %}
   </li>
   {%- endfor %}
 </ul>


### PR DESCRIPTION
## Summary

Reported in prod: \`/providers?issuing_state=CA\` showed a CT-located provider — correct behavior (they hold a CA license; the filter is scoped to licensure, not practice location) but visually confusing.

Two small clarifications:

- Filter label changed: **"Issuing state" → "Licensed in state"**. Less ambiguous about what the filter scopes.
- Each list row now appends **"Licensed in: <states>"** — a deduplicated, sorted list of the provider's licensure \`issuing_state\` values. Multi-state providers visibly show why they match a single-state filter.

## Test plan

- [x] New \`test_list_providers_shows_licensure_states\` covers a CT-located provider with CA + CT licensures, asserts "Licensed in: CA, CT" appears in the rendered page.
- [x] Full \`pytest\` (949 pass, 52 skip)
- [x] \`dev lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)