### PR TITLE
fix(chrome): preload Lucide woff2 to kill icon-flicker on first paint

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -493,6 +493,43 @@ async def test_detail_omits_inline_create_provider_for_other_user(
     assert _inline_create_provider_link(tree) is None
 
 
+# --- Chrome: font preload (icon-flicker fix) ----------------------------
+
+
+async def test_base_template_preloads_lucide_icon_font(
+    authenticated_client: AsyncClient,
+):
+    """``base.html`` emits a `<link rel="preload">` for the Lucide
+    woff2 font ahead of the stylesheet `<link>` so the icon font
+    fetch runs in parallel with the CSS fetch rather than waiting for
+    it to parse. This eliminates the icon-flicker that's otherwise
+    visible on every first paint while ``<i class="icon-x">`` elements
+    render as blank space waiting for the font.
+
+    Pin the contract: the preload URL MUST match the CSS's woff2 URL
+    *exactly* (including the cache-buster query) or the browser sees
+    them as different resources and the preload is wasted."""
+    response = await authenticated_client.get("/users/me")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    preload = tree.css_first('link[rel="preload"][as="font"]')
+    assert preload is not None, "Lucide woff2 preload <link> is missing"
+    href = preload.attributes.get("href") or ""
+    assert "lucide.woff2" in href
+    assert preload.attributes.get("type") == "font/woff2"
+    # Required for cross-origin font preloads — without it, the
+    # browser fetches the font twice (once preload, once for real).
+    assert "crossorigin" in preload.attributes
+    # The companion stylesheet `<link>` references the same font URL
+    # via its `@font-face` rule; the preload's href must include the
+    # CSS's cache-buster so the browser deduplicates the requests.
+    assert "?t=" in href, (
+        "preload href must include the lucide.css cache-buster query "
+        "(`?t=...`); without exact-URL match the browser issues a "
+        "second font request and the preload is wasted"
+    )
+
+
 # --- Chrome: nav active state -------------------------------------------
 
 

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -14,8 +14,30 @@
        version deliberately. The CSS defines `<i class="icon-<name>">`
        per Lucide icon (e.g. `icon-baby`, `icon-shield-check`); see the
        icon dicts in `src/domain/models/enums.py` for the per-enum
-       mappings. The font itself is pulled via the CSS's relative
-       `url(./lucide.woff2)`, so no second `<link>` is needed. #}
+       mappings.
+
+       The `<link rel="preload">` for the woff2 is the cure for icon
+       flicker on first paint: without it, the browser fetches
+       `lucide.css` first, parses it, discovers the `@font-face` rule's
+       relative `url("lucide.woff2?t=...")` reference, and only THEN
+       fetches the 220kb font — every `<i class="icon-x">` renders as
+       blank space for the duration. Preloading kicks the font fetch
+       off in parallel with the CSS, so by the time the CSS's
+       `@font-face` resolves, the woff2 is already in browser cache and
+       the first paint includes the icons.
+
+       The cache-buster `?t=1736516416702` is baked into the pinned
+       version's CSS (see `curl -s
+       https://unpkg.com/lucide-static@0.471.0/font/lucide.css`).
+       Browsers match preloads to actual requests by exact URL, so the
+       two URLs MUST share the same query string. Bump the timestamp
+       here in lockstep with any version bump above. #}
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      crossorigin
+      href="https://unpkg.com/lucide-static@0.471.0/font/lucide.woff2?t=1736516416702" />
     <link
       rel="stylesheet"
       href="https://unpkg.com/lucide-static@0.471.0/font/lucide.css" />


### PR DESCRIPTION
## Summary

The icon flicker users see on every first paint comes from icon-font FOUT — the chain is:

1. Browser fetches \`lucide.css\` (linked in \`<head>\`)
2. Parses the CSS, discovers \`@font-face { src: url(\"lucide.woff2?t=...\") }\`
3. **Only now** starts fetching the 220kb font
4. Renders — every \`<i class=\"icon-x\">\` is blank space until step 3 completes; once the font arrives, the icons \"flicker\" in

Adding \`<link rel=\"preload\" as=\"font\" type=\"font/woff2\" crossorigin>\` ahead of the stylesheet kicks the font fetch off in parallel with the CSS fetch, so by the time the CSS's \`@font-face\` resolves the woff2 is already in browser cache and the icons land on the first paint.

One gotcha — the preload href has to match the CSS's woff2 URL *exactly*, including the cache-buster query (\`?t=1736516416702\`) that's baked into Lucide's CSS at release time. Browsers match preloads to subsequent requests by URL equality; any mismatch wastes the preload and issues a second font request. The new inline comment in \`base.html\` captures this so a future version bump touches both in lockstep.

## What I considered + skipped

- **Self-hosting the font** — eliminates third-party CDN dependency. Bigger change (would introduce a \`src/static/\` asset directory + StaticFiles mount + 220kb binary in the repo). Defer until we have other reasons to self-host assets.
- **Switching from icon font to inline SVG sprite** — fully eliminates FOUT (no font load = no FOUT). ~30+ icon usages across templates would need migration. Defer; preload should be enough.

## Test plan

- [x] \`dev test\` — 1379 passed (one new chrome test pins the preload contract: link present, href shape, type, crossorigin, cache-buster query)
- [x] \`dev lint\` — clean
- [ ] Manual smoke test in a browser after merge: hard-refresh any authenticated page; icons should appear with the page chrome, not after it

🤖 Generated with [Claude Code](https://claude.com/claude-code)