### PR TITLE
Page-kind base templates: breadcrumb falls out automatically

### DIFF
--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -23,7 +23,8 @@ Files prefixed with `_` are shared partials, `{% include %}`d from full pages �
 - `index_table.html` — `index_table(items, headers, row, empty, id=None, row_kwargs={})`: the standard index-page table chrome (wrapping `<div class="index-table">`, `<table role="grid">`, empty-state `<p class="index-empty">`). The wrapper owns mobile-overflow: a site-wide `overflow-x: auto` in `base.html` scrolls a wide table inside its container instead of pushing the viewport wide, so list pages on a phone show a scroll-affordance rather than breaking layout. Headers and rows come from a cluster-local `<resource>/_columns.html` that exports `<resource>_headers()` and `<resource>_row(item, **row_kwargs)`. Every `/<collection>` list page renders through it — see `providers/list.html` for the canonical use. When the cluster's column macros read resource-specific Jinja context (e.g. `LICENSE_TYPES` flowing in via `EntitySpec.static_context`), import them `with context`. Pages with rich empty states (CTAs, per-viewer branches) invoke the macro via `{% call index_table(...) %}<p class="index-empty">…</p>{% endcall %}` and provide their own empty body.
 - `index_filters.html` — `index_filters(filters, action, values)`: filter form for an index page. Reads the `filters` tuple `handle_list` echoes into context (`Filter` instances declared on `EntitySpec.filters`; see [`../../framework/dispatch/filters.py`](../../framework/dispatch/filters.py)) and renders one control per filter (`<input type="search">` for `TextFilter`, `<select>` / `<select multiple>` for `ChoiceFilter`) inside a `<fieldset><legend>Filter</legend>` with Apply + Clear buttons. Plain `<form method="get">` — no JS, no progressive add/remove chrome. Every declared filter is always visible; users fill the ones they want and ignore the rest. Live today on `/posts`; the other list pages still use the legacy single-`QueryParam` shape and migrate when their filter set grows.
 - `_provider_row.html` — `provider_headers()`, `provider_row(provider)`: the provider row shape, shared across `/providers`, `/users/me/favorites`, `/users/{id}/providers`, and the embedded `<section>Providers</section>` on `/users/{id}`. Lives in `_shared/` (not `providers/`) because cross-cluster template imports aren't allowed; provider-specific filter form stays in `providers/_columns.html` since only the /providers index uses it.
-- `list_page.html` — `list_breadcrumb(label)` and `list_toolbar(filters, action, values)`: chrome helpers for the canonical list page. `list_breadcrumb` renders the single-segment "current resource" crumb; `list_toolbar` wraps the filter widget in the `.toolbar-left` zone and accepts a `{% call %}` body for the `.toolbar-right` action cluster. Both are opt-in fillers for the `breadcrumb` and `toolbar` blocks in `base.html`; subresource lists with multi-segment breadcrumbs (e.g. `Users › <username> › Providers`) keep using the underlying `breadcrumb()` primitive from `_breadcrumb.html`. See `posts/list.html` and `providers/list.html` for canonical use.
+- `_list_page.html`, `_detail_page.html`, `_form_page.html` — page-kind base templates that pre-fill the breadcrumb block. See the **Page-kind base templates** section below.
+- `list_page.html` — `list_toolbar(filters, action, values)`: the toolbar shell for a list page. Wraps the filter widget in the `.toolbar-left` zone and accepts a `{% call %}` body for the `.toolbar-right` action cluster (typically the Create-resource button). Filling the `toolbar` block is still per-page since filter values and action labels are page-specific; this macro is just a one-line shortcut for the common shape. See `posts/list.html` and `providers/list.html` for canonical use.
 
 ## Page chrome contract
 
@@ -43,19 +44,48 @@ Every page extending `base.html` lands the same three-strip chrome above its con
 
 **Primary nav** lives in `base.html` and renders on every screen (authed *and* anonymous). Its right-side slot (`#primary-nav`) swaps the profile icon for a Login link depending on `is_authenticated`. Pages don't extend it.
 
