### PR TITLE
feat: route registry as template URL SOT — entity_url + lint (closes #552)

### DIFF
--- a/scripts/dev/template_route_check.py
+++ b/scripts/dev/template_route_check.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Forbid hardcoded entity-collection paths in Jinja templates.
+
+The systemic fix for #552: templates reference URL paths through the
+``entity_url`` / ``entity_form_url`` Jinja globals (defined in
+``src/framework/rendering/route_urls.py``) so the entity registry is
+the single source of truth for resource URL shape. Without this rule,
+stale links like ``/organizations/new`` (#550) can creep back in: a
+hardcoded path doesn't get a compile-time check that a matching route
+is mounted.
+
+What the lint flags
+-------------------
+
+A string literal whose **first path segment** matches the URL-collection
+of any registered top-level entity. Examples:
+
+  ``href="/posts/form"``                — flagged
+  ``href="/organizations/{{ id }}"``    — flagged (literal first segment)
+  ``"/users/me"`` in any context        — flagged
+  ``request.url.path == '/providers'``  — flagged
+  ``href="?kind=client_referral"``      — not flagged (relative, no `/`)
+  ``href="{{ entity_url('post') }}"``   — not flagged (no literal segment)
+  ``"/licensures"`` (sub of provider)   — not flagged (not top-level)
+
+Jinja comments (``{# ... #}``) are stripped before scanning so docstring
+examples in macro headers don't false-positive.
+
+Exit code 0 = clean; 1 = violations found (prints them).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATE_ROOTS = (
+    _REPO_ROOT / "src" / "domain" / "templates",
+    _REPO_ROOT / "src" / "framework" / "templates",
+)
+_JINJA_COMMENT_RE = re.compile(r"\{#.*?#\}", re.DOTALL)
+
+
+def _load_collections() -> set[str]:
+    """Top-level collection names from the live entity registry.
+
+    Adding a new top-level entity automatically extends the lint —
+    no per-script update needed.
+
+    Owned subentities (provider credentials) have ``url_collection``
+    too, but their routes nest under the parent (no top-level path
+    starts with ``/licensures``), so they're filtered out.
+    """
+    # Lazy import + ensure routes are loaded so the registry is populated.
+    sys.path.insert(0, str(_REPO_ROOT))
+    import src.domain.routes  # noqa: F401 — side-effect import
+    from src.framework.dispatch.registry import entity_registry
+
+    out: set[str] = set()
+    for spec in entity_registry.specs():
+        if spec.parent is not None:
+            # Owned subentity — never appears as a top-level path segment.
+            continue
+        if spec.prefix_override is not None:
+            seg = spec.prefix_override.lstrip("/").split("/", 1)[0]
+            if seg:
+                out.add(seg)
+        else:
+            out.add(spec.url_collection)
+    return out
+
+
+def _strip_comments(text: str) -> str:
+    return _JINJA_COMMENT_RE.sub("", text)
+
+
+def _build_pattern(collections: set[str]) -> re.Pattern[str]:
+    """Match a string literal whose first path segment is a known
+    collection. Single- or double-quoted; word-boundary after the
+    collection name so ``/users_foo`` doesn't false-positive."""
+    alt = "|".join(re.escape(c) for c in sorted(collections))
+    return re.compile(rf"""(['"])(/(?:{alt})\b[^'"]*)(['"])""")
+
+
+def _violations(path: Path, pattern: re.Pattern[str]) -> list[tuple[Path, int, str]]:
+    text = _strip_comments(path.read_text(encoding="utf-8"))
+    out: list[tuple[Path, int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for m in pattern.finditer(line):
+            out.append((path, lineno, m.group(2)))
+    return out
+
+
+def _iter_templates() -> list[Path]:
+    files: list[Path] = []
+    for root in _TEMPLATE_ROOTS:
+        if not root.exists():
+            continue
+        files.extend(sorted(root.rglob("*.html")))
+    return files
+
+
+def main() -> int:
+    collections = _load_collections()
+    pattern = _build_pattern(collections)
+
+    all_violations: list[tuple[Path, int, str]] = []
+    for path in _iter_templates():
+        all_violations.extend(_violations(path, pattern))
+
+    if all_violations:
+        print(
+            f"❌ Found {len(all_violations)} hardcoded entity URL"
+            f"{'s' if len(all_violations) != 1 else ''} in templates:\n"
+        )
+        for path, lineno, literal in all_violations:
+            rel = path.relative_to(_REPO_ROOT)
+            print(f"  {rel}:{lineno}: {literal!r}")
+        print(
+            "\nUse `entity_url(name, *, id=None, subresource=None)` or "
+            "`entity_form_url(name, *, id=None)` instead — see "
+            "src/framework/rendering/route_urls.py.\n"
+            "Known top-level entity collections: " + ", ".join(sorted(collections))
+        )
+        return 1
+
+    print(
+        f"✅ No hardcoded entity URLs in templates "
+        f"({len(_iter_templates())} files checked)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/test_template_route_check.py
+++ b/scripts/dev/test_template_route_check.py
@@ -1,0 +1,166 @@
+"""Tests for ``template_route_check``.
+
+The lint reads its known-collection set from the live entity registry,
+so adding a new top-level entity automatically extends the lint with no
+script change. Tests below construct synthetic template content rather
+than asserting against the repo's own templates (which a passing
+``main()`` already pins indirectly).
+"""
+
+from scripts.dev.template_route_check import (
+    _build_pattern,
+    _strip_comments,
+    _violations,
+)
+
+_COLLECTIONS = {"organizations", "providers", "posts", "users"}
+_PATTERN = _build_pattern(_COLLECTIONS)
+
+
+def _scan(text: str) -> list[str]:
+    """Return the literal matches the pattern finds in ``text``,
+    after stripping Jinja comments — mirrors ``_violations`` minus
+    the file-system step."""
+    stripped = _strip_comments(text)
+    return [m.group(2) for m in _PATTERN.finditer(stripped)]
+
+
+# --- The bug class -----------------------------------------------------
+
+
+def test_flags_hardcoded_form_url_in_href():
+    assert _scan('<a href="/organizations/form">New</a>') == ["/organizations/form"]
+
+
+def test_flags_hardcoded_url_in_hx_post():
+    assert _scan('<form hx-post="/posts">') == ["/posts"]
+
+
+def test_flags_hardcoded_subresource_url():
+    """Sub-of-known-collection paths (`/users/me`) start with a known
+    top-level segment — still flagged. Author uses
+    ``entity_url('user', id='me')`` or ``entity_url('user_favorite')``."""
+    assert _scan('<a href="/users/me">Profile</a>') == ["/users/me"]
+
+
+def test_flags_url_with_jinja_interpolation_in_middle():
+    """Literal first segment is enough — interpolation doesn't rescue."""
+    assert _scan('<a href="/posts/{{ post.id }}">x</a>') == ["/posts/{{ post.id }}"]
+
+
+def test_flags_literal_in_set_statement():
+    """Jinja statement blocks are NOT stripped — literals in
+    ``{% set ... %}`` get caught too."""
+    matches = _scan('{% set resource_url = "/organizations" %}')
+    assert matches == ["/organizations"]
+
+
+def test_flags_literal_in_macro_arg():
+    """Macro calls inside ``{{ ... }}`` are not stripped — author
+    should pass ``entity_url(...)`` to the macro instead."""
+    matches = _scan('{{ confirm_delete_button("/posts/" ~ post.id, "Delete?") }}')
+    assert "/posts/" in matches
+
+
+def test_flags_literal_in_request_path_comparison():
+    """The base.html nav uses ``request.url.path == '/users/me'`` to
+    derive active-page state. Migration: hoist the path into a
+    ``{% set _x = entity_url(...) %}`` and compare against ``_x``."""
+    matches = _scan("{% if request.url.path == '/users/me' %}...{% endif %}")
+    assert matches == ["/users/me"]
+
+
+# --- The good cases ----------------------------------------------------
+
+
+def test_does_not_flag_entity_url_call():
+    """The whole point — the helper's output is the canonical URL
+    and contains no literal collection path in template source."""
+    assert _scan("<a href=\"{{ entity_url('post') }}\">Posts</a>") == []
+
+
+def test_does_not_flag_entity_form_url_with_id():
+    assert (
+        _scan("<a href=\"{{ entity_form_url('provider', id=p.id) }}\">Edit</a>") == []
+    )
+
+
+def test_does_not_flag_relative_url():
+    """Query-only links (``?kind=client_referral``) are fine as-is —
+    they don't anchor at a collection root."""
+    assert _scan('<a href="?kind=client_referral">x</a>') == []
+
+
+def test_does_not_flag_root_link():
+    """The root link ``/`` doesn't start with any known collection."""
+    assert _scan('<a href="/">Home</a>') == []
+
+
+def test_does_not_flag_non_entity_first_segment():
+    """``/auth/login`` and ``/static/foo.css`` aren't entity paths."""
+    assert _scan('<a href="/auth/login">Sign in</a>') == []
+    assert _scan('<link href="/static/style.css" rel="stylesheet">') == []
+
+
+def test_does_not_flag_word_boundary_lookalike():
+    """``/users_audit_log`` isn't ``/users`` — the ``\\b`` boundary
+    after the collection name guards against false positives on names
+    that share a prefix."""
+    assert _scan('<a href="/users_audit_log/x">x</a>') == []
+
+
+def test_strips_jinja_comments():
+    """Doc-only examples inside ``{# ... #}`` blocks are stripped
+    before scanning — macro headers can illustrate usage with literal
+    paths without tripping the lint."""
+    text = (
+        "{# Example:\n"
+        '  {{ inline_add_form("/providers/" ~ p.id ~ "/licensures") }}\n'
+        "#}\n"
+        '<form action="/posts">x</form>'
+    )
+    matches = _scan(text)
+    # Only the live `/posts`, not the `/providers/` inside the comment.
+    assert matches == ["/posts"]
+
+
+def test_strips_multiline_jinja_comments():
+    text = "{# line 1\nline 2 with /posts literal\nline 3 #}\nreal /posts is here"
+    stripped = _strip_comments(text)
+    assert "line 2" not in stripped
+    assert "real /posts is here" in stripped
+
+
+# --- Pattern construction ----------------------------------------------
+
+
+def test_pattern_includes_all_known_collections():
+    """The pattern is regenerated from the registry; every known
+    collection must be in the alternation."""
+    for c in _COLLECTIONS:
+        # Match a literal URL for each collection.
+        assert _PATTERN.search(f'"/{c}"')
+
+
+def test_pattern_anchors_on_string_quote():
+    """The lint matches inside a quoted string only — paths in prose
+    text (not quoted) don't match. Avoids hitting docstring URLs in
+    non-Jinja-comment prose."""
+    assert _PATTERN.search("See /posts for more") is None
+    assert _PATTERN.search('See "/posts" for more') is not None
+
+
+# --- File-level integration --------------------------------------------
+
+
+def test_violations_reports_file_and_line(tmp_path):
+    f = tmp_path / "bad.html"
+    f.write_text("<p>fine</p>\n" '<a href="/posts/form">new</a>\n' "<p>also fine</p>\n")
+    out = _violations(f, _PATTERN)
+    assert out == [(f, 2, "/posts/form")]
+
+
+def test_violations_returns_empty_for_clean_file(tmp_path):
+    f = tmp_path / "ok.html"
+    f.write_text("<a href=\"{{ entity_url('post') }}\">Posts</a>")
+    assert _violations(f, _PATTERN) == []

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -240,6 +240,10 @@ class QualityCommands:
                 "🐍 Checking Python cluster boundaries...",
                 [sys.executable, "scripts/dev/python_cluster_imports_check.py"],
             ),
+            (
+                "🔗 Checking template route literals...",
+                [sys.executable, "scripts/dev/template_route_check.py"],
+            ),
         ]
 
         exit_code = 0

--- a/src/domain/routes/RESOURCE_GRAMMAR.md
+++ b/src/domain/routes/RESOURCE_GRAMMAR.md
@@ -99,6 +99,8 @@ A form page MAY host multiple `<form>` HTML tags posting to different action end
 
 **Every form-bearing resource MUST have a contract test pair** in [`tests/test_contract/`](../../../tests/test_contract/README.md). One consumer test (browser drives the form, asserts the request shape via Pact) and one provider test (running provider verified against the pact). Contract tests catch template ↔ route drift that no single colocated test can — adding them is part of the definition of done for any new HTML form.
 
+**Templates MUST reference parent-resource and form-page URLs through `entity_url` / `entity_form_url`** (Jinja globals registered by [`src/framework/rendering/route_urls.py`](../../framework/rendering/route_urls.py)). Hardcoded paths like `href="/organizations/form"` are forbidden by [`scripts/dev/template_route_check.py`](../../../scripts/dev/template_route_check.py) — the helpers read the URL from the entity registry, so a `url_collection` rename or a grammar shape change is a one-place edit. Subresource URLs (state axes, field clusters) pass through `entity_url(name, id=..., subresource="...")`; multi-segment nested URLs concatenate the leaf path onto a helper call.
+
 ### 4. revisions
 
 When edits to a `published` resource must not be destructive (audit, review, autosave):

--- a/src/domain/templates/favorites/list.html
+++ b/src/domain/templates/favorites/list.html
@@ -12,7 +12,7 @@
   id="favorites-table",
 ) %}
 <p id="favorites-empty">
-  No favorites yet. <a href="/providers">Browse providers</a> to add some.
+  No favorites yet. <a href="{{ entity_url('provider') }}">Browse providers</a> to add some.
 </p>
 {% endcall %}
 {% endblock %}

--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -1,13 +1,13 @@
 {% extends "views/detail.html" %}
 
-{% set resource_url = "/organizations" %}
+{% set resource_url = entity_url('organization') %}
 
 {% block resource_label %}Organizations{% endblock %}
 {% block current_label %}{{ organization.name }}{% endblock %}
 
 {% block actions %}
 {% if can_edit %}
-<li><a href="/organizations/{{ organization.id }}/form" role="button" class="outline">Edit organization</a></li>
+<li><a href="{{ entity_form_url('organization', id=organization.id) }}" role="button" class="outline">Edit organization</a></li>
 {% endif %}
 {% endblock %}
 
@@ -19,7 +19,7 @@
       <dt>Name</dt><dd>{{ organization.name }}</dd>
       <dt>Type</dt><dd>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</dd>
       <dt>Parent organization</dt>
-      <dd>{% if organization.parent_org_id %}<a href="/organizations/{{ organization.parent_org_id }}">{{ organization.parent_org_id }}</a>{% else %}— (root)
+      <dd>{% if organization.parent_org_id %}<a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent_org_id }}</a>{% else %}— (root)
       {% endif %}</dd>
     </dl>
   </section>

--- a/src/domain/templates/organizations/form_edit.html
+++ b/src/domain/templates/organizations/form_edit.html
@@ -2,8 +2,8 @@
 {%- from "_shared/form_fields.html" import select_field, text_field -%}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
 
-{% set resource_url = "/organizations" %}
-{% set resource_detail_url = "/organizations/" ~ organization.id %}
+{% set resource_url = entity_url('organization') %}
+{% set resource_detail_url = entity_url('organization', id=organization.id) %}
 
 {% block resource_label %}Organizations{% endblock %}
 {% block current_label %}{{ organization.name }}{% endblock %}
@@ -11,7 +11,7 @@
 {% block content %}
 <section>
   <h2>Organization</h2>
-  <form hx-patch="/organizations/{{ organization.id }}">
+  <form hx-patch="{{ entity_url('organization', id=organization.id) }}">
     <fieldset>
       <legend>Identity</legend>
       {{ text_field("name", "Name", current=organization.name, maxlength=200) }}
@@ -31,8 +31,8 @@
 
 <section>
   <h2>Delete</h2>
-  {{ confirm_delete_button("/organizations/" ~ organization.id, "Delete this organization?") }}
+  {{ confirm_delete_button(entity_url('organization', id=organization.id), "Delete this organization?") }}
 </section>
 
-<p><a href="/organizations/{{ organization.id }}" role="button" class="secondary outline">Cancel</a></p>
+<p><a href="{{ entity_url('organization', id=organization.id) }}" role="button" class="secondary outline">Cancel</a></p>
 {% endblock %}

--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -1,12 +1,12 @@
 {% extends "views/form_new.html" %}
 {%- from "_shared/form_fields.html" import select_field, text_field -%}
 
-{% set resource_url = "/organizations" %}
+{% set resource_url = entity_url('organization') %}
 
 {% block resource_label %}Organizations{% endblock %}
 
 {% block content %}
-<form hx-post="/organizations">
+<form hx-post="{{ entity_url('organization') }}">
   <fieldset>
     <legend>Organization</legend>
     {{ text_field("name", "Name", maxlength=200) }}

--- a/src/domain/templates/organizations/list.html
+++ b/src/domain/templates/organizations/list.html
@@ -3,7 +3,7 @@
 {% block resource_label %}Organizations{% endblock %}
 
 {% block actions %}
-<li><a href="/organizations/form" role="button">Create organization</a></li>
+<li><a href="{{ entity_form_url('organization') }}" role="button">Create organization</a></li>
 {% endblock %}
 
 {% block content %}
@@ -19,9 +19,9 @@
   <tbody>
     {%- for org in organizations %}
     <tr>
-      <td><a href="/organizations/{{ org.id }}">{{ org.name }}</a></td>
+      <td><a href="{{ entity_url('organization', id=org.id) }}">{{ org.name }}</a></td>
       <td>{{ ORGANIZATION_TYPES_LABELS[org.type] }}</td>
-      <td>{% if org.parent_org_id %}<a href="/organizations/{{ org.parent_org_id }}">Parent</a>{% else %}—{% endif %}</td>
+      <td>{% if org.parent_org_id %}<a href="{{ entity_url('organization', id=org.parent_org_id) }}">Parent</a>{% else %}—{% endif %}</td>
     </tr>
     {%- endfor %}
   </tbody>

--- a/src/domain/templates/posts/_item.html
+++ b/src/domain/templates/posts/_item.html
@@ -132,7 +132,7 @@ per-kind, so a single-kind filter doesn't need to suppress anything.
 {%- set posture = insurance_posture(post) -%}
 <article data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
   <header class="post-header">
-    <strong><a href="/posts/{{ post.id }}">{{ headline_text }}{% if state %}, {{ state }}{% endif %}</a></strong>
+    <strong><a href="{{ entity_url('post', id=post.id) }}">{{ headline_text }}{% if state %}, {{ state }}{% endif %}</a></strong>
     {{ _modality_chips(in_person, virtual) }}
     <small>{{ post.created_at | format_post_date }}</small>
   </header>

--- a/src/domain/templates/posts/_owner_actions.html
+++ b/src/domain/templates/posts/_owner_actions.html
@@ -17,6 +17,6 @@
 #}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
 {% if can_edit %}
-<li><a href="/posts/{{ post.id }}/form" role="button" class="outline">Edit</a></li>
-<li>{{ confirm_delete_button("/posts/" ~ post.id, "Permanently delete this post? This cannot be undone.") }}</li>
+<li><a href="{{ entity_form_url('post', id=post.id) }}" role="button" class="outline">Edit</a></li>
+<li>{{ confirm_delete_button(entity_url('post', id=post.id), "Permanently delete this post? This cannot be undone.") }}</li>
 {% endif %}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -1,6 +1,6 @@
 {% extends "views/detail.html" %}
 
-{% set resource_url = "/posts" %}
+{% set resource_url = entity_url('post') %}
 
 {% block resource_label %}Posts{% endblock %}
 {% block current_label %}Post{% endblock %}
@@ -24,7 +24,7 @@
 {% set d = post.client_referral_detail %}
   <p>
     <span data-kind-chip="client_referral">Seeking</span>
-    <small>by <a href="/users/{{ post.owner_id }}">{{ post.owner.username }}</a> · {{ post.created_at | format_post_date }}</small>
+    <small>by <a href="{{ entity_url('user', id=post.owner_id) }}">{{ post.owner.username }}</a> · {{ post.created_at | format_post_date }}</small>
   </p>
 
   <p>{{ d.description }}</p>
@@ -67,7 +67,7 @@
 {% set p = d.provider %}
   <p>
     <span data-kind-chip="provider_availability">Providing</span>
-    <small>by <a href="/users/{{ post.owner_id }}">{{ post.owner.username }}</a> · {{ post.created_at | format_post_date }}</small>
+    <small>by <a href="{{ entity_url('user', id=post.owner_id) }}">{{ post.owner.username }}</a> · {{ post.created_at | format_post_date }}</small>
   </p>
 
   {% if d.description %}
@@ -76,7 +76,7 @@
 
   <dl>
     <dt>Practice</dt>
-    <dd><a href="/providers/{{ p.id }}">{{ p.org.name }}</a></dd>
+    <dd><a href="{{ entity_url('provider', id=p.id) }}">{{ p.org.name }}</a></dd>
     <dt>Location</dt>
     <dd>{{ p.location_city }}, {{ p.location_state }} {{ p.location_zip }}</dd>
     <dt>In-person sessions</dt>
@@ -144,7 +144,7 @@
 {% set prog = d.program %}
   <p>
     <span data-kind-chip="provider_availability">Providing</span>
-    <small>by <a href="/users/{{ post.owner_id }}">{{ post.owner.username }}</a> &middot; {{ post.created_at | format_post_date }}</small>
+    <small>by <a href="{{ entity_url('user', id=post.owner_id) }}">{{ post.owner.username }}</a> &middot; {{ post.created_at | format_post_date }}</small>
   </p>
 
   {% if d.description %}
@@ -153,7 +153,7 @@
 
   <dl>
     <dt>Program</dt>
-    <dd><a href="/programs/{{ prog.id }}">{{ prog.name }}</a></dd>
+    <dd><a href="{{ entity_url('program', id=prog.id) }}">{{ prog.name }}</a></dd>
     <dt>Organization</dt>
     <dd>{{ prog.organization.name }}</dd>
     {% if prog.state_preference %}

--- a/src/domain/templates/posts/edit_client_referral.html
+++ b/src/domain/templates/posts/edit_client_referral.html
@@ -1,14 +1,14 @@
 {% extends "views/form_edit.html" %}
 {% from "posts/_client_referral_form.html" import client_referral_form %}
 
-{% set resource_url = "/posts" %}
-{% set resource_detail_url = "/posts/" ~ post.id %}
+{% set resource_url = entity_url('post') %}
+{% set resource_detail_url = entity_url('post', id=post.id) %}
 
 {% block resource_label %}Posts{% endblock %}
 {% block current_label %}Post{% endblock %}
 
 {% block content %}
-{{ client_referral_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=client_referral_create_schema) }}
+{{ client_referral_form("patch", entity_url('post', id=post.id), "Save changes", post=post, schema=client_referral_create_schema) }}
 
