### PR TITLE
Framework: add form_extras_path spec hook (#533)

### DIFF
--- a/src/domain/logic/providers/handlers.py
+++ b/src/domain/logic/providers/handlers.py
@@ -35,8 +35,6 @@ from src.domain.specs.provider import PROVIDER_ENTITY
 from src.framework.audit.repository import AuditRepository
 from src.framework.dispatch.handlers import (
     handle_create,
-    handle_get_edit_form,
-    handle_get_new_form,
     handle_update,
 )
 from src.framework.dispatch.pagination import (
@@ -92,46 +90,27 @@ async def _assert_org_belongs_to(
         )
 
 
-async def handle_get_provider_new_form(
+async def provider_form_extras(
     *,
-    request: Request,
+    target: Provider | None,
     requesting_user: User,
     organization_repo: OrganizationRepository,
+    **_: Any,
 ) -> dict[str, Any]:
-    """Provider create-form handler. Extends the framework's default by
-    loading the user's visible Organizations into the context for the
-    Org-picker dropdown — Provider create takes ``org_id`` (#524), and
-    the form needs a populated select."""
-    context = await handle_get_new_form(
-        PROVIDER_ENTITY, request=request, requesting_user=requesting_user
-    )
-    context["orgs"] = await _orgs_visible_to(organization_repo, requesting_user)
-    return context
+    """Per-viewer form extras for `make_new_form_handler` /
+    `make_edit_form_handler` against `PROVIDER_ENTITY`.
 
-
-async def handle_get_provider_edit_form(
-    *,
-    request: Request,
-    provider_id: UUID,
-    repo: ProviderRepository,
-    requesting_user: User,
-    organization_repo: OrganizationRepository,
-) -> dict[str, Any]:
-    """Provider edit-form handler. Mirror of the new-form handler — the
-    Org-picker dropdown lists the user's visible Orgs, with the
-    Provider's current ``org_id`` pre-selected (the template handles
-    the `selected` attribute). ``provider_id`` is the URL's path param
-    (``PROVIDER_ENTITY.id_param``); it's forwarded to the framework's
-    ``handle_get_edit_form`` as ``target_id``."""
-    context = await handle_get_edit_form(
-        PROVIDER_ENTITY,
-        request=request,
-        target_id=provider_id,
-        repo=repo,
-        requesting_user=requesting_user,
-    )
-    context["orgs"] = await _orgs_visible_to(organization_repo, requesting_user)
-    return context
+    Loads the requesting user's visible Organizations into the context
+    for the Org-picker dropdown — Provider create/update takes
+    ``org_id`` (#524), and the form needs a populated select. The
+    framework invokes this on both the create path (``target=None``)
+    and the edit path (``target=<provider row>``); the dropdown is the
+    same either way — the template handles pre-selecting the row's
+    current ``org_id`` via the standard `selected` attribute.
+    """
+    return {
+        "orgs": await _orgs_visible_to(organization_repo, requesting_user),
+    }
 
 
 async def handle_create_provider(

--- a/src/domain/logic/providers/test_handlers.py
+++ b/src/domain/logic/providers/test_handlers.py
@@ -14,9 +14,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.requests import Request
 
 from src.domain.logic.favorites.repository import UserFavoriteRepository
+from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.providers.handlers import (
     handle_list_user_providers,
     provider_detail_extras,
+    provider_form_extras,
 )
 from src.domain.logic.providers.repository import ProviderRepository
 from src.domain.logic.providers.schema import (
@@ -28,6 +30,7 @@ from src.domain.logic.providers.schema import (
 from src.domain.logic.users.repository import UserRepository
 from src.domain.models import (
     AuditLog,
+    Provider,
     ProviderLicensure,
     User,
 )
@@ -547,3 +550,73 @@ async def test_create_provider_allows_multiple_per_user(
     assert second.id != first_id
     assert second.owner_id == user.id
     assert second.org.name == "Second Practice"
+
+
+# --- provider_form_extras (#533) -----------------------------------------
+
+
+async def test_provider_form_extras_returns_owners_visible_orgs(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Owner sees only the Orgs they own. Mirrors the previous
+    `handle_get_provider_new_form` behavior, now provided by the
+    framework via `form_extras_path`."""
+    owner = await _seed_user(db_test_session_manager)
+    stranger = await _seed_user(db_test_session_manager)
+    owned_id = await _seed_org(db_test_session_manager, owner_id=owner.id, name="Mine")
+    await _seed_org(db_test_session_manager, owner_id=stranger.id, name="Other")
+
+    async with db_test_session_manager() as session:
+        org_repo = OrganizationRepository(session)
+        # Create path: target is None.
+        result = await provider_form_extras(
+            target=None,
+            requesting_user=owner,
+            organization_repo=org_repo,
+        )
+        assert [o.id for o in result["orgs"]] == [owned_id]
+
+
+async def test_provider_form_extras_superuser_sees_all_orgs(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Superusers see every Org regardless of ownership — same
+    semantics as the previous bespoke handler."""
+    admin = await _seed_user(db_test_session_manager, is_superuser=True)
+    other = await _seed_user(db_test_session_manager)
+    await _seed_org(db_test_session_manager, owner_id=admin.id, name="Admin Org")
+    await _seed_org(db_test_session_manager, owner_id=other.id, name="Other Org")
+
+    async with db_test_session_manager() as session:
+        org_repo = OrganizationRepository(session)
+        result = await provider_form_extras(
+            target=None,
+            requesting_user=admin,
+            organization_repo=org_repo,
+        )
+        org_names = {o.name for o in result["orgs"]}
+        assert "Admin Org" in org_names
+        assert "Other Org" in org_names
+
+
+async def test_provider_form_extras_edit_path_passes_target(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """On the edit path the framework passes the loaded Provider as
+    `target`. The current implementation doesn't read it, but the
+    callable must accept it without complaint — the contract is the
+    same on both paths."""
+    owner = await _seed_user(db_test_session_manager)
+    await _seed_org(db_test_session_manager, owner_id=owner.id, name="Owned")
+    provider_id, *_ = await _seed_provider(db_test_session_manager, user_id=owner.id)
+
+    async with db_test_session_manager() as session:
+        provider_repo = ProviderRepository(session)
+        provider = await provider_repo.get_by_model_id(Provider, provider_id)
+        org_repo = OrganizationRepository(session)
+        result = await provider_form_extras(
+            target=provider,
+            requesting_user=owner,
+            organization_repo=org_repo,
+        )
+        assert "orgs" in result

--- a/src/domain/routes/providers.py
+++ b/src/domain/routes/providers.py
@@ -1,7 +1,5 @@
 from src.domain.logic.providers.handlers import (
     handle_create_provider,
-    handle_get_provider_edit_form,
-    handle_get_provider_new_form,
     handle_update_provider,
 )
 from src.domain.specs.provider import PROVIDER_ENTITY
@@ -14,24 +12,24 @@ from src.framework.dispatch.resource_routes import mount_entity
 router = register_entity(PROVIDER_ENTITY)
 
 
-# Every verb auto-binds except `create`, `update`, `form_new`, and
-# `form_edit`, which are overridden so the Provider create/edit form
-# can render an Org-picker dropdown scoped to the requesting user's
-# Organizations and so the wire-level POST/PATCH reject `org_id`
-# values pointing at Orgs the user doesn't own (#524). Per-viewer
-# detail extras (`provider_detail_extras` + the user-favorite repo
-# it needs) live on the spec via dotted-path late-binding. Owned
-# credential subentities (licensure, education, certification)
-# self-register on `PROVIDER_ENTITY.children` and pick up the same
-# auto-bind for their create / update / delete factories.
+# Every verb auto-binds except `create` and `update`, which are
+# overridden so the wire-level POST/PATCH reject `org_id` values
+# pointing at Orgs the user doesn't own (#524). The create/edit form's
+# per-viewer Org-picker dropdown is now driven by
+# `form_extras_path` on the spec (#533) — the framework threads the
+# `OrganizationRepository` into the factory-built form handlers via
+# `form_extras_repos`. Per-viewer detail extras
+# (`provider_detail_extras` + the user-favorite repo it needs) live on
+# the spec via the same dotted-path late-binding. Owned credential
+# subentities (licensure, education, certification) self-register on
+# `PROVIDER_ENTITY.children` and pick up the same auto-bind for their
+# create / update / delete factories.
 mount_entity(
     router,
     PROVIDER_ENTITY,
     handlers={
         "create": handle_create_provider,
         "update": handle_update_provider,
-        "form_new": handle_get_provider_new_form,
-        "form_edit": handle_get_provider_edit_form,
     },
     owned_subentities=(LICENSURE_ENTITY, EDUCATION_ENTITY, CERTIFICATION_ENTITY),
 )

--- a/src/domain/specs/provider.py
+++ b/src/domain/specs/provider.py
@@ -19,6 +19,7 @@ Read by:
 from typing import Final
 
 from src.domain.logic.favorites.repository import UserFavoriteRepository
+from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.providers.schema import (
     ProviderCreate,
     ProviderRead,
@@ -95,6 +96,12 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     # Per-viewer detail extras live on the spec — see `EntitySpec`.
     detail_extras_path="src.domain.logic.providers.handlers.provider_detail_extras",
     detail_extras_repos=(("user_favorite_repo", UserFavoriteRepository),),
+    # The create/edit form's Org-picker dropdown is scoped per-viewer to
+    # the user's owned Organizations (#524). The framework invokes the
+    # extras callable on both the create path (target=None) and the
+    # edit path (target=<row>) — see `EntitySpec.form_extras_path`.
+    form_extras_path="src.domain.logic.providers.handlers.provider_form_extras",
+    form_extras_repos=(("organization_repo", OrganizationRepository),),
     # Provider templates render credential-type display labels and the
     # tuples behind the filter/select dropdowns. Tying them to the spec
     # (instead of Jinja globals) means a new credential-type tuple

--- a/src/domain/specs/test_spec_conformance.py
+++ b/src/domain/specs/test_spec_conformance.py
@@ -268,6 +268,23 @@ def test_list_extras_repos_requires_list_extras_path(spec: EntitySpec) -> None:
     assert spec.list_extras_path is not None
 
 
+@_PARAM_ALL
+def test_form_extras_path_requires_form_route(spec: EntitySpec) -> None:
+    """Spec construction would have raised if this held false; the
+    conformance suite pins the invariant across every entity so adding
+    a new one doesn't accidentally re-create the bug."""
+    if spec.form_extras_path is None:
+        pytest.skip(f"{spec.name!r} has no form_extras_path")
+    assert spec.routes.form_new or spec.routes.form_edit
+
+
+@_PARAM_ALL
+def test_form_extras_repos_requires_form_extras_path(spec: EntitySpec) -> None:
+    if not spec.form_extras_repos:
+        pytest.skip(f"{spec.name!r} has no form_extras_repos")
+    assert spec.form_extras_path is not None
+
+
 # --- Visibility ----------------------------------------------------------
 
 

--- a/src/framework/dispatch/entity_spec.py
+++ b/src/framework/dispatch/entity_spec.py
@@ -354,25 +354,40 @@ class EntitySpec:
     # entities leave as None.
     singleton_alias: tuple[str, Callable[..., Any]] | None = None
 
-    # Detail / list extras (per-viewer / per-list customization) --------
-    # `detail_extras_path` and `list_extras_path` are dotted import paths
-    # (e.g. `"src.domain.logic.users.handlers.user_detail_extras"`) to the
+    # Detail / list / form extras (per-viewer / per-list / per-form
+    # customization) ----------------------------------------------------
+    # `detail_extras_path`, `list_extras_path`, and `form_extras_path`
+    # are dotted import paths (e.g.
+    # `"src.domain.logic.users.handlers.user_detail_extras"`) to the
     # per-viewer extras callable consumed by `make_detail_handler` /
-    # `make_list_handler`. The path is resolved lazily via
+    # `make_list_handler` / `make_new_form_handler` +
+    # `make_edit_form_handler`. The path is resolved lazily via
     # `importlib.import_module` + `getattr` at mount time, *after* both
     # the spec module and the logic module have been imported — so the
     # spec module never has to import from `src.logic.<entity>`, which
     # would close the cycle (logic modules import from the spec). Same
     # late-binding trick `StateAxis.handler_path` already uses.
     #
-    # `detail_extras_repos` / `list_extras_repos` declare typed repo
-    # kwargs the extras callable receives. Repository classes live below
-    # specs in the import order, so the type-class import is cycle-safe
-    # and the field carries real classes (not strings).
+    # `detail_extras_repos` / `list_extras_repos` / `form_extras_repos`
+    # declare typed repo kwargs the extras callable receives. Repository
+    # classes live below specs in the import order, so the type-class
+    # import is cycle-safe and the field carries real classes (not strings).
+    #
+    # The `form_extras_path` callable is invoked by *both* the create-form
+    # and edit-form handlers; signature is
+    # ``async def f(*, target: Model | None, requesting_user: User,
+    # request: Request, <repo_kwargs>) -> dict[str, Any]``. ``target`` is
+    # ``None`` on the create path and the loaded row on the edit path —
+    # extras callables that need to pre-select the current row's values
+    # (Org-picker, etc.) read it; create-only extras can ignore it. The
+    # returned dict merges into the form template context (last-write-
+    # wins, mirroring detail/list).
     detail_extras_path: str | None = None
     detail_extras_repos: tuple[tuple[str, type], ...] = ()
     list_extras_path: str | None = None
     list_extras_repos: tuple[tuple[str, type], ...] = ()
+    form_extras_path: str | None = None
+    form_extras_repos: tuple[tuple[str, type], ...] = ()
 
     # Static context bindings -------------------------------------------
     # Constant key→value pairs that `handle_detail` / `handle_list` merge
@@ -633,6 +648,20 @@ class EntitySpec:
             raise ValueError(
                 f"EntitySpec({self.name!r}) declares list_extras_repos but "
                 "no list_extras_path — the typed-repo kwargs would have "
+                "no consumer."
+            )
+        if self.form_extras_path is not None and not (
+            self.routes.form_new or self.routes.form_edit
+        ):
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares form_extras_path but "
+                "neither routes.form_new nor routes.form_edit is True — "
+                "the extras would never run."
+            )
+        if self.form_extras_repos and self.form_extras_path is None:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares form_extras_repos but "
+                "no form_extras_path — the typed-repo kwargs would have "
                 "no consumer."
             )
         if self.read_schema is not None:

--- a/src/framework/dispatch/handlers.py
+++ b/src/framework/dispatch/handlers.py
@@ -308,12 +308,14 @@ _EDIT_FORM_SHAPE = _FactoryShape(
     name_template="_handle_get_{name}_edit_form",
     include_request=True,
     include_target_id=True,
+    accepts_extras=True,
 )
 _NEW_FORM_SHAPE = _FactoryShape(
     name_template="_handle_get_{name}_new_form",
     include_request=True,
     include_kind_for_polymorphic=True,
     omit_repo=True,
+    accepts_extras=True,
 )
 _DETAIL_SHAPE = _FactoryShape(
     name_template="_handle_get_{name}_detail",
@@ -437,8 +439,17 @@ async def handle_get_edit_form(
     target_id: UUID,
     repo: BaseRepository,
     requesting_user: User,
+    extras: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    extra_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Generic edit-form handler driven by `spec`."""
+    """Generic edit-form handler driven by `spec`.
+
+    When `extras` is set (threaded in by `make_edit_form_handler` from
+    the spec's `form_extras_path`), the callable is invoked with
+    ``target=<loaded row>``, ``request``, ``requesting_user``, and any
+    typed-repo kwargs declared via `form_extras_repos`. The returned
+    dict merges into the form context (last-write-wins, mirroring
+    `handle_detail` / `handle_list`)."""
     target = await repo.get_by_model_id(spec.model, target_id)
     if target is None:
         raise NotFoundError(detail=f"{spec.name.capitalize()} not found")
@@ -457,11 +468,33 @@ async def handle_get_edit_form(
     if spec.discriminator is not None:
         kind = getattr(target, spec.discriminator.column)
         context["template_name"] = spec.discriminator[kind].edit_template
+
+    if extras is not None:
+        extras_kwargs = {
+            "target": target,
+            "request": request,
+            "requesting_user": requesting_user,
+        }
+        if extra_kwargs:
+            extras_kwargs.update(extra_kwargs)
+        context.update(await extras(**extras_kwargs))
+
     return context
 
 
-def make_edit_form_handler(spec: EntitySpec):
-    return _make_factory_handler(spec, _EDIT_FORM_SHAPE, handle_get_edit_form)
+def make_edit_form_handler(
+    spec: EntitySpec,
+    *,
+    extras: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    extra_repos: tuple[tuple[str, type], ...] = (),
+):
+    return _make_factory_handler(
+        spec,
+        _EDIT_FORM_SHAPE,
+        handle_get_edit_form,
+        extras=extras,
+        extra_repos=extra_repos,
+    )
 
 
 async def handle_get_new_form(
@@ -470,6 +503,8 @@ async def handle_get_new_form(
     request: Request,
     requesting_user: User,
     kind: str | None = None,
+    extras: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    extra_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Generic create-form handler driven by `spec`.
 
@@ -499,11 +534,33 @@ async def handle_get_new_form(
         # spec's `create_adapter` is the TypeAdapter wrapper, so we bind
         # the underlying class instead.
         context["schema"] = spec.create_adapter_class
+
+    if extras is not None:
+        extras_kwargs = {
+            "target": None,
+            "request": request,
+            "requesting_user": requesting_user,
+        }
+        if extra_kwargs:
+            extras_kwargs.update(extra_kwargs)
+        context.update(await extras(**extras_kwargs))
+
     return context
 
 
-def make_new_form_handler(spec: EntitySpec):
-    return _make_factory_handler(spec, _NEW_FORM_SHAPE, handle_get_new_form)
+def make_new_form_handler(
+    spec: EntitySpec,
+    *,
+    extras: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+    extra_repos: tuple[tuple[str, type], ...] = (),
+):
+    return _make_factory_handler(
+        spec,
+        _NEW_FORM_SHAPE,
+        handle_get_new_form,
+        extras=extras,
+        extra_repos=extra_repos,
+    )
 
 
 async def handle_detail(

--- a/src/framework/dispatch/resource_routes.py
+++ b/src/framework/dispatch/resource_routes.py
@@ -1239,6 +1239,15 @@ def mount_entity(
             "— pick one. Extras are for the factory-built path; an "
             "explicit handler owns its own."
         )
+    if entity.form_extras_path is not None and (
+        "form_new" in handlers or "form_edit" in handlers
+    ):
+        raise ValueError(
+            f"mount_entity({entity.name!r}): spec declares "
+            "form_extras_path alongside an explicit handlers['form_new'] "
+            "or handlers['form_edit'] — pick one. Extras are for the "
+            "factory-built path; an explicit handler owns its own."
+        )
 
     detail_extras = (
         _resolve_dotted_path(entity, entity.detail_extras_path, "detail_extras_path")
@@ -1248,6 +1257,11 @@ def mount_entity(
     list_extras = (
         _resolve_dotted_path(entity, entity.list_extras_path, "list_extras_path")
         if entity.list_extras_path is not None
+        else None
+    )
+    form_extras = (
+        _resolve_dotted_path(entity, entity.form_extras_path, "form_extras_path")
+        if entity.form_extras_path is not None
         else None
     )
 
@@ -1288,6 +1302,12 @@ def mount_entity(
                 entity,
                 extras=list_extras,
                 extra_repos=entity.list_extras_repos,
+            )
+        elif verb in ("form_new", "form_edit"):
+            built = maker(
+                entity,
+                extras=form_extras,
+                extra_repos=entity.form_extras_repos,
             )
         else:
             built = maker(entity)

--- a/src/framework/dispatch/test_handlers.py
+++ b/src/framework/dispatch/test_handlers.py
@@ -1784,6 +1784,139 @@ async def test_make_new_form_handler_delegates_to_handle_get_new_form():
     assert context["current_user"] is user
 
 
+# --- form_extras (create- + edit-form extras) framework tests ------------
+
+
+@pytest.mark.asyncio
+async def test_new_form_invokes_form_extras_with_target_none():
+    """`handle_get_new_form` calls the `extras` callable with
+    `target=None` (no row is loaded on the create path) and merges the
+    returned dict into the context."""
+    captured: dict[str, Any] = {}
+
+    async def extras(**kwargs):
+        captured.update(kwargs)
+        return {"orgs": ["a", "b"]}
+
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        create_adapter=_FormSchema,
+        routes=RouteSet(create=True, form_new=True),
+    )
+    user = _user()
+    request = SimpleNamespace()
+
+    context = await handle_get_new_form(
+        spec,
+        request=request,
+        requesting_user=user,
+        extras=extras,
+        extra_kwargs={"organization_repo": "REPO_SENTINEL"},
+    )
+
+    assert captured["target"] is None
+    assert captured["request"] is request
+    assert captured["requesting_user"] is user
+    assert captured["organization_repo"] == "REPO_SENTINEL"
+    assert context["orgs"] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_edit_form_invokes_form_extras_with_target_row():
+    """`handle_get_edit_form` calls the `extras` callable with the
+    loaded row bound to `target` and merges the returned dict into the
+    context (last-write-wins over spec.static_context)."""
+    captured: dict[str, Any] = {}
+
+    async def extras(**kwargs):
+        captured.update(kwargs)
+        return {"orgs": ["x"]}
+
+    spec = _top_level_spec(write_authz=None)
+    target_id = uuid4()
+    target = _FixtureRow(id=target_id)
+    repo = _FakeRepo()
+    repo.seed(_FixtureRow, target)
+    user = _user()
+    request = SimpleNamespace()
+
+    context = await handle_get_edit_form(
+        spec,
+        request=request,
+        target_id=target_id,
+        repo=repo,
+        requesting_user=user,
+        extras=extras,
+        extra_kwargs={"organization_repo": "REPO_SENTINEL"},
+    )
+
+    assert captured["target"] is target
+    assert captured["request"] is request
+    assert captured["requesting_user"] is user
+    assert captured["organization_repo"] == "REPO_SENTINEL"
+    assert context["orgs"] == ["x"]
+    assert context["widget"] is target
+
+
+def test_make_edit_form_handler_includes_extra_repos_in_signature():
+    """`extra_repos=` declared on the factory adds typed-repo kwargs to
+    the synthesized signature so FastAPI's DI can resolve them."""
+
+    class _RepoMarker:
+        pass
+
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+    )
+
+    async def extras(**_):
+        return {}
+
+    handler = make_edit_form_handler(
+        spec,
+        extras=extras,
+        extra_repos=(("organization_repo", _RepoMarker),),
+    )
+    sig = inspect.signature(handler)
+    assert "organization_repo" in sig.parameters
+    assert sig.parameters["organization_repo"].annotation is _RepoMarker
+
+
+def test_make_new_form_handler_includes_extra_repos_in_signature():
+    class _RepoMarker:
+        pass
+
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_FixtureRow,
+        audit=_audit(),
+        create_adapter=_FormSchema,
+        routes=RouteSet(create=True, form_new=True),
+    )
+
+    async def extras(**_):
+        return {}
+
+    handler = make_new_form_handler(
+        spec,
+        extras=extras,
+        extra_repos=(("organization_repo", _RepoMarker),),
+    )
+    sig = inspect.signature(handler)
+    assert "organization_repo" in sig.parameters
+    assert sig.parameters["organization_repo"].annotation is _RepoMarker
+
+
 # --- handle_detail framework tests ---------------------------------------
 
 

--- a/src/framework/dispatch/test_resource_routes.py
+++ b/src/framework/dispatch/test_resource_routes.py
@@ -1105,6 +1105,12 @@ async def _stub_list_extras(**_kw):
     return {}
 
 
+async def _stub_form_extras(**_kw):
+    """Module-level extras callable targeted via `form_extras_path` in
+    the form-extras threading tests."""
+    return {}
+
+
 def _stub_audit() -> _AuditedResource:
     return _AuditedResource(
         type="thing",
@@ -1780,6 +1786,138 @@ def test_spec_list_extras_path_threaded_to_factory():
         restore()
     list_handler = next(k["handler"] for n, k in captured if n == "mount_list")
     assert list_handler.__name__ == "_handle_list_widget"
+
+
+def test_mount_entity_form_extras_threaded_to_factory():
+    """`form_extras_path` on the spec resolves via `importlib` at mount
+    time and threads into *both* `make_new_form_handler` and
+    `make_edit_form_handler`; the synthesis adds the typed-repo kwargs
+    (from `form_extras_repos`) to each built handler's signature."""
+    from pydantic import TypeAdapter
+
+    spec = _EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+        create_adapter=TypeAdapter(_AxisBody),
+        update_adapter=TypeAdapter(_AxisBody),
+        routes=_RouteSet(form_new=True, form_edit=True),
+        templates=_Templates(
+            form_new="w/new.html",
+            form_edit="w/edit.html",
+        ),
+        form_extras_path=f"{__name__}._stub_form_extras",
+        form_extras_repos=(("organization_repo", UserRepository),),
+    )
+
+    captured, restore = _capture_top_level_mounts()
+    try:
+        mount_entity(None, spec, handlers={})
+    finally:
+        restore()
+
+    import inspect
+
+    # `mount_form` is called twice (new + edit); both handlers must
+    # carry the typed-repo kwarg.
+    form_calls = [k for n, k in captured if n == "mount_form"]
+    assert len(form_calls) == 2
+    for call in form_calls:
+        params = inspect.signature(call["handler"]).parameters
+        assert "organization_repo" in params
+
+
+def test_mount_entity_form_extras_with_explicit_form_new_handler_raises():
+    """`form_extras_path` is for the factory-built path; declaring it
+    on the spec alongside an explicit `handlers["form_new"]` is
+    ambiguous (the explicit handler would silently win) — surface at
+    mount time."""
+    from pydantic import TypeAdapter
+
+    spec = _EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+        create_adapter=TypeAdapter(_AxisBody),
+        routes=_RouteSet(form_new=True),
+        templates=_Templates(form_new="w/new.html"),
+        form_extras_path=f"{__name__}._stub_form_extras",
+    )
+
+    async def my_form_new(**_kw):  # pragma: no cover
+        return {}
+
+    with pytest.raises(ValueError, match="form_extras_path"):
+        mount_entity(
+            None,
+            spec,
+            handlers={"form_new": my_form_new},
+        )
+
+
+def test_mount_entity_form_extras_with_explicit_form_edit_handler_raises():
+    """Mirror of the form_new check — also fires when the explicit
+    handler is `form_edit`."""
+    from pydantic import TypeAdapter
+
+    spec = _EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=SimpleNamespace,
+        audit=_stub_audit(),
+        update_adapter=TypeAdapter(_AxisBody),
+        routes=_RouteSet(form_edit=True),
+        templates=_Templates(form_edit="w/edit.html"),
+        form_extras_path=f"{__name__}._stub_form_extras",
+    )
+
+    async def my_form_edit(**_kw):  # pragma: no cover
+        return {}
+
+    with pytest.raises(ValueError, match="form_extras_path"):
+        mount_entity(
+            None,
+            spec,
+            handlers={"form_edit": my_form_edit},
+        )
+
+
+def test_spec_form_extras_without_form_route_raises():
+    """Declaring form_extras_path on a spec whose neither form route is
+    opted in is dead config — the extras would never run. Surfaces at
+    spec construction time."""
+    with pytest.raises(ValueError, match="routes.form_new"):
+        _EntitySpec(
+            name="widget",
+            url_collection="widgets",
+            id_param="widget_id",
+            model=SimpleNamespace,
+            audit=_stub_audit(),
+            routes=_RouteSet(),  # both form_new and form_edit off
+            form_extras_path=f"{__name__}._stub_form_extras",
+        )
+
+
+def test_spec_form_extras_repos_without_path_raises():
+    """`form_extras_repos` without `form_extras_path` is dead config —
+    the typed-repo kwargs would have no consumer. Surfaces at spec
+    construction time."""
+    with pytest.raises(ValueError, match="form_extras_repos"):
+        _EntitySpec(
+            name="widget",
+            url_collection="widgets",
+            id_param="widget_id",
+            model=SimpleNamespace,
+            audit=_stub_audit(),
+            routes=_RouteSet(form_new=True),
+            templates=_Templates(form_new="w/new.html"),
+            form_extras_repos=(("x", UserRepository),),
+        )
 
 
 def test_mount_delete_404_propagates_from_handler():


### PR DESCRIPTION
Closes #533.

## Summary

- Adds `form_extras_path: str | None` and `form_extras_repos: tuple[tuple[str, type], ...]` to `EntitySpec`, mirroring the existing `detail_extras_path` / `list_extras_path` pair. The framework's create-form and edit-form handlers invoke the resolved callable at render time and merge the returned dict into the template context (last-write-wins). Validation at spec construction: `form_extras_path` requires `routes.form_new` or `routes.form_edit` opted in; `form_extras_repos` requires a path. Symmetric mount-time guard fires if the spec declares the path alongside an explicit `handlers["form_new"]` / `handlers["form_edit"]`.
- Inner-handler signatures `handle_get_edit_form` / `handle_get_new_form` gain `extras=` and `extra_kwargs=` kwargs; the edit-form path passes the loaded row as `target=<row>`, the new-form path passes `target=None`. `_EDIT_FORM_SHAPE.accepts_extras` and `_NEW_FORM_SHAPE.accepts_extras` are flipped so `_make_factory_handler` synthesizes the extras glue. The `make_*` factories accept `extras=` / `extra_repos=` exactly like `make_detail_handler` / `make_list_handler` do.
- Same PR migrates Provider off the bespoke `handle_get_provider_new_form` / `handle_get_provider_edit_form` handlers introduced by PR #531 (#524 follow-up). A single new `provider_form_extras` callable provides the Org-picker dropdown for both form templates; the routes file drops the two `handlers={...}` entries.

## Contract surface

- No HTTP request / response shape changes — Provider create/edit form templates render the same context keys (`orgs`, `provider`, `current_user`, `request`).
- No URL changes, no persisted JSON changes, no DB constraint changes.
- Framework `EntitySpec` API gains two fields; both default to `None` / `()` so existing entities are unaffected.

## Test plan

- [x] `dev test` (1142 passed, 73 skipped)
- [x] `dev test contract` (16 passed) — including the Provider create-form and edit-form pact verifications, which exercise the new factory-built handlers end-to-end
- [x] `dev lint` (all green)
- [ ] Manual browser smoke: open `/providers/form` and `/providers/{id}/form`; verify the Org-picker still lists only the requesting user's owned Orgs (superusers see every Org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)