### PR TITLE
Expand seed data: 5 more users, 12 client referrals, 7 more PAs, dates spread

### DIFF
--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -9,12 +9,21 @@ Idempotent:
   - Provider-availability posts are matched by
     (kind='provider_availability', owner_id, provider_id); existing
     rows are skipped.
+  - Client-referral posts are matched by
+    (kind='client_referral', owner_id, description); duplicates are
+    skipped. Descriptions are verbose enough that this collision is
+    essentially never a real-data conflict.
 
 All fixture users share the password `password`.
+
+Each post fixture declares `days_ago: int`; the seed overrides the
+server-defaulted `created_at` to `now - days_ago` so the listings page
+renders a spread of dates rather than a wall of identical timestamps.
 """
 
 import asyncio
 import sys
+from datetime import datetime, timedelta, timezone
 from typing import Any, TypedDict
 
 # Local import to avoid circulars at module import time
@@ -24,7 +33,13 @@ from sqlalchemy import select
 from src.auth_config import UserManager
 from src.db import async_session_maker
 from src.domain.logic.users.schema import UserCreate
-from src.domain.models import Post, Provider, ProviderAvailabilityDetail, User
+from src.domain.models import (
+    ClientReferralDetail,
+    Post,
+    Provider,
+    ProviderAvailabilityDetail,
+    User,
+)
 
 SHARED_PASSWORD = "password"
 
@@ -37,7 +52,14 @@ class FixtureUser(TypedDict):
 
 class FixtureProviderAvailability(TypedDict):
     owner_email: str
+    days_ago: int
     provider: dict[str, Any]
+    detail: dict[str, Any]
+
+
+class FixtureClientReferral(TypedDict):
+    owner_email: str
+    days_ago: int
     detail: dict[str, Any]
 
 
@@ -45,17 +67,27 @@ FIXTURE_USERS: list[FixtureUser] = [
     {"email": "admin@example.com", "username": "admin", "is_superuser": True},
     {"email": "alice@example.com", "username": "alice", "is_superuser": False},
     {"email": "bob@example.com", "username": "bob", "is_superuser": False},
+    # Additional fixture clinicians so posts span more authors — gives
+    # the /posts feed a more realistic "many voices" feel and lets the
+    # `posted_by` filter actually narrow things on dev data.
+    {"email": "dr_chen@example.com", "username": "dr_chen", "is_superuser": False},
+    {"email": "dr_patel@example.com", "username": "dr_patel", "is_superuser": False},
+    {"email": "dr_rivera@example.com", "username": "dr_rivera", "is_superuser": False},
+    {"email": "dr_okafor@example.com", "username": "dr_okafor", "is_superuser": False},
+    {"email": "dr_jansen@example.com", "username": "dr_jansen", "is_superuser": False},
 ]
 
 
 # Real-world canonical examples that drive the schema-evolution work in
-# the issue series spawned by #420. Each fixture now declares its
-# Provider profile (practice + location + delivery format) alongside
-# the PA announcement (#448). The seed creates/reuses the Provider,
-# then points the PA's `provider_id` at it.
+# the issue series spawned by #420. Each fixture declares its Provider
+# profile (practice + location + delivery format) alongside the PA
+# announcement (#448). The seed creates/reuses the Provider, then
+# points the PA's `provider_id` at it. `days_ago` spreads `created_at`
+# across the last ~6 months so the listing page shows date variance.
 FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
     {
         "owner_email": "alice@example.com",
+        "days_ago": 2,
         "provider": {
             "practice_name": "Katie Reeves, PhD",
             # Telehealth-only practice — no city/ZIP in the source
@@ -98,6 +130,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
     },
     {
         "owner_email": "alice@example.com",
+        "days_ago": 14,
         "provider": {
             "practice_name": "Camp BooHoo",
             "location_city": "Santa Clara",
@@ -138,6 +171,7 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
     },
     {
         "owner_email": "alice@example.com",
+        "days_ago": 30,
         "provider": {
             "practice_name": "RISE IOP at CHC",
             "location_city": "Palo Alto",
@@ -181,7 +215,600 @@ FIXTURE_PROVIDER_AVAILABILITY: list[FixtureProviderAvailability] = [
             "languages": ["en", "es"],
         },
     },
+    {
+        "owner_email": "dr_chen@example.com",
+        "days_ago": 5,
+        "provider": {
+            "practice_name": "Lakeside Therapy Collective",
+            "location_city": "Seattle",
+            "location_state": "WA",
+            "location_zip": "98101",
+            "in_person_sessions": "yes",
+            "virtual_sessions": "yes",
+            "accepts_in_network": True,
+            "accepts_out_of_network": True,
+            "in_network_carriers": ["aetna", "anthem_bcbs", "cigna"],
+            "sliding_scale": False,
+            "cost": "$180–$220 / 50-min session",
+        },
+        "detail": {
+            "description": (
+                "Group practice of six licensed therapists. Currently accepting "
+                "adults and couples for weekly psychotherapy — anxiety, "
+                "depression, attachment, and life transitions. "
+                "Mix of in-person and telehealth slots."
+            ),
+            "referral_instructions": (
+                "Send a referral via our intake form or call (206) 555-0142."
+            ),
+            "website": "https://lakesidetherapy.example.com",
+            "desired_times": [],
+            "services": ["psychotherapy", "couples_therapy"],
+            "settings": ["outpatient"],
+            "treatment_modality": "Integrative, attachment-focused",
+            "age_groups": ["adults_25_64", "older_adults_65_plus"],
+            "languages": ["en"],
+        },
+    },
+    {
+        "owner_email": "dr_patel@example.com",
+        "days_ago": 1,
+        "provider": {
+            "practice_name": "Greenfield Psychiatry",
+            "location_city": "Brooklyn",
+            "location_state": "NY",
+            "location_zip": "11215",
+            "in_person_sessions": "yes",
+            "virtual_sessions": "yes",
+            "accepts_in_network": True,
+            "accepts_out_of_network": False,
+            "in_network_carriers": [
+                "aetna",
+                "cigna",
+                "optum",
+                "united_healthcare",
+                "anthem_bcbs",
+            ],
+            "sliding_scale": False,
+            "cost": None,
+        },
+        "detail": {
+            "description": (
+                "Outpatient adult psychiatry — evaluations, medication "
+                "management, and brief psychotherapy. Two new openings this "
+                "month for in-network adults. Hindi and Gujarati spoken."
+            ),
+            "referral_instructions": (
+                "Please send referrals via fax (718-555-0188) or our patient " "portal."
+            ),
+            "website": "https://greenfieldpsychiatry.example.com",
+            "desired_times": [],
+            "services": ["evaluation", "medication_management", "psychotherapy"],
+            "settings": ["outpatient"],
+            "treatment_modality": "Psychopharmacology, supportive therapy",
+            "age_groups": ["young_adults_19_24", "adults_25_64"],
+            "languages": ["en"],
+        },
+    },
+    {
+        "owner_email": "dr_rivera@example.com",
+        "days_ago": 9,
+        "provider": {
+            "practice_name": "Rivera Family Psychology",
+            "location_city": "Austin",
+            "location_state": "TX",
+            "location_zip": "78704",
+            "in_person_sessions": "no",
+            "virtual_sessions": "yes",
+            "accepts_in_network": False,
+            "accepts_out_of_network": True,
+            "in_network_carriers": [],
+            "sliding_scale": True,
+            "cost": "$160 / 50 min · sliding scale to $75",
+        },
+        "detail": {
+            "description": (
+                "Bilingual (Spanish/English) child and family psychologist. "
+                "Telehealth across Texas. Specializing in early childhood "
+                "behavioral concerns, parent coaching, and trauma in young "
+                "children."
+            ),
+            "referral_instructions": (
+                "Email referrals to intake@riverafamilypsych.example.com — "
+                "include a brief reason for referral and parent contact info."
+            ),
+            "website": "https://riverafamilypsych.example.com",
+            "desired_times": [],
+            "services": ["psychotherapy", "evaluation", "family_therapy"],
+            "settings": ["outpatient"],
+            "treatment_modality": "Parent–Child Interaction Therapy (PCIT)",
+            "age_groups": ["children_0_5", "children_6_10", "preteens_11_13"],
+            "languages": ["en", "es"],
+        },
+    },
+    {
+        "owner_email": "dr_okafor@example.com",
+        "days_ago": 21,
+        "provider": {
+            "practice_name": "Beacon Hill Family Therapy",
+            "location_city": "Boston",
+            "location_state": "MA",
+            "location_zip": "02114",
+            "in_person_sessions": "yes",
+            "virtual_sessions": "yes",
+            "accepts_in_network": True,
+            "accepts_out_of_network": True,
+            "in_network_carriers": [
+                "aetna",
+                "anthem_bcbs",
+                "cigna",
+                "optum",
+                "tricare",
+                "united_healthcare",
+            ],
+            "sliding_scale": True,
+            "cost": "$200 / session, sliding scale available",
+        },
+        "detail": {
+            "description": (
+                "Family-systems practice serving adolescents and their "
+                "families. Specialties: school refusal, divorce/coparenting, "
+                "and emerging-adult separation. Most major insurance accepted."
+            ),
+            "referral_instructions": (
+                "Phone intake preferred: (617) 555-0119. Voicemail returned "
+                "within 24 business hours."
+            ),
+            "website": "https://beaconhillfamily.example.com",
+            "desired_times": [],
+            "services": ["family_therapy", "psychotherapy", "case_management"],
+            "settings": ["outpatient"],
+            "treatment_modality": "Structural and Bowenian family therapy",
+            "age_groups": [
+                "preteens_11_13",
+                "adolescents_14_18",
+                "young_adults_19_24",
+                "adults_25_64",
+            ],
+            "languages": ["en"],
+        },
+    },
+    {
+        "owner_email": "dr_jansen@example.com",
+        "days_ago": 60,
+        "provider": {
+            "practice_name": "Mountainview Residential",
+            "location_city": "Boulder",
+            "location_state": "CO",
+            "location_zip": "80302",
+            "in_person_sessions": "yes",
+            "virtual_sessions": "no",
+            # Insurance posture: program negotiates rates case-by-case.
+            # `please_contact` would be the right CHECK value if we had
+            # one on Provider; the model uses booleans, so we encode
+            # the same intent as "self-pay only" + cost text.
+            "accepts_in_network": False,
+            "accepts_out_of_network": True,
+            "in_network_carriers": [],
+            "sliding_scale": False,
+            "cost": "Please contact for rate sheet",
+        },
+        "detail": {
+            "description": (
+                "30- and 60-day residential program for adolescents with "
+                "co-occurring eating disorders and mood disorders. "
+                "Intentionally small (12 beds); structured milieu with "
+                "individual, group, and family therapy."
+            ),
+            "referral_instructions": (
+                "Admissions team handles all clinical inquiries. Call "
+                "(303) 555-0177 ext. 2 for an admissions clinician."
+            ),
+            "website": "https://mountainviewres.example.com",
+            "desired_times": [],
+            "schedule_text": "Rolling admissions; 30- and 60-day tracks",
+            "services": [
+                "psychotherapy",
+                "medication_management",
+                "group_therapy",
+                "family_therapy",
+            ],
+            "settings": ["residential"],
+            "treatment_modality": "Enhanced CBT-E for eating disorders",
+            "age_groups": ["adolescents_14_18"],
+            "languages": ["en"],
+        },
+    },
+    {
+        "owner_email": "dr_chen@example.com",
+        "days_ago": 45,
+        "provider": {
+            "practice_name": "Cascade PHP",
+            "location_city": "Tacoma",
+            "location_state": "WA",
+            "location_zip": "98402",
+            "in_person_sessions": "yes",
+            "virtual_sessions": "no",
+            "accepts_in_network": True,
+            "accepts_out_of_network": True,
+            "in_network_carriers": [
+                "aetna",
+                "anthem_bcbs",
+                "kaiser",
+                "medicaid",
+                "optum",
+            ],
+            "sliding_scale": False,
+            "cost": None,
+        },
+        "detail": {
+            "description": (
+                "Adult partial-hospitalization program — 5 days/week, 6 hours/day. "
+                "DBT skills, process group, individual therapy, and med "
+                "management for mood, anxiety, and trauma-related conditions."
+            ),
+            "referral_instructions": (
+                "Self-referrals and clinician referrals both welcome. Online "
+                "intake form on website routes to admissions same-day."
+            ),
+            "website": "https://cascadephp.example.com",
+            "desired_times": [],
+            "schedule_text": "M-F 9am–3pm; 4-6 week average length of stay",
+            "services": [
+                "psychotherapy",
+                "medication_management",
+                "group_therapy",
+            ],
+            "settings": ["php"],
+            "treatment_modality": "DBT-informed PHP",
+            "age_groups": ["adults_25_64"],
+            "languages": ["en"],
+        },
+    },
+    {
+        "owner_email": "bob@example.com",
+        "days_ago": 110,
+        "provider": {
+            "practice_name": "North Loop Counseling",
+            "location_city": "Minneapolis",
+            "location_state": "MN",
+            "location_zip": "55401",
+            "in_person_sessions": "yes",
+            "virtual_sessions": "yes",
+            "accepts_in_network": True,
+            "accepts_out_of_network": False,
+            "in_network_carriers": ["anthem_bcbs", "medicaid", "united_healthcare"],
+            "sliding_scale": True,
+            "cost": "$150 / session · sliding to $40",
+        },
+        "detail": {
+            "description": (
+                "Solo LMFT practice. Currently has one Tuesday evening slot "
+                "open for an adult or couple. Strong fit for ambivalence in "
+                "relationships, attachment ruptures, and identity work."
+            ),
+            "referral_instructions": (
+                "Text the practice line at (612) 555-0203 with a brief intro "
+                "and I'll respond within 2 business days."
+            ),
+            "website": None,
+            "desired_times": [
+                "tuesday_evening",
+            ],
+            "services": ["psychotherapy", "couples_therapy"],
+            "settings": ["outpatient"],
+            "treatment_modality": "AEDP, IFS",
+            "age_groups": ["adults_25_64"],
+            "languages": ["en"],
+        },
+    },
 ]
+
+
+# Client-referral fixtures. Each is a clinician referring out one of
+# their clients — the description is the part a reader scans on the
+# listings page. Spread across states, age bands, insurance postures,
+# and service needs so the /posts filters actually narrow on real data.
+FIXTURE_CLIENT_REFERRAL: list[FixtureClientReferral] = [
+    {
+        "owner_email": "bob@example.com",
+        "days_ago": 0,
+        "detail": {
+            "location_city": "Seattle",
+            "location_state": "WA",
+            "location_zip": "98109",
+            "location_in_person": "yes",
+            "location_virtual": "yes",
+            "desired_times": ["wednesday_afternoon", "thursday_afternoon"],
+            "age_groups": ["adolescents_14_18"],
+            "languages": ["en"],
+            "description": (
+                "Looking for a trauma-focused therapist for a 14-year-old "
+                "(she/her) with complex PTSD and emerging self-injury. Mom is "
+                "engaged and on board. Aetna in-network strongly preferred; "
+                "family is open to telehealth if needed."
+            ),
+            "services": ["psychotherapy"],
+            "treatment_modality": "TF-CBT or EMDR preferred",
+            "insurance": "in_network",
+        },
+    },
+    {
+        "owner_email": "dr_chen@example.com",
+        "days_ago": 3,
+        "detail": {
+            "location_city": "Tacoma",
+            "location_state": "WA",
+            "location_zip": "98402",
+            "location_in_person": "yes",
+            "location_virtual": "no",
+            "desired_times": ["monday_morning", "wednesday_morning"],
+            "age_groups": ["children_6_10"],
+            "languages": ["en", "es"],
+            "description": (
+                "Seeking a Spanish-speaking child psychologist for a 7yo with "
+                "selective mutism. Family lives in Tacoma; in-person required. "
+                "Mom has Medicaid (Apple Health). Parent coaching component "
+                "important — family is open to PCIT."
+            ),
+            "services": ["psychotherapy", "evaluation"],
+            "treatment_modality": "PCIT or behavior-based",
+            "insurance": "in_network",
+        },
+    },
+    {
+        "owner_email": "dr_patel@example.com",
+        "days_ago": 6,
+        "detail": {
+            "location_city": "Brooklyn",
+            "location_state": "NY",
+            "location_zip": "11201",
+            "location_in_person": "yes",
+            "location_virtual": "yes",
+            "desired_times": [
+                "monday_evening",
+                "tuesday_evening",
+                "wednesday_evening",
+            ],
+            "age_groups": ["adults_25_64"],
+            "languages": ["en"],
+            "description": (
+                "Adult patient (he/him, 38) with treatment-resistant depression "
+                "and longstanding alcohol use. Currently on lithium augmentation. "
+                "Looking for a DBT-trained therapist who is comfortable holding "
+                "a long-term frame. Out-of-network OK; he can pay $150–200."
+            ),
+            "services": ["psychotherapy"],
+            "treatment_modality": "DBT or DBT-informed",
+            "insurance": "out_of_network",
+        },
+    },
+    {
+        "owner_email": "dr_rivera@example.com",
+        "days_ago": 11,
+        "detail": {
+            "location_city": "Austin",
+            "location_state": "TX",
+            "location_zip": "78704",
+            "location_in_person": "no",
+            "location_virtual": "yes",
+            "desired_times": ["saturday_morning", "sunday_morning"],
+            "age_groups": ["young_adults_19_24"],
+            "languages": ["en", "es"],
+            "description": (
+                "20yo college student (she/they) reaching out for support around "
+                "gender identity and family conflict. Family is Spanish-speaking "
+                "and not yet involved. Wants a queer-affirming, Spanish-fluent "
+                "therapist; telehealth so they can do sessions from dorm."
+            ),
+            "services": ["psychotherapy"],
+            "treatment_modality": None,
+            "insurance": "self_pay_only",
+        },
+    },
+    {
+        "owner_email": "dr_okafor@example.com",
+        "days_ago": 18,
+        "detail": {
+            "location_city": "Cambridge",
+            "location_state": "MA",
+            "location_zip": "02139",
+            "location_in_person": "yes",
+            "location_virtual": "no",
+            "desired_times": [],
+            "age_groups": ["preteens_11_13"],
+            "languages": ["en"],
+            "description": (
+                "Looking for an evaluator (psychoeducational or "
+                "neuropsychological) for an 11yo with longstanding attention "
+                "and reading concerns. School is requesting a recent eval to "
+                "update the IEP. Family has BCBS PPO."
+            ),
+            "services": ["evaluation"],
+            "treatment_modality": None,
+            "insurance": "in_network",
+        },
+    },
+    {
+        "owner_email": "alice@example.com",
+        "days_ago": 25,
+        "detail": {
+            "location_city": "Oakland",
+            "location_state": "CA",
+            "location_zip": "94609",
+            "location_in_person": "yes",
+            "location_virtual": "yes",
+            "desired_times": [
+                "monday_afternoon",
+                "tuesday_afternoon",
+                "thursday_afternoon",
+            ],
+            "age_groups": ["adults_25_64"],
+            "languages": ["en"],
+            "description": (
+                "Couple in their early 30s seeking couples therapy. Recent "
+                "relational rupture (infidelity disclosed 6 weeks ago) and "
+                "both partners are motivated to do the work. Prefer a Bay-Area "
+                "therapist trained in EFT or Gottman."
+            ),
+            "services": ["couples_therapy"],
+            "treatment_modality": "EFT or Gottman",
+            "insurance": "out_of_network",
+        },
+    },
+    {
+        "owner_email": "dr_jansen@example.com",
+        "days_ago": 33,
+        "detail": {
+            "location_city": "Denver",
+            "location_state": "CO",
+            "location_zip": "80205",
+            "location_in_person": "yes",
+            "location_virtual": "no",
+            "desired_times": [],
+            "age_groups": ["adolescents_14_18"],
+            "languages": ["en"],
+            "description": (
+                "Stepping down a 17yo from our residential program — needs a "
+                "twice-weekly outpatient psychiatrist for medication management "
+                "and an outpatient DBT therapist to continue skills. Family is "
+                "fully invested. Kaiser Colorado."
+            ),
+            "services": ["medication_management", "psychotherapy"],
+            "treatment_modality": "DBT",
+            "insurance": "in_network",
+        },
+    },
+    {
+        "owner_email": "bob@example.com",
+        "days_ago": 40,
+        "detail": {
+            "location_city": "Minneapolis",
+            "location_state": "MN",
+            "location_zip": "55403",
+            "location_in_person": "yes",
+            "location_virtual": "yes",
+            "desired_times": ["friday_morning"],
+            "age_groups": ["older_adults_65_plus"],
+            "languages": ["en"],
+            "description": (
+                "72yo widow referred by her PCP for late-life depression "
+                "following her husband's death 11 months ago. Strong fit for a "
+                "geriatric-informed therapist. Medicare; willing to travel "
+                "within the Twin Cities."
+            ),
+            "services": ["psychotherapy"],
+            "treatment_modality": None,
+            "insurance": "in_network",
+        },
+    },
+    {
+        "owner_email": "dr_chen@example.com",
+        "days_ago": 55,
+        "detail": {
+            "location_city": "Seattle",
+            "location_state": "WA",
+            "location_zip": "98115",
+            "location_in_person": "no",
+            "location_virtual": "yes",
+            "desired_times": ["wednesday_evening", "thursday_evening"],
+            "age_groups": ["children_0_5", "children_6_10"],
+            "languages": ["en"],
+            "description": (
+                "Parents of a 5yo with newly identified autism are looking for "
+                "a parent-coaching clinician (ESDM or similar). Want telehealth "
+                "so both parents can join sessions from work. Premera BCBS."
+            ),
+            "services": ["family_therapy", "case_management"],
+            "treatment_modality": "ESDM or PCIT",
+            "insurance": "in_network",
+        },
+    },
+    {
+        "owner_email": "dr_patel@example.com",
+        "days_ago": 72,
+        "detail": {
+            "location_city": "Queens",
+            "location_state": "NY",
+            "location_zip": "11375",
+            "location_in_person": "yes",
+            "location_virtual": "yes",
+            "desired_times": [],
+            "age_groups": ["adults_25_64"],
+            "languages": ["en"],
+            "description": (
+                "Adult patient with bipolar I, currently stable on lithium and "
+                "lurasidone. Needs a long-term outpatient psychiatrist as "
+                "primary care moves out of NYC. Open to in-person or telehealth. "
+                "Aetna PPO."
+            ),
+            "services": ["medication_management"],
+            "treatment_modality": None,
+            "insurance": "in_network",
+        },
+    },
+    {
+        "owner_email": "dr_okafor@example.com",
+        "days_ago": 95,
+        "detail": {
+            "location_city": "Boston",
+            "location_state": "MA",
+            "location_zip": "02118",
+            "location_in_person": "yes",
+            "location_virtual": "no",
+            "desired_times": [
+                "monday_morning",
+                "tuesday_morning",
+                "wednesday_morning",
+                "thursday_morning",
+                "friday_morning",
+            ],
+            "age_groups": ["young_adults_19_24", "adults_25_64"],
+            "languages": ["en"],
+            "description": (
+                "Group practice has openings for IOP-level adults stepping "
+                "down from inpatient. Need community-based clinicians who can "
+                "see daily for 3-4 weeks while we coordinate care. Will "
+                "accept any major insurance — please contact for specifics."
+            ),
+            "services": ["case_management"],
+            "treatment_modality": None,
+            "insurance": "please_contact",
+        },
+    },
+    {
+        "owner_email": "alice@example.com",
+        "days_ago": 165,
+        "detail": {
+            "location_city": "San Francisco",
+            "location_state": "CA",
+            "location_zip": "94110",
+            "location_in_person": "no",
+            "location_virtual": "yes",
+            "desired_times": ["saturday_afternoon"],
+            "age_groups": ["adults_25_64"],
+            "languages": ["en"],
+            "description": (
+                "Tech-industry client (mid-30s, he/him) with longstanding "
+                "social anxiety and recent depression. Hours are unpredictable. "
+                "Weekend availability and telehealth are non-negotiable. "
+                "Self-pay; budget is generous."
+            ),
+            "services": ["psychotherapy"],
+            "treatment_modality": "CBT or ACT",
+            "insurance": "self_pay_only",
+        },
+    },
+]
+
+
+def _shift_created_at(post: Post, days_ago: int) -> None:
+    """Override the `server_default=func.now()` on `Post.created_at` with
+    a deterministic offset so the listings feed shows a spread of dates.
+    Set before the row is flushed so the INSERT carries our value, not
+    the server clock.
+    """
+    post.created_at = datetime.now(timezone.utc) - timedelta(days=days_ago)
 
 
 async def seed_users() -> tuple[int, int]:
@@ -280,6 +907,7 @@ async def seed_provider_availability() -> tuple[int, int]:
                 continue
 
             post = Post(kind="provider_availability", owner_id=owner.id)
+            _shift_created_at(post, fixture["days_ago"])
             post.provider_availability_detail = ProviderAvailabilityDetail(
                 provider_id=provider.id, **fixture["detail"]
             )
@@ -294,14 +922,69 @@ async def seed_provider_availability() -> tuple[int, int]:
     return created, skipped
 
 
+async def seed_client_referral() -> tuple[int, int]:
+    """Seed client-referral posts (the seeking side). Idempotent on
+    `(kind, owner_id, description)`: descriptions are verbose enough
+    that re-running matches the same row, never a collision with a
+    real one."""
+    created = 0
+    skipped = 0
+
+    async with async_session_maker() as session:
+        for fixture in FIXTURE_CLIENT_REFERRAL:
+            owner_result = await session.execute(
+                select(User).where(User.email == fixture["owner_email"])
+            )
+            owner = owner_result.scalar_one_or_none()
+            description = fixture["detail"]["description"]
+            short = description[:40] + "…"
+            if owner is None:
+                print(
+                    f"⚠️  CR post '{short}': "
+                    f"owner {fixture['owner_email']} not found, skipping"
+                )
+                skipped += 1
+                continue
+
+            existing = await session.execute(
+                select(Post)
+                .join(ClientReferralDetail, ClientReferralDetail.post_id == Post.id)
+                .where(
+                    Post.kind == "client_referral",
+                    Post.owner_id == owner.id,
+                    ClientReferralDetail.description == description,
+                )
+            )
+            if existing.scalar_one_or_none() is not None:
+                print(
+                    f"⏭️  CR post '{short}' by {fixture['owner_email']} "
+                    f"already exists, skipping"
+                )
+                skipped += 1
+                continue
+
+            post = Post(kind="client_referral", owner_id=owner.id)
+            _shift_created_at(post, fixture["days_ago"])
+            post.client_referral_detail = ClientReferralDetail(**fixture["detail"])
+            session.add(post)
+            print(f"✅ Created CR post '{short}' by {fixture['owner_email']}")
+            created += 1
+
+        await session.commit()
+
+    return created, skipped
+
+
 async def seed_all() -> int:
     users_created, users_skipped = await seed_users()
     pa_created, pa_skipped = await seed_provider_availability()
+    cr_created, cr_skipped = await seed_client_referral()
 
     print(
         f"\n🌱 Seed complete:"
         f" {users_created} users created ({users_skipped} skipped),"
-        f" {pa_created} provider-availability posts created ({pa_skipped} skipped)"
+        f" {pa_created} provider-availability posts created ({pa_skipped} skipped),"
+        f" {cr_created} client-referral posts created ({cr_skipped} skipped)"
     )
     if users_created > 0:
         print(f"   Password for all fixture users: {SHARED_PASSWORD}")

--- a/scripts/dev/test_seed.py
+++ b/scripts/dev/test_seed.py
@@ -1,22 +1,34 @@
 """Tests for `scripts/dev/seed.py`.
 