-**Breadcrumb zone bar** (`{% block breadcrumb %}`, macro in `_shared/_breadcrumb.html`) renders Pico's native breadcrumb above the toolbar. Every authenticated page extends the block — chrome consistency is the goal. The shape follows the resource hierarchy `list > detail > edit/new`, each level appending one segment:
+**Breadcrumb zone bar** (`{% block breadcrumb %}`, macro in `_shared/_breadcrumb.html`) renders Pico's native breadcrumb above the toolbar. Pages don't fill this block themselves — they `{% extends %}` a **page-kind base template** that fills it from declarative metadata blocks (see below). The shape follows the resource hierarchy `list > detail > edit/new`, each level appending one segment:
 
-| Page type        | URL example                    | Breadcrumb                            |
-| ---------------- | ------------------------------ | ------------------------------------- |
-| Resource list    | `/posts`                       | `Posts`                               |
-| Resource detail  | `/posts/{id}`                  | `Posts › Post`                        |
-| Resource new     | `/posts/form`                  | `Posts › New`                         |
-| Resource edit    | `/posts/{id}/form`             | `Posts › Post › Edit`                 |
-| Subresource list | `/users/{id}/providers`        | `Users › <username> › Providers`      |
+| Page type        | URL example                    | Breadcrumb                            | Page-kind base                  |
+| ---------------- | ------------------------------ | ------------------------------------- | ------------------------------- |
+| Resource list    | `/posts`                       | `Posts`                               | `_shared/_list_page.html`       |
+| Resource detail  | `/posts/{id}`                  | `Posts › Post`                        | `_shared/_detail_page.html`     |
+| Resource new     | `/posts/form`                  | `Posts › New`                         | `_shared/_form_page.html`       |
+| Resource edit    | `/posts/{id}/form`             | `Posts › Post › Edit`                 | `_shared/_form_page.html`       |
+| Subresource list | `/users/{id}/providers`        | `Users › <username> › Providers`      | `base.html` + `breadcrumb()`    |
 
-Every prior segment is a link (`<a href="…">`); the trailing segment is the current page (no `href`, gets `aria-current="page"`). Single-segment list breadcrumbs are still wrapped in the nav so the chrome strip is present and the strip height stays consistent across pages.
+Every prior segment is a link (`<a href="…">`); the trailing segment is the current page (no `href`, gets `aria-current="page"`). Public auth-flow pages (`/auth/login`, `/auth/register`, …) extend `base.html` directly — they aren't in the resource hierarchy.
 
-Public auth-flow pages (`/auth/login`, `/auth/register`, …) opt out — they aren't in the resource hierarchy.
+## Page-kind base templates
+
+Instead of rewiring the breadcrumb block in every page, page templates `{% extends %}` one of three sub-base templates in `_shared/` and declare their position in the hierarchy via small metadata blocks. The base template uses those blocks to fill `{% block breadcrumb %}` automatically.
+
+```jinja
+{# posts/list.html #}
+{% extends "_shared/_list_page.html" %}
+{% block resource_label %}Posts{% endblock %}
+{% block content %}…{% endblock %}
+
+{# posts/detail.html #}
+{% extends "_shared/_detail_page.html" %}
+{% block resource_label %}Posts{% endblock %}
+{% block resource_url %}/posts{% endblock %}
+{% block current_label %}Post{% endblock %}
+{% block content %}…{% endblock %}
+
+{# posts/edit_client_referral.html #}
+{% extends "_shared/_form_page.html" %}
+{% block resource_label %}Posts{% endblock %}
+{% block resource_url %}/posts{% endblock %}
+{% block parent_label %}Post{% endblock %}
+{% block parent_url %}/posts/{{ post.id }}{% endblock %}
+{% block current_label %}Edit{% endblock %}
+{% block content %}…{% endblock %}
+```
+
+`_list_page.html` reads `resource_label`. `_detail_page.html` reads `resource_label`, `resource_url`, `current_label`. `_form_page.html` reads those three plus optional `parent_label` + `parent_url` — when both are set, the breadcrumb nests a detail crumb between the resource and the current page (the canonical edit-page shape). When parent blocks are empty, the form base renders `Resource › Current` (the canonical new-page shape).
+
+Subresource list pages (e.g. `/users/{id}/providers`) don't fit any of the three shapes and extend `base.html` directly, filling `{% block breadcrumb %}` with the `breadcrumb()` primitive from `_shared/_breadcrumb.html`.
 
 **Toolbar / action bar** is the zone bar for page-scoped controls. See `_shared/_toolbar.html` for the two-zone layout (`.toolbar-left` fills the row for filters; `.toolbar-right` parks page actions on the right; single-action toolbars right-align without wrappers). The toolbar is the single home for the page's **primary resource actions**: Edit, Delete, Deactivate/Reactivate, Favorite/Unfavorite. List pages compose the toolbar with `index_filters(...)` in the left zone and a Create-resource action in the right zone; detail pages compose it with the resource's action partial (`_owner_actions.html`, `_admin_actions.html`) or open-coded buttons. Pages without page-scoped controls leave the block empty.
 

