### PR TITLE
Provider: add org_id FK + backfill from practice_name (#520)

### DIFF
--- a/alembic/versions/b1f9a3c5d7e2_add_provider_org_id_column.py
+++ b/alembic/versions/b1f9a3c5d7e2_add_provider_org_id_column.py
@@ -1,0 +1,49 @@
+"""add provider.org_id column (nullable)
+
+PR 2 of the Org/Program roadmap (#520), schema half. Adds
+``providers.org_id`` as a nullable FK to ``organizations.id``. The
+column is intentionally nullable here — the data backfill that
+populates every existing row, then promotes the column to ``NOT NULL``,
+lives in the follow-up data migration ``c2e0b4d6f8a3``.
+
+Per ``alembic/README.md``: schema-only here, data backfill is a
+separate file. Splitting the two keeps each migration small and
+reviewable; the backfill knows it can `SELECT` from a stable schema.
+
+Revision ID: b1f9a3c5d7e2
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-17
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b1f9a3c5d7e2"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "providers"
+_FK_NAME = "fk_providers_org_id_organizations"
+
+
+def upgrade() -> None:
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.add_column(sa.Column("org_id", sa.Uuid(), nullable=True))
+        batch_op.create_foreign_key(
+            _FK_NAME,
+            "organizations",
+            ["org_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_constraint(_FK_NAME, type_="foreignkey")
+        batch_op.drop_column("org_id")

--- a/alembic/versions/c2e0b4d6f8a3_backfill_provider_org_id.py
+++ b/alembic/versions/c2e0b4d6f8a3_backfill_provider_org_id.py
@@ -1,0 +1,166 @@
+"""backfill provider.org_id from practice_name
+
+PR 2 of the Org/Program roadmap (#520), data half. Walks the existing
+``providers`` rows grouped by ``practice_name``, creates one
+``Organization`` per distinct name, points every matching provider at
+it, then tightens ``providers.org_id`` to ``NOT NULL``.
+
+Per-group bookkeeping:
+
+* **One Org per distinct ``practice_name``** — the same practice run by
+  multiple owners still collapses to a single Org (PR 3 will revisit
+  whether that's the right default; today it preserves the "one
+  practice, one directory entry" reading users already have).
+* **Type:** ``solo_practice`` when the group has exactly one provider,
+  ``group_practice`` when it has more. Two tokens covers every existing
+  shape; admins can reclassify in PR 3+ once the create form exists.
+* **Owner:** the owner of the group's *lowest-``created_at``* provider —
+  deterministic so the migration is replayable.
+* **Root:** every backfill Org is its own root (``parent_org_id IS NULL``,
+  ``root_org_id = id``). Hierarchies are PR 4's concern.
+
+The downgrade defensively refuses if any ``organizations`` row exists
+that this migration didn't create (i.e. an Org with no referencing
+``providers`` row, or whose ``name`` no longer matches the referencing
+providers' ``practice_name``). Mirrors ``e7b3c2a8f1d4``'s pattern:
+don't silently destroy data that arrived after the migration.
+
+Revision ID: c2e0b4d6f8a3
+Revises: b1f9a3c5d7e2
+Create Date: 2026-05-17
+"""
+
+import uuid
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c2e0b4d6f8a3"
+down_revision: Union[str, None] = "b1f9a3c5d7e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Walk distinct practice_name values. For each, pick the lowest-
+    # created_at provider as the deterministic owner-source, count
+    # group size, then create the Org and point every matching row at it.
+    groups = bind.execute(sa.text("""
+            SELECT practice_name, COUNT(*) AS provider_count
+            FROM providers
+            WHERE org_id IS NULL
+            GROUP BY practice_name
+            """)).fetchall()
+
+    for group in groups:
+        owner_row = bind.execute(
+            sa.text("""
+                SELECT owner_id
+                FROM providers
+                WHERE practice_name = :practice_name AND org_id IS NULL
+                ORDER BY created_at ASC, id ASC
+                LIMIT 1
+                """),
+            {"practice_name": group.practice_name},
+        ).fetchone()
+        assert owner_row is not None  # group came from this same table
+
+        org_type = "solo_practice" if group.provider_count == 1 else "group_practice"
+        # SQLite's sqlite3 driver can't bind a uuid.UUID object; the
+        # Uuid type stores hex. Use .hex consistently (matches the
+        # pattern from 537ba27726f9).
+        org_id = uuid.uuid4().hex
+
+        bind.execute(
+            sa.text("""
+                INSERT INTO organizations (
+                    id, name, type, owner_id,
+                    parent_org_id, root_org_id,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, :name, :type, :owner_id,
+                    NULL, :id,
+                    CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                )
+                """),
+            {
+                "id": org_id,
+                "name": group.practice_name,
+                "type": org_type,
+                "owner_id": owner_row.owner_id,
+            },
+        )
+
+        bind.execute(
+            sa.text("""
+                UPDATE providers
+                SET org_id = :org_id
+                WHERE practice_name = :practice_name AND org_id IS NULL
+                """),
+            {"org_id": org_id, "practice_name": group.practice_name},
+        )
+
+    # Promote org_id to NOT NULL now that every row carries one.
+    with op.batch_alter_table("providers") as batch_op:
+        batch_op.alter_column("org_id", nullable=False)
+
+
+def downgrade() -> None:
+    """Refuse if any Org exists that this migration didn't create, then
+    null out every ``providers.org_id`` and delete the backfill-Orgs.
+
+    "Created by this migration" means: at least one provider currently
+    points at the Org via ``org_id`` AND every such provider's
+    ``practice_name`` equals the Org's ``name``. Anything else is data
+    the migration must not destroy."""
+    bind = op.get_bind()
+
+    # Find orgs the backfill couldn't possibly have created in its
+    # known shape. Two failure modes:
+    #
+    #   1) the Org has zero referencing providers (some other writer
+    #      created it post-migration);
+    #   2) at least one referencing provider's practice_name disagrees
+    #      with the Org's name (the mirror has been broken — the
+    #      migration's invariant no longer holds for this row).
+    suspect_orgs = bind.execute(sa.text("""
+            SELECT o.id, o.name
+            FROM organizations AS o
+            LEFT JOIN providers AS p ON p.org_id = o.id
+            GROUP BY o.id, o.name
+            HAVING COUNT(p.id) = 0
+                OR SUM(CASE WHEN p.practice_name = o.name THEN 0 ELSE 1 END) > 0
+            """)).fetchall()
+    if suspect_orgs:
+        names = ", ".join(f"{row.name!r}" for row in suspect_orgs)
+        raise RuntimeError(
+            f"cannot downgrade: {len(suspect_orgs)} organization(s) not "
+            f"created by this migration: {names}; resolve manually before "
+            "downgrading"
+        )
+
+    with op.batch_alter_table("providers") as batch_op:
+        batch_op.alter_column("org_id", nullable=True)
+
+    # Collect the org IDs we're about to delete BEFORE nulling out the
+    # FKs, otherwise the join can't tell us which orgs to drop.
+    backfill_org_ids = [
+        row.org_id
+        for row in bind.execute(
+            sa.text("SELECT DISTINCT org_id FROM providers WHERE org_id IS NOT NULL")
+        ).fetchall()
+    ]
+
+    bind.execute(sa.text("UPDATE providers SET org_id = NULL"))
+
+    if backfill_org_ids:
+        bind.execute(
+            sa.text("DELETE FROM organizations WHERE id IN :ids").bindparams(
+                sa.bindparam("ids", expanding=True)
+            ),
+            {"ids": backfill_org_ids},
+        )

--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -23,6 +23,7 @@ renders a spread of dates rather than a wall of identical timestamps.
 
 import asyncio
 import sys
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, TypedDict
 
@@ -35,6 +36,7 @@ from src.db import async_session_maker
 from src.domain.logic.users.schema import UserCreate
 from src.domain.models import (
     ClientReferralDetail,
+    Organization,
     Post,
     Provider,
     ProviderAvailabilityDetail,
@@ -920,7 +922,30 @@ async def seed_provider_availability() -> tuple[int, int]:
             )
             provider = provider_result.scalar_one_or_none()
             if provider is None:
-                provider = Provider(owner_id=owner.id, **fixture["provider"])
+                # PR 2 of the Org roadmap (#520) requires a Provider to
+                # carry an `org_id`. Find-or-create an Organization by
+                # name so seeded Providers cluster under the same Org
+                # the directory will eventually surface — keeps the
+                # mirror invariant (`provider.practice_name == org.name`)
+                # holding without forcing each fixture to declare its Org.
+                org_result = await session.execute(
+                    select(Organization).where(Organization.name == practice_name)
+                )
+                org = org_result.scalar_one_or_none()
+                if org is None:
+                    org = Organization(
+                        id=uuid.uuid4(),
+                        name=practice_name,
+                        type="solo_practice",
+                        owner_id=owner.id,
+                    )
+                    org.root_org_id = org.id
+                    session.add(org)
+                    await session.flush()
+
+                provider = Provider(
+                    owner_id=owner.id, org_id=org.id, **fixture["provider"]
+                )
                 session.add(provider)
                 await session.flush()
                 providers_created += 1

--- a/src/domain/logic/favorites/test_handlers.py
+++ b/src/domain/logic/favorites/test_handlers.py
@@ -31,7 +31,7 @@ from src.domain.models import AuditLog, User, UserFavorite
 from src.framework.audit.core import AuditAction
 from src.framework.audit.repository import AuditRepository
 from src.framework.http.exceptions import NotFoundError
-from tests.helpers import create_test_user, make_provider
+from tests.helpers import create_test_user, make_provider_with_org
 
 pytestmark = pytest.mark.asyncio
 
@@ -67,7 +67,7 @@ async def _seed_provider(
     practice_name: str = "Acme Health",
 ):
     owner = create_test_user(username=f"owner-{uuid.uuid4()}")
-    provider = make_provider(owner_id=owner.id, practice_name=practice_name)
+    provider = make_provider_with_org(owner_id=owner.id, practice_name=practice_name)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(owner)

--- a/src/domain/logic/favorites/test_repository.py
+++ b/src/domain/logic/favorites/test_repository.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.logic.favorites.repository import UserFavoriteRepository
 from src.domain.models import User, UserFavorite
-from tests.helpers import create_test_user, make_provider
+from tests.helpers import create_test_user, make_provider_with_org
 
 pytestmark = pytest.mark.asyncio
 
@@ -37,7 +37,7 @@ async def _seed_provider(
     practice_name: str = "Acme Health",
 ):
     owner = create_test_user(username=f"owner-{uuid.uuid4()}")
-    provider = make_provider(owner_id=owner.id, practice_name=practice_name)
+    provider = make_provider_with_org(owner_id=owner.id, practice_name=practice_name)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(owner)

--- a/src/domain/logic/posts/test_persistence.py
+++ b/src/domain/logic/posts/test_persistence.py
@@ -22,8 +22,8 @@ from src.framework.persistence.base_repository import BaseRepository
 from tests.helpers import (
     create_test_user,
     make_client_referral_detail,
-    make_provider,
     make_provider_availability_detail,
+    make_provider_with_org,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -45,7 +45,7 @@ async def _seed_owner_and_provider(db_test_session_manager, **provider_overrides
     in the DB to satisfy the FK.
     """
     owner = create_test_user(username=f"owner-{uuid.uuid4()}")
-    provider = make_provider(owner_id=owner.id, **provider_overrides)
+    provider = make_provider_with_org(owner_id=owner.id, **provider_overrides)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(owner)

--- a/src/domain/logic/providers/repository.py
+++ b/src/domain/logic/providers/repository.py
@@ -1,9 +1,11 @@
-from typing import Sequence
+import uuid
+from typing import Any, Sequence
 from uuid import UUID
 
 from sqlalchemy import select
 
-from src.domain.models import Provider, ProviderLicensure
+from src.domain.models import Organization, Provider, ProviderLicensure
+from src.framework.http.exceptions import NotFoundError
 from src.framework.persistence.base_repository import BaseRepository
 
 
@@ -71,3 +73,89 @@ class ProviderRepository(BaseRepository):
     # The framework's `handle_create` calls `repo.create(Provider(...))`
     # (the public alias on `BaseRepository`) directly — no `create_provider`
     # wrapper needed. Inline credential rows append via `repo.add_child`.
+    #
+    # The `create` / `patch` overrides below maintain the mirror invariant
+    # between ``Provider.practice_name`` and ``Provider.org.name`` —
+    # see ``src/domain/models/providers/README.md``. Mirrors the shape
+    # of ``OrganizationRepository`` (PR 1, roadmap).
+    # TODO(roadmap-pr-3): drop these overrides when ``practice_name``
+    # leaves Provider and reads switch to ``provider.org.name`` directly.
+
+    async def _find_or_create_org_for(
+        self, *, owner_id: UUID, practice_name: str
+    ) -> Organization:
+        """Resolve the Org for a Provider whose only Org-pointer is its
+        free-text ``practice_name``. PR 2 of the roadmap has no Org-
+        picker UI yet, so the repository auto-routes new Providers to
+        the Org with a matching name — find-or-create keyed on
+        ``Organization.name``. New Orgs are ``solo_practice`` rooted at
+        themselves; PR 3+ revisits classification when the explicit
+        Org-create form lands."""
+        stmt = select(Organization).filter(Organization.name == practice_name).limit(1)
+        org = (await self.session.execute(stmt)).scalars().first()
+        if org is not None:
+            return org
+        new_org = Organization(
+            id=uuid.uuid4(),
+            name=practice_name,
+            type="solo_practice",
+            owner_id=owner_id,
+        )
+        new_org.root_org_id = new_org.id
+        self.session.add(new_org)
+        await self.session.flush()
+        await self.session.refresh(new_org)
+        return new_org
+
+    async def create(self, obj: Provider) -> Provider:
+        """Override the framework's `create` to enforce the mirror
+        invariant ``provider.practice_name == provider.org.name``.
+
+        If the caller supplied ``org_id`` directly (no current writer
+        does today, but tests and PR 3's create form will), the FK is
+        validated and ``practice_name`` is overwritten from the Org's
+        name. Otherwise the repository find-or-creates an Org keyed on
+        ``practice_name``."""
+        if obj.org_id is None:
+            org = await self._find_or_create_org_for(
+                owner_id=obj.owner_id, practice_name=obj.practice_name
+            )
+            obj.org_id = org.id
+        else:
+            org = await self._get_by_id(Organization, obj.org_id)
+            if org is None:
+                raise NotFoundError(
+                    detail=f"Organization {obj.org_id} not found",
+                )
+        obj.practice_name = org.name
+        return await self._persist_new(obj)
+
+    async def patch(self, obj: Provider, **fields: Any) -> Provider:
+        """Override `patch` so any change touching the mirror columns
+        keeps ``practice_name`` and ``org.name`` in lockstep.
+
+        Three cases the override handles:
+        1. ``org_id`` in the payload → look up that Org, overwrite
+           ``practice_name`` with its ``name`` (and drop any conflicting
+           ``practice_name`` value from the payload).
+        2. ``practice_name`` in the payload (and ``org_id`` not) →
+           find-or-create an Org with that name, reassign ``org_id``,
+           write ``practice_name`` from the resolved Org.
+        3. Neither in the payload → pass straight through.
+        """
+        new_org_id = fields.get("org_id")
+        new_practice_name = fields.get("practice_name")
+        if new_org_id is not None:
+            org = await self._get_by_id(Organization, new_org_id)
+            if org is None:
+                raise NotFoundError(
+                    detail=f"Organization {new_org_id} not found",
+                )
+            fields["practice_name"] = org.name
+        elif new_practice_name is not None and new_practice_name != obj.practice_name:
+            org = await self._find_or_create_org_for(
+                owner_id=obj.owner_id, practice_name=new_practice_name
+            )
+            fields["org_id"] = org.id
+            fields["practice_name"] = org.name
+        return await self._patch(obj, **fields)

--- a/src/domain/logic/providers/test_handlers.py
+++ b/src/domain/logic/providers/test_handlers.py
@@ -38,10 +38,10 @@ from src.framework.dispatch.handlers import handle_create, handle_detail, handle
 from src.framework.http.exceptions import ForbiddenError, NotFoundError
 from tests.helpers import (
     create_test_user,
-    make_provider,
     make_provider_certification,
     make_provider_education,
     make_provider_licensure,
+    make_provider_with_org,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -86,7 +86,7 @@ async def _seed_provider(
     with_education: bool = False,
     with_certification: bool = False,
 ) -> tuple[uuid.UUID, uuid.UUID | None, uuid.UUID | None, uuid.UUID | None]:
-    provider = make_provider(owner_id=user_id)
+    provider = make_provider_with_org(owner_id=user_id)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)

--- a/src/domain/logic/providers/test_repository.py
+++ b/src/domain/logic/providers/test_repository.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.logic.providers.repository import ProviderRepository
 from src.domain.models import (
+    Organization,
     Provider,
     ProviderCertification,
     ProviderEducation,
@@ -24,10 +25,10 @@ from src.domain.models import (
 )
 from tests.helpers import (
     create_test_user,
-    make_provider,
     make_provider_certification,
     make_provider_education,
     make_provider_licensure,
+    make_provider_with_org,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -258,7 +259,7 @@ async def test_delete_provider_cascades_licensures(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            provider = make_provider(owner_id=user.id)
+            provider = make_provider_with_org(owner_id=user.id)
             session.add(provider)
             await session.flush()
             session.add(
@@ -338,8 +339,8 @@ async def test_list_providers_no_filters_returns_all(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            session.add(make_provider(owner_id=user_a.id))
-            session.add(make_provider(owner_id=user_b.id))
+            session.add(make_provider_with_org(owner_id=user_a.id))
+            session.add(make_provider_with_org(owner_id=user_b.id))
 
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
@@ -355,8 +356,8 @@ async def test_list_providers_filtered_by_license_type(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            provider_a = make_provider(owner_id=user_a.id)
-            provider_b = make_provider(owner_id=user_b.id)
+            provider_a = make_provider_with_org(owner_id=user_a.id)
+            provider_b = make_provider_with_org(owner_id=user_b.id)
             session.add_all([provider_a, provider_b])
             await session.flush()
             session.add(
@@ -385,8 +386,8 @@ async def test_list_providers_filtered_by_issuing_state(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            provider_a = make_provider(owner_id=user_a.id)
-            provider_b = make_provider(owner_id=user_b.id)
+            provider_a = make_provider_with_org(owner_id=user_a.id)
+            provider_b = make_provider_with_org(owner_id=user_b.id)
             session.add_all([provider_a, provider_b])
             await session.flush()
             session.add(
@@ -417,9 +418,9 @@ async def test_list_providers_combined_filter_is_anded(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            provider_a = make_provider(owner_id=user_a.id)
-            provider_b = make_provider(owner_id=user_b.id)
-            provider_c = make_provider(owner_id=user_c.id)
+            provider_a = make_provider_with_org(owner_id=user_a.id)
+            provider_b = make_provider_with_org(owner_id=user_b.id)
+            provider_c = make_provider_with_org(owner_id=user_c.id)
             session.add_all([provider_a, provider_b, provider_c])
             await session.flush()
             # A: matches both filters
@@ -458,7 +459,7 @@ async def test_list_providers_distinct_when_multiple_licensures_match(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            provider = make_provider(owner_id=user.id)
+            provider = make_provider_with_org(owner_id=user.id)
             session.add(provider)
             await session.flush()
             session.add(
@@ -494,7 +495,7 @@ async def test_licensure_crud_round_trip(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            provider = make_provider(owner_id=user.id)
+            provider = make_provider_with_org(owner_id=user.id)
             session.add(provider)
             await session.flush()
             provider_id = provider.id
@@ -540,7 +541,7 @@ async def test_education_crud_round_trip(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            provider = make_provider(owner_id=user.id)
+            provider = make_provider_with_org(owner_id=user.id)
             session.add(provider)
             await session.flush()
             provider_id = provider.id
@@ -585,7 +586,7 @@ async def test_certification_crud_round_trip(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            provider = make_provider(owner_id=user.id)
+            provider = make_provider_with_org(owner_id=user.id)
             session.add(provider)
             await session.flush()
             provider_id = provider.id
@@ -621,3 +622,134 @@ async def test_certification_crud_round_trip(
     async with db_test_session_manager() as session:
         repo = ProviderRepository(session)
         assert await repo.get_by_model_id(ProviderCertification, cert_id) is None
+
+
+# --- Org mirror invariant (PR 2 of the Org/Program roadmap, #520) ---------
+# `Provider.practice_name` is a temporary denormalized mirror of
+# `provider.org.name` while the directory transitions from free-text
+# practice names to Org-backed ones. The repository's `create` / `patch`
+# overrides enforce the mirror. PR 3 drops `practice_name` and these
+# tests with it; the colocation pins the invariant in the meantime.
+
+
+async def test_create_auto_finds_or_creates_org_from_practice_name(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Two providers created with the same `practice_name` collapse to a
+    single Org — `create`'s find-or-create keys on `Organization.name`."""
+    user_a = await _seed_user(db_test_session_manager)
+    user_b = await _seed_user(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderRepository(session)
+        p1 = await repo.create(
+            Provider(
+                owner_id=user_a.id,
+                practice_name="Shared Practice",
+                location_city="Chicago",
+                location_state="IL",
+                location_zip="60601",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+            )
+        )
+        p2 = await repo.create(
+            Provider(
+                owner_id=user_b.id,
+                practice_name="Shared Practice",
+                location_city="Chicago",
+                location_state="IL",
+                location_zip="60601",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+            )
+        )
+        await session.commit()
+        assert p1.org_id is not None
+        assert p1.org_id == p2.org_id
+        assert p1.practice_name == "Shared Practice"
+        assert p2.practice_name == "Shared Practice"
+
+
+async def test_create_mirrors_practice_name_from_existing_org(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """If the caller passes ``org_id`` explicitly, the override overwrites
+    ``practice_name`` from the Org's name — the Org is the source of truth."""
+    user = await _seed_user(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            org = Organization(
+                id=uuid.uuid4(),
+                name="Canonical Org Name",
+                type="clinic",
+                owner_id=user.id,
+            )
+            org.root_org_id = org.id
+            session.add(org)
+        org_id = org.id
+
+    async with db_test_session_manager() as session:
+        repo = ProviderRepository(session)
+        created = await repo.create(
+            Provider(
+                owner_id=user.id,
+                org_id=org_id,
+                practice_name="Wrong Name Caller Passed",
+                location_city="Chicago",
+                location_state="IL",
+                location_zip="60601",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+            )
+        )
+        await session.commit()
+        assert created.org_id == org_id
+        assert created.practice_name == "Canonical Org Name"
+
+
+async def test_patch_changing_org_id_rewrites_practice_name(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """A PATCH that swaps ``org_id`` pulls ``practice_name`` from the new
+    Org — keeps the mirror invariant after a reassignment."""
+    user = await _seed_user(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            other_org = Organization(
+                id=uuid.uuid4(),
+                name="Other Practice",
+                type="clinic",
+                owner_id=user.id,
+            )
+            other_org.root_org_id = other_org.id
+            session.add(other_org)
+        other_org_id = other_org.id
+
+    async with db_test_session_manager() as session:
+        repo = ProviderRepository(session)
+        provider = await repo.create(
+            Provider(
+                owner_id=user.id,
+                practice_name="Original Practice",
+                location_city="Chicago",
+                location_state="IL",
+                location_zip="60601",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+            )
+        )
+        await session.commit()
+        provider_id = provider.id
+        assert provider.practice_name == "Original Practice"
+
+    async with db_test_session_manager() as session:
+        repo = ProviderRepository(session)
+        provider = await repo.get_by_model_id(Provider, provider_id)
+        assert provider is not None
+        await repo.patch(provider, org_id=other_org_id)
+        await session.commit()
+        assert provider.org_id == other_org_id
+        assert provider.practice_name == "Other Practice"

--- a/src/domain/models/favorites/test_user_favorite_models.py
+++ b/src/domain/models/favorites/test_user_favorite_models.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.models import Provider, User, UserFavorite
-from tests.helpers import create_test_user, make_provider
+from tests.helpers import create_test_user, make_provider_with_org
 
 pytestmark = pytest.mark.asyncio
 
@@ -21,7 +21,7 @@ async def _seed_user_and_provider(
 ) -> tuple[User, Provider]:
     user = create_test_user()
     owner = create_test_user()
-    provider = make_provider(owner_id=owner.id)
+    provider = make_provider_with_org(owner_id=owner.id)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(user)

--- a/src/domain/models/organizations/README.md
+++ b/src/domain/models/organizations/README.md
@@ -1,12 +1,12 @@
 # Organizations cluster
 
-First-class directory entity for clinics, group practices, health systems, and solo-practice shells. PR 1 of the Org/Program roadmap — this cluster ships standalone; no relationships from `Organization` to `Provider` yet. The Provider migration onto `org_id` lands in PR 2.
+First-class directory entity for clinics, group practices, health systems, and solo-practice shells. PR 2 of the Org/Program roadmap (#520) wired Provider to Organization via `Provider.org_id` and surfaces a `providers` collection here.
 
 The parent layer's conventions (BaseModel inheritance, FK CASCADE, migration workflow) live in [`../README.md`](../README.md); this README covers what's specific to organizations.
 
 ## Files
 
-- `organization.py` — `Organization`. Hierarchy via a nullable self-FK `parent_org_id` and a denormalized non-nullable `root_org_id`. Tied to a `User` via non-unique `owner_id` FK + CASCADE (mirrors `Provider.owner_id` — one user may own many orgs). Enum column `type` CHECKs against `ORGANIZATION_TYPES` from [`../enums.py`](../enums.py).
+- `organization.py` — `Organization`. Hierarchy via a nullable self-FK `parent_org_id` and a denormalized non-nullable `root_org_id`. Tied to a `User` via non-unique `owner_id` FK + CASCADE (mirrors `Provider.owner_id` — one user may own many orgs). Enum column `type` CHECKs against `ORGANIZATION_TYPES` from [`../enums.py`](../enums.py). Exposes a `providers` collection via the `Provider.org_id` FK (PR 2 of the roadmap, #520); the FK is `ON DELETE RESTRICT`, so deleting an Org with Providers fails loudly rather than silently orphaning them.
 
 ## The `parent_org_id` + `root_org_id` invariant
 

--- a/src/domain/models/organizations/organization.py
+++ b/src/domain/models/organizations/organization.py
@@ -53,3 +53,9 @@ class Organization(BaseModel):
         remote_side="Organization.id",
         foreign_keys=[parent_org_id],
     )
+    # Providers that belong to this Org. PR 2 of the roadmap (#520).
+    # Cascade is FK-side ``RESTRICT`` (deleting an Org with Providers
+    # fails loudly rather than silently orphaning); the ORM relationship
+    # is read-only from the Org side. PR 3+ adds the create form that
+    # picks an Org explicitly.
+    providers = relationship("Provider", back_populates="org")

--- a/src/domain/models/providers/README.md
+++ b/src/domain/models/providers/README.md
@@ -26,6 +26,23 @@ Before this extraction the four model files were flat siblings of the rest of `s
 
 Pulling them into `providers/` makes the boundary explicit. The cross-cluster shared modules (the controlled-vocabulary tuples in [`../enums.py`](../enums.py), the `BaseModel` in [`src/framework/persistence/base_model.py`](../../../framework/persistence/base_model.py)) stay at the parent level because the `posts/` cluster also consumes them.
 
+## The `org_id` + `practice_name` mirror
+
+PR 2 of the Org/Program roadmap (#520). `Provider.org_id` is a NOT NULL FK to `organizations.id` — every Provider belongs to exactly one Org. `Provider.practice_name` exists alongside it as a **denormalized mirror** of `provider.org.name`.
+
+**The invariant: `provider.practice_name == provider.org.name`, for every row, at all times.**
+
+The mirror is enforced in [`../../logic/providers/repository.py`](../../logic/providers/repository.py) (`ProviderRepository.create` / `patch`), mirroring the shape `OrganizationRepository` uses for its own `root_org_id` denormalization (PR 1):
+
+- On `create`: if `org_id` is set, `practice_name` is overwritten from the Org's `name`. If `org_id` is unset (today's wire shape — no Org-picker in the create form yet), the repo find-or-creates an Org keyed on `practice_name` and assigns its id.
+- On `patch`: a change to `org_id` rewrites `practice_name` from the new Org; a change to `practice_name` find-or-creates an Org and reassigns `org_id`.
+
+**Why a mirror at all.** Templates, Pydantic schemas, contract tests, and repository queries currently read `provider.practice_name` directly (~100+ call sites). The mirror keeps those callers untouched in PR 2 — the migration vehicle costs one column and one repo override; the alternative was a multi-PR template / schema / contract sweep behind a feature flag.
+
+**Lifetime.** PR 3 of the roadmap drops `practice_name` and switches every reader to `provider.org.name`. The override and this section go with it. The repository override is marked `# TODO(roadmap-pr-3)` so the cleanup is grep-able.
+
+The two columns being required to agree is the only place this codebase deliberately violates the "one source of truth" rule in CLAUDE.md — it's load-bearing only because PR 3 is the next change.
+
 ## Adding a new credential sub-record type
 
 If the `Provider` directory entry needs a fourth credential category (e.g. board certifications distinct from professional certifications, malpractice insurance records, etc.):

--- a/src/domain/models/providers/provider.py
+++ b/src/domain/models/providers/provider.py
@@ -39,6 +39,16 @@ class Provider(LocationMixin, BaseModel):
         nullable=False,
     )
     user = relationship("User")
+    # `org_id` is the source of truth for which Organization this
+    # Provider belongs to. `practice_name` is a denormalized mirror of
+    # `org.name` — see the README for the invariant + lifetime.
+    # TODO(roadmap-pr-3): drop `practice_name` and read `org.name`.
+    org_id = Column(
+        Uuid(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    org = relationship("Organization", back_populates="providers")
     practice_name = Column(Text, nullable=False)
     in_person_sessions = Column(Text, nullable=False)
     virtual_sessions = Column(Text, nullable=False)

--- a/src/domain/models/providers/test_provider_models.py
+++ b/src/domain/models/providers/test_provider_models.py
@@ -18,22 +18,30 @@ from src.domain.models import (
     ProviderEducation,
     ProviderLicensure,
 )
-from tests.helpers import create_test_user
+from tests.helpers import create_test_user, make_organization_row
 
 pytestmark = pytest.mark.asyncio
 
 
 def _make_provider(user, **overrides) -> Provider:
+    """Build an unbound Provider wired to a fresh root Organization so
+    the PR 2 NOT-NULL ``org_id`` + mirror invariant hold at flush time.
+    Save-update cascade picks the Org up via ``provider.org``; callers
+    can keep their pre-PR-2 ``session.add(provider)`` shape."""
+    practice_name = overrides.pop("practice_name", "Acme Health")
+    org = make_organization_row(owner_id=user.id, name=practice_name)
     defaults = dict(
         user=user,
-        practice_name="Acme Health",
+        practice_name=practice_name,
         location_city="Springfield",
         location_state="IL",
         location_zip="62701",
         in_person_sessions="yes",
         virtual_sessions="no",
     )
-    return Provider(**{**defaults, **overrides})
+    provider = Provider(org_id=org.id, **{**defaults, **overrides})
+    provider.org = org
+    return provider
 
 
 async def test_create_provider_persists(
@@ -72,17 +80,7 @@ async def test_provider_allows_multiple_per_user(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            session.add(
-                Provider(
-                    owner_id=user.id,
-                    practice_name="Other Practice",
-                    location_city="Springfield",
-                    location_state="IL",
-                    location_zip="62701",
-                    in_person_sessions="yes",
-                    virtual_sessions="no",
-                )
-            )
+            session.add(_make_provider(user, practice_name="Other Practice"))
 
         result = await session.execute(
             select(Provider).filter(Provider.owner_id == user.id)

--- a/src/domain/routes/test_favorites.py
+++ b/src/domain/routes/test_favorites.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.models import AuditLog, User, UserFavorite
-from tests.helpers import create_test_user, make_provider
+from tests.helpers import create_test_user, make_provider_with_org
 
 pytestmark = pytest.mark.asyncio
 
@@ -26,7 +26,7 @@ async def _seed_provider(
     practice_name: str = "Acme Health",
 ) -> uuid.UUID:
     owner = create_test_user(username=f"owner-{uuid.uuid4()}")
-    provider = make_provider(owner_id=owner.id, practice_name=practice_name)
+    provider = make_provider_with_org(owner_id=owner.id, practice_name=practice_name)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(owner)

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -18,8 +18,8 @@ from tests.helpers import (
     client_referral_payload,
     create_test_user,
     make_client_referral_detail,
-    make_provider,
     make_provider_availability_detail,
+    make_provider_with_org,
     promote_to_admin,
     provider_availability_payload,
 )
@@ -48,7 +48,9 @@ def _provider_availability_post(
     is added to a session — callers do `session.add(post)` and the
     Provider goes in too with the right FK order."""
     if provider is None:
-        provider = make_provider(owner_id=owner_id, practice_name=practice_name)
+        provider = make_provider_with_org(
+            owner_id=owner_id, practice_name=practice_name
+        )
     if provider.id is None:
         provider.id = uuid.uuid4()
     post = Post(kind="provider_availability", owner_id=owner_id)
@@ -224,7 +226,7 @@ async def test_list_provider_availability_item_shape(
     post = _provider_availability_post(
         practice_name=practice_name,
         owner_id=author.id,
-        provider=make_provider(
+        provider=make_provider_with_org(
             owner_id=author.id,
             practice_name=practice_name,
             location_city="Portland",
@@ -1062,7 +1064,7 @@ async def test_list_filters_by_state_across_polymorphic_paths(
     offering_nj = _provider_availability_post(
         practice_name=f"clinic-{uuid.uuid4()}",
         owner_id=author.id,
-        provider=make_provider(
+        provider=make_provider_with_org(
             owner_id=author.id,
             practice_name=f"clinic-{uuid.uuid4()}",
             location_state="NJ",
@@ -1071,7 +1073,7 @@ async def test_list_filters_by_state_across_polymorphic_paths(
     offering_tx = _provider_availability_post(
         practice_name=f"clinic-{uuid.uuid4()}",
         owner_id=author.id,
-        provider=make_provider(
+        provider=make_provider_with_org(
             owner_id=author.id,
             practice_name=f"clinic-{uuid.uuid4()}",
             location_state="TX",
@@ -1117,7 +1119,7 @@ async def test_list_filters_by_city_substring_across_polymorphic_paths(
     offering_match = _provider_availability_post(
         practice_name=f"clinic-{uuid.uuid4()}",
         owner_id=author.id,
-        provider=make_provider(
+        provider=make_provider_with_org(
             owner_id=author.id,
             practice_name=f"clinic-{uuid.uuid4()}",
             location_city="Spring Hill",
@@ -1974,7 +1976,9 @@ async def test_create_provider_availability_happy_path(
     practice_name = f"Acme-{uuid.uuid4()}"
     # PA points at a Provider via `provider_id` (#448); seed one owned by
     # the requesting user so the FK resolves at write time.
-    provider = make_provider(owner_id=logged_in_user.id, practice_name=practice_name)
+    provider = make_provider_with_org(
+        owner_id=logged_in_user.id, practice_name=practice_name
+    )
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)
@@ -2031,7 +2035,7 @@ async def test_create_provider_availability_strips_whitespace(
 ):
     """Whitespace stripping applies to PA's remaining free-text wire fields.
     (Practice-name whitespace stripping is exercised on Provider post-#448.)"""
-    provider = make_provider(owner_id=logged_in_user.id)
+    provider = make_provider_with_org(owner_id=logged_in_user.id)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)
@@ -2077,7 +2081,7 @@ async def test_get_provider_availability_form_renders(
     """`GET /posts/form?kind=provider_availability` renders the kind-specific
     create form. Per #448, the form needs the user to own at least one
     Provider profile (otherwise it shows the create-a-provider stub)."""
-    provider = make_provider(owner_id=logged_in_user.id)
+    provider = make_provider_with_org(owner_id=logged_in_user.id)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)
@@ -2105,7 +2109,7 @@ async def test_provider_availability_form_renders_free_text_fields(
     marker on the schema), `website` as `<input type="url">` (driven by
     `HtmlUrl` — #446). A regression where either marker stops being picked
     up would render fields as the wrong control and silently break the form."""
-    provider = make_provider(owner_id=logged_in_user.id)
+    provider = make_provider_with_org(owner_id=logged_in_user.id)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)
@@ -2128,7 +2132,7 @@ async def test_provider_availability_form_renders_languages_multi_select(
     """`languages` renders as a `<select multiple>` via `field_for`'s
     `list[Literal[*T]]` arm (#425). Confirms the schema-driven multi-
     select dispatch is wired end-to-end through the unified widget."""
-    provider = make_provider(owner_id=logged_in_user.id)
+    provider = make_provider_with_org(owner_id=logged_in_user.id)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)
@@ -2152,7 +2156,7 @@ async def test_provider_availability_form_renders_age_groups_multi_select(
     """`age_groups` renders as a 7-option `<select multiple>` via
     `field_for`'s `list[Literal[*T]]` arm (#430). First 7-option consumer
     of the multi-select rails."""
-    provider = make_provider(owner_id=logged_in_user.id)
+    provider = make_provider_with_org(owner_id=logged_in_user.id)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)

--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -16,10 +16,10 @@ from src.domain.models import (
 from src.framework.audit.repository import AuditRepository
 from tests.helpers import (
     create_test_user,
-    make_provider,
     make_provider_certification,
     make_provider_education,
     make_provider_licensure,
+    make_provider_with_org,
     promote_to_admin,
     provider_payload,
 )
@@ -37,7 +37,7 @@ async def _seed_provider_for(
     **overrides,
 ) -> uuid.UUID:
     """Insert a provider owned by `user_id` and return its id."""
-    provider = make_provider(owner_id=user_id, **overrides)
+    provider = make_provider_with_org(owner_id=user_id, **overrides)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.models import AuditLog, User
 from src.framework.audit.repository import AuditRepository
-from tests.helpers import create_test_user, make_provider, promote_to_admin
+from tests.helpers import create_test_user, make_provider_with_org, promote_to_admin
 
 # Mark all tests in this module as async
 pytestmark = pytest.mark.asyncio
@@ -427,8 +427,8 @@ async def test_detail_lists_owned_providers(
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(target)
-    first = make_provider(owner_id=target.id, practice_name="First")
-    second = make_provider(owner_id=target.id, practice_name="Second")
+    first = make_provider_with_org(owner_id=target.id, practice_name="First")
+    second = make_provider_with_org(owner_id=target.id, practice_name="Second")
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add_all([first, second])
@@ -700,7 +700,7 @@ async def _seed_user_provider(
     user_id: uuid.UUID,
     practice_name: str,
 ) -> uuid.UUID:
-    provider = make_provider(owner_id=user_id, practice_name=practice_name)
+    provider = make_provider_with_org(owner_id=user_id, practice_name=practice_name)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)

--- a/src/framework/persistence/test_base_repository.py
+++ b/src/framework/persistence/test_base_repository.py
@@ -16,7 +16,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.models import Provider, ProviderLicensure, User
 from src.framework.persistence.base_repository import BaseRepository
-from tests.helpers import create_test_user, make_provider, make_provider_licensure
+from tests.helpers import (
+    create_test_user,
+    make_provider_licensure,
+    make_provider_with_org,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -172,7 +176,7 @@ async def test_count_respects_distinct_with_join(
         async with session.begin():
             session.add(owner)
 
-    provider = make_provider(owner_id=owner.id)
+    provider = make_provider_with_org(owner_id=owner.id)
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(provider)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 # Need ORM models
 from src.domain.models import (
     ClientReferralDetail,
+    Organization,
     Provider,
     ProviderAvailabilityDetail,
     ProviderCertification,
@@ -204,8 +205,74 @@ def certification_payload(**overrides: Any) -> dict[str, Any]:
 
 
 def make_provider(*, owner_id: UUID, **overrides: Any) -> Provider:
-    """Build a `Provider` ORM row with CHECK-valid defaults."""
+    """Build a `Provider` ORM row with CHECK-valid defaults.
+
+    PR 2 of the Org roadmap (#520) introduced ``Provider.org_id`` as a
+    NOT NULL FK. Callers persisting the returned row must either:
+
+    * pass ``org_id=<existing-org.id>`` in ``overrides`` (Org persisted
+      separately via ``make_organization_row`` + ``session.add``); or
+    * route the create through ``ProviderRepository.create``, which
+      find-or-creates an Org from ``practice_name``.
+
+    Bare ORM constructors without one of the above will trip the
+    ``NOT NULL`` constraint at flush time.
+    """
     return Provider(owner_id=owner_id, **{**_PROVIDER_DEFAULTS, **overrides})
+
+
+def make_organization_row(
+    *,
+    owner_id: UUID,
+    name: str = "Acme Health",
+    type_: str = "solo_practice",
+    org_id: UUID | None = None,
+) -> Organization:
+    """Build a root ``Organization`` ORM row that satisfies the
+    ``root_org_id`` invariant (root: ``root_org_id = id``,
+    ``parent_org_id = NULL``).
+
+    Assigns ``id`` eagerly so callers can pass ``org.id`` straight into
+    a sibling ``make_provider`` without an intermediate flush — mirrors
+    the eager assignment ``OrganizationRepository.create`` does."""
+    obj = Organization(
+        id=org_id or uuid.uuid4(),
+        name=name,
+        type=type_,
+        owner_id=owner_id,
+    )
+    obj.root_org_id = obj.id
+    return obj
+
+
+def make_provider_with_org(
+    *,
+    owner_id: UUID,
+    practice_name: str = "Acme Health",
+    org: Organization | None = None,
+    **overrides: Any,
+) -> Provider:
+    """Build a Provider wired to a matching Organization (PR 2 mirror
+    invariant: ``provider.practice_name == org.name``).
+
+    The Org is attached via ``provider.org = org`` rather than just
+    ``org_id`` so SQLAlchemy's default save-update cascade picks the
+    Org up when the Provider is added to a session — callers can stay
+    on the single-add ``session.add(provider)`` shape they used before
+    PR 2 introduced ``org_id``.
+
+    Pass ``org=<instance>`` when multiple Providers share an Org;
+    practice_name is taken from the Org in that case."""
+    if org is None:
+        org = make_organization_row(owner_id=owner_id, name=practice_name)
+    provider = make_provider(
+        owner_id=owner_id,
+        org_id=org.id,
+        practice_name=org.name,
+        **{k: v for k, v in overrides.items() if k != "practice_name"},
+    )
+    provider.org = org
+    return provider
 
 
 def make_provider_licensure(


### PR DESCRIPTION
Closes #520. PR 2 of 5 in the Org/Program roadmap.

## Summary

- Add `Provider.org_id` as a NOT NULL FK to `organizations.id`.
- Backfill it from existing `practice_name` groups — one Org per distinct name, type `solo_practice` / `group_practice` by group size, owner = lowest-`created_at` provider's owner.
- Keep `Provider.practice_name` as a denormalized mirror of `org.name`; mirror invariant enforced in `ProviderRepository.create` / `patch` (matching `OrganizationRepository`'s PR 1 shape).
- No templates, no Pydantic schemas, no contract test changes — the mirror is the migration vehicle for PR 3.

The mirror logic carries `TODO(roadmap-pr-3)` markers so PR 3's cleanup is grep-able.

## Test plan

- [x] `dev migrate roundtrip` — upgrade → downgrade → upgrade clean.
- [x] `dev test` — 1124 passed / 59 skipped.
- [x] `dev lint` — clean.
- [x] `scripts/dev/test_seed.py` — fresh-DB seed produces Providers with correct Org mirror.
- [x] New colocated tests pin the mirror invariant on create + patch.

## Per-PR retrospective

### Wide blast radius from one NOT NULL column
**Friction:** Adding `org_id` NOT NULL forced touching every test that constructs a `Provider` (~30 sites across 11 files). Mechanical but verbose.
**Fix:** A `make_provider_with_org(...)` helper that returns a Provider wired to an Org via `provider.org = org` (save-update cascade handles persistence) collapsed the per-site change to a single-token rename.
**Why didn't existing patterns prevent this?** No existing pattern — first time a Provider FK migrated from absent to NOT NULL without a wire change. `tests/helpers.py` already had `make_provider` but not a paired-Org variant.
**Could this class recur elsewhere?** Yes — every future PR that adds a NOT NULL FK without changing the create payload will face the same churn. Worth keeping `make_provider_with_org` as the prototype if a similar shape arrives (e.g. `Provider.program_id` in PR 5).
**Effort:** Small.

### Deterministic owner pick during backfill
**Friction:** The issue specified "lowest `created_at` provider's owner" as the deterministic pick for Org owner. Implementing it is one `ORDER BY created_at ASC, id ASC LIMIT 1`. No friction here, but worth confirming in the retro that the heuristic produced sensible results.
**Fix:** None needed for PR 2 — the backfill ran on the test suite's tiny dataset without surprises. PR 3's create form will need a UX answer for "two providers share a practice_name with different owners — whose Org is it?"; leaving as a flag for the PR 3 design conversation.
**Why didn't existing patterns prevent this?** N/A — first deterministic-owner backfill in this repo.
**Could this class recur elsewhere?** Yes (PR 4's Program entity backfill, if/when needed). The pattern of "deterministic pick from a group" is reusable.
**Effort:** Small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)