### PR TITLE
Extend chrome breadcrumb to list and subresource pages

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -565,18 +565,23 @@ async def test_admin_can_patch_anyone_post(
 # --- Chrome abstraction --------------------------------------------------
 
 
-async def test_list_page_does_not_render_breadcrumb(
+async def test_list_page_renders_single_segment_breadcrumb(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """The page chrome abstraction is `list > detail > edit/new`: lists
-    are the root of the resource hierarchy and don't carry a breadcrumb;
-    detail and form pages do. Pin the absence on `/posts` so the rule
-    doesn't drift template-by-template."""
+    """Every page in the chrome contract carries a breadcrumb. List
+    pages are the root of the resource hierarchy and render as a
+    single segment (the resource label, no parent link, marked
+    `aria-current="page"`). Detail and form pages extend that with
+    `Resource › … › Current`. Pin the shape on `/posts` so the
+    abstraction doesn't drift template-by-template."""
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    assert tree.css_first('nav[aria-label="breadcrumb"]') is None
+    items = tree.css('nav[aria-label="breadcrumb"] ul > li')
+    assert [li.text(strip=True) for li in items] == ["Posts"]
+    assert items[0].attributes.get("aria-current") == "page"
+    assert items[0].css_first("a") is None
 
 
 # --- Zone bar ------------------------------------------------------------

--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -42,16 +42,19 @@ Every page extending `base.html` lands the same three-strip chrome above its con
 
 **Primary nav** lives in `base.html` and renders on every screen (authed *and* anonymous). Its right-side slot (`#primary-nav`) swaps the profile icon for a Login link depending on `is_authenticated`. Pages don't extend it.
 
-**Breadcrumb zone bar** (`{% block breadcrumb %}`, macro in `_shared/_breadcrumb.html`) renders Pico's native breadcrumb above the toolbar. Pages opt in by extending the block; otherwise it's invisible. The shape follows the resource hierarchy `list > detail > edit/new`:
+**Breadcrumb zone bar** (`{% block breadcrumb %}`, macro in `_shared/_breadcrumb.html`) renders Pico's native breadcrumb above the toolbar. Every authenticated page extends the block — chrome consistency is the goal. The shape follows the resource hierarchy `list > detail > edit/new`, each level appending one segment:
 
-| Page type        | URL example              | Breadcrumb                    |
-| ---------------- | ------------------------ | ----------------------------- |
-| Resource list    | `/posts`                 | *(none — root of hierarchy)*  |
-| Resource detail  | `/posts/{id}`            | `Posts › Post`                |
-| Resource new     | `/posts/form`            | `Posts › New`                 |
-| Resource edit    | `/posts/{id}/form`       | `Posts › Post › Edit`         |
+| Page type        | URL example                    | Breadcrumb                            |
+| ---------------- | ------------------------------ | ------------------------------------- |
+| Resource list    | `/posts`                       | `Posts`                               |
+| Resource detail  | `/posts/{id}`                  | `Posts › Post`                        |
+| Resource new     | `/posts/form`                  | `Posts › New`                         |
+| Resource edit    | `/posts/{id}/form`             | `Posts › Post › Edit`                 |
+| Subresource list | `/users/{id}/providers`        | `Users › <username> › Providers`      |
 
-The leading segment is the resource label linked to its list page; the trailing segment is the current page (no `href`, gets `aria-current="page"`). Subresource list pages (`/users/{id}/providers`) are still list pages and stay breadcrumb-less.
+Every prior segment is a link (`<a href="…">`); the trailing segment is the current page (no `href`, gets `aria-current="page"`). Single-segment list breadcrumbs are still wrapped in the nav so the chrome strip is present and the strip height stays consistent across pages.
+
+Public auth-flow pages (`/auth/login`, `/auth/register`, …) opt out — they aren't in the resource hierarchy.
 
 **Toolbar / action bar** is the zone bar for page-scoped controls. See `_shared/_toolbar.html` for the two-zone layout (`.toolbar-left` fills the row for filters; `.toolbar-right` parks page actions on the right; single-action toolbars right-align without wrappers). The toolbar is the single home for the page's **primary resource actions**: Edit, Delete, Deactivate/Reactivate, Favorite/Unfavorite. List pages compose the toolbar with `index_filters(...)` in the left zone and a Create-resource action in the right zone; detail pages compose it with the resource's action partial (`_owner_actions.html`, `_admin_actions.html`) or open-coded buttons. Pages without page-scoped controls leave the block empty.
 

--- a/src/domain/templates/favorites/list.html
+++ b/src/domain/templates/favorites/list.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "_shared/_provider_row.html" import provider_headers, provider_row -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Favorites", none)]) }}
+{% endblock %}
 
 {% block content %}
 {% call index_table(

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import toolbar -%}
 {%- from "_shared/index_filters.html" import index_filters -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 {%- from "posts/_item.html" import post_item with context -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Posts", none)]) }}
+{% endblock %}
 
 {% block toolbar %}
 {% call toolbar() %}

--- a/src/domain/templates/providers/list.html
+++ b/src/domain/templates/providers/list.html
@@ -3,6 +3,11 @@
 {%- from "_shared/_provider_row.html" import provider_headers, provider_row -%}
 {%- from "_shared/_toolbar.html" import toolbar -%}
 {%- from "_shared/index_filters.html" import index_filters -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Providers", none)]) }}
+{% endblock %}
 
 {% block toolbar %}
 {% call toolbar() %}

--- a/src/domain/templates/users/list.html
+++ b/src/domain/templates/users/list.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "users/_columns.html" import user_headers, user_row -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([("Users", none)]) }}
+{% endblock %}
 
 {% block content %}
 {{ index_table(

--- a/src/domain/templates/users/providers_list.html
+++ b/src/domain/templates/users/providers_list.html
@@ -1,6 +1,15 @@
 {% extends "base.html" %}
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "_shared/_provider_row.html" import provider_headers, provider_row -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block breadcrumb %}
+{{ breadcrumb([
+  ("Users", "/users"),
+  (target_user.username, "/users/" ~ target_user.id),
+  ("Providers", none),
+]) }}
+{% endblock %}
 
 {% block content %}
 {% call index_table(


### PR DESCRIPTION
Revising the breadcrumb abstraction: every authenticated page carries one so the chrome strip is consistent, not just detail/form pages. Triggered by noticing that `/users` had no breadcrumb under the prior rule.

## Summary
- **List pages get a single-segment breadcrumb** with the resource label (`Posts`, `Providers`, `Users`, `Favorites`). No parent link; `aria-current="page"` on the lone segment.
- **Subresource list** `/users/{id}/providers` renders the full chain `Users › <username> › Providers`.
- Detail and form pages keep their shapes from earlier PRs (`Posts › Post`, `Posts › Post › Edit`, etc.).
- Public auth-flow pages stay breadcrumb-less — they aren't in the resource hierarchy.

## The chrome abstraction (revised)

| Page type        | URL example                    | Breadcrumb                            |
| ---------------- | ------------------------------ | ------------------------------------- |
| Resource list    | `/posts`                       | `Posts`                               |
| Resource detail  | `/posts/{id}`                  | `Posts › Post`                        |
| Resource new     | `/posts/form`                  | `Posts › New`                         |
| Resource edit    | `/posts/{id}/form`             | `Posts › Post › Edit`                 |
| Subresource list | `/users/{id}/providers`        | `Users › <username> › Providers`      |

The `/posts` guardrail test was flipped from "no breadcrumb on lists" to "single-segment breadcrumb on lists" so the new rule is pinned.

## Test plan
- [x] `dev test` (992 passed, 52 skipped)
- [x] `dev lint`
- [ ] Eyes-on every list page (`/posts`, `/providers`, `/users`, `/users/me/favorites`, `/users/{id}/providers`) to confirm the single-segment or full-chain breadcrumb renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)