--- a/src/domain/templates/_shared/_detail_page.html
+++ b/src/domain/templates/_shared/_detail_page.html
@@ -1,0 +1,30 @@
+{# Base template for a resource **detail page** (`/posts/{id}`,
+   `/providers/{id}`, `/users/{id}`). Children `{% extends %}` this
+   file instead of `base.html` directly; the breadcrumb is filled in
+   automatically from the three child blocks below.
+
+   Required child blocks:
+     resource_label — the resource label (`Posts`, `Providers`, …)
+                      used for the parent crumb's text.
+     resource_url   — the resource list URL (`/posts`) used as the
+                      parent crumb's `href`.
+     current_label  — the trailing crumb's text (`Post`, the user's
+                      username, the provider's `practice_name`).
+
+   Optional child blocks (forwarded to `base.html`):
+     toolbar, content, head, container_class.
+#}
+
+{% extends "base.html" %}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block resource_label %}Resource{% endblock %}
+{% block resource_url %}/{% endblock %}
+{% block current_label %}Detail{% endblock %}
+
+{% block breadcrumb %}
+{{ breadcrumb([
+  (self.resource_label(), self.resource_url() | trim),
+  (self.current_label(), none),
+]) }}
+{% endblock %}

--- a/src/domain/templates/_shared/_form_page.html
+++ b/src/domain/templates/_shared/_form_page.html
@@ -1,0 +1,43 @@
+{# Base template for a resource **form page** — both **new** and
+   **edit** flavors. Children `{% extends %}` this file instead of
+   `base.html` directly; the breadcrumb is filled in automatically.
+
+   New pages (`/posts/form`, `/providers/form`) leave `parent_label`
+   empty and render `Resource › New`. Edit pages
+   (`/posts/{id}/form`, `/providers/{id}/form`) set `parent_label` +
+   `parent_url` to nest a detail crumb between resource and current
+   — `Resource › Detail › Edit`.
+
+   Required child blocks:
+     resource_label — `Posts`, `Providers`, …
+     resource_url   — `/posts`, `/providers`, …
+     current_label  — `New`, `Edit`.
+
+   Optional child blocks (set on edit pages):
+     parent_label   — the detail crumb's text (`Post`, username,
+                      `practice_name`). Empty/whitespace → omit.
+     parent_url     — the detail crumb's `href`
+                      (`/posts/{{ post.id }}`, …).
+
+   Optional child blocks (forwarded to `base.html`):
+     toolbar, content, head, container_class.
+#}
+
+{% extends "base.html" %}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block resource_label %}Resource{% endblock %}
+{% block resource_url %}/{% endblock %}
+{% block parent_label %}{% endblock %}
+{% block parent_url %}{% endblock %}
+{% block current_label %}Form{% endblock %}
+
+{% block breadcrumb %}
+{%- set ns = namespace(items=[(self.resource_label(), self.resource_url() | trim)]) -%}
+{%- set _parent = self.parent_label() | trim -%}
+{%- if _parent -%}
+{%- set ns.items = ns.items + [(_parent, self.parent_url() | trim)] -%}
+{%- endif -%}
+{%- set ns.items = ns.items + [(self.current_label(), none)] -%}
+{{ breadcrumb(ns.items) }}
+{% endblock %}

