### PR TITLE
Action-bar consistency: layout-invisible wrappers + drop the one that didn't earn its keep

### DIFF
--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -370,13 +370,10 @@ async def test_provider_detail_favorite_toggle_lives_in_toolbar(
     response = await authenticated_client.get(f"/providers/{provider_id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    assert tree.css_first(".toolbar span.favorite-toggle") is not None
-    # The favorite toggle is not duplicated inside <article>.
-    assert tree.css_first("article span.favorite-toggle") is None
-    # And the Favorite button posts to the canonical edge endpoint.
-    btn = tree.css_first(".toolbar span.favorite-toggle button")
-    assert btn is not None
-    assert btn.attributes.get("hx-post") == f"/users/me/favorites/{provider_id}"
+    favorite_selector = f'button[hx-post="/users/me/favorites/{provider_id}"]'
+    assert tree.css_first(f".toolbar {favorite_selector}") is not None
+    # The favorite button is not duplicated inside <article>.
+    assert tree.css_first(f"article {favorite_selector}") is None
 
 
 async def test_provider_form_new_omits_bottom_back_link(

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -12,7 +12,6 @@
    `can_edit` and `is_favorited` are computed by handle_get_provider_detail;
    templates do not re-derive authorization predicates inline. #}
 {% if is_authenticated %}
-<span class="favorite-toggle">
   {% if is_favorited %}
   <button type="button"
           class="secondary outline"
@@ -27,7 +26,6 @@
     Favorite
   </button>
   {% endif %}
-</span>
 {% endif %}
 {% if can_edit %}
 <a href="/providers/{{ provider.id }}/form" role="button" class="outline">Edit provider</a>

--- a/src/framework/templates/_shared/_toolbar.html
+++ b/src/framework/templates/_shared/_toolbar.html
@@ -15,6 +15,14 @@ in `.toolbar-right` for an explicit right-anchored cluster. Single-
 action toolbars can skip the wrappers — a lone child still parks at
 the right edge via the toolbar's `justify-content: flex-end`.
 
+Action-bar contract: each direct child of `.toolbar` is a button-
+shaped element (`<button>`, `<a role="button">`, ...). A page that
+needs a DOM/test hook around an action may wrap it in a `<span>` —
+`base.html` styles `.toolbar > span` as `display: contents`, so the
+wrapper stays in the DOM (test selectors, `data-*` attributes work)
+while the inner buttons become the actual flex children. Either
+shape — wrapped or bare — aligns identically.
+
     Two-zone bar (e.g. /posts):
 
         {% call toolbar() %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -83,6 +83,13 @@
          lone child still parks at the right edge. `flex-wrap` lets
          long rows wrap onto multiple lines on narrow viewports. */
       .toolbar { display: flex; justify-content: flex-end; align-items: center; flex-wrap: wrap; gap: 1rem; }
+      /* Action-bar children align as individual flex items. `<span>`
+         wrappers used purely as test/data hooks (e.g. `.favorite-toggle`,
+         `.admin-actions`, `.owner-actions`) become layout-invisible so
+         their inner buttons participate directly in the toolbar's row —
+         same alignment + gap as bare button-shaped children. The span
+         stays in the DOM for selectors and `data-*` attributes. */
+      .toolbar > span { display: contents; }
       .toolbar-left { flex: 1; min-width: 0; display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
       .toolbar-right { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
       /* Breadcrumb zone bar. Pico already styles the markup

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -84,11 +84,12 @@
          long rows wrap onto multiple lines on narrow viewports. */
       .toolbar { display: flex; justify-content: flex-end; align-items: center; flex-wrap: wrap; gap: 1rem; }
       /* Action-bar children align as individual flex items. `<span>`
-         wrappers used purely as test/data hooks (e.g. `.favorite-toggle`,
-         `.admin-actions`, `.owner-actions`) become layout-invisible so
-         their inner buttons participate directly in the toolbar's row —
-         same alignment + gap as bare button-shaped children. The span
-         stays in the DOM for selectors and `data-*` attributes. */
+         wrappers used as DOM-grouping hooks (e.g. `.admin-actions`,
+         `.owner-actions` — both carry `data-*` attributes and bundle
+         two buttons) become layout-invisible so their inner buttons
+         participate directly in the toolbar's row — same alignment +
+         gap as bare button-shaped children. The span stays in the DOM
+         for selectors and `data-*` attributes. */
       .toolbar > span { display: contents; }
       .toolbar-left { flex: 1; min-width: 0; display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
       .toolbar-right { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }


### PR DESCRIPTION
## Summary

Follow-up to #491. The view-type rails landed but the **action bar** had two consistency gaps left over from before the rails existed:

1. **Wrapper spans broke flex alignment.** Three action partials (`favorite-toggle`, `admin-actions`, `owner-actions`) wrap their buttons in a `<span>` for test/data hooks. Each span is an inline element that inherits Pico's root line-height, so its bounding box is taller than the button inside. With `align-items: center` on `.toolbar`, a wrapped button rendered at a slightly different vertical position than a bare `<a role="button">` sibling — the askew look on `/providers/{id}`.

2. **`.favorite-toggle` didn't pull its weight.** Unlike `.admin-actions` and `.owner-actions` — which bundle 2 buttons each and carry `data-user-id` / `data-post-id` — `.favorite-toggle` wrapped a single button with no data attributes. It existed only as a test-selector hook for something the button already encoded via its `hx-post`/`hx-delete` URL.

### What's in this PR

- **`a54cdf7`**: Style `.toolbar > span` as `display: contents`. Wrapper spans drop out of the flex tree so their inner buttons become the actual flex children, picking up the toolbar's uniform alignment and `gap: 1rem`. Spans stay in the DOM, so existing test selectors and `data-*` attributes keep working for the wrappers that earn their keep. Documents the action-bar contract in `_shared/_toolbar.html`'s docstring.

- **`74eca27`**: Drop the `.favorite-toggle` span from `providers/detail.html`. Rewrite the 3 test assertions to use the semantic attribute selector `button[hx-post="/users/me/favorites/{id}"]` — matching what the button *is*, not a wrapper that existed only to be selectable.

### Contract surfaces

- **HTML structure of the action bar**: simpler — one fewer DOM node on `/providers/{id}`. No selector that survived this PR breaks. The CSS rule is purely additive.
- **HTTP response shape**: no change.
- **Tests**: 3 selectors in `test_providers.py` updated to attribute-based form. All 21 provider tests pass.

## Test plan

- [x] `python -m pytest src/domain/routes/test_providers.py` — 21 passed.
- [x] `python -m pytest src/domain/routes/test_providers.py src/domain/routes/test_users.py src/domain/routes/test_posts.py src/framework/templates/test_views.py` — 138 passed.
- [ ] UI smoke: load `/providers/{id}` and confirm the Favorite + Edit buttons render flush on the same row.

https://claude.ai/code/session_01MNfATnPYcCW2wDso4Gnxtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNfATnPYcCW2wDso4Gnxtd)_