-<p><a href="/posts/{{ post.id }}" role="button" class="secondary outline">Cancel</a></p>
+<p><a href="{{ entity_url('post', id=post.id) }}" role="button" class="secondary outline">Cancel</a></p>
 {% endblock %}

--- a/src/domain/templates/posts/edit_program_availability.html
+++ b/src/domain/templates/posts/edit_program_availability.html
@@ -1,14 +1,14 @@
 {% extends "views/form_edit.html" %}
 {% from "posts/_program_availability_form.html" import program_availability_form %}
 
-{% set resource_url = "/posts" %}
-{% set resource_detail_url = "/posts/" ~ post.id %}
+{% set resource_url = entity_url('post') %}
+{% set resource_detail_url = entity_url('post', id=post.id) %}
 
 {% block resource_label %}Posts{% endblock %}
 {% block current_label %}Post{% endblock %}
 
 {% block content %}
-{{ program_availability_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=program_availability_create_schema, current_user=current_user) }}
+{{ program_availability_form("patch", entity_url('post', id=post.id), "Save changes", post=post, schema=program_availability_create_schema, current_user=current_user) }}
 
-<p><a href="/posts/{{ post.id }}" role="button" class="secondary outline">Cancel</a></p>
+<p><a href="{{ entity_url('post', id=post.id) }}" role="button" class="secondary outline">Cancel</a></p>
 {% endblock %}