--- a/src/domain/templates/_shared/_list_page.html
+++ b/src/domain/templates/_shared/_list_page.html
@@ -1,0 +1,24 @@
+{# Base template for a resource **list page** (`/posts`, `/providers`,
+   `/users`, `/users/me/favorites`). Children `{% extends %}` this
+   file instead of `base.html` directly; the breadcrumb is filled in
+   automatically from the `resource_label` block.
+
+   Required child blocks:
+     resource_label — the resource label as the current crumb
+                      (`Posts`, `Providers`, …).
+
+   Optional child blocks (forwarded to `base.html`):
+     toolbar, content, head, container_class.
+
+   Subresource list pages (e.g. `/users/{id}/providers` with crumb
+   `Users › <username> › Providers`) don't fit this single-segment
+   shape — extend `base.html` directly and use the `breadcrumb()`
+   primitive in `_breadcrumb.html` instead.
+#}
+
+{% extends "base.html" %}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+
+{% block resource_label %}Resource{% endblock %}
+
+{% block breadcrumb %}{{ breadcrumb([(self.resource_label(), none)]) }}{% endblock %}

--- a/src/domain/templates/_shared/list_page.html
+++ b/src/domain/templates/_shared/list_page.html
@@ -1,16 +1,9 @@
-{# Chrome helpers for the canonical list page.
+{# Toolbar helper for the canonical list page.
 
-A list page (`/posts`, `/providers`, `/users`, `/users/me/favorites`)
-lands the same chrome above its content: a single-segment breadcrumb
-naming the resource, and an optional toolbar holding the filter
-widget on the left and page actions on the right. The macros in this
-file collapse that boilerplate so the list templates focus on the
-list shape (table vs `<ul>`, empty state, row partial).
-
-Pages still `{% extends "base.html" %}` directly — these macros just
-fill the `breadcrumb` and `toolbar` blocks with one-line calls:
-
-    {% block breadcrumb %}{{ list_breadcrumb("Posts") }}{% endblock %}
+List pages extend `_shared/_list_page.html` (which auto-fills the
+breadcrumb from the `resource_label` block); this file just supplies
+the optional toolbar shell that wraps the filter widget on the left
+and accepts a `{% call %}` body for the right-zone action cluster:
 
     {% block toolbar %}
     {% call list_toolbar(filters=filters, action="/posts", values={...}) %}
@@ -20,21 +13,9 @@ fill the `breadcrumb` and `toolbar` blocks with one-line calls:
 
 When a page has neither a filter widget nor a right-zone action it
 omits the toolbar block entirely — `list_toolbar` is opt-in.
-Subresource lists with multi-segment breadcrumbs
-(`Users › <username> › Providers`) fall back to the underlying
-`breadcrumb()` primitive in [`_breadcrumb.html`](_breadcrumb.html);
-this file is the simple-case fast path, not a one-size-fits-all
-wrapper.
 #}
 
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 {%- from "_shared/index_filters.html" import index_filters -%}
-
-{# Single-segment list breadcrumb — the resource label as the
-   current page (`aria-current="page"`, no link). #}
-{% macro list_breadcrumb(label) -%}
-{{ breadcrumb([(label, none)]) }}
-{%- endmacro %}
 
 {# List-page toolbar shell. Renders the filter widget in the left
    zone when `filters` is provided; renders the `{% call %}` body in
@@ -49,8 +30,9 @@ wrapper.
      values:  dict of `{filter.name: current_value}`; passed straight
               through to `index_filters`.
    The macro caller body becomes the right-zone action cluster — a
-   `Create <resource>` link, an Export button, etc. #}
-{# The toolbar markup is inlined here (rather than delegating to the
+   `Create <resource>` link, an Export button, etc.
+
+   The toolbar markup is inlined here (rather than delegating to the
    `toolbar()` macro in `_toolbar.html`) because Jinja's `caller` is
    shadowed inside a nested `{% call %}`: if this macro tried to
    `{% call toolbar() %}{% if caller %}…{% endif %}{% endcall %}`,

--- a/src/domain/templates/favorites/list.html
+++ b/src/domain/templates/favorites/list.html
@@ -1,9 +1,8 @@
-{% extends "base.html" %}
+{% extends "_shared/_list_page.html" %}
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "_shared/_provider_row.html" import provider_headers, provider_row -%}
-{%- from "_shared/list_page.html" import list_breadcrumb -%}
 
-{% block breadcrumb %}{{ list_breadcrumb("Favorites") }}{% endblock %}
+{% block resource_label %}Favorites{% endblock %}
 
 {% block content %}
 {% call index_table(

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -1,10 +1,9 @@
-{% extends "base.html" %}
+{% extends "_shared/_detail_page.html" %}
 {%- from "_shared/_toolbar.html" import toolbar -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([("Posts", "/posts"), ("Post", none)]) }}
-{% endblock %}
+{% block resource_label %}Posts{% endblock %}
+{% block resource_url %}/posts{% endblock %}
+{% block current_label %}Post{% endblock %}
 
 {% block toolbar %}
 {% call toolbar() %}

--- a/src/domain/templates/posts/edit_client_referral.html
+++ b/src/domain/templates/posts/edit_client_referral.html
@@ -1,14 +1,11 @@
-{% extends "base.html" %}
+{% extends "_shared/_form_page.html" %}
 {% from "posts/_client_referral_form.html" import client_referral_form %}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([
-  ("Posts", "/posts"),
-  ("Post", "/posts/" ~ post.id),
-  ("Edit", none),
-]) }}
-{% endblock %}
+{% block resource_label %}Posts{% endblock %}
+{% block resource_url %}/posts{% endblock %}
+{% block parent_label %}Post{% endblock %}
+{% block parent_url %}/posts/{{ post.id }}{% endblock %}
+{% block current_label %}Edit{% endblock %}
 
 {% block content %}
 {{ client_referral_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=client_referral_create_schema) }}

--- a/src/domain/templates/posts/edit_provider_availability.html
+++ b/src/domain/templates/posts/edit_provider_availability.html
@@ -1,14 +1,11 @@
-{% extends "base.html" %}
+{% extends "_shared/_form_page.html" %}
 {% from "posts/_provider_availability_form.html" import provider_availability_form %}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([
-  ("Posts", "/posts"),
-  ("Post", "/posts/" ~ post.id),
-  ("Edit", none),
-]) }}
-{% endblock %}
+{% block resource_label %}Posts{% endblock %}
+{% block resource_url %}/posts{% endblock %}
+{% block parent_label %}Post{% endblock %}
+{% block parent_url %}/posts/{{ post.id }}{% endblock %}
+{% block current_label %}Edit{% endblock %}
 
 {% block content %}
 {{ provider_availability_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=provider_availability_create_schema, current_user=current_user) }}

