### PR TITLE
framework: import AuditLog directly from framework/audit/log

### DIFF
--- a/src/domain/logic/favorites/test_handlers.py
+++ b/src/domain/logic/favorites/test_handlers.py
@@ -27,8 +27,9 @@ from src.domain.logic.favorites.handlers import (
 )
 from src.domain.logic.favorites.repository import UserFavoriteRepository
 from src.domain.logic.providers.repository import ProviderRepository
-from src.domain.models import AuditLog, User, UserFavorite
+from src.domain.models import User, UserFavorite
 from src.framework.audit.core import AuditAction
+from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 from src.framework.http.exceptions import NotFoundError
 from tests.helpers import create_test_user, make_provider_with_org

--- a/src/domain/logic/providers/test_handlers.py
+++ b/src/domain/logic/providers/test_handlers.py
@@ -29,13 +29,13 @@ from src.domain.logic.providers.schema import (
 )
 from src.domain.logic.users.repository import UserRepository
 from src.domain.models import (
-    AuditLog,
     Provider,
     ProviderLicensure,
     User,
 )
 from src.domain.specs.provider import PROVIDER_ENTITY
 from src.framework.audit.core import AuditAction
+from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 from src.framework.dispatch.handlers import handle_create, handle_detail, handle_list
 from src.framework.http.exceptions import ForbiddenError, NotFoundError

--- a/src/domain/logic/verifications/test_handlers.py
+++ b/src/domain/logic/verifications/test_handlers.py
@@ -26,7 +26,8 @@ from src.domain.logic.verifications.handlers import (
     run_provider_verification,
 )
 from src.domain.logic.verifications.repository import VerificationRepository
-from src.domain.models import AuditLog, Provider, User, Verification
+from src.domain.models import Provider, User, Verification
+from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 from src.framework.http.exceptions import NotFoundError
 from tests.helpers import create_test_user, make_provider_with_org

--- a/src/domain/models/README.md
+++ b/src/domain/models/README.md
@@ -9,7 +9,7 @@ A model in cluster A does not import from cluster B. Shared primitives hoist to 
 ## Parent-level shared
 
 - `enums.py` — controlled-vocabulary tuples + `*_LABELS` dicts + `*_ICONS` dicts (Lucide icon names, consumed by listing-row macros) + `check_in_tuple_sql`. Single source of truth that Pydantic `Literal[*TUPLE]`, Jinja form macros, and DB `CHECK` constraints all derive from. A *leaf* (no internal imports) so any cluster can import without cycling. Both `*_LABELS` and `*_ICONS` are keyed by the storage value, so renaming a *label* doesn't propagate; renaming an *enum value* touches the tuple, the labels dict, and the icons dict in lockstep (guardrail tests in the relevant `test_schema.py` fail if any goes missing).
-- `__init__.py` — re-exports model classes and the framework primitives (`Base`, `BaseModel`, `metadata`, `AuditLog`) from [`../../framework/`](../../framework/) so external code can always say `from src.domain.models import ...`.
+- `__init__.py` — re-exports model classes and the framework primitives (`Base`, `BaseModel`, `metadata`) from [`../../framework/`](../../framework/) so external code can always say `from src.domain.models import ...`. The `AuditLog` model is framework-owned and imported directly from [`../../framework/audit/log.py`](../../framework/audit/log.py).
 
 ## Polymorphic entities (the post-shape)
 

