### PR TITLE
UI tweaks: invert desired-times grid; drop leading space on checkbox/radio labels

### DIFF
--- a/src/domain/templates/_shared/form_fields.html
+++ b/src/domain/templates/_shared/form_fields.html
@@ -78,8 +78,8 @@ canonical use.
 {% macro radio_bool_field(name, label, current=None, required=True) -%}
 <fieldset>
   <legend>{{ label }}</legend>
-  <label><input type="radio" name="{{ name }}" value="true"{% if current is sameas true %} checked{% endif %}{% if required %} required{% endif %} /> Yes</label>
-  <label><input type="radio" name="{{ name }}" value="false"{% if current is sameas false %} checked{% endif %}{% if required %} required{% endif %} /> No</label>
+  <label><input type="radio" name="{{ name }}" value="true"{% if current is sameas true %} checked{% endif %}{% if required %} required{% endif %} />Yes</label>
+  <label><input type="radio" name="{{ name }}" value="false"{% if current is sameas false %} checked{% endif %}{% if required %} required{% endif %} />No</label>
 </fieldset>
 {%- endmacro %}
 
@@ -96,8 +96,7 @@ the upcoming `settings` field on `provider_availability` reuses it. #}
   <legend>{{ label }}</legend>
   {%- for v in options %}
   <label>
-    <input type="checkbox" name="{{ name }}" value="{{ v }}"{% if v in selected %} checked{% endif %} />
-    {{ labels[v] if labels else v }}
+    <input type="checkbox" name="{{ name }}" value="{{ v }}"{% if v in selected %} checked{% endif %} />{{ labels[v] if labels else v }}
   </label>
   {%- endfor %}
 </fieldset>
@@ -139,22 +138,19 @@ posts an empty array. #}
     <thead>
       <tr>
         <th></th>
-        {%- for part in DESIRED_TIME_PARTS %}
-        <th scope="col">{{ DESIRED_TIME_PART_LABELS[part] }}</th>
+        {%- for day in DESIRED_TIME_DAYS %}
+        <th scope="col">{{ DESIRED_TIME_DAY_LABELS[day] }}</th>
         {%- endfor %}
       </tr>
     </thead>
     <tbody>
-      {%- for day in DESIRED_TIME_DAYS %}
+      {%- for part in DESIRED_TIME_PARTS %}
       <tr>
-        <th scope="row">{{ DESIRED_TIME_DAY_LABELS[day] }}</th>
-        {%- for part in DESIRED_TIME_PARTS %}
+        <th scope="row">{{ DESIRED_TIME_PART_LABELS[part] }}</th>
+        {%- for day in DESIRED_TIME_DAYS %}
         {%- set token = day ~ "_" ~ part -%}
         <td>
-          <label>
-            <input type="checkbox" name="{{ name }}" value="{{ token }}"{% if token in selected %} checked{% endif %} />
-            <span class="visually-hidden">{{ DESIRED_TIME_DAY_LABELS[day] }} {{ DESIRED_TIME_PART_LABELS[part]|lower }}</span>
-          </label>
+          <input type="checkbox" name="{{ name }}" value="{{ token }}"{% if token in selected %} checked{% endif %} aria-label="{{ DESIRED_TIME_DAY_LABELS[day] }} {{ DESIRED_TIME_PART_LABELS[part]|lower }}" />
         </td>
         {%- endfor %}
       </tr>


### PR DESCRIPTION
## Summary

Three small form-rendering fixes reported in prod:

1. **Desired-times grid inversion** — days are now columns, parts (Morning/Afternoon/Evening) are rows. Reads more naturally for the "morning availability across the week" mental model.
2. **Drop per-cell text in the grid** — \`<span class="visually-hidden">\` was rendering as visible text because the CSS class isn't defined anywhere (it predated Pico). Cell is now just the checkbox; screen readers get context from \`<th>\` headers + a per-input \`aria-label\`.
3. **Remove leading whitespace before label text** on \`multi_select_field\` and \`radio_bool_field\` — the single space character between \`<input>\` and the label text rendered as visible padding. Pico's CSS handles spacing via margin; the literal char is unnecessary.

## Test plan

- [x] Full \`pytest\` (949 pass, 52 skip)
- [x] \`dev lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)