--- a/src/domain/templates/posts/form_new.html
+++ b/src/domain/templates/posts/form_new.html
@@ -1,9 +1,8 @@
-{% extends "base.html" %}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+{% extends "_shared/_form_page.html" %}
 
-{% block breadcrumb %}
-{{ breadcrumb([("Posts", "/posts"), ("New", none)]) }}
-{% endblock %}
+{% block resource_label %}Posts{% endblock %}
+{% block resource_url %}/posts{% endblock %}
+{% block current_label %}New{% endblock %}
 
 {# Kind-picker for `GET /posts/form` (no `?kind=`). Each option is a
    stand-alone `<a role="button">` describing the post the user is

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -1,8 +1,8 @@
-{% extends "base.html" %}
-{%- from "_shared/list_page.html" import list_breadcrumb, list_toolbar -%}
+{% extends "_shared/_list_page.html" %}
+{%- from "_shared/list_page.html" import list_toolbar -%}
 {%- from "posts/_item.html" import post_item with context -%}
 
-{% block breadcrumb %}{{ list_breadcrumb("Posts") }}{% endblock %}
+{% block resource_label %}Posts{% endblock %}
 
 {% block toolbar %}
 {% call list_toolbar(

--- a/src/domain/templates/posts/new_client_referral.html
+++ b/src/domain/templates/posts/new_client_referral.html
@@ -1,10 +1,9 @@
-{% extends "base.html" %}
+{% extends "_shared/_form_page.html" %}
 {% from "posts/_client_referral_form.html" import client_referral_form %}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([("Posts", "/posts"), ("New", none)]) }}
-{% endblock %}
+{% block resource_label %}Posts{% endblock %}
+{% block resource_url %}/posts{% endblock %}
+{% block current_label %}New{% endblock %}
 
 {% block content %}
 <p>Per <code>notes/forms_spec.md</code>. No PII.</p>

--- a/src/domain/templates/posts/new_provider_availability.html
+++ b/src/domain/templates/posts/new_provider_availability.html
@@ -1,10 +1,9 @@
-{% extends "base.html" %}
+{% extends "_shared/_form_page.html" %}
 {% from "posts/_provider_availability_form.html" import provider_availability_form %}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([("Posts", "/posts"), ("New", none)]) }}