--- a/src/domain/models/__init__.py
+++ b/src/domain/models/__init__.py
@@ -1,4 +1,8 @@
-from src.framework.audit.log import AuditLog
+# Side-effect import: AuditLog is framework-owned (`framework/audit/log.py`)
+# but the class declaration must run before Alembic reads `metadata` here,
+# otherwise `audit_log` won't be registered for autogenerate. Direct
+# consumers should import from `src.framework.audit.log`, not from here.
+from src.framework.audit.log import AuditLog  # noqa: F401
 from src.framework.persistence.base_model import Base, BaseModel, metadata
 
 from .enums import (
@@ -30,7 +34,6 @@ from .users.user import User
 from .verifications.verification import Verification
 
 __all__ = [
-    "AuditLog",
     "Base",
     "BaseModel",
     "CLIENT_AGE_GROUPS",

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -5,7 +5,8 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import AuditLog, User
+from src.domain.models import User
+from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 
 pytestmark = pytest.mark.asyncio

--- a/src/domain/routes/test_favorites.py
+++ b/src/domain/routes/test_favorites.py
@@ -14,7 +14,8 @@ from selectolax.parser import HTMLParser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import AuditLog, User, UserFavorite
+from src.domain.models import User, UserFavorite
+from src.framework.audit.log import AuditLog
 from tests.helpers import create_test_user, make_provider_with_org
 
 pytestmark = pytest.mark.asyncio

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -8,7 +8,8 @@ from sqlalchemy import select
 # Import session maker type for hinting
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import AuditLog, User
+from src.domain.models import User
+from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 from tests.helpers import create_test_user, make_provider_with_org, promote_to_admin
 

--- a/src/framework/README.md
+++ b/src/framework/README.md
@@ -28,6 +28,6 @@ Per-mount docstrings in [`dispatch/resource_routes.py`](dispatch/resource_routes
 
 ## Import discipline
 
-Framework code reads specs **via parameters, not via imports** — nothing under this directory imports from `src/domain/` at module load time. The one exception is the `AuditLog` SQLAlchemy class at `src/domain/models/__init__.py`, which the audit framework reads directly.
+Framework code reads specs **via parameters, not via imports**. Framework-owned SQLAlchemy classes (`Base`, `BaseModel`, `AuditLog`) live under `framework/` and are imported directly there; the audit framework owns `AuditLog` at [`audit/log.py`](audit/log.py), not through a domain re-export.
 
 The auth-resolved actor is typed via the structural [`Actor` protocol](actor.py), so generic handlers (`dispatch/handlers.py`), audit (`audit/core.py`), authz predicates (`authz.py`), and chrome context (`http/responses.py`) take `Actor` / `Actor | None` instead of a concrete domain `User`. The domain's `User` model satisfies the protocol by structure; tests can pass a `SimpleNamespace`.

--- a/src/framework/audit/core.py
+++ b/src/framework/audit/core.py
@@ -13,8 +13,8 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from src.domain.models import AuditLog
 from src.framework.actor import Actor
+from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 
 logger = logging.getLogger(__name__)

--- a/src/framework/audit/repository.py
+++ b/src/framework/audit/repository.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from sqlalchemy import select
 
-from src.domain.models import AuditLog
+from src.framework.audit.log import AuditLog
 from src.framework.persistence.base_repository import BaseRepository
 
 

--- a/src/framework/audit/test_core.py
+++ b/src/framework/audit/test_core.py
@@ -11,7 +11,6 @@ import pytest
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import AuditLog
 from src.framework.audit.core import (
     AuditAction,
     AuditedResource,
@@ -20,6 +19,7 @@ from src.framework.audit.core import (
     mutate,
     record_audit,
 )
+from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 from src.framework.persistence.base_repository import BaseRepository
 from tests.helpers import create_test_user

--- a/src/framework/audit/test_repository.py
+++ b/src/framework/audit/test_repository.py
@@ -11,7 +11,8 @@ import uuid
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import AuditLog, User
+from src.domain.models import User
+from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 from tests.helpers import create_test_user
 

--- a/src/jobs/test_hello_world.py
+++ b/src/jobs/test_hello_world.py
@@ -9,8 +9,8 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import AuditLog
 from src.framework.audit.core import AuditAction
+from src.framework.audit.log import AuditLog
 from src.jobs import hello_world
 
 pytestmark = pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`AuditLog` already lives at `src/framework/audit/log.py` — it's framework-owned. But every framework consumer (`audit/core.py`, `audit/repository.py`, and their tests) was importing it via `src.domain.models`, which re-exported it from the same framework module. The round-trip `framework → domain → framework` was structurally misleading: it implied `AuditLog` was domain code.

This PR makes every framework-side import direct and drops `AuditLog` from `src/domain/models/__init__.py`'s `__all__`. Six domain test files that read `AuditLog` through the re-export now import it from framework directly.

A side-effect import of `AuditLog` is preserved inside `domain/models/__init__.py` with an explanatory comment — Alembic autogenerate does `from src.domain.models import metadata` and needs the class declaration to have run by then for `audit_log` to appear in `metadata`.

**Stacked on top of #549** (Actor protocol). Merging order matters: #549 lands first.

## Changes

- `src/framework/audit/core.py`, `src/framework/audit/repository.py`, `src/framework/audit/test_core.py`, `src/framework/audit/test_repository.py`: import `AuditLog` from `src.framework.audit.log`.
- `src/jobs/test_hello_world.py`, `src/domain/logic/{favorites,providers,verifications}/test_handlers.py`, `src/domain/routes/test_{users,favorites,auth_routes}.py`: same.
- `src/domain/models/__init__.py`: drop `AuditLog` from `__all__`; keep the import as a documented side-effect for Alembic metadata.
- `src/framework/README.md`, `src/domain/models/README.md`: update the import-discipline narrative.

## Test plan

- [x] `dev test` — 1307 passed, 80 skipped
- [x] `dev lint` — all checks green
- [ ] Alembic autogenerate metadata visibility — verified via the runtime test suite (all `audit_log` write/read tests pass), but a full `alembic revision --autogenerate` dry-run would catch a registration regression sooner. Not run here.

## Follow-ups (separate PRs)

- Invert the repository DI registry in `framework/persistence/dependencies.py`.
- Make template globals registration spec-driven (`framework/rendering/templating.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)