### PR TITLE
Default home /posts + Bedlam Connect branding

### DIFF
--- a/src/domain/templates/auth/forgot_password.html
+++ b/src/domain/templates/auth/forgot_password.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %} {% block title %}Forgot password{% endblock %}
+{% extends "base.html" %}
 {% block container_class %}narrow{% endblock %}
 {% block content %}
 <article>

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %} {% block title %}Login{% endblock %}
+{% extends "base.html" %}
 {% block container_class %}narrow{% endblock %}
 {% block content %}
 <article>

--- a/src/domain/templates/auth/register.html
+++ b/src/domain/templates/auth/register.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %} {% block title %}Register{% endblock %}
+{% extends "base.html" %}
 {% block container_class %}narrow{% endblock %}
 {% block content %}
 <article>

--- a/src/domain/templates/auth/reset_password.html
+++ b/src/domain/templates/auth/reset_password.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %} {% block title %}Reset password{% endblock %}
+{% extends "base.html" %}
 {% block container_class %}narrow{% endblock %}
 {% block content %}
 <article>

--- a/src/domain/templates/base.html
+++ b/src/domain/templates/base.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <title>{% block title %}AI again{% endblock %}</title>
+    {# title-case-ignore: "Bedlam Connect" is a brand name #}
+    <title>Bedlam Connect</title>
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
@@ -64,6 +65,10 @@
     {% if is_authenticated %}
     <header class="container">
       <nav aria-label="Primary">
+        <ul>
+          {# title-case-ignore: "Bedlam Connect" is a brand name #}
+          <li><strong><a href="/" class="contrast">Bedlam Connect</a></strong></li>
+        </ul>
         <ul id="primary-nav">
           <li><a href="/posts">Posts</a></li>
           <li><a href="/users">Users</a></li>

--- a/src/domain/templates/favorites/list.html
+++ b/src/domain/templates/favorites/list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}My favorites{% endblock %}
+
 {% block content %}
 <h1>My favorites</h1>
 

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -1,11 +1,4 @@
 {% extends "base.html" %}
-{% block title %}
-{%- if post.kind == "client_referral" -%}
-Client referral
-{%- elif post.kind == "provider_availability" -%}
-Provider availability: {{ post.provider_availability_detail.provider.practice_name }}
-{%- endif -%}
-{% endblock %}
 {% block content %}
 <article>
 {% if post.kind == "client_referral" %}

--- a/src/domain/templates/posts/edit_client_referral.html
+++ b/src/domain/templates/posts/edit_client_referral.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "posts/_client_referral_form.html" import client_referral_form %}
-{% block title %}Edit client referral{% endblock %}
+
 {% block content %}
 <h1>Edit client referral</h1>
 {{ client_referral_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=client_referral_create_schema) }}

--- a/src/domain/templates/posts/edit_provider_availability.html
+++ b/src/domain/templates/posts/edit_provider_availability.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "posts/_provider_availability_form.html" import provider_availability_form %}
-{% block title %}Edit provider availability{% endblock %}
+
 {% block content %}
 <h1>Edit provider availability</h1>
 {{ provider_availability_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=provider_availability_create_schema, current_user=current_user) }}

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Posts{% endblock %}
+
 {% block content %}
 <h1>Posts</h1>
 

--- a/src/domain/templates/posts/new_client_referral.html
+++ b/src/domain/templates/posts/new_client_referral.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "posts/_client_referral_form.html" import client_referral_form %}
-{% block title %}New client referral{% endblock %}
+
 {% block content %}
 <h1>New client referral</h1>
 <p>Per <code>notes/forms_spec.md</code>. No PII.</p>

--- a/src/domain/templates/posts/new_provider_availability.html
+++ b/src/domain/templates/posts/new_provider_availability.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "posts/_provider_availability_form.html" import provider_availability_form %}
-{% block title %}New provider availability{% endblock %}
+
 {% block content %}
 <h1>New provider availability</h1>
 {% if not current_user.providers %}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% block title %}Provider: {{ provider.practice_name }}{% endblock %}
 {% block content %}
 <article>
   <header>

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -3,7 +3,7 @@
 {%- from "_shared/forms.html" import inline_add_form -%}
 {%- from "_shared/sections.html" import list_or_empty -%}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
-{% block title %}Edit provider{% endblock %}
+
 {% block content %}
 <h1>Edit provider</h1>
 

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {%- from "_shared/form_fields.html" import field_for, radio_bool_field, text_field -%}
-{% block title %}Create provider{% endblock %}
+
 {% block content %}
 <h1>Create provider</h1>
 <p>Practice details only. Add licensures, education, and certifications after creating the provider.</p>

--- a/src/domain/templates/providers/list.html
+++ b/src/domain/templates/providers/list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {%- from "_shared/form_fields.html" import filter_select_field -%}
-{% block title %}Providers{% endblock %}
+
 {% block content %}
 <h1>Providers</h1>
 

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% block title %}User: {{ target_user.username }}{% endblock %}
 {% block content %}
 <article>
   <header>

--- a/src/domain/templates/users/list.html
+++ b/src/domain/templates/users/list.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Users{% endblock %}
+
 {% block content %}
 <h1>Users</h1>
 

--- a/src/domain/templates/users/providers_list.html
+++ b/src/domain/templates/users/providers_list.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% block title %}Providers — {{ target_user.username }}{% endblock %}
 {% block content %}
 {% if is_self %}
 <h1 id="user-providers-heading">Your providers</h1>

--- a/src/main.py
+++ b/src/main.py
@@ -69,7 +69,7 @@ async def unauthorized_exception_handler(request: Request, exc: HTTPException):
 
 @app.get("/")
 def read_root():
-    return RedirectResponse(url="/users", status_code=302)
+    return RedirectResponse(url="/posts", status_code=302)
 
 
 app.include_router(


### PR DESCRIPTION
## Summary

- Root \`/\` redirects to \`/posts\` (was \`/users\`).
- All pages titled "Bedlam Connect" — per-page \`{% block title %}\` overrides stripped (page identity shows via on-page \`<h1>\`).
- Pico-style brand in the primary nav: brand link as a first \`<ul>\` child of \`<nav>\` per Pico's two-list nav pattern.

\`title-case-ignore\` comments shield the proper noun from the sentence-case linter.

## Test plan

- [x] Full \`pytest\` (949 pass, 52 skip)
- [x] \`dev lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)