### PR TITLE
Convert /users list to the shared index_table

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -87,7 +87,7 @@ async def test_list_users_multiple_users(
     assert "text/html" in response.headers["content-type"]
 
     tree = HTMLParser(response.text)
-    user_list_items = tree.css("#user-list > li")
+    user_list_items = tree.css("#user-list tbody tr")
     assert len(user_list_items) == 2, "Expected two users in the list"
 
     usernames_found = {item.text() for item in user_list_items}

--- a/src/domain/templates/users/_columns.html
+++ b/src/domain/templates/users/_columns.html
@@ -1,0 +1,39 @@
+{# Column macros for the users index table.
+
+`user_row` renders both the row and the deactivated state styling
+(`class="deactivated"` on the `<tr>`) — the same hook the previous
+`<li class="deactivated">` carried, so existing CSS continues to apply.
+
+The Actions cell `{% include %}`s the shared `_admin_actions.html`
+partial. Macros isolate `{% include %}` from the page-level rendering
+context, so `can_admin_actions` is threaded through as a `row_kwargs`
+arg by `users/list.html` and re-bound via `{% with %}` here. The
+partial then sees both `target_user` and `can_admin_actions` and
+renders nothing when the viewer is not an admin (its existing guard).
+#}
+
+{% macro user_headers() -%}
+<th scope="col">Username</th>
+<th scope="col">Status</th>
+<th scope="col">Actions</th>
+{%- endmacro %}
+
+{% macro user_row(user, can_admin_actions=False) -%}
+<tr data-row-id="{{ user.id }}"{% if not user.is_active %} class="deactivated"{% endif %}>
+  <td data-label="Username" class="primary">
+    <a href="/users/{{ user.id }}">{{ user.username }}</a>
+  </td>
+  <td data-label="Status">
+    {%- if user.is_active -%}
+      Active
+    {%- else -%}
+      <em>Deactivated</em>
+    {%- endif -%}
+  </td>
+  <td data-label="Actions">
+    {%- with target_user = user, can_admin_actions = can_admin_actions -%}
+      {%- include "users/_admin_actions.html" -%}
+    {%- endwith -%}
+  </td>
+</tr>
+{%- endmacro %}

--- a/src/domain/templates/users/list.html
+++ b/src/domain/templates/users/list.html
@@ -1,21 +1,16 @@
 {% extends "base.html" %}
+{%- from "_shared/index_table.html" import index_table -%}
+{%- from "users/_columns.html" import user_headers, user_row -%}
 
 {% block content %}
 <h1>Users</h1>
 
-{% if users %}
-<ul id="user-list">
-  {% for user in users %}
-  <li{% if not user.is_active %} class="deactivated"{% endif %}>
-    <a href="/users/{{ user.id }}">{{ user.username }}</a>
-    {% if not user.is_active %} <small><em>(deactivated)</em></small>{% endif %}
-    {% with target_user = user %}
-      {% include "users/_admin_actions.html" %}
-    {% endwith %}
-  </li>
-  {% endfor %}
-</ul>
-{% else %}
-<p>No users found.</p>
-{% endif %}
+{{ index_table(
+  items=users,
+  headers=user_headers,
+  row=user_row,
+  empty="No users found.",
+  id="user-list",
+  row_kwargs={"can_admin_actions": can_admin_actions},
+) }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- `users/list.html` now goes through `index_table` with a cluster-local `users/_columns.html`.
- Status moves into its own column (Active / Deactivated); the deactivated row class moves from `<li>` to `<tr>` so existing CSS continues to apply.
- `can_admin_actions` threads through `row_kwargs` (macros isolate `{% include %}` from page-level context) and gets re-bound via `{% with %}` before including `_admin_actions.html` — the partial is unchanged.

## Test plan
- [x] `dev test` — 949 passed, 52 skipped
- [x] `dev lint` — all checks green
- [x] `dev test tests/test_contract` — 16 passed
- [ ] CI green on PR
- [ ] Manual smoke: `/users` renders as table; admin sees actions per non-self row; reactivate/deactivate buttons swap based on row state

🤖 Generated with [Claude Code](https://claude.com/claude-code)