### PR TITLE
Drop `+ Post` from primary nav

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -530,27 +530,6 @@ async def test_admin_can_patch_anyone_post(
     assert response.json()["description"] == "moderated"
 
 
-# --- Create form page (GET /posts/form) ----------------------------------
-
-
-async def test_nav_has_permanent_create_post_link(
-    authenticated_client: AsyncClient,
-    logged_in_user: User,
-):
-    """The primary nav carries a `+ Post` entry on every authenticated
-    page. Clicking it lands on the kind picker (`/posts/form` with no
-    `?kind=`). The link is in `#primary-nav` so it's visible across
-    the app, not just on `/posts`."""
-    response = await authenticated_client.get("/posts")
-    assert response.status_code == 200
-    tree = HTMLParser(response.text)
-    # The `+ Post` CTA moved to the right-side `<ul>` in the slimmed
-    # primary nav — look it up under `nav[aria-label="Primary"]`.
-    nav_link = tree.css_first('nav[aria-label="Primary"] a[href="/posts/form"]')
-    assert nav_link is not None
-    assert "Post" in nav_link.text(strip=True)
-
-
 # --- Filter form ---------------------------------------------------------
 
 

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -23,18 +23,17 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """Authenticated pages render the primary nav with two entries:
-    the permanent `+ Post` CTA (routes to the kind picker at
-    `/posts/form`) and the `/users/me` profile icon. Section links
-    (Posts / Users / Providers / Favorites) are reachable from
-    within their pages rather than from the top-level chrome."""
+    """Authenticated pages render the primary nav with a single
+    `/users/me` profile shortcut. Section links (Posts / Users /
+    Providers / Favorites) and the create-post CTA are reachable
+    from within their pages rather than from the top-level chrome."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     nav_items = tree.css("#primary-nav > li > a")
     hrefs = {a.attributes.get("href") for a in nav_items}
-    assert hrefs == {"/posts/form", "/users/me"}
+    assert hrefs == {"/users/me"}
 
 
 async def test_base_template_hides_nav_for_anonymous_visitors(

--- a/src/domain/templates/base.html
+++ b/src/domain/templates/base.html
@@ -116,10 +116,6 @@
           <li><strong><a href="/" class="contrast">Bedlam Connect</a></strong></li>
         </ul>
         <ul id="primary-nav">
-          {# Permanent create-post entry point — every authenticated
-             page has a one-click route to the kind picker at
-             `/posts/form`, where users pick Seeking or Providing. #}
-          <li><a href="/posts/form" role="button">+ Post</a></li>{# title-case-ignore: "+ Post" is a verb-form CTA — title-case linter wants "+ post" (sentence-case verb), but the visible capitalization signals action #}
           <li>
             <a href="/users/me" aria-label="Profile"{% if _on_profile %} aria-current="page" class="contrast"{% endif %}>
               {# Lucide `user` icon, inlined. `currentColor` makes it

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -22,9 +22,8 @@
 {% endblock %}
 
 {% block content %}
-{# Create-post entry lives in the primary nav as `+ Post` — see
-   `base.html`. The picker page (`/posts/form` with no `?kind=`)
-   handles the kind selection. #}
+{# Kind picker lives at `/posts/form` (no `?kind=`) — no UI entry
+   point currently links to it; reachable by typing the URL. #}
 {%- set any_filter_active =
   selected_kind or selected_q or selected_posted_by
   or selected_state or selected_city


### PR DESCRIPTION
## Summary
- Remove the `+ Post` CTA from `#primary-nav` introduced by #480.
- The kind picker at `/posts/form` still exists and works by direct URL — there is just no UI entry point linking to it.
- Updates the stale comment in `posts/list.html` so it no longer claims the entry lives in the nav.
- Drops `test_nav_has_permanent_create_post_link` and the `/posts/form` href in `test_base_template_renders_primary_nav_when_authenticated`.

## Test plan
- [ ] Visit any authenticated page; only the brand and profile icon appear in the header.
- [ ] Decide where the create-post entry should live (toolbar on `/posts`?) and file as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)