### PR TITLE
APScheduler rails + hello-world audited job (closes #529)

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,3 +5,7 @@ SECRET=test-secret-key-for-local-testing-only
 DATABASE_URL=sqlite+aiosqlite:///./test.db
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 ENVIRONMENT=development
+# Keep APScheduler idle under pytest. `src/main.py` lifespan still calls
+# `register_jobs(make_scheduler())` so tests can introspect what's wired,
+# but `.start()` is skipped. See `src/jobs/README.md`.
+DISABLE_SCHEDULER=1

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -43,3 +43,12 @@ chmod +x deploy.sh cleanup-docker.sh
 ```
 
 `./deploy.sh` is idempotent — re-running it after a failure rolls back to the working color.
+
+## Scheduled work: APScheduler vs host cron
+
+Two scheduling rails coexist:
+
+- **In-process (APScheduler)** — jobs that need the application's plumbing (`async_session_maker`, audit repository, domain handlers). Started from `src/main.py`'s `lifespan` and configured under [`src/jobs/`](../src/jobs/README.md).
+- **Host cron** — jobs that operate outside the app process (e.g. `droplet-files/cleanup-docker.sh` prunes container layers). These keep their place at the host level and never go through APScheduler.
+
+Pick the rail by where the work happens, not by cadence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ app = [
     "fastapi-users[sqlalchemy]",
     "aiosqlite",
     "pydantic-settings",
-    "asyncstdlib"
+    "asyncstdlib",
+    "apscheduler>=3.10,<4"
 ]
 
 dev = [

--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -114,6 +114,7 @@ class TitleCaseChecker:
         # Tech / framework names
         "FastAPI",
         "SQLAlchemy",
+        "APScheduler",
         "Jinja2",
         "pytest",
         "GitHub",

--- a/src/README.md
+++ b/src/README.md
@@ -22,6 +22,9 @@ Plus three loose files at `src/`:
 - **`db.py`** — database engine / session factory.
 - **`auth_config.py`** — fastapi-users setup.
 
+And one documented bucket-grammar deviation:
+- **[`jobs/`](jobs/README.md)** — APScheduler-driven in-process jobs. App-level glue that's neither domain-specific nor reusable framework; each job opens its own `async_session_maker` session and writes a `record_audit(...)` row.
+
 ## How the buckets relate
 
 ```

--- a/src/framework/audit/core.py
+++ b/src/framework/audit/core.py
@@ -62,6 +62,7 @@ class AuditAction(str, Enum):
     DELETE_CERTIFICATION = "delete_certification"
     ADD_FAVORITE = "add_favorite"
     REMOVE_FAVORITE = "remove_favorite"
+    JOB_RUN_STARTED = "job_run_started"
 
 
 Verb = Literal["create", "update", "delete"]

--- a/src/framework/audit/test_audit_action_drift.py
+++ b/src/framework/audit/test_audit_action_drift.py
@@ -11,12 +11,18 @@ flags any missing piece.
 from src.domain.specs import ALL_ENTITY_SPECS
 from src.framework.audit.core import AuditAction
 
-# Bespoke members not modeled by any spec. `REGISTER` is fired by the
-# fastapi-users self-signup flow in `src/logic/auth/auth_processing.py`
-# — there is no `RegistrationEntity` spec, the verb just sits on top of
-# `User`. Keep tight: add an entry only when adding a corresponding
+# Bespoke members not modeled by any spec.
+#
+# - `REGISTER` is fired by the fastapi-users self-signup flow in
+#   `src/logic/auth/auth_processing.py` — there is no `RegistrationEntity`
+#   spec, the verb just sits on top of `User`.
+# - `JOB_RUN_STARTED` is fired by APScheduler-driven background jobs in
+#   `src/jobs/` (system actor; `resource_type="job"`; per-run `resource_id`).
+#   There is no spec home: a "job ran" event has no `AuditedResource` shape.
+#
+# Keep tight: add an entry only when adding a corresponding
 # `record_audit(action=...)` callsite.
-_BESPOKE: frozenset[str] = frozenset({"REGISTER"})
+_BESPOKE: frozenset[str] = frozenset({"REGISTER", "JOB_RUN_STARTED"})
 
 
 def _expected_members() -> set[str]:

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -1,0 +1,39 @@
+# Background jobs
+
+In-process scheduled work, driven by [APScheduler](https://apscheduler.readthedocs.io/) and started from [`src/main.py`](../main.py)'s `lifespan`.
+
+## Why this directory exists (bucket-grammar deviation)
+
+[`src/README.md`](../README.md) describes a strict two-bucket grammar — `framework/` (domain-agnostic) and `domain/` (entity-specific). `src/jobs/` is a **documented third top-level bucket**, in the same loose-files-at-`src/` category as `main.py`, `db.py`, and `auth_config.py`: app-level glue that is neither domain-specific nor reusable framework.
+
+A job needs:
+
+- A real DB session sharing the production engine and metadata (`async_session_maker` from [`../db.py`](../db.py)).
+- The same audit discipline mutation handlers obey: every meaningful state change writes a `record_audit(...)` row in the same transaction as the change.
+
+That's two app-level dependencies plus a scheduler, which doesn't fit cleanly under `framework/` (which knows nothing about specs or domain data) or `domain/<entity>/` (jobs cut across entities).
+
+If a future job's logic is naturally owned by one entity (e.g. nightly verification belongs to providers), the **handler** can live under `src/domain/logic/<entity>/`; this directory just owns the scheduling glue that calls it.
+
+## Rails
+
+Every job in this directory MUST:
+
+1. **Open its own session via `async_session_maker`** — never a FastAPI `Depends`, since there is no request at job-execution time.
+2. **Write an audit row** via `record_audit(...)` (or `record_audit_for(...)`/`async with mutate(...)`) for every meaningful state change, then commit. The system-actor convention is `actor_id=None`; `AuditLog.actor_id` is `nullable=True` with `ON DELETE SET NULL` ([`../framework/audit/log.py`](../framework/audit/log.py)).
+
+The `JOB_RUN_STARTED` action is bespoke (no spec home) — see [`../framework/audit/test_audit_action_drift.py`](../framework/audit/test_audit_action_drift.py).
+
+## Files
+
+- `scheduler.py` — `make_scheduler()` constructs an `AsyncIOScheduler`; `register_jobs(scheduler)` adds every job. Kept separate so tests can introspect registrations without `.start()`-ing.
+- `hello_world.py` — smallest job that exercises the rails. Cadence comes from `JOBS_HELLO_WORLD_INTERVAL_MIN` (default `60`); set it to `1` locally to watch the audit row appear.
+- `test_*.py` — colocated unit tests per the repo's [definition of done](../../CLAUDE.md#definition-of-done).
+
+## Disabling the scheduler
+
+Set `DISABLE_SCHEDULER=1` to skip `scheduler.start()` in [`../main.py`](../main.py). `register_jobs` still runs so the job table is introspectable; the scheduler simply never fires. The test environment sets this in `.env.test`.
+
+## APScheduler vs system cron
+
+Use APScheduler when a job needs **app rails** — the real `async_session_maker`, audit repository, domain handlers, in-process logging. Use a host-level cron ([`../../deployment/README.md`](../../deployment/README.md)) for jobs that operate outside the app (e.g. `deployment/droplet-files/cleanup-docker.sh` prunes container layers).

--- a/src/jobs/hello_world.py
+++ b/src/jobs/hello_world.py
@@ -1,0 +1,35 @@
+"""Hello-world job: the smallest possible proof that the APScheduler rails
+work end-to-end.
+
+Reads a session from `async_session_maker` (the same session factory the
+HTTP layer uses) and writes a single `JOB_RUN_STARTED` audit row with the
+system-actor convention (`actor_id=None`). The presence of this row in
+`audit_log` after one interval is the canary that the scheduler is
+running inside the app process and that jobs see the same DB the app
+sees.
+"""
+
+import logging
+from uuid import uuid4
+
+from src.db import async_session_maker
+from src.framework.audit.core import AuditAction, record_audit
+from src.framework.audit.repository import AuditRepository
+
+logger = logging.getLogger(__name__)
+
+
+async def run_hello_world() -> None:
+    async with async_session_maker() as session:
+        audit_repo = AuditRepository(session)
+        await record_audit(
+            audit_repo,
+            actor_id=None,
+            resource_type="job",
+            resource_id=uuid4(),
+            action=AuditAction.JOB_RUN_STARTED,
+            before=None,
+            after={"job": "hello_world"},
+        )
+        await session.commit()
+    logger.info("hello_world job completed")

--- a/src/jobs/scheduler.py
+++ b/src/jobs/scheduler.py
@@ -1,0 +1,28 @@
+"""Scheduler construction and job registration.
+
+`make_scheduler` and `register_jobs` are deliberately separate so tests
+can introspect what's registered without starting the scheduler (calling
+`.start()` would spin up a real background thread).
+"""
+
+import os
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from src.jobs.hello_world import run_hello_world
+
+
+def make_scheduler() -> AsyncIOScheduler:
+    return AsyncIOScheduler()
+
+
+def register_jobs(scheduler: AsyncIOScheduler) -> None:
+    interval_min = int(os.getenv("JOBS_HELLO_WORLD_INTERVAL_MIN", "60"))
+    scheduler.add_job(
+        run_hello_world,
+        trigger=IntervalTrigger(minutes=interval_min),
+        id="hello_world",
+        coalesce=True,
+        max_instances=1,
+    )

--- a/src/jobs/test_hello_world.py
+++ b/src/jobs/test_hello_world.py
@@ -1,0 +1,36 @@
+"""Pins the hello-world rails: one audit row per invocation, system actor.
+
+If this test fails after a change to `record_audit` or to the
+`JOB_RUN_STARTED` action, you've either drifted the system-actor convention
+or moved the audit call out of the job — see `src/jobs/README.md`.
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.models import AuditLog
+from src.framework.audit.core import AuditAction
+from src.jobs import hello_world
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_run_hello_world_writes_one_system_actor_audit_row(
+    monkeypatch: pytest.MonkeyPatch,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    monkeypatch.setattr(hello_world, "async_session_maker", db_test_session_manager)
+
+    await hello_world.run_hello_world()
+
+    async with db_test_session_manager() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.action == AuditAction.JOB_RUN_STARTED.value
+    assert row.actor_id is None
+    assert row.resource_type == "job"
+    assert row.before is None
+    assert row.after == {"job": "hello_world"}

--- a/src/jobs/test_scheduler.py
+++ b/src/jobs/test_scheduler.py
@@ -1,0 +1,35 @@
+"""Pins the scheduler-construction contract: `register_jobs` adds the
+declared jobs against the constructed scheduler without ever starting it.
+
+Starting an `AsyncIOScheduler` in a unit test would spin up a real
+background thread; `register_jobs` is deliberately separate so this test
+can assert what's wired up by inspecting `scheduler.get_jobs()`.
+"""
+
+from apscheduler.triggers.interval import IntervalTrigger
+
+from src.jobs.hello_world import run_hello_world
+from src.jobs.scheduler import make_scheduler, register_jobs
+
+
+def test_register_jobs_adds_hello_world_with_interval_trigger():
+    scheduler = make_scheduler()
+    register_jobs(scheduler)
+
+    jobs = {job.id: job for job in scheduler.get_jobs()}
+    assert "hello_world" in jobs
+
+    hello = jobs["hello_world"]
+    assert hello.func is run_hello_world
+    assert isinstance(hello.trigger, IntervalTrigger)
+    assert not scheduler.running
+
+
+def test_register_jobs_respects_interval_env(monkeypatch):
+    monkeypatch.setenv("JOBS_HELLO_WORLD_INTERVAL_MIN", "7")
+
+    scheduler = make_scheduler()
+    register_jobs(scheduler)
+
+    hello = scheduler.get_job("hello_world")
+    assert hello.trigger.interval.total_seconds() == 7 * 60

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from src.domain.logic.users.schema import UserRead
 from src.domain.routes import auth_pages, auth_routes
 from src.framework.dispatch.registry import entity_registry
 from src.framework.http.middleware import StripEmptyQueryParamsMiddleware
+from src.jobs.scheduler import make_scheduler, register_jobs
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -41,7 +42,23 @@ async def lifespan(app: FastAPI):
         logger.error("Application startup aborted due to database issues")
         raise
 
-    yield
+    # APScheduler runs inside the app process so jobs share the real
+    # async_session_maker and audit repository (see src/jobs/README.md).
+    # DISABLE_SCHEDULER=1 keeps the scheduler idle under pytest while
+    # still letting tests inspect register_jobs(make_scheduler()).
+    scheduler = make_scheduler()
+    register_jobs(scheduler)
+    scheduler_running = False
+    if os.getenv("DISABLE_SCHEDULER") != "1":
+        scheduler.start()
+        scheduler_running = True
+        logger.info("APScheduler started")
+
+    try:
+        yield
+    finally:
+        if scheduler_running:
+            scheduler.shutdown(wait=False)
 
 
 app = FastAPI(title="Bedlam Connect", lifespan=lifespan)


### PR DESCRIPTION
## Summary

Workstream B / PR 1 of 2 in the verification pipeline (closes #529). Stands up the in-process scheduling rails so later jobs — starting with B2 nightly verification (#530) — have a documented home and a working precedent for the system-actor audit convention.

- `src/jobs/` is a **new third top-level under `src/`**, alongside `framework/` and `domain/` — a documented deviation from the two-bucket grammar in [`src/README.md`](https://github.com/willthefirst/bedlam-connect/blob/issue-529-verification-b1/src/README.md). Jobs need app-level plumbing (`async_session_maker`, `AuditRepository`) but cut across entities, so neither bucket is a clean fit. The new `src/jobs/README.md` flags the deviation and documents the rails.
- `AuditAction.JOB_RUN_STARTED` is bespoke — no `AuditedResource` shape for "a job ran". Added to `_BESPOKE` in `test_audit_action_drift.py`, same pattern as `REGISTER`.
- `make_scheduler()` and `register_jobs()` are deliberately separate so tests can introspect registrations without starting a real background thread.
- `DISABLE_SCHEDULER=1` (set in `.env.test`) keeps APScheduler idle under pytest; `register_jobs(...)` still runs so the job table is inspectable.

## Pre-implementation contract-surface check

- **HTTP / URL / persisted formats:** no changes. Adds one new bespoke `AuditAction` value (`job_run_started`) — additive on the persisted vocabulary.
- **New runtime dep:** `apscheduler>=3.10,<4` added to `[project.optional-dependencies].app`.
- **Smaller prep PR?** No — this is already the smallest meaningful unit (wiring + one sample job; splitting further would leave no end-to-end proof of the rails).
- **Breaking surfaces:** none.

## Test plan

- [x] `dev test` — 1234 passed, 80 skipped.
- [x] `dev lint` — all checks green.
- [x] App boots: `from src.main import app` imports cleanly with apscheduler wired into the lifespan.
- [ ] Local end-to-end (reviewer-side, optional): `JOBS_HELLO_WORLD_INTERVAL_MIN=1 DISABLE_SCHEDULER= dev up`, wait one minute, confirm an `audit_log` row with `action='job_run_started'` and `actor_id IS NULL`.

## Follow-up

B2 (#530) depends on A4 (#528) — the verification orchestrator — which in turn depends on A2/A3 (#526/#527). B2 cannot ship until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)