### PR TITLE
Introduce shared index_table macro; convert /providers to a table

### DIFF
--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -212,8 +212,8 @@ async def test_list_providers_renders_html(
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     tree = HTMLParser(response.text)
-    items = tree.css("ul.providers-list li")
-    assert len(items) == 1
+    rows = tree.css("#providers-table tbody tr")
+    assert len(rows) == 1
     assert tree.css_first(f'a[href="/providers/{provider_id}"]') is not None
     assert "Open House" in response.text
 
@@ -222,10 +222,11 @@ async def test_list_providers_shows_licensure_states(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
-    """Each list row surfaces the provider's licensure issuing states so
-    matches against `?issuing_state=` are visually obvious — a CT-located
-    provider holding a CA license shows `Licensed in: CA, CT` and the
-    user can see why they appeared in a CA filter (#458 follow-up)."""
+    """Each list row surfaces the provider's licensure issuing states in
+    its "Licensed in" cell so matches against `?issuing_state=` are
+    visually obvious — a CT-located provider holding a CA license shows
+    `CA, CT` and the user can see why they appeared in a CA filter
+    (#458 follow-up)."""
     other = create_test_user(username=f"other-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -252,21 +253,26 @@ async def test_list_providers_shows_licensure_states(
     response = await authenticated_client.get("/providers")
 
     assert response.status_code == 200
-    assert "Licensed in: CA, CT" in response.text
+    tree = HTMLParser(response.text)
+    licensed_in_cell = tree.css_first(
+        f'tr[data-row-id="{provider_id}"] td[data-label="Licensed in"]'
+    )
+    assert licensed_in_cell is not None
+    assert licensed_in_cell.text(strip=True) == "CA, CT"
 
 
 async def test_list_providers_renders_empty_state(
     authenticated_client: AsyncClient,
 ):
     """With no persisted providers, the page renders a friendly empty
-    message instead of an empty `<ul>`. With no filter set, the filter
+    message instead of an empty `<table>`. With no filter set, the filter
     form's `<option value="">Any</option>` is the preselected entry on
     each `<select>` (the `filter_select_field` macro contract)."""
     response = await authenticated_client.get("/providers")
     assert response.status_code == 200
     assert "No providers found" in response.text
     tree = HTMLParser(response.text)
-    assert tree.css_first("ul.providers-list") is None
+    assert tree.css_first("#providers-table") is None
     for select_name in ("license_type", "issuing_state"):
         selected = tree.css_first(f'select[name="{select_name}"] option[selected]')
         assert selected is not None
@@ -308,8 +314,8 @@ async def test_list_providers_filters_by_license_type(
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    items = tree.css("ul.providers-list li")
-    assert len(items) == 1
+    rows = tree.css("#providers-table tbody tr")
+    assert len(rows) == 1
     assert tree.css_first(f'a[href="/providers/{provider_a}"]') is not None
     assert tree.css_first(f'a[href="/providers/{provider_b}"]') is None
     # Filter form preserves the active selection.
@@ -341,8 +347,8 @@ async def test_list_providers_treats_empty_filter_values_as_absent(
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    items = tree.css("ul.providers-list li")
-    assert len(items) == 1, "Empty filter values should not exclude rows"
+    rows = tree.css("#providers-table tbody tr")
+    assert len(rows) == 1, "Empty filter values should not exclude rows"
 
 
 # --- Provider update ------------------------------------------------------

--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -20,6 +20,7 @@ Files prefixed with `_` are shared partials, `{% include %}`d from full pages �
 - `forms.html` — `inline_add_form(...)`: single-fieldset form skeleton for sub-resource add forms.
 - `sections.html` — `list_or_empty(...)`: `<ul>` or empty-state. Caller passes the `<li>` body via `{% call(item) %}...{% endcall %}`.
 - `actions.html` — `confirm_delete_button(...)`: HTMX `hx-delete` button with confirm dialog.
+- `index_table.html` — `index_table(items, headers, row, empty, id=None, row_kwargs={})`: the standard index-page table chrome (wrapping `<div>`, `<table role="grid">`, empty-state `<p class="index-empty">`). Headers and rows come from a cluster-local `<resource>/_columns.html` that exports `<resource>_headers()` and `<resource>_row(item, **row_kwargs)`. Every `/<collection>` list page renders through it — see `providers/list.html` for the canonical use. When the cluster's column macros read resource-specific Jinja context (e.g. `LICENSE_TYPES` flowing in via `EntitySpec.static_context`), import them `with context`.
 
 `filter_select_field` (for list-page filters) is never required and offers a leading "Any" option so users can clear filters; `select_field` (for create/edit) is required by default with an optional disabled placeholder.
 

--- a/src/domain/templates/_shared/index_table.html
+++ b/src/domain/templates/_shared/index_table.html
@@ -1,0 +1,44 @@
+{# Standard index-page table chrome.
+
+Every `/<collection>` list page is filter-bar + table + per-row actions
+(see ../README.md). This macro wraps the table/empty-state branch so
+each list page is a thin wrapper around two cluster-local macros: one
+returning the `<th>` cells, one returning the `<tr>` row.
+
+Args:
+  items:        iterable of model rows.
+  headers:      zero-arg macro returning the `<th>` cells for `<thead>`.
+                See e.g. `providers/_columns.html`.
+  row:          one-arg macro `row(item)` returning the full `<tr>...</tr>`
+                — the row owns its own data attributes (`data-row-id`) and
+                per-cell `data-label` so tests select stably and a later
+                mobile-stack pattern can attach without re-templating.
+  empty:        text shown when `items` is empty.
+  id:           optional id for the `<table>` (lets tests scope to the
+                table for that page).
+  row_kwargs:   passed to `row(item, **row_kwargs)` for per-viewer flags
+                (e.g. `is_favorited_lookup`) that the row macro needs but
+                that vary per-page. Default `{}` — most lists don't need it.
+
+Why a macro at all (vs. each list.html owning the table chrome): the
+empty-state branch and the wrapping `<div class="index-table">` are the
+load-bearing repeated structure — collapsing them here keeps every list
+honest about the empty-state contract (`<p class="index-empty">…`) so a
+single CSS rule styles every empty list the same way.
+#}
+{% macro index_table(items, headers, row, empty, id=None, row_kwargs={}) -%}
+{% if items %}
+<div class="index-table">
+  <table{% if id %} id="{{ id }}"{% endif %} role="grid">
+    <thead><tr>{{ headers() }}</tr></thead>
+    <tbody>
+      {%- for item in items %}
+{{ row(item, **row_kwargs) }}
+      {%- endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<p class="index-empty">{{ empty }}</p>
+{% endif %}
+{%- endmacro %}

--- a/src/domain/templates/providers/_columns.html
+++ b/src/domain/templates/providers/_columns.html
@@ -1,0 +1,70 @@
+{# Column macros for the providers index table.
+
+The grammar is one cluster-local `_columns.html` per resource (see
+../README.md). Three macros — headers, row, filters — drive the
+provider table on /providers and (in a later PR) the owner-scoped
+/users/{id}/providers and /users/me/favorites listings.
+
+Required context for `provider_row`: just the row's `provider`.
+Per-viewer flags (e.g. `is_favorited`) join later as keyword args
+threaded through `index_table`'s `row_kwargs`.
+
+The Insurance cell composes the same posture summary used on the
+provider detail card (#449): "In-net" / "Out-net" / "Self-pay", with
+optional "+slide" when sliding scale is on. One enum-mapped value,
+not three. Sliding scale is intentionally folded in so the column is
+narrow.
+#}
+{%- from "_shared/form_fields.html" import filter_select_field -%}
+
+{% macro provider_headers() -%}
+<th scope="col">Practice</th>
+<th scope="col">Location</th>
+<th scope="col">Licensed in</th>
+<th scope="col">Insurance</th>
+{%- endmacro %}
+
+{% macro provider_row(provider) -%}
+{%- set issuing_states = provider.licensures | map(attribute='issuing_state') | unique | sort | list -%}
+<tr data-row-id="{{ provider.id }}">
+  <td data-label="Practice" class="primary">
+    <a href="/providers/{{ provider.id }}">{{ provider.practice_name }}</a>
+  </td>
+  <td data-label="Location">{{ provider.location_city }}, {{ provider.location_state }}</td>
+  <td data-label="Licensed in">
+    {%- if issuing_states -%}
+      {{ issuing_states | join(', ') }}
+    {%- else -%}
+      &mdash;
+    {%- endif -%}
+  </td>
+  <td data-label="Insurance">
+    {%- if provider.accepts_in_network and provider.accepts_out_of_network -%}
+      In-net &amp; out-net
+    {%- elif provider.accepts_in_network -%}
+      In-net
+    {%- elif provider.accepts_out_of_network -%}
+      Out-net
+    {%- else -%}
+      Self-pay
+    {%- endif -%}
+    {%- if provider.sliding_scale %} <small>· sliding</small>{% endif -%}
+  </td>
+</tr>
+{%- endmacro %}
+
+{% macro provider_filters(selected_license_type, selected_issuing_state) -%}
+<form method="get" action="/providers">
+  <fieldset>
+    <legend>Filter</legend>
+    <div class="grid">
+      {{ filter_select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, current=selected_license_type) }}
+      {{ filter_select_field("issuing_state", "Licensed in state", US_STATES, current=selected_issuing_state) }}
+    </div>
+    <div class="grid inline">
+      <button type="submit">Apply</button>
+      <a href="/providers" role="button" class="secondary outline">Clear</a>
+    </div>
+  </fieldset>
+</form>
+{%- endmacro %}

--- a/src/domain/templates/providers/list.html
+++ b/src/domain/templates/providers/list.html
@@ -1,37 +1,22 @@
 {% extends "base.html" %}
-{%- from "_shared/form_fields.html" import filter_select_field -%}
+{%- from "_shared/index_table.html" import index_table -%}
+{# `with context` so `provider_filters` can read the provider-specific
+   enum tuples (`LICENSE_TYPES`, `US_STATES`) that flow into the page
+   from `PROVIDER_ENTITY.static_context` (and `US_STATES` from the
+   Jinja globals); without it, macros run in an isolated scope and
+   the filter selects render empty. #}
+{%- from "providers/_columns.html" import provider_headers, provider_row, provider_filters with context -%}
 
 {% block content %}
 <h1>Providers</h1>
 
-<form method="get" action="/providers">
-  <fieldset>
-    <legend>Filter</legend>
-    <div class="grid">
-      {{ filter_select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, current=selected_license_type) }}
-      {{ filter_select_field("issuing_state", "Licensed in state", US_STATES, current=selected_issuing_state) }}
-    </div>
-    <div class="grid inline">
-      <button type="submit">Apply</button>
-      <a href="/providers" role="button" class="secondary outline">Clear</a>
-    </div>
-  </fieldset>
-</form>
+{{ provider_filters(selected_license_type, selected_issuing_state) }}
 
-{% if providers %}
-<ul class="providers-list">
-  {%- for provider in providers %}
-  {%- set issuing_states = provider.licensures | map(attribute='issuing_state') | unique | sort | list -%}
-  <li>
-    <a href="/providers/{{ provider.id }}">{{ provider.practice_name }}</a>
-    &mdash; {{ provider.location_city }}, {{ provider.location_state }}
-    {%- if issuing_states %}
-    <br /><small>Licensed in: {{ issuing_states | join(', ') }}</small>
-    {%- endif %}
-  </li>
-  {%- endfor %}
-</ul>
-{% else %}
-<p>No providers found.</p>
-{% endif %}
+{{ index_table(
+  items=providers,
+  headers=provider_headers,
+  row=provider_row,
+  empty="No providers found.",
+  id="providers-table",
+) }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- First of a 5-PR sweep converging every `/<collection>` list page on the same chrome (filter bar + table + row actions), driven by a cluster-local `_columns.html`.
- Adds `src/domain/templates/_shared/index_table.html` and `providers/_columns.html`; `providers/list.html` shrinks to a thin wrapper.
- Tests moved off `ul.providers-list li` onto `#providers-table tbody tr` / `tr[data-row-id]` / `td[data-label]` selectors.

The Insurance cell collapses provider posture into a one-token tag (`In-net` / `Out-net` / `Self-pay` `+ sliding`) so the column reads narrow. Sliding scale folds in rather than getting its own column.

Other list pages (`/users`, `/users/me/favorites`, `/users/{id}/providers`, `/posts`) still render their current `<ul>`s — they convert in follow-up PRs sequenced on this one.

## Test plan
- [x] `dev test` — 949 passed, 52 skipped
- [x] `dev lint` — all checks green
- [x] `dev test tests/test_contract` — 16 passed
- [ ] CI green on PR
- [ ] Manual smoke: `/providers` list renders as table; filters preselect; empty-state renders with `<p class="index-empty">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)