### PR TITLE
Action-bar grammar: natural-width buttons, no wrapper spans

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -1056,11 +1056,9 @@ async def test_detail_page_shows_edit_link_for_owner(
     response = await authenticated_client.get(f"/posts/{post.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    actions = tree.css_first("span.owner-actions")
-    assert actions is not None
-    edit_link = actions.css_first("a")
+    edit_link = tree.css_first(f"a[href='/posts/{post.id}/form']")
     assert edit_link is not None
-    assert edit_link.attributes.get("href") == f"/posts/{post.id}/form"
+    assert edit_link.attributes.get("role") == "button"
 
 
 async def test_detail_page_shows_edit_link_for_admin(
@@ -1079,7 +1077,7 @@ async def test_detail_page_shows_edit_link_for_admin(
     response = await authenticated_client.get(f"/posts/{post.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    assert tree.css_first("span.owner-actions") is not None
+    assert tree.css_first(f"a[href='/posts/{post.id}/form']") is not None
 
 
 async def test_detail_page_hides_edit_link_for_stranger(
@@ -1097,7 +1095,8 @@ async def test_detail_page_hides_edit_link_for_stranger(
     response = await authenticated_client.get(f"/posts/{post.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    assert tree.css_first("span.owner-actions") is None
+    assert tree.css_first(f"a[href='/posts/{post.id}/form']") is None
+    assert tree.css_first(f"button[hx-delete='/posts/{post.id}']") is None
 
 
 async def test_detail_page_delete_button_for_owner(
@@ -1115,12 +1114,9 @@ async def test_detail_page_delete_button_for_owner(
     response = await authenticated_client.get(f"/posts/{post.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    actions = tree.css_first("span.owner-actions")
-    assert actions is not None
-    button = actions.css_first("button")
+    button = tree.css_first(f"button[hx-delete='/posts/{post.id}']")
     assert button is not None
     assert button.text().strip() == "Delete"
-    assert button.attributes.get("hx-delete") == f"/posts/{post.id}"
     assert button.attributes.get("hx-confirm")
 
 
@@ -1141,9 +1137,8 @@ async def test_detail_page_delete_button_for_admin(
     response = await authenticated_client.get(f"/posts/{post.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    button = tree.css_first("span.owner-actions button")
+    button = tree.css_first(f"button[hx-delete='/posts/{post.id}']")
     assert button is not None
-    assert button.attributes.get("hx-delete") == f"/posts/{post.id}"
 
 
 # --- Audit log -----------------------------------------------------------

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -135,7 +135,7 @@ async def test_list_hides_admin_actions_for_non_admin(
     response = await authenticated_client.get("/users")
     tree = HTMLParser(response.text)
     assert (
-        tree.css_first("span.admin-actions") is None
+        tree.css_first("button[hx-put*='/activation']") is None
     ), "Non-admin should not see admin action buttons"
 
 
@@ -153,12 +153,10 @@ async def test_list_shows_admin_actions_for_admin(
 
     response = await authenticated_client.get("/users")
     tree = HTMLParser(response.text)
-    actions = tree.css("span.admin-actions")
-    assert len(actions) == 1, "Expected one admin-actions span (one non-self row)"
-    buttons = actions[0].css("button")
-    button_labels = {b.text().strip() for b in buttons}
-    assert "Deactivate" in button_labels
-    assert "Delete" in button_labels
+    activation_buttons = tree.css(f"button[hx-put='/users/{other.id}/activation']")
+    assert len(activation_buttons) == 1, "Expected one activation button (one non-self row)"
+    assert activation_buttons[0].text().strip() == "Deactivate"
+    assert tree.css_first(f"button[hx-delete='/users/{other.id}']") is not None
 
 
 async def test_list_shows_reactivate_for_deactivated_user(
@@ -175,9 +173,9 @@ async def test_list_shows_reactivate_for_deactivated_user(
 
     response = await authenticated_client.get("/users")
     tree = HTMLParser(response.text)
-    button_labels = {b.text().strip() for b in tree.css("span.admin-actions button")}
-    assert "Reactivate" in button_labels
-    assert "Deactivate" not in button_labels
+    activation_button = tree.css_first(f"button[hx-put='/users/{other.id}/activation']")
+    assert activation_button is not None
+    assert activation_button.text().strip() == "Reactivate"
 
 
 # --- Detail page ---------------------------------------------------------
@@ -312,7 +310,7 @@ async def test_detail_shows_admin_actions_for_admin(
 
     response = await authenticated_client.get(f"/users/{target.id}")
     tree = HTMLParser(response.text)
-    assert tree.css_first("span.admin-actions") is not None
+    assert tree.css_first(f"button[hx-put='/users/{target.id}/activation']") is not None
 
 
 async def test_detail_admin_actions_render_inside_toolbar(
@@ -331,9 +329,10 @@ async def test_detail_admin_actions_render_inside_toolbar(
 
     response = await authenticated_client.get(f"/users/{target.id}")
     tree = HTMLParser(response.text)
-    assert tree.css_first(".toolbar span.admin-actions") is not None
+    activation_selector = f"button[hx-put='/users/{target.id}/activation']"
+    assert tree.css_first(f".toolbar {activation_selector}") is not None
     # Sanity: not duplicated inside <article>.
-    assert tree.css_first("article span.admin-actions") is None
+    assert tree.css_first(f"article {activation_selector}") is None
 
 
 async def test_detail_hides_admin_actions_for_non_admin(
@@ -349,7 +348,7 @@ async def test_detail_hides_admin_actions_for_non_admin(
 
     response = await authenticated_client.get(f"/users/{target.id}")
     tree = HTMLParser(response.text)
-    assert tree.css_first("span.admin-actions") is None
+    assert tree.css_first(f"button[hx-put='/users/{target.id}/activation']") is None
 
 
 async def test_detail_shows_providers_empty_state(

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -154,7 +154,9 @@ async def test_list_shows_admin_actions_for_admin(
     response = await authenticated_client.get("/users")
     tree = HTMLParser(response.text)
     activation_buttons = tree.css(f"button[hx-put='/users/{other.id}/activation']")
-    assert len(activation_buttons) == 1, "Expected one activation button (one non-self row)"
+    assert (
+        len(activation_buttons) == 1
+    ), "Expected one activation button (one non-self row)"
     assert activation_buttons[0].text().strip() == "Deactivate"
     assert tree.css_first(f"button[hx-delete='/users/{other.id}']") is not None
 

--- a/src/domain/templates/posts/_owner_actions.html
+++ b/src/domain/templates/posts/_owner_actions.html
@@ -7,14 +7,14 @@
                 `src/logic/_authz.py`. The partial does not introspect
                 `current_user`; the rule lives in the predicate module.
 
-   Renders nothing unless `can_edit` is truthy. Backend authz lives in
-   src/logic/posts/post_processing.py — this `{% if %}` is presentation
-   only.
+   Renders nothing unless `can_edit` is truthy. The buttons themselves
+   carry the post's identity in their `href` / `hx-delete` URLs; tests
+   find them by attribute rather than a wrapper class. Backend authz
+   lives in src/logic/posts/post_processing.py — this `{% if %}` is
+   presentation only.
 #}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
 {% if can_edit %}
-<span class="owner-actions" data-post-id="{{ post.id }}">
-  <a href="/posts/{{ post.id }}/form" role="button" class="outline">Edit</a>
-  {{ confirm_delete_button("/posts/" ~ post.id, "Permanently delete this post? This cannot be undone.") }}
-</span>
+<a href="/posts/{{ post.id }}/form" role="button" class="outline">Edit</a>
+{{ confirm_delete_button("/posts/" ~ post.id, "Permanently delete this post? This cannot be undone.") }}
 {% endif %}

--- a/src/domain/templates/users/_admin_actions.html
+++ b/src/domain/templates/users/_admin_actions.html
@@ -7,37 +7,38 @@
                           (`viewer.id != target.id`). The partial does
                           not introspect `current_user`.
 
-   Renders nothing unless `can_admin_actions` is truthy. To add a new
-   admin action, append a button below; every view that includes this
-   partial picks it up automatically.
+   Renders nothing unless `can_admin_actions` is truthy. The buttons
+   themselves carry the user's identity in their `hx-*` URLs
+   (`/users/{id}/activation`, `/users/{id}`); tests find them by
+   attribute rather than a wrapper class. To add a new admin action,
+   append a button below; every view that includes this partial picks
+   it up automatically.
 
    Backend self-guards live in src/logic/users/user_processing.py — this
    `{% if %}` is presentation only.
 #}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
 {% if can_admin_actions %}
-<span class="admin-actions" data-user-id="{{ target_user.id }}">
-  {% if target_user.is_active %}
-  <button
-    type="button"
-    class="secondary outline"
-    hx-put="/users/{{ target_user.id }}/activation"
-    hx-ext="json-enc"
-    hx-vals='{"state": "deactivated"}'
-    hx-confirm="Deactivate {{ target_user.username }}? They will be unable to log in until reactivated.">
-    Deactivate
-  </button>
-  {% else %}
-  <button
-    type="button"
-    class="secondary outline"
-    hx-put="/users/{{ target_user.id }}/activation"
-    hx-ext="json-enc"
-    hx-vals='{"state": "active"}'
-    hx-confirm="Reactivate {{ target_user.username }}?">
-    Reactivate
-  </button>
-  {% endif %}
-  {{ confirm_delete_button("/users/" ~ target_user.id, "Permanently delete " ~ target_user.username ~ "? This cannot be undone.") }}
-</span>
+{% if target_user.is_active %}
+<button
+  type="button"
+  class="secondary outline"
+  hx-put="/users/{{ target_user.id }}/activation"
+  hx-ext="json-enc"
+  hx-vals='{"state": "deactivated"}'
+  hx-confirm="Deactivate {{ target_user.username }}? They will be unable to log in until reactivated.">
+  Deactivate
+</button>
+{% else %}
+<button
+  type="button"
+  class="secondary outline"
+  hx-put="/users/{{ target_user.id }}/activation"
+  hx-ext="json-enc"
+  hx-vals='{"state": "active"}'
+  hx-confirm="Reactivate {{ target_user.username }}?">
+  Reactivate
+</button>
+{% endif %}
+{{ confirm_delete_button("/users/" ~ target_user.id, "Permanently delete " ~ target_user.username ~ "? This cannot be undone.") }}
 {% endif %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -83,17 +83,12 @@
          lone child still parks at the right edge. `flex-wrap` lets
          long rows wrap onto multiple lines on narrow viewports. */
       .toolbar { display: flex; justify-content: flex-end; align-items: center; flex-wrap: wrap; gap: 1rem; }
-      /* Action-bar children align as individual flex items. `<span>`
-         wrappers used as DOM-grouping hooks (e.g. `.admin-actions`,
-         `.owner-actions` — both carry `data-*` attributes and bundle
-         two buttons) become layout-invisible so their inner buttons
-         participate directly in the toolbar's row — same alignment +
-         gap as bare button-shaped children. The span stays in the DOM
-         for selectors and `data-*` attributes. Pico's default
-         `<button>` is `display: block; width: 100%` (form-shaped); the
-         action bar overrides to natural-width inline buttons — same
-         pattern as `.filter-chips` / `.filter-actions` above. */
-      .toolbar > span { display: contents; }
+      /* Pico's default `<button>` is `display: block; width: 100%`
+         (form-shaped); the action bar overrides to natural-width
+         inline buttons — same pattern as `.filter-chips` /
+         `.filter-actions` above. Each action is a bare button-shaped
+         element (`<button>`, `<a role="button">`) — no wrapping spans
+         — so this selector reaches every action child directly. */
       .toolbar button, .toolbar [role="button"] { width: auto; margin: 0; }
       .toolbar-left { flex: 1; min-width: 0; display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
       .toolbar-right { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -89,8 +89,12 @@
          two buttons) become layout-invisible so their inner buttons
          participate directly in the toolbar's row — same alignment +
          gap as bare button-shaped children. The span stays in the DOM
-         for selectors and `data-*` attributes. */
+         for selectors and `data-*` attributes. Pico's default
+         `<button>` is `display: block; width: 100%` (form-shaped); the
+         action bar overrides to natural-width inline buttons — same
+         pattern as `.filter-chips` / `.filter-actions` above. */
       .toolbar > span { display: contents; }
+      .toolbar button, .toolbar [role="button"] { width: auto; margin: 0; }
       .toolbar-left { flex: 1; min-width: 0; display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
       .toolbar-right { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
       /* Breadcrumb zone bar. Pico already styles the markup

--- a/tests/test_contract/tests/consumer/test_post_owner_actions.py
+++ b/tests/test_contract/tests/consumer/test_post_owner_actions.py
@@ -63,8 +63,8 @@ async def test_consumer_delete_button_click(origin_with_routes: str, page: Page)
 
     with pact:
         await page.goto(detail_page_url)
-        await page.wait_for_selector("span.owner-actions button")
-        await page.locator("span.owner-actions button", has_text="Delete").click()
+        await page.wait_for_selector("button[hx-delete^='/posts/']")
+        await page.locator("button[hx-delete^='/posts/']", has_text="Delete").click()
         await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
 
     # Pact verification happens automatically on context exit.

--- a/tests/test_contract/tests/consumer/test_user_admin_actions.py
+++ b/tests/test_contract/tests/consumer/test_user_admin_actions.py
@@ -81,8 +81,8 @@ async def test_consumer_deactivate_button_click(origin_with_routes: str, page: P
 
     with pact:
         await page.goto(detail_page_url)
-        await page.wait_for_selector("span.admin-actions button")
-        await page.locator("span.admin-actions button", has_text="Deactivate").click()
+        await page.wait_for_selector("button[hx-put*='/activation']")
+        await page.locator("button[hx-put*='/activation']", has_text="Deactivate").click()
         await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
 
     # Pact verification happens automatically on context exit.

--- a/tests/test_contract/tests/consumer/test_user_admin_actions.py
+++ b/tests/test_contract/tests/consumer/test_user_admin_actions.py
@@ -82,7 +82,9 @@ async def test_consumer_deactivate_button_click(origin_with_routes: str, page: P
     with pact:
         await page.goto(detail_page_url)
         await page.wait_for_selector("button[hx-put*='/activation']")
-        await page.locator("button[hx-put*='/activation']", has_text="Deactivate").click()
+        await page.locator(
+            "button[hx-put*='/activation']", has_text="Deactivate"
+        ).click()
         await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
 
     # Pact verification happens automatically on context exit.


### PR DESCRIPTION
## Summary

Two-commit follow-up to #491 / #492 that collapses the action-bar grammar to the minimum.

### `e128628` — Make action-bar buttons natural-width

Pico v2 styles `<button>` as `display: block; width: 100%` (form-shaped). The project already overrides this for `.filter-chips` / `.filter-actions` two lines above in `base.html`, but the action bar's `.toolbar` never got the same override. It went unnoticed until #492 made `.toolbar > span` layout-invisible — before that, the `<span>` wrapper around the Favorite button was an inline flex item with shrink-to-fit width, accidentally constraining the button's `width: 100%` to the span's narrow content width. Once the span dissolved, Pico's full-width default surfaced.

One line, mirroring the existing precedent:

```css
.toolbar button, .toolbar [role="button"] { width: auto; margin: 0; }
```

### `caaa1b3` — Drop action-bar wrapper spans entirely

`<span class="admin-actions">` and `<span class="owner-actions">` were test-selector hooks that didn't earn their cost. Tests only ever used the class selector, never the `data-user-id` / `data-post-id` attributes the spans also carried. Each button's `hx-*` / `href` URL already encodes the user's or post's identity — a more durable selector than a wrapper class because it matches the button's actual contract with the backend.

The toolbar grammar in `base.html` collapses to:

```css
.toolbar { display: flex; ...; gap: 1rem; }
.toolbar button, .toolbar [role="button"] { width: auto; margin: 0; }
```

…dropping the `.toolbar > span { display: contents; }` rule (and the comment explaining why it existed) — unneeded once no spans live inside the toolbar.

Action partials become markup-minimal — each action is a bare `<button>` or `<a role="button">`. The chrome rule ("primary resource actions live in the toolbar, not in `<article>`") is still pinned by the same toolbar/article duplicate-check pattern; the selector just matches the button directly.

### Test selector rewrites

11 assertions across `test_users.py` and `test_posts.py` rewritten from `span.<class>` / `span.<class> button` to attribute-based selectors:

| Before | After |
| --- | --- |
| `span.admin-actions` | `button[hx-put='/users/{id}/activation']` |
| `span.admin-actions button` (Delete) | `button[hx-delete='/users/{id}']` |
| `span.owner-actions a` | `a[href='/posts/{id}/form']` |
| `span.owner-actions button` | `button[hx-delete='/posts/{id}']` |

### Contract surfaces

- **HTML structure**: action partials lose their wrapping `<span>` and `data-*` attributes. No CSS or JS uses them; only the now-rewritten tests did.
- **HTTP response shape**: no change.
- **Routes / persisted state**: no change.

## Test plan

- [x] `python -m pytest -q` — **1001 passed, 52 skipped**.
- [x] `dev lint` (template-imports check) — 40 files checked, clean.
- [ ] UI smoke: action-bar buttons render natural-width on a single row across `/providers/{id}`, `/users/{id}` (as admin), and `/posts/{id}` (as owner).

https://claude.ai/code/session_01MNfATnPYcCW2wDso4Gnxtd