### PR TITLE
Primary nav: render on every screen

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -36,19 +36,32 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     assert hrefs == {"/users/me"}
 
 
-async def test_base_template_hides_nav_for_anonymous_visitors(
+async def test_base_template_renders_primary_nav_for_anonymous_visitors(
     test_client: AsyncClient,
 ):
-    """Public pages (auth flow) must not link to auth-gated sections —
-    those links would 401 and clutter the page for users who can't use
-    them yet. The chrome `{% if is_authenticated %}` gate is what
-    enforces this; the four scalars from `base_context(None)` are what
-    let `base.html` make the call without per-handler boilerplate."""
+    """The primary nav renders on every screen — public auth-flow pages
+    included — so the chrome stays consistent across the auth gate.
+    Anonymous visitors get the brand link plus a Login shortcut on the
+    right (no `/users/me` link, which would 401). The `{% if
+    is_authenticated %}` branch lives inside `#primary-nav` so the
+    nav scaffold is always present and only its right-side item swaps."""
     response = await test_client.get("/auth/login")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    assert tree.css_first("#primary-nav") is None
+    nav = tree.css_first('nav[aria-label="Primary"]')
+    assert nav is not None
+    # Brand link is present on the left.
+    brand = nav.css_first('a[href="/"]')
+    assert brand is not None
+    # Right-side slot has the Login link; no profile link.
+    nav_items = tree.css("#primary-nav > li > a")
+    hrefs = {a.attributes.get("href") for a in nav_items}
+    assert hrefs == {"/auth/login"}
+    # The current Login link is marked aria-current="page".
+    login_link = tree.css_first('#primary-nav a[href="/auth/login"]')
+    assert login_link is not None
+    assert login_link.attributes.get("aria-current") == "page"
 
 
 # --- Listing -------------------------------------------------------------

--- a/src/domain/templates/base.html
+++ b/src/domain/templates/base.html
@@ -130,8 +130,16 @@
     {% endif %}
   </head>
   <body>
-    {% if is_authenticated %}
-    {%- set _on_profile = request.url.path == '/users/me' or request.url.path.startswith('/users/me/') -%}
+    {# Primary nav renders on every screen so the chrome stays
+       consistent between authenticated app pages and the public auth
+       flow. The right-side slot (`#primary-nav`) adapts: authed users
+       see the profile icon (with `aria-current="page"` while on
+       `/users/me`); anonymous visitors see a Login link. The brand
+       link goes to `/`, which redirects authed users to `/posts` and
+       unauthed users to the login page — safe on either side of the
+       auth gate. #}
+    {%- set _on_profile = is_authenticated and (request.url.path == '/users/me' or request.url.path.startswith('/users/me/')) -%}
+    {%- set _on_login = request.url.path == '/auth/login' -%}
     <header class="container">
       <nav aria-label="Primary">
         <ul>
@@ -139,6 +147,7 @@
           <li><strong><a href="/" class="contrast">Bedlam Connect</a></strong></li>
         </ul>
         <ul id="primary-nav">
+          {% if is_authenticated %}
           <li>
             <a href="/users/me" aria-label="Profile"{% if _on_profile %} aria-current="page" class="contrast"{% endif %}>
               {# Lucide `user` icon, inlined. `currentColor` makes it
@@ -147,10 +156,14 @@
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
             </a>
           </li>
+          {% else %}
+          <li>
+            <a href="/auth/login"{% if _on_login %} aria-current="page" class="contrast"{% endif %}>Login</a>
+          </li>
+          {% endif %}
         </ul>
       </nav>
     </header>
-    {% endif %}
     <main class="container {% block container_class %}{% endblock %}">
       {# Breadcrumb zone bar — `{% block breadcrumb %}` accepts the
          `breadcrumb(items)` macro from `_shared/_breadcrumb.html`.


### PR DESCRIPTION
First step toward systematizing the navbar across all templates: make it appear consistently on every screen, including the public auth flow.

## Summary
- Drop the `{% if is_authenticated %}` gate around the entire `<header>` in `base.html`. The nav scaffold (brand + `#primary-nav`) now renders on every page that extends `base.html`.
- The right-side slot still adapts to auth state: authed users see the profile icon (`aria-current` while on `/users/me`); anonymous visitors see a Login link (`aria-current` while on `/auth/login`).
- Flip the test that pinned the opposite contract — `test_base_template_hides_nav_for_anonymous_visitors` is now `test_base_template_renders_primary_nav_for_anonymous_visitors`, asserting brand + Login presence and no `/users/me` link.

## Why this is safe
The brand link goes to `/`, which redirects authed users to `/posts` and unauthed users to the login page — fine on either side of the auth gate. The right-side slot conditionally renders only the link appropriate to the viewer's auth state, so no auth-gated link leaks to anonymous visitors.

## Test plan
- [x] `dev test` (990 passed, 52 skipped)
- [x] `dev lint`
- [ ] Eyes-on `/auth/login`, `/auth/register`, `/auth/forgot-password`: brand + Login visible. Authed: brand + profile icon visible everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)