### PR TITLE
Add Referrals / Openings / Directory shortcuts to primary nav

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -23,17 +23,61 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """Authenticated pages render the primary nav with a single
-    `/users/me` profile shortcut. Section links (Posts / Users /
-    Providers / Favorites) and the create-post CTA are reachable
+    """Authenticated pages render the primary nav with section
+    shortcuts (Referrals / Openings / Directory) on the left and a
+    single `/users/me` profile shortcut on the right. Other section
+    links (Users / Favorites) and the create-post CTA are reachable
     from within their pages rather than from the top-level chrome."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    nav_items = tree.css("#primary-nav > li > a")
-    hrefs = {a.attributes.get("href") for a in nav_items}
-    assert hrefs == {"/users/me"}
+    profile_items = tree.css("#primary-nav > li > a")
+    profile_hrefs = {a.attributes.get("href") for a in profile_items}
+    assert profile_hrefs == {"/users/me"}
+    section_items = tree.css('nav[aria-label="Primary"] > ul:first-of-type > li > a')
+    section_hrefs = [a.attributes.get("href") for a in section_items]
+    # Brand link is `<li><strong><a>` so the `> li > a` direct-child
+    # selector picks up only the section shortcuts (Referrals /
+    # Openings / Directory) in render order.
+    assert section_hrefs == [
+        "/posts?kind=client_referral",
+        "/posts?kind=provider_availability",
+        "/providers",
+    ]
+
+
+async def test_primary_nav_highlights_active_section(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """The Posts list is one route partitioned by `?kind=`, so the
+    Referrals and Openings shortcuts only light up when both the path
+    and the `kind` query param match. Directory matches any path under
+    `/providers`."""
+    referrals = await authenticated_client.get("/posts?kind=client_referral")
+    tree = HTMLParser(referrals.text)
+    assert (
+        tree.css_first(
+            'nav[aria-label="Primary"] a[href="/posts?kind=client_referral"]'
+        ).attributes.get("aria-current")
+        == "page"
+    )
+    assert (
+        tree.css_first(
+            'nav[aria-label="Primary"] a[href="/posts?kind=provider_availability"]'
+        ).attributes.get("aria-current")
+        is None
+    )
+
+    directory = await authenticated_client.get("/providers")
+    tree = HTMLParser(directory.text)
+    assert (
+        tree.css_first('nav[aria-label="Primary"] a[href="/providers"]').attributes.get(
+            "aria-current"
+        )
+        == "page"
+    )
 
 
 async def test_base_template_renders_primary_nav_for_anonymous_visitors(

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -63,7 +63,7 @@ Every page extending `base.html` lands the same three-strip chrome above its con
 └───────────────────────────────────────────────────────────┘
 ```
 
-**Primary nav** lives in `base.html` and renders on every screen (authed *and* anonymous). Its right-side slot (`#primary-nav`) swaps the profile icon for a Login link depending on `is_authenticated`. Pages don't extend it.
+**Primary nav** lives in `base.html` and renders on every screen (authed *and* anonymous). The left-side slot carries the brand link plus (when authed) section shortcuts: Referrals (`/posts?kind=client_referral`), Openings (`/posts?kind=provider_availability`), Directory (`/providers`). The right-side slot (`#primary-nav`) swaps the profile icon for a Login link depending on `is_authenticated`. Active state is matched against `request.url.path` plus `request.query_params['kind']` for the kind-partitioned Posts links. Pages don't extend it.
 
 **Breadcrumb zone bar** (`{% block breadcrumb %}`, macro in `_shared/_breadcrumb.html`) renders Pico's native breadcrumb above the toolbar. Every authenticated page extends the block — chrome consistency is the goal. The shape follows the resource hierarchy `list > detail > edit/new`, each level appending one segment:
 

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -160,11 +160,27 @@
        auth gate. #}
     {%- set _on_profile = is_authenticated and (request.url.path == '/users/me' or request.url.path.startswith('/users/me/')) -%}
     {%- set _on_login = request.url.path == '/auth/login' -%}
+    {# Section shortcuts. Posts is one route partitioned by `?kind=`, so
+       Referrals/Openings disambiguate via the query param; Directory is
+       its own route under `/providers`. Active-state matching keeps
+       sub-paths highlighted (e.g. `/providers/42/edit` keeps Directory
+       lit) while only the bare `/posts` list with the matching `?kind=`
+       lights Referrals/Openings — detail pages drop the query param. #}
+    {%- set _post_kind = request.query_params.get('kind') if is_authenticated else none -%}
+    {%- set _on_posts_list = is_authenticated and request.url.path == '/posts' -%}
+    {%- set _on_referrals = _on_posts_list and _post_kind == 'client_referral' -%}
+    {%- set _on_openings = _on_posts_list and _post_kind == 'provider_availability' -%}
+    {%- set _on_directory = is_authenticated and (request.url.path == '/providers' or request.url.path.startswith('/providers/')) -%}
     <header>
       <nav aria-label="Primary">
         <ul>
           {# title-case-ignore: "Bedlam Connect" is a brand name #}
           <li><strong><a href="/" class="contrast">Bedlam Connect</a></strong></li>
+          {% if is_authenticated %}
+          <li><a href="/posts?kind=client_referral"{% if _on_referrals %} aria-current="page" class="contrast"{% endif %}>Referrals</a></li>
+          <li><a href="/posts?kind=provider_availability"{% if _on_openings %} aria-current="page" class="contrast"{% endif %}>Openings</a></li>
+          <li><a href="/providers"{% if _on_directory %} aria-current="page" class="contrast"{% endif %}>Directory</a></li>
+          {% endif %}
         </ul>
         <ul id="primary-nav">
           {% if is_authenticated %}

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -230,6 +230,10 @@ class _RequestStub:
         path = "/"
 
     url = _Url()
+    # `base.html` reads `request.query_params.get('kind')` to highlight
+    # the section-shortcut links; an empty mapping mirrors the no-query
+    # case for view-template unit tests.
+    query_params: dict[str, str] = {}
 
 
 def _request_stub() -> _RequestStub:


### PR DESCRIPTION
## Summary
- Add three section shortcuts to the primary nav (authed only): **Referrals** (`/posts?kind=client_referral`), **Openings** (`/posts?kind=provider_availability`), **Directory** (`/providers`).
- Active state matches `request.url.path` plus `request.query_params['kind']` so the kind-partitioned Posts links only light up on the bare list with the matching `?kind=`.
- Update the framework `README.md` paragraph on the primary nav and the `_RequestStub` used by `views/` template unit tests.

## Test plan
- [x] `dev test` (1025 passed)
- [x] `dev lint`
- [x] New test `test_primary_nav_highlights_active_section` covers `/posts?kind=client_referral` and `/providers` aria-current.
- [x] Existing `test_base_template_renders_primary_nav_when_authenticated` updated to pin the new section hrefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)