-Two invariants matter beyond "the script ran":
-  - On a fresh DB, `seed_provider_availability` inserts the full fixture
-    set and populates each parent `Post` with its detail row in the
-    same flush. A regression where the parent is committed without the
-    detail would 500 every read view that joins the detail in.
-  - Re-running is a no-op. The idempotency key (kind, owner_id,
-    practice_name) keeps `dev seed` safe to run repeatedly during
-    development.
+Three invariants matter beyond "the script ran":
+  - On a fresh DB, the seed functions insert the full fixture set and
+    populate each parent `Post` with its detail row in the same flush.
+    A regression where the parent is committed without the detail
+    would 500 every read view that joins the detail in.
+  - Re-running is a no-op. The idempotency keys
+    (provider_availability: `kind + owner_id + practice_name`;
+    client_referral: `kind + owner_id + description`) keep `dev seed`
+    safe to run repeatedly during development.
+  - `created_at` is varied via the per-fixture `days_ago` field so the
+    listings feed renders a spread of dates, not a wall of identical
+    timestamps. A regression where the `_shift_created_at` override
+    silently became a no-op would collapse the feed back to one date.
 """
+
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import select
 
 from scripts.dev import seed
-from src.domain.models import Post, ProviderAvailabilityDetail, User
+from src.domain.models import ClientReferralDetail, Post, ProviderAvailabilityDetail
 from tests.fixtures import async_test_sessionmaker
 from tests.helpers import create_test_user
+
+# Counts derive from the fixture lists themselves so adding/removing a
+# fixture is a one-line edit in `seed.py` without test-count drift.
+_PA_COUNT = len(seed.FIXTURE_PROVIDER_AVAILABILITY)
+_CR_COUNT = len(seed.FIXTURE_CLIENT_REFERRAL)
 
 
 @pytest.fixture(autouse=True)
@@ -25,12 +37,18 @@ def patch_session_maker(monkeypatch):
     monkeypatch.setattr(seed, "async_session_maker", async_test_sessionmaker)
 
 
-async def _insert_alice() -> User:
-    user = create_test_user(email="alice@example.com", username="alice")
+async def _insert_all_fixture_users() -> None:
+    """Persist all fixture users so the post seeders have valid owners
+    to FK against. Each test inserts the full set so individual tests
+    don't need to know which users own which fixtures."""
     async with async_test_sessionmaker() as session:
         async with session.begin():
