### PR TITLE
feat(providers): Create CTAs on /providers Directory and /users/me profile

### DIFF
--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -388,6 +388,26 @@ async def test_list_providers_shows_licensure_states(
     assert licensed_in_cell.text(strip=True) == "CA, CT"
 
 
+async def test_list_providers_renders_create_toolbar_action(
+    authenticated_client: AsyncClient,
+):
+    """`/providers` (Directory) carries a 'Create provider' toolbar
+    button — matches the orgs/programs/posts list convention so an
+    authenticated user always has a discoverable Create entry point.
+    The route's auth is `AUTHENTICATED` (creation is not gated to
+    owners/admins), so the button shows to every authenticated viewer."""
+    response = await authenticated_client.get("/providers")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    action = None
+    for anchor in tree.css('menu.toolbar-right > li > a[role="button"]'):
+        if "Create provider" in (anchor.text() or ""):
+            action = anchor
+            break
+    assert action is not None, "Create provider toolbar action is missing on /providers"
+    assert action.attributes.get("href") == "/providers/form"
+
+
 async def test_list_providers_renders_empty_state(
     authenticated_client: AsyncClient,
 ):
@@ -499,16 +519,22 @@ async def test_list_providers_treats_empty_filter_values_as_absent(
 # --- Chrome: toolbar + form affordances --------------------------------
 
 
-async def test_providers_list_toolbar_renders_only_filter_link(
+async def test_providers_list_toolbar_renders_filter_link_and_create_action(
     authenticated_client: AsyncClient,
 ):
-    """`/providers` has no list-level action (no Create button), so the
-    toolbar renders only the filter link — no action menu."""
+    """`/providers` toolbar carries both the filter link (left) and a
+    'Create provider' action (right). The Create button matches the
+    orgs/programs/posts list-page convention; the dedicated
+    `test_list_providers_renders_create_toolbar_action` test above
+    pins the action's `href` shape — this one pins the toolbar
+    composition (filter ✕ actions both present)."""
     response = await authenticated_client.get("/providers")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert tree.css_first("a.toolbar-filter-link") is not None
-    assert tree.css_first("menu.toolbar-right") is None
+    action_menu = tree.css_first("menu.toolbar-right")
+    assert action_menu is not None
+    assert "Create provider" in action_menu.text()
 
 
 async def test_provider_detail_favorite_toggle_lives_in_toolbar(

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -446,6 +446,53 @@ async def test_detail_lists_owned_providers(
     assert hrefs == {f"/providers/{first.id}", f"/providers/{second.id}"}
 
 
+def _inline_create_provider_link(tree: HTMLParser):
+    """The detail page's Providers section renders the self-only
+    Create CTA as `<p><a role="button">Create provider</a></p>` after
+    the providers table. Distinct from the toolbar variant on
+    `/users/{id}/providers` — this one is the profile inline preview."""
+    for anchor in tree.css('section a[role="button"]'):
+        if "Create provider" in (anchor.text() or ""):
+            return anchor
+    return None
+
+
+async def test_detail_shows_inline_create_provider_for_self(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`/users/me` (and `/users/{my_id}`) renders an inline 'Create
+    provider' button inside the Providers section so the profile is
+    a self-discovery entry point — without the user clicking through
+    to the dedicated `/users/me/providers` page."""
+    response = await authenticated_client.get("/users/me")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    action = _inline_create_provider_link(tree)
+    assert action is not None, "self profile is missing inline Create provider link"
+    assert action.attributes.get("href") == "/providers/form"
+
+
+async def test_detail_omits_inline_create_provider_for_other_user(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Viewing another user's profile (including as admin) does NOT
+    surface the Create provider CTA — that affordance is self-only,
+    mirroring the toolbar variant on `/users/{id}/providers`."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    target = create_test_user(username=f"target-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(target)
+
+    response = await authenticated_client.get(f"/users/{target.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert _inline_create_provider_link(tree) is None
+
+
 # --- Chrome: nav active state -------------------------------------------
 
 

--- a/src/domain/templates/providers/list.html
+++ b/src/domain/templates/providers/list.html
@@ -4,6 +4,17 @@
 
 {% block resource_label %}Providers{% endblock %}
 
+{# `is_authenticated` is set by `handle_list_provider`'s context; any
+   authenticated user may create a Provider (the route's auth policy
+   only gates *mutations* of an existing row, not creation). The button
+   matches the toolbar-action convention used by `/organizations`,
+   `/programs`, and `/posts`. #}
+{% block actions %}
+{% if is_authenticated %}
+<li><a href="{{ entity_form_url('provider') }}" role="button">Create provider</a></li>
+{% endif %}
+{% endblock %}
+
 {% block content %}
 {{ index_table(
   items=providers,

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -45,6 +45,14 @@
     ) %}
     <p id="user-detail-providers-empty">No providers yet.</p>
     {% endcall %}
+    {# Self-only Create CTA — the profile is the natural discovery
+       point for "make my own provider". The dedicated
+       `/users/me/providers` page carries the same action in its
+       toolbar (added in 3b59933f); this inline button is the version
+       a user sees on the profile preview, without an extra click. #}
+    {% if is_self %}
+    <p><a href="{{ entity_form_url('provider') }}" role="button" class="outline">Create provider</a></p>
+    {% endif %}
   </section>
 
 </article>


### PR DESCRIPTION
Continues the Provider CRUD discoverability sweep that 3b59933f started (toolbar Create on \`/users/{id}/providers\` self-view, owner Delete on \`/providers/{id}\`). Two more entry points were still missing.

## Summary

- **\`/providers\` (Directory)** — previously had a filter-link-only toolbar. Every other list page (orgs/programs/posts) carries a Create button there; providers now matches the convention. Visible to any authenticated viewer (the route's auth-deps are \`AUTHENTICATED\`; only mutations of existing rows are owner/admin gated).
- **\`/users/{id}\` profile** — had a Providers section showing the user's providers but no inline way to add one. The dedicated \`/users/me/providers\` page already had this in its toolbar; the profile inline button (self-gated via \`is_self\`) saves a click for the most-common landing path.

## Tests

Four colocated route tests:

- \`test_list_providers_renders_create_toolbar_action\` — pins the action's href shape.
- \`test_providers_list_toolbar_renders_filter_link_and_create_action\` — renamed from \`...renders_only_filter_link\` (which explicitly asserted no Create button on the Directory). New version asserts both toolbar regions populate.
- \`test_detail_shows_inline_create_provider_for_self\` — \`/users/me\` profile renders the inline Create button.
- \`test_detail_omits_inline_create_provider_for_other_user\` — admin viewing another user's profile does NOT see the self-only CTA.

## Test plan

- [x] \`dev test\` — 1378 passed
- [x] \`dev lint\` — clean
- [ ] Smoke-test in a browser: nav \"Directory\" → \`/providers\` shows Create button → click → lands on \`/providers/form\`; \`/users/me\` shows Create button inside Providers section; \`/users/{other_id}\` does NOT show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)