### PR TITLE
Refresh posts card: kind-aware demographics, modality chips, icon spacing

### DIFF
--- a/src/domain/templates/posts/_item.html
+++ b/src/domain/templates/posts/_item.html
@@ -77,15 +77,15 @@ per-kind, so a single-kind filter doesn't need to suppress anything.
 {%- if in_person == "please_contact" or virtual == "please_contact" -%}
 <span class="post-modality">Contact for format</span>
 {%- else -%}
-{%- if virtual == "yes" %}<span class="post-modality"><i class="icon-video" aria-hidden="true"></i> Virtual</span>{% endif -%}
-{%- if in_person == "yes" %}<span class="post-modality"><i class="icon-map-pin" aria-hidden="true"></i> In-person</span>{% endif -%}
+{%- if virtual == "yes" %}<span class="post-modality"><i class="icon-video" aria-hidden="true"></i>Virtual</span>{% endif -%}
+{%- if in_person == "yes" %}<span class="post-modality"><i class="icon-map-pin" aria-hidden="true"></i>In-person</span>{% endif -%}
 {%- endif -%}
 {%- endmacro %}
 
 {% macro _service_item(value, label_dict, icon_dict) -%}
 {#- One `<li>` for a service or setting: icon + label. The icon is
     decorative; the label carries the meaning for screen readers. -#}
-<li><i class="icon-{{ icon_dict[value] }}" aria-hidden="true"></i> {{ label_dict[value] }}</li>
+<li><i class="icon-{{ icon_dict[value] }}" aria-hidden="true"></i>{{ label_dict[value] }}</li>
 {%- endmacro %}
 
 {% macro post_item(post, active_kind=None) -%}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -81,11 +81,12 @@
       }
       /* In-person / virtual chips: icon + short label, muted color
          so the headline stays the visual lead. Flex items in the
-         header gap pick up the parent's 0.5rem separation. */
+         header gap pick up the parent's 0.5rem separation. Icon →
+         label spacing comes from the global icon rule below, not
+         a local `gap`. */
       #posts-list > article > header.post-header > .post-modality {
         display: inline-flex;
         align-items: center;
-        gap: 0.25rem;
         color: var(--pico-muted-color);
         font-size: 0.875rem;
       }
@@ -128,7 +129,6 @@
       #posts-list > article > .post-grid section.post-services > ul > li {
         display: flex;
         align-items: center;
-        gap: 0.4rem;
         padding: 0.1rem 0;
       }
       /* Demographics `<dl>`: one `<div>` per fact, "Label: value"
@@ -147,7 +147,10 @@
       #posts-list > article > .post-grid section.post-facts dt::after { content: ": "; }
       /* CR location chunk: `<dt>` is icon-only (`aria-label` carries
          meaning for screen readers), so suppress the trailing colon
-         that the generic rule above adds to every `<dt>`. */
+         that the generic rule above adds to every `<dt>`. Icon →
+         `<dd>` spacing comes from the icon's own `margin-inline-end`
+         (set in the global icon rule below), which extends past
+         the inline `<dt>` into the inline flow. */
       #posts-list > article > .post-grid section.post-facts dl > div.post-location > dt::after { content: ""; }
       #posts-list > article > .post-grid section.post-facts dl > div.post-location > dt { font-weight: normal; }
       #posts-list > article > .post-grid section.post-facts dd { display: inline; margin: 0; }
@@ -155,15 +158,28 @@
          only the listing row swaps the chip for the left edge. */
       [data-kind-chip="client_referral"] { color: darkorange; font-weight: 600; }
       [data-kind-chip="provider_availability"] { color: darkcyan; font-weight: 600; }
-      /* Lucide icon sizing tuned for the inline service icons.
-         `color: inherit` lets each icon pick up the surrounding text
-         color — so an icon inside a `<small>` or a `.secondary`
-         button matches the text next to it. */
+      /* Lucide icons — single source of truth for sizing AND
+         spacing. `color: inherit` lets each icon pick up the
+         surrounding text color (so an icon inside a `<small>` or a
+         `.secondary` button matches the text next to it).
+         `margin-inline-end` is applied unconditionally so the
+         canonical "icon to the left of a label" pattern —
+         `<button><i class="icon-x"></i>Save</button>`,
+         `<span><i class="icon-x"></i>Label</span>`,
+         `<dt><i class="icon-x"></i></dt><dd>Value</dd>` — works in
+         any container without per-component flex `gap` or literal
+         HTML whitespace. A conditional rule (e.g.
+         `:not(:last-child)`) wouldn't work: CSS structural
+         pseudo-classes count element siblings only, so an `<i>`
+         followed by a bare text node is still `:last-child` and
+         would be excluded. Icons that genuinely need no trailing
+         space (icon-only buttons, etc.) should override locally. */
       [class^="icon-"], [class*=" icon-"] {
         font-size: 1.1em;
         vertical-align: -0.15em;
         line-height: 1;
         color: inherit;
+        margin-inline-end: 0.25em;
       }
       /* Page-scoped zone bar. Every page that needs page-scoped
          controls renders a single `<div class="toolbar">` strip


### PR DESCRIPTION
## Summary

Refresh of the posts listing card across five commits, ending with a DRY consolidation of Lucide icon spacing.

- Rename PA age label from \"Treats\" to \"Ages\"; kind-aware age labels; simplify gender labels; bare CR contact band.
- Surface in-person/virtual posture as icon chips next to the headline (`📹 Virtual`, `📍 In-person`).
- Recompose the CR card: age + gender headline, demoted state into a location chunk (icon-only \`<dt>\` + city, ST), header/footer bands.
- Footer Email CTA + Pico classful container; nameless contact band (the headline already names the contact).
- Centralize Lucide icon spacing into a single \`margin-inline-end\` on \`[class^=\"icon-\"]\`; drop per-component flex \`gap\` and the per-row \`<dt>\` margin; remove redundant whitespace in templates.

## Test plan

- [x] \`dev test src/domain/routes/test_posts.py\` (85 passed)
- [ ] Visual check: CR card, PA card, modality chips, services list, location chunk all render with correct icon spacing
- [ ] Visual check: navbar profile icon unaffected (inlined SVG, not \`class=\"icon-*\"\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)