-            session.add(user)
-    return user
+            for fixture in seed.FIXTURE_USERS:
+                session.add(
+                    create_test_user(
+                        email=fixture["email"], username=fixture["username"]
+                    )
+                )
 
 
 async def _all_pa_posts() -> list[Post]:
@@ -41,18 +59,29 @@ async def _all_pa_posts() -> list[Post]:
         return list(result.scalars().all())
 
 
-async def test_inserts_three_pa_posts_on_fresh_db(db_test_session_manager):
-    await _insert_alice()
+async def _all_cr_posts() -> list[Post]:
+    async with async_test_sessionmaker() as session:
+        result = await session.execute(
+            select(Post).where(Post.kind == "client_referral")
+        )
+        return list(result.scalars().all())
+
+
+# --- provider_availability ------------------------------------------------
+
+
+async def test_inserts_all_pa_posts_on_fresh_db(db_test_session_manager):
+    await _insert_all_fixture_users()
 
     created, skipped = await seed.seed_provider_availability()
 
-    assert (created, skipped) == (3, 0)
+    assert (created, skipped) == (_PA_COUNT, 0)
     posts = await _all_pa_posts()
-    assert len(posts) == 3
+    assert len(posts) == _PA_COUNT
 
 
-async def test_each_post_has_populated_detail_relationship(db_test_session_manager):
-    await _insert_alice()
+async def test_each_pa_post_has_populated_detail_relationship(db_test_session_manager):
+    await _insert_all_fixture_users()
 
     await seed.seed_provider_availability()
 