--- a/src/domain/templates/posts/edit_provider_availability.html
+++ b/src/domain/templates/posts/edit_provider_availability.html
@@ -1,14 +1,14 @@
 {% extends "views/form_edit.html" %}
 {% from "posts/_provider_availability_form.html" import provider_availability_form %}
 
-{% set resource_url = "/posts" %}
-{% set resource_detail_url = "/posts/" ~ post.id %}
+{% set resource_url = entity_url('post') %}
+{% set resource_detail_url = entity_url('post', id=post.id) %}
 
 {% block resource_label %}Posts{% endblock %}
 {% block current_label %}Post{% endblock %}
 
 {% block content %}
-{{ provider_availability_form("patch", "/posts/" ~ post.id, "Save changes", post=post, schema=provider_availability_create_schema, current_user=current_user) }}
+{{ provider_availability_form("patch", entity_url('post', id=post.id), "Save changes", post=post, schema=provider_availability_create_schema, current_user=current_user) }}
 
-<p><a href="/posts/{{ post.id }}" role="button" class="secondary outline">Cancel</a></p>
+<p><a href="{{ entity_url('post', id=post.id) }}" role="button" class="secondary outline">Cancel</a></p>
 {% endblock %}

--- a/src/domain/templates/posts/form_new.html
+++ b/src/domain/templates/posts/form_new.html
@@ -1,6 +1,6 @@
 {% extends "views/form_new.html" %}
 
