### PR TITLE
test(contract): organization-create-form + program-create-form pairs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,8 @@ markers = [
     "users: contract pairs whose provider is `users-api`",
     "posts: contract pairs whose provider is `posts-api`",
     "providers: contract pairs whose provider is `providers-api`",
+    "organizations: contract pairs whose provider is `organizations-api`",
+    "programs: contract pairs whose provider is `programs-api`",
 ]
 
 [tool.title-case-check]

--- a/tests/test_contract/constants.py
+++ b/tests/test_contract/constants.py
@@ -30,6 +30,17 @@ STUB_PROVIDER_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
 PROVIDER_PATCH_API_PATH = f"/providers/{STUB_PROVIDER_ID}"
 PROVIDER_EDIT_FORM_PAGE_PATH = f"/providers/{STUB_PROVIDER_ID}/form"
 
+# Organization create form pact.
+ORGANIZATION_CREATE_API_PATH = "/organizations"
+ORGANIZATION_CREATE_FORM_PAGE_PATH = "/organizations/form"
+
+# Program create form pact. Programs attach to an existing Organization
+# via the form's `org_id` dropdown; the consumer stub seeds one Org
+# (`STUB_PROGRAM_FORM_ORG_ID`) so the pact body is deterministic.
+PROGRAM_CREATE_API_PATH = "/programs"
+PROGRAM_CREATE_FORM_PAGE_PATH = "/programs/form"
+STUB_PROGRAM_FORM_ORG_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+
 # Provider states
 PROVIDER_STATE_USER_DOES_NOT_EXIST = f"User {TEST_EMAIL} does not exist"
 PROVIDER_STATE_USER_EXISTS_AND_ACTIVE = f"User {TARGET_USER_ID} exists and is active"
@@ -40,6 +51,8 @@ PROVIDER_STATE_USER_CAN_CREATE_PROVIDER = "User can create a provider"
 PROVIDER_STATE_PROVIDER_EXISTS_AND_OWNED = (
     f"Provider {STUB_PROVIDER_ID} exists and is owned by the requester"
 )
+PROVIDER_STATE_USER_CAN_CREATE_ORGANIZATION = "User can create an organization"
+PROVIDER_STATE_USER_CAN_CREATE_PROGRAM = "User can create a program"
 
 # Consumer / provider Pact identifiers
 CONSUMER_NAME_REGISTRATION = "registration-form"
@@ -55,6 +68,12 @@ CONSUMER_NAME_PROVIDER_CREATE_FORM = "provider-create-form"
 CONSUMER_NAME_PROVIDER_EDIT_FORM = "provider-edit-form"
 PROVIDER_NAME_PROVIDERS = "providers-api"
 
+CONSUMER_NAME_ORGANIZATION_CREATE_FORM = "organization-create-form"
+PROVIDER_NAME_ORGANIZATIONS = "organizations-api"
+
+CONSUMER_NAME_PROGRAM_CREATE_FORM = "program-create-form"
+PROVIDER_NAME_PROGRAMS = "programs-api"
+
 # Timeouts
 NETWORK_TIMEOUT_MS = 500
 
@@ -64,3 +83,5 @@ PACT_PORT_USER_ACTIVATION = 1235
 PACT_PORT_POST_DELETE = 1238
 PACT_PORT_PROVIDER_CREATE = 1239
 PACT_PORT_PROVIDER_EDIT = 1240
+PACT_PORT_ORGANIZATION_CREATE = 1241
+PACT_PORT_PROGRAM_CREATE = 1242

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -14,7 +14,12 @@ import uvicorn
 from fastapi import FastAPI, Request
 
 from src.auth_config import current_active_user, current_admin_user
+from src.domain.logic.programs.schema import ProgramCreate
 from src.domain.logic.providers.schema import ProviderCreate
+from src.domain.models.enums import (
+    ORGANIZATION_TYPES,
+    ORGANIZATION_TYPES_LABELS,
+)
 from src.domain.routes import auth_pages
 from src.framework import APIResponse
 
@@ -33,6 +38,11 @@ STUB_POST_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
 # `STUB_PROVIDER_ID` in `tests/test_contract/constants.py`.
 STUB_PROVIDER_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
 
