### PR TITLE
Nightly provider-verification job (closes #530)

### DIFF
--- a/src/domain/logic/providers/repository.py
+++ b/src/domain/logic/providers/repository.py
@@ -38,6 +38,21 @@ class ProviderRepository(BaseRepository):
             limit=limit,
         )
 
+    async def list_for_verification(self) -> Sequence[Provider]:
+        """Return providers eligible for the nightly verification job
+        (`src/jobs/nightly_verification.py`).
+
+        Eligibility today is the minimum that's clearly correct:
+        non-deleted providers. We deliberately do NOT skip rows
+        verified within the last 24h — NPPES has no published rate
+        limit and the per-call timeout (10s) bounds total runtime, so
+        a "verified yesterday" provider re-verifying tonight is cheap
+        and keeps the daily badge fresh. Revisit this filter when
+        rate-limiting actually bites or the provider count grows past
+        O(1000).
+        """
+        return await self._list(select(Provider).filter(Provider.deleted_at.is_(None)))
+
     async def list_providers(
         self,
         *,

--- a/src/domain/logic/providers/test_repository.py
+++ b/src/domain/logic/providers/test_repository.py
@@ -440,6 +440,37 @@ async def test_list_providers_combined_filter_is_anded(
         assert [p.id for p in providers] == [keep_id]
 
 
+async def test_list_for_verification_returns_non_deleted_providers(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Eligibility for nightly verification is `deleted_at IS NULL` — see
+    `ProviderRepository.list_for_verification` docstring for the rationale.
+    """
+    import datetime
+
+    user_a = await _seed_user(db_test_session_manager)
+    user_b = await _seed_user(db_test_session_manager)
+    user_c = await _seed_user(db_test_session_manager)
+
+    kept_a = await _seed_provider(db_test_session_manager, owner_id=user_a.id)
+    kept_b = await _seed_provider(
+        db_test_session_manager, owner_id=user_b.id, practice_name="Other"
+    )
+    deleted = await _seed_provider(
+        db_test_session_manager, owner_id=user_c.id, practice_name="Gone"
+    )
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            row = await session.get(Provider, deleted.id)
+            row.deleted_at = datetime.datetime.now(datetime.timezone.utc)
+
+    async with db_test_session_manager() as session:
+        repo = ProviderRepository(session)
+        eligible = await repo.list_for_verification()
+        assert {p.id for p in eligible} == {kept_a.id, kept_b.id}
+
+
 async def test_list_providers_distinct_when_multiple_licensures_match(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):

--- a/src/domain/logic/verifications/README.md
+++ b/src/domain/logic/verifications/README.md
@@ -11,6 +11,11 @@ Persistence + pure-function primitives for the provider verification pipeline. T
 - `scoring.py` — `score_verification(...)` table-driven rules over `(NppesResult, OigResult, provider name)` → `Score(status, flags, name_match_score)`. No I/O.
 - `handlers.py` — `run_provider_verification(...)` orchestrator + `handle_create_provider_verification(...)` admin-only retrigger. Composes the primitives with persistence + audit + an `httpx.AsyncClient`. The bespoke route lives at [`../../routes/verifications.py`](../../routes/verifications.py) and is wired into `src/main.py` next to the other hand-rolled routers.
 
+The orchestrator has two callers:
+
+1. **`handle_create_provider_verification`** in this file (admin retrigger; `actor_id=requesting_user.id`).
+2. **`run_nightly_verification`** in [`../../../jobs/nightly_verification.py`](../../../jobs/nightly_verification.py) (daily APScheduler job; `actor_id=None`).
+
 (`__init__.py` is intentionally empty — these are imported directly via `src.domain.logic.verifications.nppes`/`.oig`/`.scoring`/`.repository`/`.schema`/`.handlers`.)
 
 ## Why pure functions, not classes

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -28,6 +28,7 @@ The `JOB_RUN_STARTED` action is bespoke (no spec home) — see [`../framework/au
 
 - `scheduler.py` — `make_scheduler()` constructs an `AsyncIOScheduler`; `register_jobs(scheduler)` adds every job. Kept separate so tests can introspect registrations without `.start()`-ing.
 - `hello_world.py` — smallest job that exercises the rails. Cadence comes from `JOBS_HELLO_WORLD_INTERVAL_MIN` (default `60`); set it to `1` locally to watch the audit row appear.
+- `nightly_verification.py` — runs the provider-verification orchestrator (`run_provider_verification` from [`../domain/logic/verifications/handlers.py`](../domain/logic/verifications/handlers.py)) for every non-deleted provider, sequentially, with `actor_id=None`. Schedule comes from `JOBS_NIGHTLY_VERIFICATION_CRON` (default `0 3 * * *` — daily at 03:00 server-local). Per-provider failures are logged and skipped; the loop never re-raises so one bad lookup can't strand the rest of the batch. Each per-provider call commits its own transaction inside the orchestrator.
 - `test_*.py` — colocated unit tests per the repo's [definition of done](../../CLAUDE.md#definition-of-done).
 
 ## Disabling the scheduler

--- a/src/jobs/nightly_verification.py
+++ b/src/jobs/nightly_verification.py
@@ -1,0 +1,60 @@
+"""Nightly provider-verification job.
+
+Iterates every non-deleted `Provider` and calls
+`run_provider_verification(...)` (the orchestrator from #528) with
+`actor_id=None` — the audit framework treats `None` as the system actor
+(`AuditLog.actor_id` is nullable with `ON DELETE SET NULL`; see
+`src/framework/audit/log.py`).
+
+Each per-provider call owns its own transaction (the orchestrator
+commits before returning), so a mid-loop failure can only lose the
+provider it raised on — earlier providers' verification rows are durable
+and later providers still run. Failures are logged with the offending
+provider id; the loop never re-raises.
+
+Sequential is intentional. NPPES is a free public registry with no
+documented rate limit; the LEIE check is local. The per-call timeout
+(see `_HTTP_TIMEOUT_SECONDS` in `src/domain/logic/verifications/handlers.py`)
+bounds total runtime. If the provider count grows past O(1000), revisit
+concurrency in a follow-up — don't bolt it on here.
+"""
+
+import logging
+
+import httpx
+
+from src.db import async_session_maker
+from src.domain.logic.providers.repository import ProviderRepository
+from src.domain.logic.verifications.handlers import run_provider_verification
+from src.domain.logic.verifications.repository import VerificationRepository
+from src.framework.audit.repository import AuditRepository
+
+logger = logging.getLogger(__name__)
+
+_HTTP_TIMEOUT_SECONDS = 10.0
+
+
+async def run_nightly_verification() -> None:
+    async with async_session_maker() as session:
+        provider_repo = ProviderRepository(session)
+        verification_repo = VerificationRepository(session)
+        audit_repo = AuditRepository(session)
+        providers = await provider_repo.list_for_verification()
+
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as http:
+            for provider in providers:
+                try:
+                    await run_provider_verification(
+                        provider_id=provider.id,
+                        verification_repo=verification_repo,
+                        provider_repo=provider_repo,
+                        audit_repo=audit_repo,
+                        http=http,
+                        actor_id=None,
+                    )
+                except Exception:
+                    logger.exception(
+                        "nightly verification failed for provider=%s", provider.id
+                    )
+
+    logger.info("nightly verification completed: %d providers", len(providers))

--- a/src/jobs/scheduler.py
+++ b/src/jobs/scheduler.py
@@ -8,9 +8,11 @@ can introspect what's registered without starting the scheduler (calling
 import os
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
 from src.jobs.hello_world import run_hello_world
+from src.jobs.nightly_verification import run_nightly_verification
 
 
 def make_scheduler() -> AsyncIOScheduler:
@@ -23,6 +25,19 @@ def register_jobs(scheduler: AsyncIOScheduler) -> None:
         run_hello_world,
         trigger=IntervalTrigger(minutes=interval_min),
         id="hello_world",
+        coalesce=True,
+        max_instances=1,
+    )
+
+    # `coalesce=True` + `max_instances=1` together mean a missed window
+    # (machine asleep, deploy in progress) collapses to a single run on
+    # wake-up, and the job never double-fires if a previous run is still
+    # in flight.
+    nightly_cron = os.getenv("JOBS_NIGHTLY_VERIFICATION_CRON", "0 3 * * *")
+    scheduler.add_job(
+        run_nightly_verification,
+        trigger=CronTrigger.from_crontab(nightly_cron),
+        id="nightly_verification",
         coalesce=True,
         max_instances=1,
     )

--- a/src/jobs/test_nightly_verification.py
+++ b/src/jobs/test_nightly_verification.py
@@ -1,0 +1,88 @@
+"""Pins the nightly-verification loop contract.
+
+Two invariants this file guards:
+
+1. Every eligible provider is handed to `run_provider_verification` once
+   with `actor_id=None` (the system-actor convention shared with the
+   admin retrigger endpoint when no user is logged in).
+2. One provider's failure does NOT stop the rest of the batch — the
+   orchestrator commits per-provider, so we must keep iterating after an
+   exception is logged.
+
+The orchestrator itself is stubbed: A4's `test_handlers.py` already pins
+the per-provider behaviour, and this test cares only about the loop.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.jobs import nightly_verification
+from tests.helpers import create_test_user, make_provider_with_org
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_providers(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    count: int,
+):
+    seeded = []
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            for i in range(count):
+                user = create_test_user(username=f"owner-{i}")
+                session.add(user)
+                await session.flush()
+                provider = make_provider_with_org(
+                    owner_id=user.id, practice_name=f"Practice {i}"
+                )
+                session.add(provider)
+                seeded.append(provider)
+    return seeded
+
+
+async def test_run_nightly_verification_calls_orchestrator_per_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    monkeypatch.setattr(
+        nightly_verification, "async_session_maker", db_test_session_manager
+    )
+    providers = await _seed_providers(db_test_session_manager, count=3)
+
+    calls: list[dict] = []
+
+    async def stub(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(nightly_verification, "run_provider_verification", stub)
+
+    await nightly_verification.run_nightly_verification()
+
+    assert {c["provider_id"] for c in calls} == {p.id for p in providers}
+    assert all(c["actor_id"] is None for c in calls)
+
+
+async def test_run_nightly_verification_continues_after_per_provider_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    monkeypatch.setattr(
+        nightly_verification, "async_session_maker", db_test_session_manager
+    )
+    providers = await _seed_providers(db_test_session_manager, count=3)
+    failing_id = providers[1].id
+
+    seen: list = []
+
+    async def stub(**kwargs):
+        seen.append(kwargs["provider_id"])
+        if kwargs["provider_id"] == failing_id:
+            raise RuntimeError("simulated NPPES outage")
+
+    monkeypatch.setattr(nightly_verification, "run_provider_verification", stub)
+
+    # The loop must swallow the per-provider exception and keep going.
+    await nightly_verification.run_nightly_verification()
+
+    assert set(seen) == {p.id for p in providers}

--- a/src/jobs/test_scheduler.py
+++ b/src/jobs/test_scheduler.py
@@ -6,9 +6,11 @@ background thread; `register_jobs` is deliberately separate so this test
 can assert what's wired up by inspecting `scheduler.get_jobs()`.
 """
 
+from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
 from src.jobs.hello_world import run_hello_world
+from src.jobs.nightly_verification import run_nightly_verification
 from src.jobs.scheduler import make_scheduler, register_jobs
 
 
@@ -33,3 +35,29 @@ def test_register_jobs_respects_interval_env(monkeypatch):
 
     hello = scheduler.get_job("hello_world")
     assert hello.trigger.interval.total_seconds() == 7 * 60
+
+
+def test_register_jobs_adds_nightly_verification_with_cron_trigger():
+    scheduler = make_scheduler()
+    register_jobs(scheduler)
+
+    nightly = scheduler.get_job("nightly_verification")
+    assert nightly is not None
+    assert nightly.func is run_nightly_verification
+    assert isinstance(nightly.trigger, CronTrigger)
+    # coalesce + max_instances=1 are what make the job safe across
+    # missed windows and overlapping deploys.
+    assert nightly.coalesce is True
+    assert nightly.max_instances == 1
+
+
+def test_register_jobs_respects_nightly_cron_env(monkeypatch):
+    monkeypatch.setenv("JOBS_NIGHTLY_VERIFICATION_CRON", "*/5 * * * *")
+
+    scheduler = make_scheduler()
+    register_jobs(scheduler)
+
+    nightly = scheduler.get_job("nightly_verification")
+    # Cheapest assertion that proves the env var threaded through:
+    # the parsed cron expression includes our minute spec.
+    assert "*/5" in str(nightly.trigger)


### PR DESCRIPTION
## Summary

Workstream B / PR 2 of 2 — final integration step in the verification pipeline (closes #530). Wires the A4 orchestrator into a daily APScheduler job so every non-deleted provider gets re-verified without manual intervention. Audit rows land with `actor_id=None` (system actor); the admin retrigger endpoint remains the only path for an authenticated actor.

- `ProviderRepository.list_for_verification()` — minimum-viable eligibility filter (`deleted_at IS NULL`). Skipping a "verified within last 24h" check is deliberate; the docstring explains the trade-off and the trigger to revisit.
- `src/jobs/nightly_verification.py` — sequential per-provider loop with a try/except wrapper so one provider's NPPES outage can't strand the rest of the batch. The orchestrator commits per provider, so earlier rows are durable before any later failure.
- Scheduler registration uses `CronTrigger.from_crontab(JOBS_NIGHTLY_VERIFICATION_CRON)` (default `0 3 * * *`) with `coalesce=True`, `max_instances=1` — a missed window collapses to one run on wake-up and the job never double-fires across deploys.

## Pre-implementation contract-surface check

- **HTTP / URL / DB schema / persisted formats:** no changes. Each per-provider call writes a `CREATE_VERIFICATION` audit row via the orchestrator — no new bespoke `AuditAction` member.
- **New env var:** `JOBS_NIGHTLY_VERIFICATION_CRON` with a safe production default (`0 3 * * *`).
- **Smaller prep PR?** No — depends on A4 (#528) and B1 (#529) being merged, both of which are. Splitting further would have no end-to-end target.
- **Breaking surfaces:** none.

## Test plan

- [x] `dev test` — 1304 passed, 80 skipped.
- [x] `dev lint` — all checks green.
- [x] Per-provider failure isolation pinned: `test_run_nightly_verification_continues_after_per_provider_failure`.
- [x] Scheduler-construction shape pinned: cron trigger, `coalesce=True`, `max_instances=1`.
- [ ] Local end-to-end (reviewer-side, optional): `JOBS_NIGHTLY_VERIFICATION_CRON='* * * * *' DISABLE_SCHEDULER= dev up`, seed a provider, confirm a fresh `verifications` row + matching `audit_log` entry with `actor_id IS NULL` within a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)