-{% set resource_url = "/posts" %}
+{% set resource_url = entity_url('post') %}
 
 {% block resource_label %}Posts{% endblock %}
 
@@ -13,7 +13,7 @@
    `?kind=…`, which the handler routes to the kind-specific create
    form. Two kinds today; add another `<p><a>…</a></p>` per kind. #}
 {% block content %}
-<p><a href="/posts/form?kind=client_referral" role="button">Refer a client to a provider</a></p>
-<p><a href="/posts/form?kind=provider_availability" role="button">Announce availability for new clients</a></p>
-<p><a href="/posts/form?kind=program_availability" role="button">Announce program intake</a></p>
+<p><a href="{{ entity_form_url('post') }}?kind=client_referral" role="button">Refer a client to a provider</a></p>
+<p><a href="{{ entity_form_url('post') }}?kind=provider_availability" role="button">Announce availability for new clients</a></p>
+<p><a href="{{ entity_form_url('post') }}?kind=program_availability" role="button">Announce program intake</a></p>
 {% endblock %}

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -8,7 +8,7 @@
    picks the kind there, then lands on the kind-specific create form.
    The action is a `<li>` because the toolbar's right zone is a
    `<menu class="toolbar-right">` of commands. #}
-<li><a href="/posts/form" role="button">Create post</a></li>
+<li><a href="{{ entity_form_url('post') }}" role="button">Create post</a></li>
 {% endblock %}
 
 {% block content %}

--- a/src/domain/templates/posts/new_client_referral.html
+++ b/src/domain/templates/posts/new_client_referral.html
@@ -1,11 +1,11 @@
 {% extends "views/form_new.html" %}
 {% from "posts/_client_referral_form.html" import client_referral_form %}
 
-{% set resource_url = "/posts" %}
+{% set resource_url = entity_url('post') %}
 
 {% block resource_label %}Posts{% endblock %}
 
 {% block content %}
 <p>Per <code>notes/forms_spec.md</code>. No PII.</p>
-{{ client_referral_form("post", "/posts", "Create client referral", schema=client_referral_create_schema) }}
+{{ client_referral_form("post", entity_url('post'), "Create client referral", schema=client_referral_create_schema) }}
 {% endblock %}

--- a/src/domain/templates/posts/new_program_availability.html
+++ b/src/domain/templates/posts/new_program_availability.html
@@ -1,15 +1,15 @@
 {% extends "views/form_new.html" %}
 {% from "posts/_program_availability_form.html" import program_availability_form %}
 
-{% set resource_url = "/posts" %}
+{% set resource_url = entity_url('post') %}
 
 {% block resource_label %}Posts{% endblock %}
 
 {% block content %}
 {% if not current_user.programs %}
-<p>You need a program before posting program availability. <a href="/programs/form">Create a program</a>, then return here.</p>
+<p>You need a program before posting program availability. <a href="{{ entity_form_url('program') }}">Create a program</a>, then return here.</p>
 {% else %}
 <p>Per <code>notes/forms_spec.md</code>. No PII.</p>
-{{ program_availability_form("post", "/posts", "Create program availability", schema=program_availability_create_schema, current_user=current_user) }}
+{{ program_availability_form("post", entity_url('post'), "Create program availability", schema=program_availability_create_schema, current_user=current_user) }}
 {% endif %}
 {% endblock %}

--- a/src/domain/templates/posts/new_provider_availability.html
+++ b/src/domain/templates/posts/new_provider_availability.html
@@ -1,15 +1,15 @@
 {% extends "views/form_new.html" %}
 {% from "posts/_provider_availability_form.html" import provider_availability_form %}
 
-{% set resource_url = "/posts" %}
+{% set resource_url = entity_url('post') %}
 
 {% block resource_label %}Posts{% endblock %}
 
 {% block content %}
 {% if not current_user.providers %}
-<p>You need a provider profile before posting availability. <a href="/providers/form">Create your provider profile</a>, then return here.</p>
+<p>You need a provider profile before posting availability. <a href="{{ entity_form_url('provider') }}">Create your provider profile</a>, then return here.</p>
 {% else %}
 <p>Per <code>notes/forms_spec.md</code>. No PII.</p>
-{{ provider_availability_form("post", "/posts", "Create provider availability", schema=provider_availability_create_schema, current_user=current_user) }}
+{{ provider_availability_form("post", entity_url('post'), "Create provider availability", schema=provider_availability_create_schema, current_user=current_user) }}
 {% endif %}
 {% endblock %}

--- a/src/domain/templates/programs/detail.html
+++ b/src/domain/templates/programs/detail.html
@@ -1,13 +1,13 @@
 {% extends "views/detail.html" %}
 
-{% set resource_url = "/programs" %}
+{% set resource_url = entity_url('program') %}
 
 {% block resource_label %}Programs{% endblock %}
 {% block current_label %}{{ program.name }}{% endblock %}
 
 {% block actions %}
 {% if can_edit %}
-<li><a href="/programs/{{ program.id }}/form" role="button" class="outline">Edit program</a></li>
+<li><a href="{{ entity_form_url('program', id=program.id) }}" role="button" class="outline">Edit program</a></li>
 {% endif %}
 {% endblock %}
 
@@ -17,7 +17,7 @@
     <h2>Program</h2>
     <dl>
       <dt>Name</dt><dd>{{ program.name }}</dd>
-      <dt>Organization</dt><dd><a href="/organizations/{{ program.org_id }}">{{ program.organization.name }}</a></dd>
+      <dt>Organization</dt><dd><a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a></dd>
       {% if program.description %}
       <dt>Description</dt><dd>{{ program.description }}</dd>
       {% endif %}

--- a/src/domain/templates/programs/form_edit.html
+++ b/src/domain/templates/programs/form_edit.html
@@ -2,8 +2,8 @@
 {%- from "_shared/form_fields.html" import radio_bool_field, select_field, text_field -%}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
 
-{% set resource_url = "/programs" %}
-{% set resource_detail_url = "/programs/" ~ program.id %}
+{% set resource_url = entity_url('program') %}
+{% set resource_detail_url = entity_url('program', id=program.id) %}
 
 {% block resource_label %}Programs{% endblock %}
 {% block current_label %}{{ program.name }}{% endblock %}
@@ -16,7 +16,7 @@
      Org (added by `program_form_extras` on the edit path even when
      the user doesn't own it, so the form doesn't silently drop the
      FK on submit). #}
-  <form hx-patch="/programs/{{ program.id }}">
+  <form hx-patch="{{ entity_url('program', id=program.id) }}">
     <fieldset>
       <legend>Identity</legend>
       <label for="org_id">
@@ -26,7 +26,7 @@
           <option value="{{ o.id }}"{% if o.id == program.org_id %} selected{% endif %}>{{ o.name }}</option>
           {%- endfor %}
         </select>
-        <small>Don't see your organization? <a href="/organizations/form">Create one first</a>.</small>
+        <small>Don't see your organization? <a href="{{ entity_form_url('organization') }}">Create one first</a>.</small>
       </label>
       {{ text_field("name", "Name", current=program.name) }}
       {{ text_field("description", "Description (optional)", current=program.description, required=false) }}
@@ -47,8 +47,8 @@
 
 <section>
   <h2>Delete</h2>
-  {{ confirm_delete_button("/programs/" ~ program.id, "Delete this program?") }}
+  {{ confirm_delete_button(entity_url('program', id=program.id), "Delete this program?") }}
 </section>
 
-<p><a href="/programs/{{ program.id }}" role="button" class="secondary outline">Cancel</a></p>
+<p><a href="{{ entity_url('program', id=program.id) }}" role="button" class="secondary outline">Cancel</a></p>
 {% endblock %}

--- a/src/domain/templates/programs/form_new.html
+++ b/src/domain/templates/programs/form_new.html
@@ -1,7 +1,7 @@
 {% extends "views/form_new.html" %}
 {%- from "_shared/form_fields.html" import field_for, radio_bool_field, text_field -%}
 