@@ -67,24 +96,104 @@ async def test_each_post_has_populated_detail_relationship(db_test_session_manag
     # Practice name lives on the linked Provider (#448); dereference via
     # the FK relationship on the detail row.
     practice_names = {d.provider.practice_name for d in details}
-    assert practice_names == {"Katie Reeves, PhD", "Camp BooHoo", "RISE IOP at CHC"}
+    expected = {
+        f["provider"]["practice_name"] for f in seed.FIXTURE_PROVIDER_AVAILABILITY
+    }
+    assert practice_names == expected
 
 
-async def test_rerun_is_idempotent(db_test_session_manager):
-    await _insert_alice()
+async def test_pa_rerun_is_idempotent(db_test_session_manager):
+    await _insert_all_fixture_users()
 
     first = await seed.seed_provider_availability()
     second = await seed.seed_provider_availability()
 
-    assert first == (3, 0)
-    assert second == (0, 3)
-    assert len(await _all_pa_posts()) == 3
+    assert first == (_PA_COUNT, 0)
+    assert second == (0, _PA_COUNT)
+    assert len(await _all_pa_posts()) == _PA_COUNT
 
 
-async def test_skips_when_owner_missing(db_test_session_manager, capsys):
-    # No alice in this test — every fixture row should be skipped, nothing inserted.
+async def test_pa_skips_when_owner_missing(db_test_session_manager, capsys):
+    # No fixture users seeded — every fixture row should be skipped.
     created, skipped = await seed.seed_provider_availability()
 
     assert created == 0
-    assert skipped == 3
+    assert skipped == _PA_COUNT
     assert await _all_pa_posts() == []
+
+
+# --- client_referral ------------------------------------------------------
+
+
+async def test_inserts_all_cr_posts_on_fresh_db(db_test_session_manager):
+    await _insert_all_fixture_users()
+
+    created, skipped = await seed.seed_client_referral()
+
+    assert (created, skipped) == (_CR_COUNT, 0)
+    posts = await _all_cr_posts()
+    assert len(posts) == _CR_COUNT
+
+
+async def test_each_cr_post_has_populated_detail_relationship(db_test_session_manager):
+    await _insert_all_fixture_users()
+
+    await seed.seed_client_referral()
+
+    async with async_test_sessionmaker() as session:
+        result = await session.execute(
+            select(ClientReferralDetail).join(
+                Post, Post.id == ClientReferralDetail.post_id
+            )
+        )
+        details = list(result.scalars().all())
+
+    descriptions = {d.description for d in details}
+    expected = {f["detail"]["description"] for f in seed.FIXTURE_CLIENT_REFERRAL}
+    assert descriptions == expected
+
+
+async def test_cr_rerun_is_idempotent(db_test_session_manager):
+    await _insert_all_fixture_users()
+
+    first = await seed.seed_client_referral()
+    second = await seed.seed_client_referral()
+
+    assert first == (_CR_COUNT, 0)
+    assert second == (0, _CR_COUNT)
+    assert len(await _all_cr_posts()) == _CR_COUNT
+
+
+async def test_cr_skips_when_owner_missing(db_test_session_manager):
+    created, skipped = await seed.seed_client_referral()
+
+    assert created == 0
+    assert skipped == _CR_COUNT
+    assert await _all_cr_posts() == []
+
+
+# --- created_at variance --------------------------------------------------
+
+
+async def test_seed_spreads_created_at_across_days(db_test_session_manager):
+    """`days_ago` overrides the server-defaulted `created_at` so the
+    listings feed shows a date range. Pins that the override actually
+    takes effect — a regression collapsing all posts to `now()` would
+    fail here."""
+    await _insert_all_fixture_users()
+    await seed.seed_provider_availability()
+    await seed.seed_client_referral()
+
+    posts = await _all_pa_posts() + await _all_cr_posts()
+    timestamps = {p.created_at.date() for p in posts}
+    # Every fixture declares its own `days_ago`; even one duplicate is
+    # fine, but we expect substantial spread. Assert at least 5 distinct
+    # dates across the combined fixture set so a "all-set-to-now"
+    # regression can't sneak through.
+    assert len(timestamps) >= 5
+    # And: the oldest post should be at least 90 days back, proving
+    # the spread covers a meaningful window (today's "older posts"
+    # filter exists for a reason).
+    now = datetime.now(timezone.utc).date()
+    oldest = min(timestamps)
+    assert (now - oldest).days >= 90


### PR DESCRIPTION
## Summary

- Adds 5 fixture users (`dr_chen`, `dr_patel`, `dr_rivera`, `dr_okafor`, `dr_jansen`) so post authorship spans the matrix and the `posted_by` filter has something to narrow against.
- Adds 7 more `provider_availability` fixtures: WA, NY, TX, MA, CO, MN across varied insurance postures (in-net multi-carrier, out-of-net only, please-contact, self-pay + sliding) and care settings (IOP, PHP, residential, day program).
- Adds 12 `client_referral` fixtures — the *seeking* side, completely empty on the dev DB before this — written to read like real clinicians referring out their clients. The listings page now renders something evocative on every row.
- Each fixture declares `days_ago: int`; the seed overrides `Post.created_at` so the listings feed shows dates from today through ~5 months back, exercising both branches of the new `format_post_date` filter.
- `seed_client_referral` parallels `seed_provider_availability` with the same idempotency contract (key: `kind + owner_id + description`).

## Test plan

- [x] `dev test` — 988 passed, 52 skipped (9 seed tests, up from 4)
- [x] `dev lint` — all checks green
- [x] Counts are computed from `len(seed.FIXTURE_*)` so adding a fixture is a one-line edit without test-count drift.
- [x] New test pins the `created_at` spread (≥5 distinct dates, oldest ≥90 days back) so a regression collapsing the override fails loudly.
- [ ] Run \`dev seed\` against a local dev DB and eyeball /posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)