### PR TITLE
Breadcrumb zone bar: Pico-native location chain

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -352,6 +352,38 @@ async def test_list_renders_readable_date_format(
     assert rendered in {"May 15", "May 15, 2025"}
 
 
+async def test_detail_renders_breadcrumb(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Post detail renders the Pico breadcrumb (`Posts › Post`) above
+    the page toolbar. The trailing `<li>` is marked `aria-current="page"`
+    so screen readers identify it as the current page; visual styling
+    comes from Pico's `nav[aria-label="breadcrumb"]` defaults."""
+    post = _client_referral_post(description="crumb-x", owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+        await session.refresh(post)
+        post_id = post.id
+
+    response = await authenticated_client.get(f"/posts/{post_id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    crumb = tree.css_first('nav[aria-label="breadcrumb"]')
+    assert crumb is not None
+    items = crumb.css("ul > li")
+    assert [li.text(strip=True) for li in items] == ["Posts", "Post"]
+    parent_link = items[0].css_first("a")
+    assert parent_link is not None
+    assert parent_link.attributes.get("href") == "/posts"
+    assert "aria-current" in items[-1].attributes
+    assert items[-1].attributes.get("aria-current") == "page"
+    # Current page has no link inside — it's the leaf.
+    assert items[-1].css_first("a") is None
+
+
 async def test_detail_renders_kind_chip_in_header(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/_shared/_breadcrumb.html
+++ b/src/domain/templates/_shared/_breadcrumb.html
@@ -1,0 +1,40 @@
+{# Breadcrumb zone bar primitive.
+   title-case-ignore: the literal ARIA value `breadcrumb` is Pico's hook.
+
+Renders the page's location chain as Pico's native breadcrumb nav
+above the page toolbar — see the `breadcrumb` block slot wired in
+[`../base.html`](../base.html). Pico styles the markup automatically
+(horizontal inline list, `›` separator via CSS on `li + li::before`)
+so no classes are added to the nav or list; the divider character
+is set globally in `base.html` via `--pico-nav-breadcrumb-divider`.
+
+Each item is a `(label, href)` tuple. The last item's `href` is
+typically `None` — it renders as plain text (the current page) and
+carries `aria-current="page"` for screen readers.
+
+    {{ breadcrumb([
+        ("Posts", "/posts"),
+        ("Post", "/posts/" ~ post.id),
+        ("Edit", None),
+    ]) }}
+
+Pico's docs at https://picocss.com/docs/nav#breadcrumb require an
+inner `<ul>` specifically — the built-in style hooks off the nav's
+descendant `ul`. Picking `<ol>` (semantically tempting, since
+breadcrumbs are ordered) loses Pico's auto-styling.
+#}
+
+{# title-case-ignore: literal aria-label value `breadcrumb` is the Pico hook #}
+{% macro breadcrumb(items) -%}
+{%- if items %}
+<nav aria-label="breadcrumb">
+  <ul>
+    {%- for label, href in items %}
+    <li{% if loop.last %} aria-current="page"{% endif %}>
+      {%- if href %}<a href="{{ href }}">{{ label }}</a>{% else %}{{ label }}{% endif -%}
+    </li>
+    {%- endfor %}
+  </ul>
+</nav>
+{%- endif %}
+{%- endmacro %}

--- a/src/domain/templates/base.html
+++ b/src/domain/templates/base.html
@@ -85,6 +85,24 @@
       .toolbar { display: flex; justify-content: flex-end; align-items: center; flex-wrap: wrap; gap: 1rem; }
       .toolbar-left { flex: 1; min-width: 0; display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
       .toolbar-right { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+      /* Breadcrumb zone bar. Pico already styles the markup
+         (`nav[aria-label="breadcrumb"] ul` becomes an inline list
+         with a separator via `li + li::before`); the only thing this
+         project adds is the strip's frame — subtle background +
+         bottom border to set it apart from page content — and the
+         divider character via the Pico-exposed
+         `--pico-nav-breadcrumb-divider`. Hidden on narrow viewports;
+         the location context isn't worth the row on mobile. */
+      nav[aria-label="breadcrumb"] {
+        --pico-nav-breadcrumb-divider: '›';
+        background: var(--pico-card-background-color);
+        border-bottom: var(--pico-border-width) solid var(--pico-muted-border-color);
+        padding: calc(var(--pico-spacing) * 0.5) var(--pico-spacing);
+        margin: 0 0 var(--pico-spacing) 0;
+      }
+      @media (max-width: 768px) {
+        nav[aria-label="breadcrumb"] { display: none; }
+      }
       #posts-list > div > p {
         display: -webkit-box;
         -webkit-box-orient: vertical;
@@ -134,6 +152,11 @@
     </header>
     {% endif %}
     <main class="container {% block container_class %}{% endblock %}">
+      {# Breadcrumb zone bar — `{% block breadcrumb %}` accepts the
+         `breadcrumb(items)` macro from `_shared/_breadcrumb.html`.
+         Pages set their own location context; list pages and the
+         top-level home leave the block empty. #}
+      {% block breadcrumb %}{% endblock %}
       {# Toolbar primitive — `{% block toolbar %}` accepts a `{% call %}`
          of the shared `toolbar()` macro from `_shared/_toolbar.html`.
          Renders page-scoped controls right-aligned with a horizontal

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import toolbar -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Posts", "/posts"), ("Post", none)]) }}
+{% endblock %}
 
 {% block toolbar %}
 {% call toolbar() %}

--- a/src/domain/templates/posts/edit_client_referral.html
+++ b/src/domain/templates/posts/edit_client_referral.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 {% from "posts/_client_referral_form.html" import client_referral_form %}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([
+  ("Posts", "/posts"),
+  ("Post", "/posts/" ~ post.id),
+  ("Edit", none),
+]) }}
+{% endblock %}
 
 {% block content %}
 {{ client_referral_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=client_referral_create_schema) }}

--- a/src/domain/templates/posts/edit_provider_availability.html
+++ b/src/domain/templates/posts/edit_provider_availability.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 {% from "posts/_provider_availability_form.html" import provider_availability_form %}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([
+  ("Posts", "/posts"),
+  ("Post", "/posts/" ~ post.id),
+  ("Edit", none),
+]) }}
+{% endblock %}
 
 {% block content %}
 {{ provider_availability_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=provider_availability_create_schema, current_user=current_user) }}

--- a/src/domain/templates/posts/form_new.html
+++ b/src/domain/templates/posts/form_new.html
@@ -1,4 +1,9 @@
 {% extends "base.html" %}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Posts", "/posts"), ("New", none)]) }}
+{% endblock %}
 
 {# Kind-picker for `GET /posts/form` (no `?kind=`). Each option is a
    stand-alone `<a role="button">` describing the post the user is

--- a/src/domain/templates/posts/new_client_referral.html
+++ b/src/domain/templates/posts/new_client_referral.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {% from "posts/_client_referral_form.html" import client_referral_form %}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Posts", "/posts"), ("New", none)]) }}
+{% endblock %}
 
 {% block content %}
 <p>Per <code>notes/forms_spec.md</code>. No PII.</p>

--- a/src/domain/templates/posts/new_provider_availability.html
+++ b/src/domain/templates/posts/new_provider_availability.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {% from "posts/_provider_availability_form.html" import provider_availability_form %}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Posts", "/posts"), ("New", none)]) }}
+{% endblock %}
 
 {% block content %}
 {% if not current_user.providers %}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import toolbar -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Providers", "/providers"), (provider.practice_name, none)]) }}
+{% endblock %}
 
 {% block toolbar %}
 {# Primary resource actions (Favorite toggle, Edit) live in the

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -3,6 +3,15 @@
 {%- from "_shared/forms.html" import inline_add_form -%}
 {%- from "_shared/sections.html" import list_or_empty -%}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([
+  ("Providers", "/providers"),
+  (provider.practice_name, "/providers/" ~ provider.id),
+  ("Edit", none),
+]) }}
+{% endblock %}
 
 {% block content %}
 <section>

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 {%- from "_shared/form_fields.html" import field_for, radio_bool_field, text_field -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Providers", "/providers"), ("New", none)]) }}
+{% endblock %}
 
 {% block content %}
 <p>Practice details only. Add licensures, education, and certifications after creating the provider.</p>


### PR DESCRIPTION
## Summary
- New `_shared/_breadcrumb.html` macro renders Pico's native `<nav aria-label="breadcrumb"><ul>...</ul></nav>` from `(label, href)` tuples; the last item drops the link and gets `aria-current="page"`.
- `base.html` exposes a `{% block breadcrumb %}` slot between the primary nav and the toolbar, plus the three custom CSS rules from the spec: secondary-background strip frame, `›` divider via `--pico-nav-breadcrumb-divider`, and `display: none` below 768px.
- Wired on post detail/edit/new, the post kind picker, and provider detail/edit/new. List pages and the home page leave the block empty.

## Notes
- Pico's docs say the inner list must be `<ul>` (not `<ol>`) for the auto-styling to hook in — the macro uses `<ul>`.
- The spec's `--pico-secondary-background` / `--pico-secondary-border` / `--pico-spacing-sm` aren't defined in Pico v2; substituted with `--pico-card-background-color`, `--pico-muted-border-color`, and `calc(var(--pico-spacing) * 0.5)` for the same visual intent.
- A `title-case-ignore` marker on the macro file's docstring keeps the literal ARIA value `breadcrumb` from tripping the linter (Pico's CSS hook is case-sensitive).

## Test plan
- [x] `dev test` (990 passed, 52 skipped) — new `test_detail_renders_breadcrumb` pins markup, parent link, and `aria-current`.
- [x] `dev lint`
- [ ] Eyes-on each wired page: detail, edit, new for posts and providers; the strip is present above the toolbar with the `›` separator, and hidden under 768px viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)