-{% set resource_url = "/programs" %}
+{% set resource_url = entity_url('program') %}
 
 {% block resource_label %}Programs{% endblock %}
 
@@ -12,8 +12,8 @@
    scoped per-viewer by `program_form_extras` (the spec's
    `form_extras_path`) — it lists only the Orgs the requesting user
    owns. Superusers see every Org. To attach to a new Organization,
-   create it via /organizations/form first. #}
-<form hx-post="/programs">
+   create it via `entity_form_url('organization')` first. #}
+<form hx-post="{{ entity_url('program') }}">
   <fieldset>
     <legend>Program</legend>
     <label for="org_id">
@@ -24,7 +24,7 @@
         <option value="{{ o.id }}">{{ o.name }}</option>
         {%- endfor %}
       </select>
-      <small>Don't see your organization? <a href="/organizations/form">Create one first</a>.</small>
+      <small>Don't see your organization? <a href="{{ entity_form_url('organization') }}">Create one first</a>.</small>
     </label>
     {{ field_for(schema, "name", "Name") }}
     {{ field_for(schema, "description", "Description (optional)") }}

--- a/src/domain/templates/programs/list.html
+++ b/src/domain/templates/programs/list.html
@@ -3,7 +3,7 @@
 {% block resource_label %}Programs{% endblock %}
 
 {% block actions %}
-<li><a href="/programs/form" role="button">Create program</a></li>
+<li><a href="{{ entity_form_url('program') }}" role="button">Create program</a></li>
 {% endblock %}
 
 {% block content %}
@@ -20,8 +20,8 @@
   <tbody>
     {%- for program in programs %}
     <tr>
-      <td><a href="/programs/{{ program.id }}">{{ program.name }}</a></td>
-      <td><a href="/organizations/{{ program.org_id }}">{{ program.organization.name }}</a></td>
+      <td><a href="{{ entity_url('program', id=program.id) }}">{{ program.name }}</a></td>
+      <td><a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a></td>
       <td>{{ program.state_preference or "—" }}</td>
       <td>{{ "Yes" if program.accepting_referrals else "No" }}</td>
     </tr>

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -1,6 +1,6 @@
 {% extends "views/detail.html" %}
 
-{% set resource_url = "/providers" %}
+{% set resource_url = entity_url('provider') %}
 
 {% block resource_label %}Providers{% endblock %}
 {% block current_label %}{{ provider.org.name }}{% endblock %}
@@ -17,20 +17,20 @@
   {% if is_favorited %}
   <li><button type="button"
           class="secondary outline"
-          hx-delete="/users/me/favorites/{{ provider.id }}"
+          hx-delete="{{ entity_url('user_favorite', id=provider.id) }}"
           hx-confirm="Remove this provider from your favorites?">
     Unfavorite
   </button></li>
   {% else %}
   <li><button type="button"
           class="outline"
-          hx-post="/users/me/favorites/{{ provider.id }}">
+          hx-post="{{ entity_url('user_favorite', id=provider.id) }}">
     Favorite
   </button></li>
   {% endif %}
 {% endif %}
 {% if can_edit %}
-<li><a href="/providers/{{ provider.id }}/form" role="button" class="outline">Edit provider</a></li>
+<li><a href="{{ entity_form_url('provider', id=provider.id) }}" role="button" class="outline">Edit provider</a></li>
 {% endif %}
 {% endblock %}
 
@@ -39,7 +39,7 @@
   <section>
     <h2>Practice</h2>
     <dl>
-      <dt>Practice name</dt><dd><a href="/organizations/{{ provider.org_id }}">{{ provider.org.name }}</a></dd>
+      <dt>Practice name</dt><dd><a href="{{ entity_url('organization', id=provider.org_id) }}">{{ provider.org.name }}</a></dd>
       <dt>City</dt><dd>{{ provider.location_city }}</dd>
       <dt>State</dt><dd>{{ provider.location_state }}</dd>
       <dt>ZIP</dt><dd>{{ provider.location_zip }}</dd>

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -4,8 +4,8 @@
 {%- from "_shared/sections.html" import list_or_empty -%}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
 
-{% set resource_url = "/providers" %}
-{% set resource_detail_url = "/providers/" ~ provider.id %}
+{% set resource_url = entity_url('provider') %}
+{% set resource_detail_url = entity_url('provider', id=provider.id) %}
 
 {% block resource_label %}Providers{% endblock %}
 {% block current_label %}{{ provider.org.name }}{% endblock %}
@@ -15,9 +15,9 @@
   <h2>Practice</h2>
   {# `org_id` PATCH reassigns the Provider to a different Organization;
      `org.name` itself changes by editing the Organization (not via this
-     form). To use a new Organization, create one at
-     <a href="/organizations/form">/organizations/form</a> first. See #524. #}
-  <form hx-patch="/providers/{{ provider.id }}">
+     form). To use a new Organization, create one via
+     `entity_form_url('organization')` first. See #524. #}
+  <form hx-patch="{{ entity_url('provider', id=provider.id) }}">
     <fieldset>
       <legend>Practice location</legend>
       <label for="org_id">
@@ -27,7 +27,7 @@
           <option value="{{ o.id }}"{% if o.id == provider.org_id %} selected{% endif %}>{{ o.name }}</option>
           {%- endfor %}
         </select>
-        <small>Don't see your organization? <a href="/organizations/form">Create one first</a>.</small>
+        <small>Don't see your organization? <a href="{{ entity_form_url('organization') }}">Create one first</a>.</small>
       </label>
       {{ text_field("location_city", "City", current=provider.location_city, maxlength=120) }}
       {{ select_field("location_state", "State", US_STATES, current=provider.location_state) }}
@@ -57,11 +57,11 @@
   <li>
     <strong>{{ LICENSE_TYPES_LABELS[lic.license_type] }}</strong>
     &mdash; {{ lic.license_number }} ({{ lic.issuing_state }}){% if lic.expiration_date %}, expires {{ lic.expiration_date }}{% endif %}
-    {{ confirm_delete_button("/providers/" ~ provider.id ~ "/licensures/" ~ lic.id, "Remove this licensure?") }}
+    {{ confirm_delete_button(entity_url('provider', id=provider.id) ~ "/licensures/" ~ lic.id, "Remove this licensure?") }}
   </li>
   {% endcall %}
 
