### PR TITLE
Switch Pico to the fluid-classless build

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -8,7 +8,7 @@
     <title>Bedlam Connect</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+      href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.fluid.classless.min.css" />
     {# Density overrides. Pico's defaults are generous (~1rem spacing, 1.5
        line-height, large H1). These tokens tighten the scale globally so
        templates stay vanilla Pico semantics without per-page overrides.


### PR DESCRIPTION
## Summary
- Replace `pico.min.css` with `pico.fluid.classless.min.css` — the fluid-viewport variant of Pico v2.
- `<main class="container">` / `<header class="container">` keep their markup; in the classless build the `.container` class is a no-op, but element-level styling makes `<main>` and `<header>` full-width by default, which is the point.

## Known fallout — eyeball before merging
- `<div class="grid">` (provider/post forms — `posts/_client_referral_form.html`, `providers/form_new.html`, `providers/form_edit.html`) loses its CSS grid because `.grid` isn't in the classless build. Fields will stack vertically instead of side-by-side. If we want to keep side-by-side, follow-up options:
  - Add a small bespoke `.grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--pico-spacing); }` rule in the `<style>` block.
  - Replace `class="grid"` markup with raw CSS grid wrappers.

## Test plan
- [x] `dev test` (1017 passed, 52 skipped)
- [x] `dev lint`
- [ ] Visit `/posts`, `/providers/new`, `/providers/<id>/edit` and confirm layout is acceptable (or note the grid regression and follow up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)