### PR TITLE
Systematize breadcrumb across the chrome contract

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -562,6 +562,23 @@ async def test_admin_can_patch_anyone_post(
     assert response.json()["description"] == "moderated"
 
 
+# --- Chrome abstraction --------------------------------------------------
+
+
+async def test_list_page_does_not_render_breadcrumb(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """The page chrome abstraction is `list > detail > edit/new`: lists
+    are the root of the resource hierarchy and don't carry a breadcrumb;
+    detail and form pages do. Pin the absence on `/posts` so the rule
+    doesn't drift template-by-template."""
+    response = await authenticated_client.get("/posts")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first('nav[aria-label="breadcrumb"]') is None
+
+
 # --- Zone bar ------------------------------------------------------------
 
 

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -201,6 +201,32 @@ async def test_get_user_detail_renders(
     assert target_username in tree.body.text()
 
 
+async def test_get_user_detail_renders_breadcrumb(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """User detail follows the standard `list → detail` breadcrumb
+    shape: `Users › <username>`. The first item links to the user
+    list; the trailing username is the current page (`aria-current`)."""
+    target_username = f"target-{uuid.uuid4()}"
+    target = create_test_user(username=target_username)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(target)
+
+    response = await authenticated_client.get(f"/users/{target.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    items = tree.css('nav[aria-label="breadcrumb"] ul > li')
+    assert [li.text(strip=True) for li in items] == ["Users", target_username]
+    parent = items[0].css_first("a")
+    assert parent is not None
+    assert parent.attributes.get("href") == "/users"
+    assert items[-1].attributes.get("aria-current") == "page"
+    assert items[-1].css_first("a") is None
+
+
 async def test_detail_hides_private_fields_from_strangers(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -26,7 +26,34 @@ Files prefixed with `_` are shared partials, `{% include %}`d from full pages �
 
 ## Page chrome contract
 
-Pages that need page-scoped controls render a toolbar via `{% block toolbar %}` from `_shared/_toolbar.html`. The toolbar is the single home for the page's **primary resource actions** (right-aligned, passed via the `{% call %}` body): Edit, Delete, Deactivate/Reactivate, Favorite/Unfavorite, list-page filter `<details>`. List pages compose the toolbar with `index_filters(...)` in the call body; detail pages compose it with the resource's action partial (`_owner_actions.html`, `_admin_actions.html`) or open-coded buttons. Pages without page-scoped controls leave `{% block toolbar %}` empty (or omit it).
+Every page extending `base.html` lands the same three-strip chrome above its content. From top to bottom:
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ <header> primary nav        brand + auth-aware right slot │  ← `base.html`
+├───────────────────────────────────────────────────────────┤
+│ breadcrumb zone bar          Resource › … › Current        │  ← `{% block breadcrumb %}` (detail/form pages only)
+├───────────────────────────────────────────────────────────┤
+│ toolbar / action bar         [filters left]    [actions ▶] │  ← `{% block toolbar %}`
+├───────────────────────────────────────────────────────────┤
+│ page content                                              │  ← `{% block content %}`
+└───────────────────────────────────────────────────────────┘
+```
+
+**Primary nav** lives in `base.html` and renders on every screen (authed *and* anonymous). Its right-side slot (`#primary-nav`) swaps the profile icon for a Login link depending on `is_authenticated`. Pages don't extend it.
+
+**Breadcrumb zone bar** (`{% block breadcrumb %}`, macro in `_shared/_breadcrumb.html`) renders Pico's native breadcrumb above the toolbar. Pages opt in by extending the block; otherwise it's invisible. The shape follows the resource hierarchy `list > detail > edit/new`:
+
+| Page type        | URL example              | Breadcrumb                    |
+| ---------------- | ------------------------ | ----------------------------- |
+| Resource list    | `/posts`                 | *(none — root of hierarchy)*  |
+| Resource detail  | `/posts/{id}`            | `Posts › Post`                |
+| Resource new     | `/posts/form`            | `Posts › New`                 |
+| Resource edit    | `/posts/{id}/form`       | `Posts › Post › Edit`         |
+
+The leading segment is the resource label linked to its list page; the trailing segment is the current page (no `href`, gets `aria-current="page"`). Subresource list pages (`/users/{id}/providers`) are still list pages and stay breadcrumb-less.
+
+**Toolbar / action bar** is the zone bar for page-scoped controls. See `_shared/_toolbar.html` for the two-zone layout (`.toolbar-left` fills the row for filters; `.toolbar-right` parks page actions on the right; single-action toolbars right-align without wrappers). The toolbar is the single home for the page's **primary resource actions**: Edit, Delete, Deactivate/Reactivate, Favorite/Unfavorite. List pages compose the toolbar with `index_filters(...)` in the left zone and a Create-resource action in the right zone; detail pages compose it with the resource's action partial (`_owner_actions.html`, `_admin_actions.html`) or open-coded buttons. Pages without page-scoped controls leave the block empty.
 
 Inline / subresource actions inside the page body (per-row delete buttons on `provider/form_edit.html`'s licensure list, inline-add-form submits) are **not** primary resource actions and stay where they are — they act on a single subentity, not on the page's resource.
 

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -2,6 +2,11 @@
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "_shared/_provider_row.html" import provider_headers, provider_row -%}
 {%- from "_shared/_toolbar.html" import toolbar -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Users", "/users"), (target_user.username, none)]) }}
+{% endblock %}
 
 {% block toolbar %}
 {% call toolbar() %}


### PR DESCRIPTION
Continue the chrome standardization: every detail/form page carries a breadcrumb, every list page doesn't, and the rule is documented + pinned.

## Summary
- **Wire breadcrumb on `users/detail.html`** — `Users › <username>` — closing the last detail page that lacked one. Posts and providers detail/edit/new already had it from earlier PRs.
- **Document the chrome contract** in `src/domain/templates/README.md` with an ASCII layout of the three strips (nav → breadcrumb → toolbar → content) and a table mapping page types to breadcrumb shapes for the `list > detail > edit/new` hierarchy. Subresource lists stay breadcrumb-less (still list pages).
- **Pin the abstraction** with two guardrail tests: `users/detail` renders `Users › <username>` with `aria-current` on the leaf; `/posts` (a list page) renders no breadcrumb.

## The chrome abstraction

| Page type        | URL example              | Breadcrumb                    |
| ---------------- | ------------------------ | ----------------------------- |
| Resource list    | `/posts`                 | *(none — root of hierarchy)*  |
| Resource detail  | `/posts/{id}`            | `Posts › Post`                |
| Resource new     | `/posts/form`            | `Posts › New`                 |
| Resource edit    | `/posts/{id}/form`       | `Posts › Post › Edit`         |

## Test plan
- [x] `dev test` (992 passed, 52 skipped)
- [x] `dev lint`
- [ ] Eyes-on `/users/me` and `/users/{id}` to confirm the breadcrumb shape; eyes-on `/posts`, `/providers`, `/users` to confirm no breadcrumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)