-  {% call inline_add_form("/providers/" ~ provider.id ~ "/licensures", "Add licensure", "Add licensure") %}
+  {% call inline_add_form(entity_url('provider', id=provider.id) ~ "/licensures", "Add licensure", "Add licensure") %}
     {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
     {{ text_field("license_number", "License number", maxlength=120) }}
     {{ select_field("issuing_state", "Issuing state", US_STATES, placeholder=true) }}
@@ -75,11 +75,11 @@
   <li>
     <strong>{{ EDUCATION_TYPES_LABELS[edu.education_type] }}</strong>
     &mdash; {{ edu.institution }}{% if edu.month_completed %}, {{ edu.month_completed }}{% endif %}
-    {{ confirm_delete_button("/providers/" ~ provider.id ~ "/educations/" ~ edu.id, "Remove this education entry?") }}
+    {{ confirm_delete_button(entity_url('provider', id=provider.id) ~ "/educations/" ~ edu.id, "Remove this education entry?") }}
   </li>
   {% endcall %}
 
-  {% call inline_add_form("/providers/" ~ provider.id ~ "/educations", "Add education", "Add education") %}
+  {% call inline_add_form(entity_url('provider', id=provider.id) ~ "/educations", "Add education", "Add education") %}
     {{ select_field("education_type", "Education type", EDUCATION_TYPES, labels=EDUCATION_TYPES_LABELS, placeholder=true) }}
     {{ text_field("institution", "Institution", maxlength=200) }}
     {{ text_field("month_completed", "Month completed (YYYY-MM)", required=false, pattern="\\d{4}-\\d{2}", maxlength=7) }}
@@ -92,16 +92,16 @@
   <li>
     <strong>{{ CERTIFICATION_TYPES_LABELS[cert.certification_type] }}</strong>
     &mdash; {{ cert.certifying_body }}{% if cert.expiration_date %}, expires {{ cert.expiration_date }}{% endif %}
-    {{ confirm_delete_button("/providers/" ~ provider.id ~ "/certifications/" ~ cert.id, "Remove this certification?") }}
+    {{ confirm_delete_button(entity_url('provider', id=provider.id) ~ "/certifications/" ~ cert.id, "Remove this certification?") }}
   </li>
   {% endcall %}
 
-  {% call inline_add_form("/providers/" ~ provider.id ~ "/certifications", "Add certification", "Add certification") %}
+  {% call inline_add_form(entity_url('provider', id=provider.id) ~ "/certifications", "Add certification", "Add certification") %}
     {{ select_field("certification_type", "Certification type", CERTIFICATION_TYPES, labels=CERTIFICATION_TYPES_LABELS, placeholder=true) }}
     {{ text_field("certifying_body", "Certifying body", maxlength=200) }}
     {{ text_field("expiration_date", "Expiration date (YYYY-MM-DD)", required=false, pattern="\\d{4}-\\d{2}-\\d{2}", maxlength=10) }}
   {% endcall %}
 </section>
 
-<p><a href="/providers/{{ provider.id }}" role="button" class="secondary outline">Cancel</a></p>
+<p><a href="{{ entity_url('provider', id=provider.id) }}" role="button" class="secondary outline">Cancel</a></p>
 {% endblock %}

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -1,7 +1,7 @@
 {% extends "views/form_new.html" %}
 {%- from "_shared/form_fields.html" import field_for, radio_bool_field, text_field -%}
 
-{% set resource_url = "/providers" %}
+{% set resource_url = entity_url('provider') %}
 
 {% block resource_label %}Providers{% endblock %}
 
@@ -11,10 +11,10 @@
 {# `org_id` is the FK to the Provider's Organization (the practice's
    display name lives on `org.name`). The dropdown lists every Org in
    the directory; any user may attach their Provider to any Org (#524).
-   To create a new Organization, visit
-   <a href="/organizations/form">/organizations/form</a> first; this PR
-   doesn't bundle inline-create into the Provider form. #}
-<form hx-post="/providers">
+   To create a new Organization, visit the create form
+   (use `entity_form_url('organization')`) first; this PR doesn't
+   bundle inline-create into the Provider form. #}
+<form hx-post="{{ entity_url('provider') }}">
   <fieldset>
     <legend>Practice</legend>
     <label for="org_id">
@@ -25,7 +25,7 @@
         <option value="{{ o.id }}">{{ o.name }}</option>
         {%- endfor %}
       </select>
-      <small>Don't see your organization? <a href="/organizations/form">Create one first</a>.</small>
+      <small>Don't see your organization? <a href="{{ entity_form_url('organization') }}">Create one first</a>.</small>
     </label>
     {{ field_for(schema, "location_city", "City") }}
     {{ field_for(schema, "location_state", "State") }}

--- a/src/domain/templates/users/_admin_actions.html
+++ b/src/domain/templates/users/_admin_actions.html
@@ -26,7 +26,7 @@
 <li><button
   type="button"
   class="secondary outline"
-  hx-put="/users/{{ target_user.id }}/activation"
+  hx-put="{{ entity_url('user', id=target_user.id, subresource='activation') }}"
   hx-ext="json-enc"
   hx-vals='{"state": "deactivated"}'
   hx-confirm="Deactivate {{ target_user.username }}? They will be unable to log in until reactivated.">
@@ -36,12 +36,12 @@
 <li><button
   type="button"
   class="secondary outline"
-  hx-put="/users/{{ target_user.id }}/activation"
+  hx-put="{{ entity_url('user', id=target_user.id, subresource='activation') }}"
   hx-ext="json-enc"
   hx-vals='{"state": "active"}'
   hx-confirm="Reactivate {{ target_user.username }}?">
   Reactivate
 </button></li>
 {% endif %}
-<li>{{ confirm_delete_button("/users/" ~ target_user.id, "Permanently delete " ~ target_user.username ~ "? This cannot be undone.") }}</li>
+<li>{{ confirm_delete_button(entity_url('user', id=target_user.id), "Permanently delete " ~ target_user.username ~ "? This cannot be undone.") }}</li>
 {% endif %}

--- a/src/domain/templates/users/_columns.html
+++ b/src/domain/templates/users/_columns.html
@@ -26,7 +26,7 @@ renders nothing when the viewer is not an admin (its existing guard).
 {% macro user_row(user, can_admin_actions=False) -%}
 <tr data-row-id="{{ user.id }}">
   <td data-label="Username" class="primary">
-    <a href="/users/{{ user.id }}">{{ user.username }}</a>
+    <a href="{{ entity_url('user', id=user.id) }}">{{ user.username }}</a>
   </td>
   <td data-label="Status">
     {%- if user.is_active -%}

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -2,7 +2,7 @@
 {%- from "_shared/index_table.html" import index_table -%}
 {%- from "_shared/_provider_row.html" import provider_headers, provider_row -%}
 
-{% set resource_url = "/users" %}
+{% set resource_url = entity_url('user') %}
 
 {% block resource_label %}Users{% endblock %}
 {% block current_label %}{{ target_user.username }}{% endblock %}
@@ -32,7 +32,7 @@
      the user themselves — viewing someone else's profile shouldn't
      expose their private favorites list. #}
   {% if is_self %}
-  <p><a href="/users/me/favorites">Favorites</a></p>
+  <p><a href="{{ entity_url('user_favorite') }}">Favorites</a></p>
   {% endif %}
 
   <section>

--- a/src/domain/templates/users/providers_list.html
+++ b/src/domain/templates/users/providers_list.html
@@ -9,8 +9,8 @@
    fit. #}
 {% block breadcrumb %}
 {{ breadcrumb([
-  ("Users", "/users"),
-  (target_user.username, "/users/" ~ target_user.id),
+  ("Users", entity_url('user')),
+  (target_user.username, entity_url('user', id=target_user.id)),
   ("Providers", none),
 ]) }}
 {% endblock %}
@@ -25,7 +25,7 @@
 <p id="user-providers-empty">
   {% if is_self %}
   You have not created any providers yet.
-  <a href="/providers/form" role="button" class="outline">Create your first provider</a>
+  <a href="{{ entity_form_url('provider') }}" role="button" class="outline">Create your first provider</a>
   {% else %}
   This user has no providers yet.
   {% endif %}

--- a/src/framework/rendering/route_urls.py
+++ b/src/framework/rendering/route_urls.py
@@ -1,0 +1,110 @@
+"""URL helpers for Jinja templates.
+
+Templates should not hardcode entity URL paths. ``entity_url`` and
+``entity_form_url`` compute the right path from the entity registry
+(:mod:`src.framework.dispatch.registry`), so a ``url_collection``
+rename — or a future grammar-shape change — is a one-place edit
+rather than a 70-template grep.
+
+Both helpers are registered as Jinja globals by
+:mod:`src.framework.rendering.templating`. The lint at
+``scripts/dev/template_route_check.py`` forbids hardcoded
+``/<known-collection>/...`` literals in URL attributes so the helper
+stays the only legal way to reach those paths from a template.
+
+The helpers cover the **parent-resource and form-page URLs** that
+the grammar prescribes (`src/domain/routes/RESOURCE_GRAMMAR.md`):
+
+* ``entity_url(name)`` → ``/<collection>`` (list / POST-create target)
+* ``entity_url(name, id=...)`` → ``/<collection>/<id>`` (detail / PATCH / DELETE)
+* ``entity_form_url(name)`` → ``/<collection>/form`` (create form)
+* ``entity_form_url(name, id=...)`` → ``/<collection>/<id>/form`` (edit form)
+
+Subresource URLs (state axes, field clusters, owner-scoped lists)
+stay literal in templates today — they're bespoke per resource. If a
+subresource shape repeats often enough to be worth registering, add
+a helper here rather than re-introducing literals.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from src.framework.dispatch.registry import entity_registry
+
+if TYPE_CHECKING:
+    from src.framework.dispatch.entity_spec import EntitySpec
+
+
+def _spec_by_name(name: str) -> "EntitySpec":
+    """Look up an ``EntitySpec`` by its ``name`` (e.g. ``"organization"``).
+
+    Raises ``ValueError`` for unknown names so a typo in a template
+    fails loudly at render time rather than silently producing a path
+    that 404s in the browser. The error message lists every registered
+    name so the caller can correct the spelling.
+    """
+    for spec in entity_registry.specs():
+        if spec.name == name:
+            return spec
+    known = sorted(s.name for s in entity_registry.specs())
+    raise ValueError(
+        f"Unknown entity name {name!r}. Known entities: {known}. "
+        "Entity names are singular (e.g. 'organization', not 'organizations')."
+    )
+
+
+def _prefix(spec: "EntitySpec") -> str:
+    """Compute the URL prefix for ``spec`` — mirrors the rule in
+    :func:`src.framework.dispatch.base_router._make_entity_router`."""
+    return (
+        spec.prefix_override
+        if spec.prefix_override is not None
+        else f"/{spec.url_collection}"
+    )
+
+
+def entity_url(name: str, *, id: Any = None, subresource: str | None = None) -> str:
+    """Parent-resource URL for the entity ``name``.
+
+    ``id`` may be a ``UUID``, a string, or any value that stringifies
+    cleanly — the helper does not validate the id, it just stringifies
+    it into the path. ``id="me"`` is intentionally allowed so users can
+    write ``entity_url("user", id="me")`` for the self-alias.
+
+    ``subresource`` appends a single trailing path segment for state-axis
+    / field-cluster subresources from the grammar (e.g.
+    ``/users/{id}/activation``, ``/posts/{id}/owner-actions``). Requires
+    ``id`` — a subresource without a parent id doesn't fit the grammar.
+    Multi-segment subresources (``/providers/{id}/licensures/{lic_id}``)
+    aren't covered by this helper; templates that need them keep the
+    interpolation today, and the lint accepts them when they appear
+    inside an ``entity_url(...)`` call's subresource value.
+    """
+    spec = _spec_by_name(name)
+    prefix = _prefix(spec)
+    if id is None:
+        if subresource is not None:
+            raise ValueError(
+                "entity_url: `subresource` requires `id` — subresources "
+                "without a parent id aren't in the grammar."
+            )
+        return prefix
+    base = f"{prefix}/{id}"
+    return base if subresource is None else f"{base}/{subresource}"
+
+
+def entity_form_url(name: str, *, id: Any = None) -> str:
+    """Form-page URL for the entity ``name``.
+
+    Without ``id``: the create form at ``/<collection>/form``.
+    With ``id``: the edit form at ``/<collection>/<id>/form``.
+
+    Subresource form pages (``/<collection>/<id>/<sub>/form``) are
+    bespoke; templates that need them keep using literal interpolation
+    today. If we add a third form page for any entity, extend this
+    helper rather than re-introduce literal paths.
+    """
+    spec = _spec_by_name(name)
+    prefix = _prefix(spec)
+    if id is None:
+        return f"{prefix}/form"
+    return f"{prefix}/{id}/form"

--- a/src/framework/rendering/templating.py
+++ b/src/framework/rendering/templating.py
@@ -11,6 +11,7 @@ from src.domain.logic.posts.schema import (
 from src.domain.models import enums
 from src.framework.config import settings
 from src.framework.rendering.form_fields import field_spec, register_choice_labels
+from src.framework.rendering.route_urls import entity_form_url, entity_url
 
 auto_reload = settings.ENVIRONMENT == "development"
 
@@ -111,6 +112,14 @@ _env.globals.update(
     # core → schemas import direction clean (see layer matrix in
     # `src/README.md`).
     field_spec=field_spec,
+    # `entity_url(name, *, id=None)` / `entity_form_url(name, *, id=None)`
+    # are the canonical way to reference parent-resource URLs from
+    # templates. Hardcoding `/<collection>/...` literals in `href` /
+    # `hx-*` / `action` is forbidden by the `template_route_check.py`
+    # lint — see that script and `src/framework/rendering/route_urls.py`
+    # for the rule and rationale.
+    entity_url=entity_url,
+    entity_form_url=entity_form_url,
     # Polymorphic posts have no single create-schema (the top-level
     # adapter is a discriminated union); the per-kind route handler
     # can't inject a `schema` context var without per-kind plumbing in

--- a/src/framework/rendering/test_route_urls.py
+++ b/src/framework/rendering/test_route_urls.py
@@ -1,0 +1,117 @@
+"""Tests for ``entity_url`` and ``entity_form_url``.
+
+The helpers read from the live :data:`entity_registry`, populated at
+import time by every entity route file under ``src/domain/routes/``.
+Importing ``src.main`` or any route file is enough to populate the
+registry — these tests rely on the conftest's app import chain.
+"""
+
+import uuid
+
+import pytest
+
+from src.framework.rendering.route_urls import entity_form_url, entity_url
+
+# --- entity_url --------------------------------------------------------
+
+
+def test_entity_url_collection_path_for_organization():
+    assert entity_url("organization") == "/organizations"
+
+
+def test_entity_url_collection_path_for_program():
+    assert entity_url("program") == "/programs"
+
+
+def test_entity_url_collection_path_for_provider():
+    assert entity_url("provider") == "/providers"
+
+
+def test_entity_url_collection_path_for_post():
+    assert entity_url("post") == "/posts"
+
+
+def test_entity_url_collection_path_for_user():
+    assert entity_url("user") == "/users"
+
+
+def test_entity_url_item_path_with_uuid():
+    org_id = uuid.UUID("88888888-8888-8888-8888-888888888888")
+    assert entity_url("organization", id=org_id) == f"/organizations/{org_id}"
+
+
+def test_entity_url_item_path_with_string_id():
+    assert entity_url("user", id="me") == "/users/me"
+
+
+def test_entity_url_uses_prefix_override_for_favorites():
+    """``UserFavorite`` declares ``prefix_override="/users/me/favorites"`` —
+    the helper must use it, not ``/favorites``."""
+    assert entity_url("user_favorite") == "/users/me/favorites"
+
+
+def test_entity_url_item_path_under_prefix_override():
+    provider_id = uuid.UUID("44444444-4444-4444-4444-444444444444")
+    assert (
+        entity_url("user_favorite", id=provider_id)
+        == f"/users/me/favorites/{provider_id}"
+    )
+
+
+def test_entity_url_with_subresource():
+    """State-axis subresources like ``/users/{id}/activation`` (per
+    `RESOURCE_GRAMMAR.md`) round-trip through the helper."""
+    uid = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    assert (
+        entity_url("user", id=uid, subresource="activation")
+        == f"/users/{uid}/activation"
+    )
+
+
+def test_entity_url_subresource_without_id_raises():
+    with pytest.raises(ValueError) as exc:
+        entity_url("user", subresource="activation")
+    assert "subresource" in str(exc.value)
+
+
+def test_entity_url_unknown_entity_raises():
+    """Typoed names fail loudly so the error surfaces at template render
+    time rather than producing a 404-causing path."""
+    with pytest.raises(ValueError) as exc:
+        entity_url("organizations")  # plural — common typo
+    assert "Unknown entity" in str(exc.value)
+    assert "organization" in str(exc.value)  # the singular IS registered
+
+
+# --- entity_form_url ---------------------------------------------------
+
+
+def test_entity_form_url_create_form_for_organization():
+    assert entity_form_url("organization") == "/organizations/form"
+
+
+def test_entity_form_url_edit_form_for_organization():
+    org_id = uuid.UUID("88888888-8888-8888-8888-888888888888")
+    assert entity_form_url("organization", id=org_id) == f"/organizations/{org_id}/form"
+
+
+def test_entity_form_url_create_form_for_program():
+    assert entity_form_url("program") == "/programs/form"
+
+
+def test_entity_form_url_create_form_for_provider():
+    assert entity_form_url("provider") == "/providers/form"
+
+
+def test_entity_form_url_create_form_for_post():
+    assert entity_form_url("post") == "/posts/form"
+
+
+def test_entity_form_url_edit_form_for_user():
+    uid = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    assert entity_form_url("user", id=uid) == f"/users/{uid}/form"
+
+
+def test_entity_form_url_unknown_entity_raises():
+    with pytest.raises(ValueError):
+        entity_form_url("provider_licensure_typo")

--- a/src/framework/templates/_shared/_provider_row.html
+++ b/src/framework/templates/_shared/_provider_row.html
@@ -29,7 +29,7 @@ so the table stays narrow.
 {%- set issuing_states = provider.licensures | map(attribute='issuing_state') | unique | sort | list -%}
 <tr data-row-id="{{ provider.id }}">
   <td data-label="Practice" class="primary">
-    <a href="/providers/{{ provider.id }}">{{ provider.org.name }}</a>
+    <a href="{{ entity_url('provider', id=provider.id) }}">{{ provider.org.name }}</a>
   </td>
   <td data-label="Location">{{ provider.location_city }}, {{ provider.location_state }}</td>
   <td data-label="Licensed in">

--- a/src/framework/templates/_shared/_toolbar.html
+++ b/src/framework/templates/_shared/_toolbar.html
@@ -35,7 +35,7 @@ Cap on how many filter chips appear inline before collapsing to
           active_filters=active_filters,
           search_url=search_url,
         ) %}
-          <li><a href="/posts/form" role="button">Create</a></li>
+          <li><a href="{{ entity_form_url('post') }}" role="button">Create</a></li>
         {% endcall %}
 
 Pages with no toolbar content leave `{% block toolbar %}` empty

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -261,7 +261,8 @@
        link goes to `/`, which redirects authed users to `/posts` and
        unauthed users to the login page — safe on either side of the
        auth gate. #}
-    {%- set _on_profile = is_authenticated and (request.url.path == '/users/me' or request.url.path.startswith('/users/me/')) -%}
+    {%- set _profile_path = entity_url('user', id='me') -%}
+    {%- set _on_profile = is_authenticated and (request.url.path == _profile_path or request.url.path.startswith(_profile_path + '/')) -%}
     {%- set _on_login = request.url.path == '/auth/login' -%}
     {# Section shortcuts. Posts is one route partitioned by `?kind=`, so
        Referrals/Openings disambiguate via the query param; Directory is
@@ -270,25 +271,26 @@
        lit) while only the bare `/posts` list with the matching `?kind=`
        lights Referrals/Openings — detail pages drop the query param. #}
     {%- set _post_kind = request.query_params.get('kind') if is_authenticated else none -%}
-    {%- set _on_posts_list = is_authenticated and request.url.path == '/posts' -%}
+    {%- set _on_posts_list = is_authenticated and request.url.path == entity_url('post') -%}
     {%- set _on_referrals = _on_posts_list and _post_kind == 'client_referral' -%}
     {%- set _on_openings = _on_posts_list and _post_kind == 'provider_availability' -%}
-    {%- set _on_directory = is_authenticated and (request.url.path == '/providers' or request.url.path.startswith('/providers/')) -%}
+    {%- set _directory_path = entity_url('provider') -%}
+    {%- set _on_directory = is_authenticated and (request.url.path == _directory_path or request.url.path.startswith(_directory_path + '/')) -%}
     <header class="container">
       <nav aria-label="Primary">
         <ul>
           {# title-case-ignore: "Bedlam Connect" is a brand name #}
           <li><strong><a href="/" class="contrast">Bedlam Connect</a></strong></li>
           {% if is_authenticated %}
-          <li><a href="/posts?kind=client_referral"{% if _on_referrals %} aria-current="page" class="contrast"{% endif %}>Referrals</a></li>
-          <li><a href="/posts?kind=provider_availability"{% if _on_openings %} aria-current="page" class="contrast"{% endif %}>Openings</a></li>
-          <li><a href="/providers"{% if _on_directory %} aria-current="page" class="contrast"{% endif %}>Directory</a></li>
+          <li><a href="{{ entity_url('post') }}?kind=client_referral"{% if _on_referrals %} aria-current="page" class="contrast"{% endif %}>Referrals</a></li>
+          <li><a href="{{ entity_url('post') }}?kind=provider_availability"{% if _on_openings %} aria-current="page" class="contrast"{% endif %}>Openings</a></li>
+          <li><a href="{{ entity_url('provider') }}"{% if _on_directory %} aria-current="page" class="contrast"{% endif %}>Directory</a></li>
           {% endif %}
         </ul>
         <ul id="primary-nav">
           {% if is_authenticated %}
           <li>
-            <a href="/users/me" aria-label="Profile"{% if _on_profile %} aria-current="page" class="contrast"{% endif %}>
+            <a href="{{ entity_url('user', id='me') }}" aria-label="Profile"{% if _on_profile %} aria-current="page" class="contrast"{% endif %}>
               {# Lucide `user` icon, inlined. `currentColor` makes it
                  inherit the link color (including Pico's `.contrast`
                  active state). #}

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -41,9 +41,14 @@ def _make_env() -> Environment:
         loader=ChoiceLoader([stub_loader, framework_loader]),
         autoescape=select_autoescape(["html", "xml"]),
     )
-    # The shared `_toolbar.html` / `_breadcrumb.html` macros render
-    # `breadcrumb(items)` which is pure HTML and needs no globals; no
-    # context wiring required for these tests.
+    # `base.html` references the `entity_url` / `entity_form_url`
+    # Jinja globals registered in production by
+    # `src.framework.rendering.templating`. Mirror them here so the
+    # chrome renders without needing a full app boot.
+    from src.framework.rendering.route_urls import entity_form_url, entity_url
+
+    env.globals["entity_url"] = entity_url
+    env.globals["entity_form_url"] = entity_form_url
     return env
 
 


### PR DESCRIPTION
Closes #552.

## Summary

The systemic fix for the broken-URL class of bug surfaced by #550. The original prod issue (\`/organizations/new\` 422'd because that URL never existed) was reachable because templates hardcoded a path the grammar doesn't permit, and nothing checked it. This PR makes the entity registry the single source of truth for template URLs:

- Templates reference resource URLs through new \`entity_url\` / \`entity_form_url\` Jinja globals (defined in \`src/framework/rendering/route_urls.py\`). The helpers look up each spec by name from \`entity_registry\` and compute the URL — honoring \`prefix_override\` (favorites at \`/users/me/favorites\`), accepting an \`id\` for item paths, and a \`subresource\` for state-axis URLs like \`/users/{id}/activation\`.
- A new lint at \`scripts/dev/template_route_check.py\` forbids hardcoded \`/<known-collection>/...\` paths anywhere in template source. It reads the known-collection set from the live entity registry, so adding a new top-level entity auto-extends the lint.
- 30 templates migrated. Every \`href\` / \`action\` / \`hx-*\` attribute, every \`{% set resource_url = ... %}\`, every macro call passing a URL, and every \`request.url.path == ...\` comparison now reads through the helpers.

## Why this over a path-resolution lint

The alternative I weighed: a lint that resolves every hardcoded URL against the FastAPI app's mounted routes. Same bug class, smaller scope, no migration. The downside is it only catches the *symptom* (broken URL); the *cause* (hardcoded literals) keeps recurring.

The audit before I started showed 26 hardcoded literals + 44 already-interpolated literal paths across templates, no \`url_for\` infrastructure, and a fully consistent existing pattern (\`/<collection>/{{ entity.id }}/...\`). With a 26-site migration cost, the deeper fix was worth it — a future \`url_collection\` rename or grammar shape change is now a one-place edit, and any future hardcoded path is caught by the lint at PR time, not in prod.

## Helper API

| Call | URL |
| --- | --- |
| \`entity_url('organization')\` | \`/organizations\` |
| \`entity_url('organization', id=org.id)\` | \`/organizations/{org.id}\` |
| \`entity_form_url('organization')\` | \`/organizations/form\` |
| \`entity_form_url('organization', id=org.id)\` | \`/organizations/{org.id}/form\` |
| \`entity_url('user', id='me')\` | \`/users/me\` |
| \`entity_url('user_favorite')\` | \`/users/me/favorites\` (prefix_override) |
| \`entity_url('user_favorite', id=provider.id)\` | \`/users/me/favorites/{provider.id}\` |
| \`entity_url('user', id=u.id, subresource='activation')\` | \`/users/{u.id}/activation\` |
| \`entity_url('organizations')\` | **raises** \`ValueError\` (entity names are singular) |

## Lint scope

Flags string literals whose first path segment matches a registered top-level entity. Strips Jinja comments (\`{# ... #}\`) before scanning so macro-header examples don't false-positive. Word-boundary-anchored after the collection name (so \`/users_audit_log\` ≠ \`/users\`).

| Source | Flagged? |
| --- | --- |
| \`href=\"/posts/form\"\` | yes |
| \`href=\"/organizations/{{ id }}\"\` | yes (literal first segment) |
| \`'/users/me'\` in any context | yes |
| \`request.url.path == '/providers'\` | yes |
| \`href=\"{{ entity_url('post') }}\"\` | no |
| \`href=\"?kind=client_referral\"\` | no (relative) |
| \`'/licensures'\` (provider sub-collection) | no (not top-level) |

## Test plan

- [x] \`dev test\` — 1364 passed (38 new tests across the helpers + lint + framework view chrome wiring)
- [x] \`dev test contract\` — 20 passed
- [x] \`dev lint\` — clean (template_route_check reports 53 files checked, 0 violations)
- [ ] After merge, smoke-test in prod that the page chrome (toolbar, breadcrumbs, nav active-state) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)