### PR TITLE
Wrap each post-list row in <li> instead of <div>

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -101,7 +101,7 @@ async def test_list_client_referral_item_shape(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    item = tree.css_first("#posts-list > div")
+    item = tree.css_first("#posts-list > li")
     assert item is not None
     assert item.attributes.get("data-kind") == "client_referral"
 
@@ -153,7 +153,7 @@ async def test_list_client_referral_falls_back_to_synthesized_title(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    lead = tree.css_first("#posts-list > div a")
+    lead = tree.css_first("#posts-list > li a")
     assert lead is not None
     assert lead.text(strip=True) == "Seeking in Boise, ID"
 
@@ -192,7 +192,7 @@ async def test_list_provider_availability_item_shape(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    item = tree.css_first("#posts-list > div")
+    item = tree.css_first("#posts-list > li")
     assert item is not None
     assert item.attributes.get("data-kind") == "provider_availability"
 
@@ -242,7 +242,7 @@ async def test_list_lead_contains_full_description_no_backend_truncation(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    lead = tree.css_first("#posts-list > div a")
+    lead = tree.css_first("#posts-list > li a")
     assert lead is not None
     assert lead.text(strip=True) == description
 
@@ -254,7 +254,7 @@ async def test_list_meta_is_an_inline_list_of_li_chunks(
 ):
     """Each metadata fact is its own `<li>` inside a nested `<ul>`
     after the title link — the inline-list pattern. The `·` visual
-    separator lives in CSS (`#posts-list > div > ul > li + li::before`)
+    separator lives in CSS (`#posts-list > li > ul > li + li::before`)
     rather than the markup, so the DOM text has no `·` glyphs. A
     regression that collapsed the chunks back into a single
     `·`-joined string (or onto the title line) would fail here.
@@ -282,7 +282,7 @@ async def test_list_meta_is_an_inline_list_of_li_chunks(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    item = tree.css_first("#posts-list > div")
+    item = tree.css_first("#posts-list > li")
     assert item is not None
 
     # Metadata is a nested `<ul>` of `<li>` chunks above the title —
@@ -340,7 +340,7 @@ async def test_list_renders_readable_date_format(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    item = tree.css_first("#posts-list > div")
+    item = tree.css_first("#posts-list > li")
     assert item is not None
     # First chunk of the meta `<ul>` is the leading date.
     date_cell = item.css_first("ul > li")
@@ -472,7 +472,7 @@ async def test_list_posts_one_post(
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    items = tree.css("#posts-list > div")
+    items = tree.css("#posts-list > li")
     assert len(items) == 1
     item_text = items[0].text()
     assert description in item_text
@@ -507,7 +507,7 @@ async def test_list_posts_orders_newest_first(
     assert response.status_code == 200
 
     tree = HTMLParser(response.text)
-    items = tree.css("#posts-list > div")
+    items = tree.css("#posts-list > li")
     assert len(items) == 2
     assert newer.client_referral_detail.description in items[0].text()
     assert older.client_referral_detail.description in items[1].text()
@@ -666,7 +666,7 @@ async def test_list_filters_by_kind_seeking(
     response = await authenticated_client.get("/posts?kind=client_referral")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    rows = tree.css("#posts-list > div")
+    rows = tree.css("#posts-list > li")
     assert len(rows) == 1
     assert rows[0].attributes.get("data-kind") == "client_referral"
     # The kind <select> preselects the seeking option.
@@ -675,7 +675,7 @@ async def test_list_filters_by_kind_seeking(
     assert selected_option.attributes.get("value") == "client_referral"
     # The kind chip is hidden on the cards when a single kind is selected —
     # it would be constant for every card on this page.
-    assert tree.css("#posts-list > div [data-kind-chip]") == []
+    assert tree.css("#posts-list > li [data-kind-chip]") == []
 
 
 async def test_list_rejects_unknown_kind(
@@ -719,7 +719,7 @@ async def test_list_filters_by_free_text_q_across_both_detail_tables(
     response = await authenticated_client.get("/posts?q=needle")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    rows = tree.css("#posts-list > div")
+    rows = tree.css("#posts-list > li")
     # Both `needle-*` posts match across the polymorphic OR. The
     # `haystack-*` seeker is filtered out.
     assert len(rows) == 2
@@ -756,7 +756,7 @@ async def test_list_combines_kind_and_q_with_and(
     response = await authenticated_client.get("/posts?kind=client_referral&q=needle")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    rows = tree.css("#posts-list > div")
+    rows = tree.css("#posts-list > li")
     assert len(rows) == 1
     assert rows[0].attributes.get("data-kind") == "client_referral"
 
@@ -784,7 +784,7 @@ async def test_list_filters_by_posted_by_username(
     response = await authenticated_client.get("/posts?posted_by=alice")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    rows = tree.css("#posts-list > div")
+    rows = tree.css("#posts-list > li")
     assert len(rows) == 1
     assert rows[0].attributes.get("data-row-id") == str(alice_post.id)
     # The text input echoes the URL value.
@@ -838,7 +838,7 @@ async def test_list_filters_by_state_across_polymorphic_paths(
     response = await authenticated_client.get("/posts?state=NY&state=NJ")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    rows = tree.css("#posts-list > div")
+    rows = tree.css("#posts-list > li")
     row_ids = {r.attributes.get("data-row-id") for r in rows}
     assert row_ids == {str(seeking_ny.id), str(offering_nj.id)}
     # Both NY and NJ options are preselected in the multi-<select>.
@@ -882,7 +882,7 @@ async def test_list_filters_by_city_substring_across_polymorphic_paths(
     response = await authenticated_client.get("/posts?city=spring")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    row_ids = {r.attributes.get("data-row-id") for r in tree.css("#posts-list > div")}
+    row_ids = {r.attributes.get("data-row-id") for r in tree.css("#posts-list > li")}
     assert row_ids == {str(seeking_match.id), str(offering_match.id)}
 
 
@@ -920,7 +920,7 @@ async def test_list_filters_by_age_group_json_contains(
     response = await authenticated_client.get("/posts?age_group=adults_25_64")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    row_ids = {r.attributes.get("data-row-id") for r in tree.css("#posts-list > div")}
+    row_ids = {r.attributes.get("data-row-id") for r in tree.css("#posts-list > li")}
     assert row_ids == {str(seeking_match.id), str(offering_match.id)}
 
 
@@ -948,7 +948,7 @@ async def test_list_filters_by_language_json_contains(
     response = await authenticated_client.get("/posts?language=es")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    rows = tree.css("#posts-list > div")
+    rows = tree.css("#posts-list > li")
     assert len(rows) == 1
     assert rows[0].attributes.get("data-row-id") == str(spanish_seeker.id)
 

--- a/src/domain/templates/posts/_item.html
+++ b/src/domain/templates/posts/_item.html
@@ -1,12 +1,13 @@
 {# Dense list-item macro for the posts index.
 
 Posts are polymorphic — `client_referral` (Seeking) and
-`provider_availability` (Providing). Each post renders as a plain
-`<div>` inside `<section id="posts-list">` — no per-post framing,
-no card styling, just the meta line and title flowing as content.
-Bespoke CSS is reduced to two patterns both scoped under
-`#posts-list > div`: the inline-list rules for the meta `<ul>`, and
-the line-clamp rule for the title `<p>`.
+`provider_availability` (Providing). Each post renders as an `<li>`
+inside `<ul id="posts-list">` — `<li>` is the only valid child of
+`<ul>`, so the row carries `data-row-id` / `data-kind` directly.
+No per-post framing, no card styling, just the meta line and title
+flowing as content. Bespoke CSS is reduced to two patterns both
+scoped under `#posts-list > li`: the inline-list rules for the meta
+`<ul>`, and the line-clamp rule for the title `<p>`.
 
 The row is two lines: a meta `<ul>` above, a title `<p>` below.
 Meta carries every fact about the post — date, kind chunk (Seeking
@@ -96,7 +97,7 @@ the detail page for posture and carrier specifics.
   {%- set d = post.provider_availability_detail -%}
   {%- set p = d.provider -%}
 {%- endif -%}
-<div data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
+<li data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
   <ul>{{ _meta_chunks(post, active_kind=active_kind) }}</ul>
   <p>
     <a href="/posts/{{ post.id }}">
@@ -112,5 +113,5 @@ the detail page for posture and carrier specifics.
       {%- endif -%}
     </a>
   </p>
-</div>
+</li>
 {%- endmacro %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -34,7 +34,8 @@
         --pico-font-size-h4: 1rem;
       }
       /* Posts feed — inline meta list + title line-clamp. Two
-         patterns, both scoped under `#posts-list > div`:
+         patterns, both scoped under `#posts-list > li` (each post
+         row is an `<li>`, the only valid child of the outer `<ul>`):
 
          1. Each post's meta `<ul>` is an inline-list — `<li>`
             children flow inline, and `::before` on adjacent siblings
@@ -49,10 +50,10 @@
          between cards) is whatever Pico's `<article>` defaults give
          — no bespoke CSS for the frame itself. */
       #posts-list { list-style: none; padding: 0; margin: 0; }
-      #posts-list > div { margin-block: 1.25rem; }
-      #posts-list > div > ul { padding: 0; margin: 0; list-style: none; }
-      #posts-list > div > ul > li { display: inline; }
-      #posts-list > div > ul > li + li::before { content: " · "; color: var(--pico-muted-color); }
+      #posts-list > li { margin-block: 1.25rem; }
+      #posts-list > li > ul { padding: 0; margin: 0; list-style: none; }
+      #posts-list > li > ul > li { display: inline; }
+      #posts-list > li > ul > li + li::before { content: " · "; color: var(--pico-muted-color); }
       /* Kind-chip color differentiation. `[data-kind-chip]` sits on the
          <li> wrapper in the meta line (and on a <span> in the detail
          header). Color the contained text so Seeking vs Providing reads
@@ -110,7 +111,7 @@
       @media (max-width: 768px) {
         nav[aria-label="breadcrumb"] { display: none; }
       }
-      #posts-list > div > p {
+      #posts-list > li > p {
         display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 3;


### PR DESCRIPTION
## Summary
- `<ul id=\"posts-list\">` was rendering `<div>` children — invalid HTML, since `<ul>` only allows `<li>`.
- Move the row to `<li>` and carry `data-row-id` / `data-kind` directly on it.
- Update `#posts-list > div` → `#posts-list > li` in `base.html` CSS and the 18 selectors in `test_posts.py`.

## Test plan
- [x] `dev test` (1017 passed, 52 skipped)
- [x] `dev lint`
- [ ] Eyeball the posts list page in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)