-{% endblock %}
+{% block resource_label %}Posts{% endblock %}
+{% block resource_url %}/posts{% endblock %}
+{% block current_label %}New{% endblock %}
 
 {% block content %}
 {% if not current_user.providers %}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -1,10 +1,9 @@
-{% extends "base.html" %}
+{% extends "_shared/_detail_page.html" %}
 {%- from "_shared/_toolbar.html" import toolbar -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([("Providers", "/providers"), (provider.practice_name, none)]) }}
-{% endblock %}
+{% block resource_label %}Providers{% endblock %}
+{% block resource_url %}/providers{% endblock %}
+{% block current_label %}{{ provider.practice_name }}{% endblock %}
 
 {% block toolbar %}
 {# Primary resource actions (Favorite toggle, Edit) live in the

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -1,17 +1,14 @@
-{% extends "base.html" %}
+{% extends "_shared/_form_page.html" %}
 {%- from "_shared/form_fields.html" import text_field, select_field, radio_bool_field, multi_select_field -%}
 {%- from "_shared/forms.html" import inline_add_form -%}
 {%- from "_shared/sections.html" import list_or_empty -%}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([
-  ("Providers", "/providers"),
-  (provider.practice_name, "/providers/" ~ provider.id),
-  ("Edit", none),
-]) }}
-{% endblock %}
+{% block resource_label %}Providers{% endblock %}
+{% block resource_url %}/providers{% endblock %}
+{% block parent_label %}{{ provider.practice_name }}{% endblock %}
+{% block parent_url %}/providers/{{ provider.id }}{% endblock %}
+{% block current_label %}Edit{% endblock %}
 
 {% block content %}
 <section>

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -1,10 +1,9 @@
-{% extends "base.html" %}
+{% extends "_shared/_form_page.html" %}
 {%- from "_shared/form_fields.html" import field_for, radio_bool_field, text_field -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([("Providers", "/providers"), ("New", none)]) }}
-{% endblock %}
+{% block resource_label %}Providers{% endblock %}
+{% block resource_url %}/providers{% endblock %}
+{% block current_label %}New{% endblock %}
 
 {% block content %}
 <p>Practice details only. Add licensures, education, and certifications after creating the provider.</p>

--- a/src/domain/templates/providers/list.html
+++ b/src/domain/templates/providers/list.html
@@ -1,9 +1,9 @@
-{% extends "base.html" %}
+{% extends "_shared/_list_page.html" %}
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "_shared/_provider_row.html" import provider_headers, provider_row -%}
-{%- from "_shared/list_page.html" import list_breadcrumb, list_toolbar -%}
+{%- from "_shared/list_page.html" import list_toolbar -%}
 
