### PR TITLE
Reserve scrollbar gutter to prevent horizontal layout shift

### DIFF
--- a/src/domain/templates/base.html
+++ b/src/domain/templates/base.html
@@ -15,6 +15,11 @@
        `main.container.narrow` constrains form-heavy pages to a readable
        width; list/detail pages keep the default full-width container. #}
     <style>
+      /* Reserve scrollbar gutter so pages whose content fits in the
+         viewport render at the same width as pages that overflow —
+         otherwise the layout shifts horizontally when a scrollbar
+         appears (notably on macOS with "Always show scrollbars"). */
+      html { scrollbar-gutter: stable; }
       :root {
         --pico-spacing: 0.75rem;
         --pico-form-element-spacing-vertical: 0.5rem;


### PR DESCRIPTION
## Summary
- Add `scrollbar-gutter: stable` on `<html>` in `base.html` so pages whose content fits in the viewport render at the same width as pages that overflow.
- Fixes the small horizontal layout shift visible across templates when the scrollbar appears/disappears (most noticeable on macOS with "Always show scrollbars").

## Test plan
- [ ] Visit a short page (no scrollbar needed) and a long page (scrollbar appears) and confirm content width / centering does not change between the two.
- [ ] Sanity-check in Safari, Chrome, Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)