### PR TITLE
Slim primary nav to a single profile icon

### DIFF
--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -351,20 +351,7 @@ async def test_list_providers_treats_empty_filter_values_as_absent(
     assert len(rows) == 1, "Empty filter values should not exclude rows"
 
 
-# --- Chrome: nav active state + breadcrumb ------------------------------
-
-
-async def test_primary_nav_marks_providers_active_on_providers_index(
-    authenticated_client: AsyncClient,
-):
-    response = await authenticated_client.get("/providers")
-    assert response.status_code == 200
-    tree = HTMLParser(response.text)
-    providers_link = tree.css_first('#primary-nav a[href="/providers"]')
-    posts_link = tree.css_first('#primary-nav a[href="/posts"]')
-    assert providers_link is not None
-    assert providers_link.attributes.get("aria-current") == "page"
-    assert posts_link.attributes.get("aria-current") is None
+# --- Chrome: breadcrumb -------------------------------------------------
 
 
 async def test_provider_detail_renders_breadcrumb(

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -23,15 +23,17 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """Authenticated pages include nav links to the main sections plus the
-    `/users/me` shortcut to the viewer's own user page."""
+    """Authenticated pages render the primary nav with a single
+    `/users/me` profile shortcut. Section links (Posts / Users /
+    Providers / Favorites) are reachable from within their pages
+    rather than from the top-level chrome."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     nav_items = tree.css("#primary-nav > li > a")
     hrefs = {a.attributes.get("href") for a in nav_items}
-    assert {"/posts", "/users", "/providers", "/users/me"} <= hrefs
+    assert hrefs == {"/users/me"}
 
 
 async def test_base_template_hides_nav_for_anonymous_visitors(
@@ -341,21 +343,17 @@ async def test_detail_lists_owned_providers(
 # --- Chrome: nav active state + breadcrumb ------------------------------
 
 
-async def test_primary_nav_marks_favorites_active_and_not_users(
+async def test_primary_nav_marks_profile_active_on_users_me_subpaths(
     authenticated_client: AsyncClient,
 ):
-    """On `/users/me/favorites`, more-specific section wins: Favorites
-    is active and Users / Me are not — even though all three share the
-    `/users` URL prefix."""
+    """The profile icon links to `/users/me` and shows `aria-current`
+    on any `/users/me/*` path — `/users/me/favorites` is the canonical
+    case but the rule covers every nested profile sub-route."""
     response = await authenticated_client.get("/users/me/favorites")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    favorites_link = tree.css_first('#primary-nav a[href="/users/me/favorites"]')
-    me_link = tree.css_first('#primary-nav a[href="/users/me"]')
-    users_link = tree.css_first('#primary-nav a[href="/users"]')
-    assert favorites_link.attributes.get("aria-current") == "page"
-    assert me_link.attributes.get("aria-current") is None
-    assert users_link.attributes.get("aria-current") is None
+    profile_link = tree.css_first('#primary-nav a[href="/users/me"]')
+    assert profile_link.attributes.get("aria-current") == "page"
 
 
 async def test_users_me_detail_breadcrumb_says_me(

--- a/src/domain/templates/base.html
+++ b/src/domain/templates/base.html
@@ -99,18 +99,7 @@
   </head>
   <body>
     {% if is_authenticated %}
-    {# Section-precedence rule for the active-nav indicator: more-specific
-       paths win. `/users/me/favorites` resolves to "favorites"; `/users/me`
-       (and `/users/me/providers`) to "me"; `/users/<id>` to "users". The
-       ladder is encoded here once so each `<li>` reads as a flat check. #}
-    {%- set _p = request.url.path -%}
-    {%- if _p.startswith('/users/me/favorites') -%}{%- set _section = 'favorites' -%}
-    {%- elif _p == '/users/me' or _p.startswith('/users/me/') -%}{%- set _section = 'me' -%}
-    {%- elif _p.startswith('/posts') -%}{%- set _section = 'posts' -%}
-    {%- elif _p.startswith('/providers') -%}{%- set _section = 'providers' -%}
-    {%- elif _p.startswith('/users') -%}{%- set _section = 'users' -%}
-    {%- else -%}{%- set _section = None -%}
-    {%- endif -%}
+    {%- set _on_profile = request.url.path == '/users/me' or request.url.path.startswith('/users/me/') -%}
     <header class="container">
       <nav aria-label="Primary">
         <ul>
@@ -118,11 +107,14 @@
           <li><strong><a href="/" class="contrast">Bedlam Connect</a></strong></li>
         </ul>
         <ul id="primary-nav">
-          <li><a href="/posts"{% if _section == 'posts' %} aria-current="page" class="contrast"{% endif %}>Posts</a></li>
-          <li><a href="/users"{% if _section == 'users' %} aria-current="page" class="contrast"{% endif %}>Users</a></li>
-          <li><a href="/providers"{% if _section == 'providers' %} aria-current="page" class="contrast"{% endif %}>Providers</a></li>
-          <li><a href="/users/me/favorites"{% if _section == 'favorites' %} aria-current="page" class="contrast"{% endif %}>Favorites</a></li>
-          <li><a href="/users/me"{% if _section == 'me' %} aria-current="page" class="contrast"{% endif %}>Me</a></li>
+          <li>
+            <a href="/users/me" aria-label="Profile"{% if _on_profile %} aria-current="page" class="contrast"{% endif %}>
+              {# Lucide `user` icon, inlined. `currentColor` makes it
+                 inherit the link color (including Pico's `.contrast`
+                 active state). #}
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+            </a>
+          </li>
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- Remove Posts, Users, Providers, and Favorites from the primary nav.
- Replace the "Me" text link with a lucide `user` icon (labelled "Profile" for assistive tech) pointing at `/users/me`.
- Brand link is kept. All routes still exist — they're just no longer top-level nav targets.

## Test plan
- [ ] Visit any authenticated page; only the brand and the profile icon appear in the header.
- [ ] Click the icon → lands on `/users/me`; the icon picks up Pico's `.contrast` active state.
- [ ] Hover/focus shows "Profile" via `aria-label` (screen reader announces it correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)