### PR TITLE
Render post-list meta as <dl> instead of <ul>

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -105,11 +105,14 @@ async def test_list_client_referral_item_shape(
     assert item is not None
     assert item.attributes.get("data-kind") == "client_referral"
 
-    # Kind chip: rendered when no `?kind=` filter is active.
+    # Kind chip: rendered when no `?kind=` filter is active. The chip
+    # attribute lives on the `<dl>` group wrapper `<div>`; the visible
+    # text is the `<dd>` (the `<dt>` label is visually hidden but in
+    # the DOM, so we read the `<dd>` directly for the visible value).
     chip = item.css_first("[data-kind-chip]")
     assert chip is not None
     assert chip.attributes.get("data-kind-chip") == "client_referral"
-    assert chip.text(strip=True) == "Seeking"
+    assert chip.css_first("dd").text(strip=True) == "Seeking"
 
     # Description is the link target — the lead text is the seeker's
     # own words, not a synthesized headline.
@@ -198,7 +201,7 @@ async def test_list_provider_availability_item_shape(
 
     chip = item.css_first("[data-kind-chip]")
     assert chip is not None
-    assert chip.text(strip=True) == "Providing"
+    assert chip.css_first("dd").text(strip=True) == "Providing"
 
     # Practice name is in <strong> inside the lead link.
     lead = item.css_first("a")
@@ -247,17 +250,20 @@ async def test_list_lead_contains_full_description_no_backend_truncation(
     assert lead.text(strip=True) == description
 
 
-async def test_list_meta_is_an_inline_list_of_li_chunks(
+async def test_list_meta_is_an_inline_dl_of_key_value_chunks(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """Each metadata fact is its own `<li>` inside a nested `<ul>`
-    after the title link — the inline-list pattern. The `·` visual
-    separator lives in CSS (`#posts-list > li > ul > li + li::before`)
-    rather than the markup, so the DOM text has no `·` glyphs. A
-    regression that collapsed the chunks back into a single
-    `·`-joined string (or onto the title line) would fail here.
+    """Each metadata fact is a `<dt>`/`<dd>` pair (wrapped in a
+    `<div>`, the HTML5 grouping construct inside `<dl>`) after the
+    title link. The `<dt>` label is visually hidden but read by
+    screen readers; the visible value is the `<dd><small>`. The `·`
+    visual separator lives in CSS (`#posts-list > li > dl > div +
+    div::before`) rather than the markup, so the DOM text has no `·`
+    glyphs. A regression that collapsed the chunks back into a
+    single `·`-joined string (or onto the title line) would fail
+    here.
 
     Also: no owner-username link in the listing row. The author lives
     on the detail page; the listing reads as Craigslist, not as a feed
@@ -285,22 +291,27 @@ async def test_list_meta_is_an_inline_list_of_li_chunks(
     item = tree.css_first("#posts-list > li")
     assert item is not None
 
-    # Metadata is a nested `<ul>` of `<li>` chunks above the title —
-    # the inline-list pattern. Date and the kind chip both live in
-    # this list so the whole line reads uniformly. The outer
-    # `#posts-list` `<ul>` keeps Pico-default bullets; the inner one
-    # is styled inline by CSS in base.html.
-    meta_chunks = item.css("ul > li")
+    # Metadata is a nested `<dl>` of `<div><dt><dd>` chunks above the
+    # title — the inline-list pattern. Date and the kind chip both
+    # live in this list so the whole line reads uniformly. The outer
+    # `#posts-list` `<ul>` strips bullets; the inner `<dl>` is styled
+    # inline (and its `<dt>` labels visually hidden) by CSS in
+    # base.html.
+    meta_chunks = item.css("dl > div")
     # date + Seeking + location + format + ages = 5 chunks.
     # (English-only languages are dropped by the macro since `en` is
     # the default; insurance is no longer in the listing meta —
     # readers go to the detail page for that.)
     assert len(meta_chunks) == 5
-    rendered = [li.text(strip=True) for li in meta_chunks]
-    # The first chunk is the formatted date — content depends on
-    # `now()`, so just check it's non-empty rather than pin a value.
-    assert rendered[0]
-    assert rendered[1:] == [
+    # Each chunk has both a `<dt>` label and a `<dd>` value — the
+    # screen-reader announcement is "Date: May 15", not bare "May 15".
+    labels = [chunk.css_first("dt").text(strip=True) for chunk in meta_chunks]
+    values = [chunk.css_first("dd").text(strip=True) for chunk in meta_chunks]
+    assert labels == ["Date", "Kind", "Location", "Format", "Age groups"]
+    # The first chunk's value is the formatted date — content depends
+    # on `now()`, so just check it's non-empty rather than pin a value.
+    assert values[0]
+    assert values[1:] == [
         "Seeking",
         "Seattle, WA",
         "In-person",
@@ -325,7 +336,7 @@ async def test_list_renders_readable_date_format(
     """The leading date renders Craigslist-style (`May 15`) via the
     `format_post_date` Jinja filter — *not* the raw ISO `YYYY-MM-DD`
     that `post.created_at.date()` produced before. The date is the
-    first chunk in the meta `<ul>`."""
+    first chunk in the meta `<dl>`."""
     from datetime import datetime, timezone
 
     author = create_test_user(username=f"author-{uuid.uuid4()}")
@@ -342,8 +353,9 @@ async def test_list_renders_readable_date_format(
     tree = HTMLParser(response.text)
     item = tree.css_first("#posts-list > li")
     assert item is not None
-    # First chunk of the meta `<ul>` is the leading date.
-    date_cell = item.css_first("ul > li")
+    # First chunk of the meta `<dl>` is the leading date — its `<dd>`
+    # value carries the formatted text.
+    date_cell = item.css_first("dl > div dd")
     assert date_cell is not None
     rendered = date_cell.text(strip=True)
     # `May 15` for current-year posts; `May 15, 2025` once we cross a

--- a/src/domain/templates/posts/_item.html
+++ b/src/domain/templates/posts/_item.html
@@ -7,17 +7,19 @@ inside `<ul id="posts-list">` — `<li>` is the only valid child of
 No per-post framing, no card styling, just the meta line and title
 flowing as content. Bespoke CSS is reduced to two patterns both
 scoped under `#posts-list > li`: the inline-list rules for the meta
-`<ul>`, and the line-clamp rule for the title `<p>`.
+`<dl>`, and the line-clamp rule for the title `<p>`.
 
-The row is two lines: a meta `<ul>` above, a title `<p>` below.
+The row is two lines: a meta `<dl>` above, a title `<p>` below.
 Meta carries every fact about the post — date, kind chunk (Seeking
 or Providing — colored via the `[data-kind-chip]` attribute selector
-on the `<li>` wrapper), location, in-person / virtual format, age
-groups, and languages when non-default — each chunk inside its own
-`<li><small>…</small></li>`. The inline-list
-CSS in `base.html` flips the children to `display: inline` and
-inserts a `·` between adjacent siblings via `::before`, so the
-separator lives in CSS rather than markup. The title `<p>` is
+on the `<div>` wrapper), location, in-person / virtual format, age
+groups, and languages when non-default — each fact is a `<dt>` label
+(visually hidden, announced by screen readers) plus a `<dd><small>`
+value, wrapped in a `<div>` (HTML5 permits `<div>` grouping inside
+`<dl>`). The inline-list CSS in `base.html` flips the `<div>`
+wrappers to `display: inline` and inserts a `·` between adjacent
+siblings via `::before`, so the separator lives in CSS rather than
+markup. The title `<p>` is
 `display: -webkit-box` with `-webkit-line-clamp: 2`, so long
 descriptions clamp visually to two lines with an ellipsis but stay
 in the DOM (search engines, `?q=` ILIKE, and screen readers all see
@@ -40,7 +42,7 @@ post is about:
 `active_kind` (passed via `row_kwargs`) hides the kind chunk when the
 page is filtered to a single kind — the chunk would be constant for
 every row; tests assert presence/absence via the `[data-kind-chip]`
-attribute on the meta `<li>`. The leading date renders via the
+attribute on the meta `<div>` wrapper. The leading date renders via the
 `format_post_date` filter — see
 [`src/framework/rendering/templating.py`](../../../framework/rendering/templating.py).
 Insurance posture (in-network, sliding scale, etc.) is *not* in the
@@ -49,10 +51,12 @@ the detail page for posture and carrier specifics.
 #}
 
 {% macro _meta_chunks(post, active_kind=None) -%}
-{# Yields one `<li><small>...</small></li>` per metadata chunk. The
-   wrapper `<ul>` in `post_item` styles them inline (see the
-   `#posts-list ul` rules in `base.html`); a `·` separator is inserted
-   via CSS `::before` rather than the markup. #}
+{# Yields one `<div><dt>Label</dt><dd><small>Value</small></dd></div>`
+   per metadata chunk. The wrapper `<dl>` in `post_item` styles them
+   inline (see the `#posts-list dl` rules in `base.html`); a `·`
+   separator is inserted via CSS `::before` rather than the markup.
+   `<dt>` labels are visually hidden but announced by screen readers,
+   so each chunk reads as the key/value pair it actually is. #}
 {%- if post.kind == "client_referral" -%}
   {%- set d = post.client_referral_detail -%}
   {%- set kind_label = "Seeking" -%}
@@ -69,25 +73,25 @@ the detail page for posture and carrier specifics.
   {%- set in_person = p.in_person_sessions -%}
   {%- set virtual = p.virtual_sessions -%}
 {%- endif -%}
-<li><small>{{ post.created_at | format_post_date }}</small></li>
+<div><dt>Date</dt><dd><small>{{ post.created_at | format_post_date }}</small></dd></div>
 {%- if active_kind is none %}
-<li data-kind-chip="{{ post.kind }}"><small>{{ kind_label }}</small></li>
+<div data-kind-chip="{{ post.kind }}"><dt>Kind</dt><dd><small>{{ kind_label }}</small></dd></div>
 {%- endif -%}
-{%- if city and state %}<li><small>{{ city }}, {{ state }}</small></li>{% endif %}
+{%- if city and state %}<div><dt>Location</dt><dd><small>{{ city }}, {{ state }}</small></dd></div>{% endif %}
 {%- set fmt = [] -%}
 {%- if in_person == "yes" -%}{%- set _ = fmt.append("In-person") -%}{%- endif -%}
 {%- if virtual == "yes" -%}{%- set _ = fmt.append("Virtual") -%}{%- endif -%}
-{%- if fmt %}<li><small>{{ fmt | join(" + ") }}</small></li>{% endif %}
+{%- if fmt %}<div><dt>Format</dt><dd><small>{{ fmt | join(" + ") }}</small></dd></div>{% endif %}
 {%- if d.age_groups %}
   {%- set ages = [] -%}
   {%- for g in d.age_groups[:2] -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
   {%- if d.age_groups | length > 2 -%}{%- set _ = ages.append("+" ~ (d.age_groups | length - 2)) -%}{%- endif -%}
-<li><small>{{ ages | join(", ") }}</small></li>{% endif %}
+<div><dt>Age groups</dt><dd><small>{{ ages | join(", ") }}</small></dd></div>{% endif %}
 {%- if d.languages and not (d.languages | length == 1 and d.languages[0] == "en") %}
   {%- set langs = [] -%}
   {%- for l in d.languages[:2] -%}{%- set _ = langs.append(LANGUAGE_LABELS[l]) -%}{%- endfor -%}
   {%- if d.languages | length > 2 -%}{%- set _ = langs.append("+" ~ (d.languages | length - 2)) -%}{%- endif -%}
-<li><small>{{ langs | join(", ") }}</small></li>{% endif %}
+<div><dt>Languages</dt><dd><small>{{ langs | join(", ") }}</small></dd></div>{% endif %}
 {%- endmacro %}
 
 {% macro post_item(post, active_kind=None) -%}
@@ -98,7 +102,7 @@ the detail page for posture and carrier specifics.
   {%- set p = d.provider -%}
 {%- endif -%}
 <li data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
-  <ul>{{ _meta_chunks(post, active_kind=active_kind) }}</ul>
+  <dl>{{ _meta_chunks(post, active_kind=active_kind) }}</dl>
   <p>
     <a href="/posts/{{ post.id }}">
       {%- if post.kind == "client_referral" -%}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -37,11 +37,14 @@
          patterns, both scoped under `#posts-list > li` (each post
          row is an `<li>`, the only valid child of the outer `<ul>`):
 
-         1. Each post's meta `<ul>` is an inline-list — `<li>`
-            children flow inline, and `::before` on adjacent siblings
-            inserts a `·` separator that lives in CSS rather than
-            markup. Pico's default `<ul>` would render vertically
-            with bullets; this flips it to a single inline row.
+         1. Each post's meta `<dl>` is an inline-list — `<div>`
+            groups (each wrapping a `<dt>` label + `<dd>` value)
+            flow inline, and `::before` on adjacent siblings inserts
+            a `·` separator that lives in CSS rather than markup.
+            `<dt>` labels are visually hidden (announced by screen
+            readers, invisible on screen) so the visual row stays a
+            single inline strip while the semantics describe each
+            fact as the key/value pair it actually is.
          2. Each post's title `<p>` clamps to 3 lines visually with
             an ellipsis. Long descriptions stay in the DOM so `?q=`
             ILIKE, search engines, and screen readers all see them.
@@ -51,9 +54,19 @@
          — no bespoke CSS for the frame itself. */
       #posts-list { list-style: none; padding: 0; margin: 0; }
       #posts-list > li { margin-block: 1.25rem; }
-      #posts-list > li > ul { padding: 0; margin: 0; list-style: none; }
-      #posts-list > li > ul > li { display: inline; }
-      #posts-list > li > ul > li + li::before { content: " · "; color: var(--pico-muted-color); }
+      #posts-list > li > dl { padding: 0; margin: 0; }
+      #posts-list > li > dl > div { display: inline; }
+      #posts-list > li > dl > div + div::before { content: " · "; color: var(--pico-muted-color); }
+      #posts-list > li > dl dd { display: inline; margin: 0; }
+      #posts-list > li > dl dt {
+        position: absolute;
+        width: 1px; height: 1px;
+        padding: 0; margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
       /* Kind-chip color differentiation. `[data-kind-chip]` sits on the
          <li> wrapper in the meta line (and on a <span> in the detail
          header). Color the contained text so Seeking vs Providing reads


### PR DESCRIPTION
## Summary
- Each post-list meta chunk (date, kind, location, format, age groups, languages) is a key/value pair — semantically a `<dl>`, not an unordered `<ul>`.
- Each fact becomes `<div><dt>Label</dt><dd><small>Value</small></dd></div>`. `<dt>` labels are visually hidden via the standard clip pattern but read by screen readers, so the announcement becomes "Date: May 15" / "Kind: Seeking" / "Location: Seattle, WA" instead of a bare run of values.
- Detail templates (`posts/detail.html`, `providers/detail.html`, `users/detail.html`) already use `<dl>` for the same data, so this brings the listing in line. `[data-kind-chip]` moves to the wrapper `<div>`; CSS now styles `#posts-list > li > dl` inline.

Follow-up to #495 (the `<li>` wrapper fix that's already merged).

## Test plan
- [x] `dev test` (1017 passed, 52 skipped)
- [x] `dev lint`
- [ ] Eyeball the posts list page; confirm visible row is unchanged and screen reader announces "Date / Kind / Location / Format / Age groups / Languages" labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)