-{% block breadcrumb %}{{ list_breadcrumb("Providers") }}{% endblock %}
+{% block resource_label %}Providers{% endblock %}
 
 {% block toolbar %}
 {{ list_toolbar(

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -1,12 +1,11 @@
-{% extends "base.html" %}
+{% extends "_shared/_detail_page.html" %}
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "_shared/_provider_row.html" import provider_headers, provider_row -%}
 {%- from "_shared/_toolbar.html" import toolbar -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 
-{% block breadcrumb %}
-{{ breadcrumb([("Users", "/users"), (target_user.username, none)]) }}
-{% endblock %}
+{% block resource_label %}Users{% endblock %}
+{% block resource_url %}/users{% endblock %}
+{% block current_label %}{{ target_user.username }}{% endblock %}
 
 {% block toolbar %}
 {% call toolbar() %}

--- a/src/domain/templates/users/list.html
+++ b/src/domain/templates/users/list.html
@@ -1,9 +1,8 @@
-{% extends "base.html" %}
+{% extends "_shared/_list_page.html" %}
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "users/_columns.html" import user_headers, user_row -%}
-{%- from "_shared/list_page.html" import list_breadcrumb -%}
 
-{% block breadcrumb %}{{ list_breadcrumb("Users") }}{% endblock %}
+{% block resource_label %}Users{% endblock %}
 
 {% block content %}
 {{ index_table(


### PR DESCRIPTION
Pages now declare their position in the resource hierarchy via small metadata blocks, and the breadcrumb falls out from the base template. No more per-page `breadcrumb([...])` wiring.

## Three sub-base templates in `_shared/`

| Page kind | Sub-base                | Child blocks                                                              |
| --------- | ----------------------- | ------------------------------------------------------------------------- |
| List      | `_list_page.html`       | `resource_label`                                                          |
| Detail    | `_detail_page.html`     | `resource_label`, `resource_url`, `current_label`                         |
| Form      | `_form_page.html`       | `resource_label`, `resource_url`, `current_label`, optional `parent_label` + `parent_url` |

Each sub-base extends `base.html` and fills `{% block breadcrumb %}` by reading the blocks the child overrides. The form base nests a detail crumb between resource and current only when both `parent_label` and `parent_url` are non-empty — so the same template handles both new (`Resource › New`) and edit (`Resource › Detail › Edit`) shapes.

## Before / after

```jinja
{# before: posts/detail.html #}
{% extends "base.html" %}
{%- from "_shared/_breadcrumb.html" import breadcrumb -%}

{% block breadcrumb %}
{{ breadcrumb([("Posts", "/posts"), ("Post", none)]) }}
{% endblock %}

{# after #}
{% extends "_shared/_detail_page.html" %}

{% block resource_label %}Posts{% endblock %}
{% block resource_url %}/posts{% endblock %}
{% block current_label %}Post{% endblock %}
```

## Migrated pages
- **List:** `posts/list`, `providers/list`, `users/list`, `favorites/list`
- **Detail:** `posts/detail`, `providers/detail`, `users/detail`
- **Form:** `posts/edit_client_referral`, `posts/edit_provider_availability`, `posts/new_client_referral`, `posts/new_provider_availability`, `posts/form_new`, `providers/form_new`, `providers/form_edit`

`users/providers_list` (the only subresource list, 3-segment breadcrumb) keeps extending `base.html` directly and uses the `breadcrumb()` primitive — none of the three shapes fit it.

The previously merged `list_breadcrumb(label)` macro is dropped (its sole caller, every list template, now extends `_list_page.html`). `list_toolbar(filters, action, values)` stays as the optional toolbar shortcut.

## Test plan
- [x] `dev test` (992 passed, 52 skipped) — the existing breadcrumb guardrail tests pin the rendered markup, so any rewiring would surface immediately.
- [x] `dev lint`
- [ ] Eyes-on each migrated page; the rendered breadcrumb should be byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)