+# Stable Org id seeded by the program-create stub page so the form's
+# `org_id` dropdown has a deterministic option to select; matches
+# `STUB_PROGRAM_FORM_ORG_ID` in `tests/test_contract/constants.py`.
+STUB_PROGRAM_FORM_ORG_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+
 
 class ConsumerServerConfig:
     """Toggles for which page routes the consumer server should mount.
@@ -49,6 +59,8 @@ class ConsumerServerConfig:
         posts_owner_actions: bool = False,
         provider_create_form: bool = False,
         provider_edit_form: bool = False,
+        organization_create_form: bool = False,
+        program_create_form: bool = False,
         mock_auth: bool = True,
     ):
         self.auth_pages = auth_pages
@@ -56,6 +68,8 @@ class ConsumerServerConfig:
         self.posts_owner_actions = posts_owner_actions
         self.provider_create_form = provider_create_form
         self.provider_edit_form = provider_edit_form
+        self.organization_create_form = organization_create_form
+        self.program_create_form = program_create_form
         self.mock_auth = mock_auth
 
 
@@ -241,6 +255,67 @@ def _setup_provider_edit_form_stub(app: FastAPI) -> None:
         )
 
 
+def _setup_organization_create_form_stub(app: FastAPI) -> None:
+    """Mount a stub page that renders the real `organizations/form_new.html`
+    template, so the create-form's HTMX submit is exercised without a
+    database. The template reads `ORGANIZATION_TYPES` /
+    `ORGANIZATION_TYPES_LABELS` directly from context (the production
+    path injects them from `ORGANIZATION_ENTITY.static_context`), so the
+    stub does the same."""
+
+    class _StubAttrs:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    @app.get("/organizations/form")
+    async def organization_create_form_stub_page(request: Request):
+        current_user = _StubAttrs(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000005"),
+            username="organization_owner",
+            is_superuser=False,
+        )
+        return APIResponse.html_response(
+            template_name="organizations/form_new.html",
+            context={
+                "current_user": current_user,
+                "ORGANIZATION_TYPES": ORGANIZATION_TYPES,
+                "ORGANIZATION_TYPES_LABELS": ORGANIZATION_TYPES_LABELS,
+            },
+            request=request,
+        )
+
+
+def _setup_program_create_form_stub(app: FastAPI) -> None:
+    """Mount a stub page that renders the real `programs/form_new.html`
+    template, so the create-form's HTMX submit is exercised without a
+    database. The form's `org_id` dropdown reads `organizations` from
+    context (production path: `program_form_extras` scopes the list to
+    the user's owned Orgs); the stub seeds one Org so the pact body is
+    deterministic."""
+
+    class _StubAttrs:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    @app.get("/programs/form")
+    async def program_create_form_stub_page(request: Request):
+        current_user = _StubAttrs(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000006"),
+            username="program_owner",
+            is_superuser=False,
+        )
+        org = _StubAttrs(id=STUB_PROGRAM_FORM_ORG_ID, name="Acme Counseling")
+        return APIResponse.html_response(
+            template_name="programs/form_new.html",
+            context={
+                "current_user": current_user,
+                "schema": ProgramCreate,
+                "organizations": [org],
+            },
+            request=request,
+        )
+
+
 def setup_consumer_app_routes(app: FastAPI, config: ConsumerServerConfig) -> None:
     if config.auth_pages:
         app.include_router(auth_pages.auth_pages_api_router)
@@ -252,6 +327,10 @@ def setup_consumer_app_routes(app: FastAPI, config: ConsumerServerConfig) -> Non
         _setup_provider_create_form_stub(app)
     if config.provider_edit_form:
         _setup_provider_edit_form_stub(app)
+    if config.organization_create_form:
+        _setup_organization_create_form_stub(app)
+    if config.program_create_form:
+        _setup_program_create_form_stub(app)
 
 
 def run_consumer_server_process(

--- a/tests/test_contract/manifest.py
+++ b/tests/test_contract/manifest.py
@@ -7,7 +7,9 @@ from typing import Any, Callable, Optional
 import pytest
 
 from .infrastructure.servers.consumer import (
+    _setup_organization_create_form_stub,
     _setup_post_owner_actions_stub,
+    _setup_program_create_form_stub,
     _setup_provider_create_form_stub,
     _setup_provider_edit_form_stub,
     _setup_users_admin_actions_stub,
@@ -87,6 +89,24 @@ CONTRACT_PAIRS: list[ContractPair] = [
         consumer_setup_fn=_setup_provider_edit_form_stub,
         provider_state="Provider 44444444-4444-4444-4444-444444444444 exists and is owned by the requester",
         pytest_marks=(pytest.mark.provider, pytest.mark.providers),
+    ),
+    ContractPair(
+        consumer_name="organization-create-form",
+        provider_name="organizations-api",
+        pact_port=1241,
+        handler_mocks_factory=MockDataFactory.create_organization_create_dependency_config,
+        consumer_setup_fn=_setup_organization_create_form_stub,
+        provider_state="User can create an organization",
+        pytest_marks=(pytest.mark.provider, pytest.mark.organizations),
+    ),
+    ContractPair(
+        consumer_name="program-create-form",
+        provider_name="programs-api",
+        pact_port=1242,
+        handler_mocks_factory=MockDataFactory.create_program_create_dependency_config,
+        consumer_setup_fn=_setup_program_create_form_stub,
+        provider_state="User can create a program",
+        pytest_marks=(pytest.mark.provider, pytest.mark.programs),
     ),
 ]
 

--- a/tests/test_contract/tests/consumer/test_organization_create_form.py
+++ b/tests/test_contract/tests/consumer/test_organization_create_form.py
@@ -1,0 +1,96 @@
+"""Consumer contract: filling and submitting the organization create form.
+
+Verifies that the HTMX-decorated form rendered by
+`templates/organizations/form_new.html` (mounted via the
+`organization_create_form` stub on the consumer server) issues a
+`POST /organizations` form-encoded request with the field names and
+shapes the route's `OrganizationCreate` schema expects.
+
+Pinning the **blank `parent_org_id=`** field in the request body is
+deliberate: it's exactly the wire shape that 422'd in prod (#550, fixed
+by `OptionalUuid` on `OrganizationCreate.parent_org_id`). Keeping it in
+the pact stops a future schema change from regressing the create flow
+without a contract bump.
+"""
+
+import pytest
+from pact import Like
+from playwright.async_api import Page
+
+from tests.test_contract.constants import (
+    CONSUMER_NAME_ORGANIZATION_CREATE_FORM,
+    NETWORK_TIMEOUT_MS,
+    ORGANIZATION_CREATE_API_PATH,
+    ORGANIZATION_CREATE_FORM_PAGE_PATH,
+    PACT_PORT_ORGANIZATION_CREATE,
+    PROVIDER_NAME_ORGANIZATIONS,
+    PROVIDER_STATE_USER_CAN_CREATE_ORGANIZATION,
+)
+from tests.test_contract.tests.shared.helpers import (
+    setup_pact,
+    setup_playwright_pact_interception,
+)
+
+
+@pytest.mark.parametrize(
+    "origin_with_routes",
+    [{"organization_create_form": True, "auth_pages": False}],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_consumer_organization_create_form_submits(
+    origin_with_routes: str, page: Page
+):
+    """Fill the create form on the stubbed page; assert the intercepted
+    request matches the contracted shape — including a blank
+    `parent_org_id` (the #550 regression)."""
+    pact = setup_pact(
+        CONSUMER_NAME_ORGANIZATION_CREATE_FORM,
+        PROVIDER_NAME_ORGANIZATIONS,
+        port=PACT_PORT_ORGANIZATION_CREATE,
+    )
+    mock_server_uri = pact.uri
+    form_page_url = f"{origin_with_routes}{ORGANIZATION_CREATE_FORM_PAGE_PATH}"
+    full_mock_url = f"{mock_server_uri}{ORGANIZATION_CREATE_API_PATH}"
+
+    expected_request_headers = {
+        "Content-Type": Like("application/x-www-form-urlencoded")
+    }
+    # Browser serializes inputs in DOM order. `parent_org_id` is the
+    # third field in `form_new.html` and is left blank — the empty
+    # value is what shipped #550.
+    expected_request_body = "name=Acme+Counseling" "&type=clinic" "&parent_org_id="
+
+    (
+        pact.given(PROVIDER_STATE_USER_CAN_CREATE_ORGANIZATION)
+        .upon_receiving("a request to create an organization via web form")
+        .with_request(
+            method="POST",
+            path=ORGANIZATION_CREATE_API_PATH,
+            headers=expected_request_headers,
+            body=expected_request_body,
+        )
+        .will_respond_with(
+            status=201,
+            headers={"HX-Redirect": Like("/organizations/abc/form")},
+            body={"id": Like("88888888-8888-8888-8888-888888888888")},
+        )
+    )
+
+    await setup_playwright_pact_interception(
+        page=page,
+        api_path_to_intercept=ORGANIZATION_CREATE_API_PATH,
+        mock_pact_url=full_mock_url,
+        http_method="POST",
+    )
+
+    with pact:
+        await page.goto(form_page_url)
+        await page.wait_for_selector('input[name="name"]')
+        await page.locator('input[name="name"]').fill("Acme Counseling")
+        await page.locator('select[name="type"]').select_option("clinic")
+        # parent_org_id intentionally left blank — pins #550.
+        await page.locator("button[type='submit']").click()
+        await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
+
+    # Pact verification happens automatically on context exit.

--- a/tests/test_contract/tests/consumer/test_program_create_form.py
+++ b/tests/test_contract/tests/consumer/test_program_create_form.py
@@ -1,0 +1,115 @@
+"""Consumer contract: filling and submitting the program create form.
+
+Verifies that the HTMX-decorated form rendered by
+`templates/programs/form_new.html` (mounted via the `program_create_form`
+stub on the consumer server) issues a `POST /programs` form-encoded
+request with the field names and shapes the route's `ProgramCreate`
+schema expects. The form's `org_id` dropdown is populated by
+`program_form_extras` in production (scoped to the user's owned Orgs);
+the stub seeds one Org so the pact body is deterministic.
+
+`description` (optional text) is left blank — the browser still
+submits ``description=`` and the schema's ``StrippedOptionalText``
+coerces it to ``None``.
+
+`start_date` / `end_date` are filled with concrete dates rather than
+left blank: a blank text input posts ``start_date=`` (empty string),
+which `date | None` rejects with a 422 — the same class of bug as the
+fixed-in-#550 `parent_org_id` 422, here lurking on the date fields.
+Tracked separately (see issue #551, which broadens to nullable dates).
+"""
+
+import pytest
+from pact import Like
+from playwright.async_api import Page
+
+from tests.test_contract.constants import (
+    CONSUMER_NAME_PROGRAM_CREATE_FORM,
+    NETWORK_TIMEOUT_MS,
+    PACT_PORT_PROGRAM_CREATE,
+    PROGRAM_CREATE_API_PATH,
+    PROGRAM_CREATE_FORM_PAGE_PATH,
+    PROVIDER_NAME_PROGRAMS,
+    PROVIDER_STATE_USER_CAN_CREATE_PROGRAM,
+    STUB_PROGRAM_FORM_ORG_ID,
+)
+from tests.test_contract.tests.shared.helpers import (
+    setup_pact,
+    setup_playwright_pact_interception,
+)
+
+
+@pytest.mark.parametrize(
+    "origin_with_routes",
+    [{"program_create_form": True, "auth_pages": False}],
+    indirect=True,
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_consumer_program_create_form_submits(
+    origin_with_routes: str, page: Page
+):
+    """Fill the create form on the stubbed page; assert the intercepted
+    request matches the contracted shape."""
+    pact = setup_pact(
+        CONSUMER_NAME_PROGRAM_CREATE_FORM,
+        PROVIDER_NAME_PROGRAMS,
+        port=PACT_PORT_PROGRAM_CREATE,
+    )
+    mock_server_uri = pact.uri
+    form_page_url = f"{origin_with_routes}{PROGRAM_CREATE_FORM_PAGE_PATH}"
+    full_mock_url = f"{mock_server_uri}{PROGRAM_CREATE_API_PATH}"
+
+    expected_request_headers = {
+        "Content-Type": Like("application/x-www-form-urlencoded")
+    }
+    # DOM-order field serialization. The radio `accepting_referrals`
+    # is pre-checked at "true" by the template (`current=true`), so it
+    # submits without user interaction. Dates are real values, not
+    # blanks — see module docstring.
+    expected_request_body = (
+        f"org_id={STUB_PROGRAM_FORM_ORG_ID}"
+        "&name=Intensive+Outpatient"
+        "&description="
+        "&state_preference=NY"
+        "&start_date=2026-06-01"
+        "&end_date=2026-12-31"
+        "&accepting_referrals=true"
+    )
+
+    (
+        pact.given(PROVIDER_STATE_USER_CAN_CREATE_PROGRAM)
+        .upon_receiving("a request to create a program via web form")
+        .with_request(
+            method="POST",
+            path=PROGRAM_CREATE_API_PATH,
+            headers=expected_request_headers,
+            body=expected_request_body,
+        )
+        .will_respond_with(
+            status=201,
+            headers={"HX-Redirect": Like("/programs/abc/form")},
+            body={"id": Like("99999999-9999-9999-9999-999999999999")},
+        )
+    )
+
+    await setup_playwright_pact_interception(
+        page=page,
+        api_path_to_intercept=PROGRAM_CREATE_API_PATH,
+        mock_pact_url=full_mock_url,
+        http_method="POST",
+    )
+
+    with pact:
+        await page.goto(form_page_url)
+        await page.wait_for_selector('select[name="org_id"]')
+        await page.locator('select[name="org_id"]').select_option(
+            str(STUB_PROGRAM_FORM_ORG_ID)
+        )
+        await page.locator('input[name="name"]').fill("Intensive Outpatient")
+        await page.locator('select[name="state_preference"]').select_option("NY")
+        await page.locator('input[name="start_date"]').fill("2026-06-01")
+        await page.locator('input[name="end_date"]').fill("2026-12-31")
+        await page.locator("button[type='submit']").click()
+        await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
+
+    # Pact verification happens automatically on context exit.

--- a/tests/test_contract/tests/provider/test_organizations_verification.py
+++ b/tests/test_contract/tests/provider/test_organizations_verification.py
@@ -1,0 +1,29 @@
+"""Provider verification: every `organizations-api` pair in the manifest.
+
+The route's `current_active_user` dependency is overridden by the
+provider server fixture; `_handle_create_organization` is monkey-patched
+out via the combined dependency config so this verification exercises
+only the route layer.
+"""
+
+import pytest
+from yarl import URL
+
+from tests.test_contract.manifest import combined_handler_mocks, pairs_for_provider
+from tests.test_contract.tests.shared.provider_verification_base import (
+    create_provider_test_decorator,
+    verify_pair,
+)
+
+_PROVIDER = "organizations-api"
+_PAIRS = pairs_for_provider(_PROVIDER)
+_DEPENDENCY_CONFIG = combined_handler_mocks(_PROVIDER)
+
+
+@pytest.mark.provider
+@pytest.mark.organizations
+@create_provider_test_decorator(_DEPENDENCY_CONFIG, "with_organizations_api_mocks")
+@pytest.mark.parametrize("pair", _PAIRS, ids=lambda p: p.consumer_name)
+def test_provider_organizations_pact_verification(pair, provider_server: URL):
+    """Verify every `organizations-api` Pact contract against the running provider server."""
+    verify_pair(pair, provider_server)

--- a/tests/test_contract/tests/provider/test_programs_verification.py
+++ b/tests/test_contract/tests/provider/test_programs_verification.py
@@ -1,0 +1,29 @@
+"""Provider verification: every `programs-api` pair in the manifest.
+
+The route's `current_active_user` dependency is overridden by the
+provider server fixture; `_handle_create_program` is monkey-patched out
+via the combined dependency config so this verification exercises only
+the route layer.
+"""
+
+import pytest
+from yarl import URL
+
+from tests.test_contract.manifest import combined_handler_mocks, pairs_for_provider
+from tests.test_contract.tests.shared.provider_verification_base import (
+    create_provider_test_decorator,
+    verify_pair,
+)
+
+_PROVIDER = "programs-api"
+_PAIRS = pairs_for_provider(_PROVIDER)
+_DEPENDENCY_CONFIG = combined_handler_mocks(_PROVIDER)
+
+
+@pytest.mark.provider
+@pytest.mark.programs
+@create_provider_test_decorator(_DEPENDENCY_CONFIG, "with_programs_api_mocks")
+@pytest.mark.parametrize("pair", _PAIRS, ids=lambda p: p.consumer_name)
+def test_provider_programs_pact_verification(pair, provider_server: URL):
+    """Verify every `programs-api` Pact contract against the running provider server."""
+    verify_pair(pair, provider_server)

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -170,6 +170,44 @@ class MockDataFactory:
         }
 
     @classmethod
+    def create_organization_create_dependency_config(cls) -> Dict[str, Any]:
+        """Mock for the factory-built `_handle_create_organization`.
+
+        The route under test (`POST /organizations`) reads `id` off the
+        handler's return value to build the response body and the
+        `Location` / `HX-Redirect` headers. A `SimpleNamespace` exposing
+        `id` is sufficient. The framework stitches the auto-bound handler
+        onto the route module, so contract patches target
+        `src.domain.routes.organizations._handle_create_organization`.
+        """
+        stub_organization = SimpleNamespace(
+            id=UUID("88888888-8888-8888-8888-888888888888"),
+        )
+        return {
+            "src.domain.routes.organizations._handle_create_organization": {
+                "return_value_config": stub_organization
+            }
+        }
+
+    @classmethod
+    def create_program_create_dependency_config(cls) -> Dict[str, Any]:
+        """Mock for the factory-built `_handle_create_program`.
+
+        The route under test (`POST /programs`) reads `id` off the
+        handler's return value to build the response body and the
+        `Location` / `HX-Redirect` headers. A `SimpleNamespace` exposing
+        `id` is sufficient.
+        """
+        stub_program = SimpleNamespace(
+            id=UUID("99999999-9999-9999-9999-999999999999"),
+        )
+        return {
+            "src.domain.routes.programs._handle_create_program": {
+                "return_value_config": stub_program
+            }
+        }
+
+    @classmethod
     def create_provider_update_dependency_config(cls) -> Dict[str, Any]:
         """Mock for `handle_update_provider`.
 


### PR DESCRIPTION
## Summary

Per [`RESOURCE_GRAMMAR.md`](https://github.com/willthefirst/bedlam-connect/blob/main/src/domain/routes/RESOURCE_GRAMMAR.md): every form-bearing resource MUST have a contract test pair. Organizations and programs both ship form pages (\`/organizations/form\`, \`/programs/form\`) but had no pacts — the gap that the #550 prod regression exposed. Filling it.

Two new pairs landed end-to-end:

- \`organization-create-form\` ↔ \`organizations-api\`
- \`program-create-form\` ↔ \`programs-api\`

Each pair wires the seven pieces the existing pairs (provider-create / -edit, user-admin, post-owner, registration) use: a constants entry, a consumer stub page that renders the real template, a \`MockDataFactory\` dependency config that patches the route's factory-built create handler, a \`ContractPair\` entry in \`manifest.py\`, a Playwright-driven consumer test, and a parametrized provider verification file. \`organizations\` and \`programs\` pytest marks are registered alongside the existing per-provider marks.

## Findings surfaced by the new contracts

- The org pact deliberately pins \`parent_org_id=\` (blank optional UUID) in the request body — the exact shape that 422'd in #550. Pinning the post-fix wire shape stops a future schema change from regressing the create flow silently.
- The program pact uses filled dates because \`date | None\` 422s on blank \`start_date=\` / \`end_date=\` — the same class of bug as #550, on a different scalar type. The first run of the contract suite failed loudly here; issue #551 (the \`OptionalUuid\` sweep) has been broadened to cover nullable dates and any other nullable scalar bound to a form input.

## Test plan

- [x] \`dev test tests/test_contract/test_manifest.py\` — 6 passed (uniqueness / dedup invariants hold with two new pairs)
- [x] \`dev test contract\` — 20 passed (10 consumer + provider, end to end)
- [x] \`dev test\` (default suite, excludes contract) — 1312 passed
- [x] \`dev lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)