### PR TITLE
Cleanup: dead exports, double-tagging, route-file imports

### DIFF
--- a/src/domain/routes/README.md
+++ b/src/domain/routes/README.md
@@ -13,7 +13,7 @@ The URL shape, lifecycle, and subresource conventions every resource MUST follow
 
 ```python
 from src.domain.specs.<entity> import <ENTITY>_ENTITY
-from src.framework.dispatch.registry import register_entity
+from src.framework import register_entity
 from src.framework.dispatch.resource_routes import mount_entity
 
 router = register_entity(<ENTITY>_ENTITY)

--- a/src/domain/routes/favorites.py
+++ b/src/domain/routes/favorites.py
@@ -20,7 +20,7 @@ from src.domain.logic.favorites.handlers import (
     handle_remove_favorite,
 )
 from src.domain.specs.user_favorite import FAVORITE_ENTITY
-from src.framework.dispatch.registry import register_entity
+from src.framework import register_entity
 from src.framework.dispatch.resource_routes import mount_edge_routes
 
 router = register_entity(FAVORITE_ENTITY)

--- a/src/domain/routes/organizations.py
+++ b/src/domain/routes/organizations.py
@@ -1,5 +1,5 @@
 from src.domain.specs.organization import ORGANIZATION_ENTITY
-from src.framework.dispatch.registry import register_entity
+from src.framework import register_entity
 from src.framework.dispatch.resource_routes import mount_entity
 
 router = register_entity(ORGANIZATION_ENTITY)

--- a/src/domain/routes/posts.py
+++ b/src/domain/routes/posts.py
@@ -1,5 +1,5 @@
 from src.domain.specs.post import POST_ENTITY
-from src.framework.dispatch.registry import register_entity
+from src.framework import register_entity
 from src.framework.dispatch.resource_routes import mount_entity
 
 router = register_entity(POST_ENTITY)

--- a/src/domain/routes/providers.py
+++ b/src/domain/routes/providers.py
@@ -2,7 +2,7 @@ from src.domain.specs.provider import PROVIDER_ENTITY
 from src.domain.specs.provider_certification import CERTIFICATION_ENTITY
 from src.domain.specs.provider_education import EDUCATION_ENTITY
 from src.domain.specs.provider_licensure import LICENSURE_ENTITY
-from src.framework.dispatch.registry import register_entity
+from src.framework import register_entity
 from src.framework.dispatch.resource_routes import mount_entity
 
 router = register_entity(PROVIDER_ENTITY)

--- a/src/domain/routes/users.py
+++ b/src/domain/routes/users.py
@@ -1,5 +1,5 @@
 from src.domain.specs.user import USER_ENTITY
-from src.framework.dispatch.registry import register_entity
+from src.framework import register_entity
 from src.framework.dispatch.resource_routes import mount_entity
 
 router = register_entity(USER_ENTITY)
@@ -15,4 +15,4 @@ router = register_entity(USER_ENTITY)
 #   - providers — related-list subresource, same `handler_path` path.
 # Detail extras (`user_detail_extras` + the provider repo it needs)
 # live on the spec via `detail_extras_path`.
-mount_entity(router, USER_ENTITY, handlers={})
+mount_entity(router, USER_ENTITY)

--- a/src/framework/__init__.py
+++ b/src/framework/__init__.py
@@ -1,6 +1,7 @@
 # Convenience re-exports for the most-used framework symbols.
 
-from .dispatch.base_router import BaseRouter, make_entity_router
+from .dispatch.base_router import BaseRouter
+from .dispatch.registry import register_entity
 from .http.decorators import handle_route_errors
 from .http.exceptions import (
     APIException,
@@ -19,20 +20,20 @@ from .http.responses import (
 )
 
 __all__ = [
-    "APIResponse",
-    "handle_route_errors",
     "APIException",
-    "NotFoundError",
+    "APIResponse",
     "BadRequestError",
-    "ForbiddenError",
-    "handle_fastapi_users_error",
     "BaseRouter",
-    "make_entity_router",
+    "ForbiddenError",
+    "NotFoundError",
     "created_response",
     "deleted_response",
+    "handle_fastapi_users_error",
+    "handle_route_errors",
     "parse_and_validate_form",
     "parse_form_to_payload",
     "refreshed_response",
+    "register_entity",
     "updated_response",
     "validate_or_422",
 ]

--- a/src/framework/dispatch/base_router.py
+++ b/src/framework/dispatch/base_router.py
@@ -13,13 +13,9 @@ class BaseRouter:
         self,
         router: APIRouter,
         default_tags: Optional[List[str]] = None,
-        default_dependencies: Optional[List[Depends]] = None,
     ):
         self.router = router
         self.default_tags = default_tags if default_tags is not None else []
-        self.default_dependencies = (
-            default_dependencies if default_dependencies is not None else []
-        )
 
     def add_api_route(
         self,
@@ -39,10 +35,6 @@ class BaseRouter:
         if tags:
             route_tags.extend(tags)
 
-        route_dependencies = list(self.default_dependencies)
-        if dependencies:
-            route_dependencies.extend(dependencies)
-
         decorated_endpoint = endpoint
         if apply_common_decorators:
             decorated_endpoint = handle_route_errors(decorated_endpoint)
@@ -53,7 +45,7 @@ class BaseRouter:
             decorated_endpoint,
             methods=methods,
             tags=list(set(route_tags)),  # Ensure unique tags
-            dependencies=route_dependencies,
+            dependencies=dependencies or [],
             **kwargs,
         )
 
@@ -103,18 +95,15 @@ class BaseRouter:
         return decorator
 
 
-def make_entity_router(entity: "EntitySpec") -> BaseRouter:
+def _make_entity_router(entity: "EntitySpec") -> BaseRouter:
     """Build a `BaseRouter` for `entity` with prefix + tags derived from the spec.
 
-    The prefix is ``f"/{entity.url_collection}"`` by default; entities
-    whose URL doesn't fit the convention (favorites lives under
-    ``/users/me/favorites``) set ``prefix_override`` on the spec.
-    Default tags are ``[entity.url_collection]``.
-
-    Route files don't call this directly — they call
+    Framework-internal. Route files call
     :func:`src.framework.dispatch.registry.register_entity`, which wraps
-    this helper with the registry append. See that function's docstring
-    for the full lifecycle.
+    this helper and adds the registry bookkeeping. The prefix is
+    ``f"/{entity.url_collection}"`` unless the spec sets
+    ``prefix_override`` (favorites lives at ``/users/me/favorites``);
+    default tags are ``[entity.url_collection]``.
     """
     prefix = (
         entity.prefix_override
@@ -125,26 +114,3 @@ def make_entity_router(entity: "EntitySpec") -> BaseRouter:
         router=APIRouter(prefix=prefix),
         default_tags=[entity.url_collection],
     )
-
-
-# Example of how to use this BaseRouter:
-# from fastapi import FastAPI
-# app = FastAPI()
-#
-# # In your main app or a specific module router setup
-# main_router_instance = APIRouter(prefix="/api/v1")
-# base_router_helper = BaseRouter(router=main_router_instance, default_tags=["API_V1"])
-#
-# # In a specific route file, e.g., items_routes.py
-# # items_api_router = APIRouter() # This APIRouter instance is passed to BaseRouter
-# # items_router = BaseRouter(router=items_api_router, default_tags=["Items"])
-#
-# @base_router_helper.get("/items/{item_id}")
-# async def read_item(item_id: int, q: Optional[str] = None):
-#     return {"item_id": item_id, "q": q}
-#
-# @base_router_helper.post("/items", status_code=201)
-# async def create_item(item_name: str):
-#     return {"name": item_name}
-#
-# app.include_router(main_router_instance)

--- a/src/framework/dispatch/registry.py
+++ b/src/framework/dispatch/registry.py
@@ -12,7 +12,7 @@ Lifecycle:
 
 * Each entity route file under ``src/domain/routes/`` calls
   :func:`register_entity` at import time; the call constructs the
-  ``BaseRouter`` (via :func:`make_entity_router`), appends the
+  ``BaseRouter`` (via :func:`_make_entity_router`), appends the
   ``(spec, fastapi_router)`` pair to the module-level registry, and
   returns the ``BaseRouter`` so the caller can mount handlers on it.
 * ``src/domain/routes/__init__.py`` imports every entity route module —
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Final
 
 from fastapi import APIRouter
 
-from .base_router import BaseRouter, make_entity_router
+from .base_router import BaseRouter, _make_entity_router
 
 if TYPE_CHECKING:
     from .entity_spec import EntitySpec
@@ -86,7 +86,7 @@ def register_entity(spec: "EntitySpec") -> BaseRouter:
 
     .. code-block:: python
 
-        router = make_entity_router(SPEC)
+        router = _make_entity_router(SPEC)
         spec_api_router = router.router
 
     with
@@ -98,6 +98,6 @@ def register_entity(spec: "EntitySpec") -> BaseRouter:
     The caller still mounts handlers on ``router`` exactly as before —
     ``register_entity`` only adds the registry bookkeeping.
     """
-    router = make_entity_router(spec)
+    router = _make_entity_router(spec)
     entity_registry.register(spec, router.router)
     return router

--- a/src/framework/dispatch/test_base_router.py
+++ b/src/framework/dispatch/test_base_router.py
@@ -1,9 +1,10 @@
-"""Tests for `make_entity_router` — the helper that collapses the
-APIRouter + BaseRouter scaffolding per route file.
+"""Tests for `_make_entity_router` — the framework-internal helper that
+constructs the `BaseRouter` for an entity. Route files don't call it
+directly; they call `register_entity` (which wraps it and adds registry
+bookkeeping). This module isolates the construction step.
 
 `BaseRouter` itself has implicit coverage via every route test that
-goes through a real route; this module isolates the construction
-helper.
+goes through a real route.
 """
 
 from types import SimpleNamespace
@@ -12,7 +13,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from src.framework.audit.core import AuditAction, AuditedResource, make_snapshotter
-from src.framework.dispatch.base_router import BaseRouter, make_entity_router
+from src.framework.dispatch.base_router import BaseRouter, _make_entity_router
 from src.framework.dispatch.entity_spec import AUTHENTICATED, EntitySpec, RouteSet
 
 
@@ -46,26 +47,26 @@ def _spec(**overrides) -> EntitySpec:
 
 def test_default_prefix_derives_from_url_collection():
     """No `prefix_override` → prefix is `/<url_collection>`."""
-    router = make_entity_router(_spec())
+    router = _make_entity_router(_spec())
     assert isinstance(router, BaseRouter)
     assert isinstance(router.router, APIRouter)
     assert router.router.prefix == "/widgets"
 
 
 def test_default_tags_are_url_collection():
-    router = make_entity_router(_spec())
+    router = _make_entity_router(_spec())
     assert router.default_tags == ["widgets"]
 
 
 def test_prefix_override_wins_over_default():
     """Favorites' edge entity uses `/users/me/favorites` — the helper
     honors the override and skips the `/url_collection` derivation."""
-    router = make_entity_router(_spec(prefix_override="/users/me/favorites"))
+    router = _make_entity_router(_spec(prefix_override="/users/me/favorites"))
     assert router.router.prefix == "/users/me/favorites"
 
 
 def test_prefix_override_does_not_affect_tags():
     """Tags stay tied to `url_collection` regardless of prefix override;
     the override is purely about URL shape."""
-    router = make_entity_router(_spec(prefix_override="/users/me/favorites"))
+    router = _make_entity_router(_spec(prefix_override="/users/me/favorites"))
     assert router.default_tags == ["widgets"]

--- a/src/main.py
+++ b/src/main.py
@@ -100,8 +100,11 @@ app.include_router(auth_pages.auth_pages_api_router)
 # then a single iteration over `entity_registry` — no `include_router`
 # line to forget per entity. Owned-subentity specs mount nested under
 # their parent's route file and are not registered here.
-for _spec, _router in entity_registry.entries():
-    app.include_router(_router, tags=[_spec.url_collection])
+# Tags come from each spec's `BaseRouter.default_tags`
+# (`register_entity` sets them to `[spec.url_collection]`); no need to
+# repeat them on `include_router`.
+for _, _router in entity_registry.entries():
+    app.include_router(_router)
 
 
 @app.get("/health")


### PR DESCRIPTION
Follow-up code-smell sweep from #521. No behavior change beyond de-duplicating OpenAPI tags.

## Smells fixed

1. **`mount_entity(..., handlers={})` redundancy** (`users.py`) — `mount_entity` defaults `handlers` to `None` with the same semantics. Only `users.py` was passing the explicit empty dict; dropped.

2. **`make_entity_router` was internal but publicly exported.** Now that `register_entity` is the public entry, `make_entity_router` only has one caller in the framework (`registry.py`) and one test (`test_base_router.py`). Renamed to `_make_entity_router` and dropped from `framework/__init__.py`'s `__all__`.

3. **`BaseRouter.default_dependencies` was dead code.** Every construction site only passed `router` + `default_tags`; the `default_dependencies` kwarg was never set externally. Removed the kwarg and the related list-merge in `add_api_route`.

4. **Stale 25-line example block at the bottom of `base_router.py`** showing manual `BaseRouter(router=..., default_tags=...)` instantiation. No entity route file uses that idiom anymore. Removed.

5. **`make_entity_router` docstring (mostly handled in #521)** — final polish pointing at `register_entity` as the public entry.

6. **Double-tagging on every entity route.** Verified at runtime:

   ```
   /organizations -> ['organizations', 'organizations']
   /posts -> ['posts', 'posts']
   ```

   `register_entity` sets `BaseRouter(default_tags=[url_collection])` (applied per `add_api_route`); `main.py` also passed `tags=[url_collection]` on `include_router`, which prepends tags onto every route in the included router. Dropped the `main.py` source; `BaseRouter.default_tags` is now the single source.

7. **Re-export `register_entity` from `src.framework`** so route files drop a `dispatch.registry` import line. (Tried to also re-export `mount_entity` but it introduces a circular import — `framework/__init__` → `dispatch.resource_routes` → `audit.core` → `domain.models` → `framework.audit.log` while `domain.models.__init__` is mid-load. Left `mount_entity` at its module path; route files import it directly. Noted in the commit message.)

## Verification

- `dev test` — 1121 passed.
- `dev lint` — clean.
- Runtime tag check on `/organizations`, `/posts`, `/providers`, `/users/me/favorites` — single tag per route now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)