### PR TITLE
feat(posts): post_card_view view-model (PR 1 of 3 unifying list + detail)

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -7,6 +7,7 @@ import pytest
 from src.domain.logic.posts.view import (
     client_referral_headline,
     insurance_posture_for_post,
+    post_card_view,
 )
 
 
@@ -124,3 +125,377 @@ def test_client_referral_headline_falls_back_when_age_groups_empty():
     gracefully if a future code path hands us an empty list."""
     detail = SimpleNamespace(age_groups=[], gender="male")
     assert client_referral_headline(detail) == "Client Referral"
+
+
+# --- post_card_view -----------------------------------------------------
+#
+# The view-model collapses three kind-specific detail shapes (CR has its
+# own location + a scalar gender; PA reads location + insurance off the
+# linked Provider; program reads identity off the linked Program) into
+# one flat dict that templates iterate over. Tests below build a stub
+# post per kind and pin the dict's shape end-to-end. Templates are
+# tested separately at the route level.
+
+
+def _make_cr_post(**detail_overrides):
+    """Realistic CR stub. Defaults populate every field with a sensible
+    value so tests can override only what they care about."""
+    defaults = dict(
+        location_city="Brooklyn",
+        location_state="NY",
+        location_zip="11201",
+        location_in_person="yes",
+        location_virtual="no",
+        desired_times=["weekday_morning"],
+        age_groups=["adults_25_64"],
+        languages=["en", "es"],
+        gender="female",
+        description="Looking for a therapist who takes BCBS.",
+        services=["psychotherapy", "medication_management"],
+        treatment_modality="CBT",
+        network_preference="in_network_required",
+        insurance_carrier="bcbs",
+    )
+    defaults.update(detail_overrides)
+    return SimpleNamespace(
+        kind="client_referral",
+        client_referral_detail=SimpleNamespace(**defaults),
+    )
+
+
+def _make_pa_post(*, provider_attrs=None, **detail_overrides):
+    """Realistic PA stub. Defaults populate provider + detail fields."""
+    p = dict(
+        id="prov-1",
+        org=SimpleNamespace(name="Acme Counseling"),
+        location_city="Brooklyn",
+        location_state="NY",
+        location_zip="11201",
+        in_person_sessions="yes",
+        virtual_sessions="please_contact",
+        in_network_carriers=["aetna"],
+        accepts_out_of_network=False,
+        sliding_scale=True,
+        cost="$150/session",
+    )
+    if provider_attrs:
+        p.update(provider_attrs)
+    d = dict(
+        services=["psychotherapy"],
+        settings=["individual"],
+        age_groups=["adults_25_64"],
+        languages=["en"],
+        genders=["female", "non_binary"],
+        treatment_modality="DBT",
+        description="Accepting new clients.",
+        schedule_text="Mon-Wed 9-5",
+        desired_times=["weekday_morning"],
+        website="https://example.com",
+        referral_instructions="Email intake@example.com",
+    )
+    d.update(detail_overrides)
+    return SimpleNamespace(
+        kind="provider_availability",
+        provider_availability_detail=SimpleNamespace(
+            provider=SimpleNamespace(**p),
+            **d,
+        ),
+    )
+
+
+def _make_program_post(*, program_attrs=None, **detail_overrides):
+    p = dict(
+        id="prog-1",
+        name="RISE IOP",
+        state_preference="CT",
+        organization=SimpleNamespace(name="Acme Health"),
+    )
+    if program_attrs:
+        p.update(program_attrs)
+    d = dict(
+        services=["psychotherapy"],
+        settings=["group"],
+        age_groups=["adolescents_14_18"],
+        languages=["en"],
+        genders=[],
+        treatment_modality="DBT",
+        description="Intake cohort opens June 1.",
+        schedule_text="M-F 9-3",
+        desired_times=["weekday_morning"],
+        website="https://riseiop.example.com",
+        referral_instructions=None,
+    )
+    d.update(detail_overrides)
+    return SimpleNamespace(
+        kind="program_availability",
+        program_availability_detail=SimpleNamespace(
+            program=SimpleNamespace(**p),
+            **d,
+        ),
+    )
+
+
+# --- post_card_view: client_referral ------------------------------------
+
+
+def test_view_cr_basics():
+    """Per-kind discriminators map to the unified verb vocabulary the
+    card's left-edge color and `_services_block` H4 both read from."""
+    v = post_card_view(_make_cr_post())
+    assert v["kind"] == "client_referral"
+    assert v["kind_verb"] == "Seeking"
+
+
+def test_view_cr_headline_from_age_and_gender():
+    v = post_card_view(_make_cr_post(age_groups=["adults_25_64"], gender="male"))
+    assert v["headline"] == "Adult male (25–64)"
+
+
+def test_view_cr_header_state_is_none_state_lives_in_location_chunk():
+    """CR shows state in the demographics column (`location_chunk`),
+    not in the header line — the headline already carries the
+    identity. Pin `header_state` is intentionally None for CR."""
+    v = post_card_view(_make_cr_post())
+    assert v["header_state"] is None
+    assert v["location_chunk"] == {"city": "Brooklyn", "state": "NY", "zip": "11201"}
+
+
+def test_view_cr_in_person_and_virtual_pull_from_detail_row():
+    v = post_card_view(_make_cr_post(location_in_person="yes", location_virtual="no"))
+    assert v["in_person"] == "yes"
+    assert v["virtual"] == "no"
+
+
+def test_view_cr_settings_always_empty():
+    """CR has no `settings` field on its detail row; the view-model
+    returns an empty list so templates can iterate uniformly."""
+    v = post_card_view(_make_cr_post())
+    assert v["settings"] == []
+
+
+def test_view_cr_gender_wraps_to_single_element_list():
+    """CR holds a scalar `gender`; PA/program hold a `genders` list.
+    Wrapping into a list keeps templates' iteration shape uniform —
+    the `{% for g in view.genders %}` block works for both kinds."""
+    v = post_card_view(_make_cr_post(gender="female"))
+    assert v["genders"] == ["female"]
+
+
+def test_view_cr_missing_gender_yields_empty_list():
+    v = post_card_view(_make_cr_post(gender=None))
+    assert v["genders"] == []
+
+
+def test_view_cr_full_address_composes_city_state_zip():
+    v = post_card_view(_make_cr_post())
+    assert v["full_address"] == "Brooklyn, NY 11201"
+
+
+def test_view_cr_cr_only_fields_set_pa_only_fields_none():
+    """CR populates `network_preference` / `insurance_carrier`; the
+    PA-only fields stay at their None/empty defaults."""
+    v = post_card_view(_make_cr_post())
+    assert v["network_preference"] == "in_network_required"
+    assert v["insurance_carrier"] == "bcbs"
+    assert v["sliding_scale"] is None
+    assert v["cost"] is None
+    assert v["in_network_carriers"] == []
+    assert v["accepts_out_of_network"] is None
+    assert v["practice_link"] is None
+    assert v["program_link"] is None
+
+
+def test_view_cr_no_referral_section():
+    """CR has no `website` / `referral_instructions` fields. The
+    detail page's "How to refer" section is PA/program-only."""
+    v = post_card_view(_make_cr_post())
+    assert v["referral"] is None
+
+
+# --- post_card_view: provider_availability ------------------------------
+
+
+def test_view_pa_basics():
+    v = post_card_view(_make_pa_post())
+    assert v["kind"] == "provider_availability"
+    assert v["kind_verb"] == "Providing"
+
+
+def test_view_pa_headline_is_org_name_state_from_provider():
+    """PA's identity is the practice — `provider.org.name` — with
+    state shown in the header line (the provider's `location_state`).
+    Unlike CR, the state isn't demoted to the demographics column."""
+    v = post_card_view(_make_pa_post())
+    assert v["headline"] == "Acme Counseling"
+    assert v["header_state"] == "NY"
+
+
+def test_view_pa_in_person_virtual_come_from_provider():
+    """PA's session availability lives on the linked Provider, not on
+    the post's detail row. The view-model normalizes both kinds onto
+    the same `in_person`/`virtual` keys so the card's modality chips
+    read from one source."""
+    v = post_card_view(
+        _make_pa_post(
+            provider_attrs={"in_person_sessions": "no", "virtual_sessions": "yes"}
+        )
+    )
+    assert v["in_person"] == "no"
+    assert v["virtual"] == "yes"
+
+
+def test_view_pa_practice_link_carries_id_and_org_name():
+    v = post_card_view(_make_pa_post())
+    assert v["practice_link"] == {"id": "prov-1", "name": "Acme Counseling"}
+
+
+def test_view_pa_full_address_from_provider():
+    v = post_card_view(_make_pa_post())
+    assert v["full_address"] == "Brooklyn, NY 11201"
+
+
+def test_view_pa_insurance_fields_from_provider():
+    v = post_card_view(_make_pa_post())
+    assert v["in_network_carriers"] == ["aetna"]
+    assert v["accepts_out_of_network"] is False
+    assert v["sliding_scale"] is True
+    assert v["cost"] == "$150/session"
+
+
+def test_view_pa_settings_populated_genders_as_list():
+    v = post_card_view(_make_pa_post())
+    assert v["settings"] == ["individual"]
+    assert v["genders"] == ["female", "non_binary"]
+
+
+def test_view_pa_referral_set_when_either_field_present():
+    v = post_card_view(_make_pa_post())
+    assert v["referral"] == {
+        "website": "https://example.com",
+        "instructions": "Email intake@example.com",
+    }
+
+
+def test_view_pa_referral_none_when_both_empty():
+    v = post_card_view(_make_pa_post(website=None, referral_instructions=None))
+    assert v["referral"] is None
+
+
+def test_view_pa_no_location_chunk():
+    """PA's location lives on the linked Provider and surfaces via
+    `header_state` + `full_address`. The CR-shaped `location_chunk`
+    is intentionally None for PA so the demographics column doesn't
+    render the icon-only row."""
+    v = post_card_view(_make_pa_post())
+    assert v["location_chunk"] is None
+
+
+# --- post_card_view: program_availability -------------------------------
+
+
+def test_view_program_basics():
+    v = post_card_view(_make_program_post())
+    assert v["kind"] == "program_availability"
+    assert v["kind_verb"] == "Providing"
+
+
+def test_view_program_headline_is_program_name_state_from_program():
+    v = post_card_view(_make_program_post())
+    assert v["headline"] == "RISE IOP"
+    assert v["header_state"] == "CT"
+
+
+def test_view_program_link_carries_id_and_name():
+    v = post_card_view(_make_program_post())
+    assert v["program_link"] == {"id": "prog-1", "name": "RISE IOP"}
+
+
+def test_view_program_organization_name_exposed_separately():
+    """Detail page surfaces the owning Org's name as a separate row
+    below the Program link. The view-model exposes it as a flat
+    field so the template doesn't reach for `prog.organization.name`."""
+    v = post_card_view(_make_program_post())
+    assert v["organization_name"] == "Acme Health"
+
+
+def test_view_program_no_in_person_virtual_no_insurance_no_address():
+    """Program-availability has no in-person/virtual posture (the
+    Program doesn't track session format today), no insurance posture
+    (insurance lives on Provider, not Program), and no location of
+    its own (the linked Program's `state_preference` surfaces via
+    `header_state` instead)."""
+    v = post_card_view(_make_program_post())
+    assert v["in_person"] is None
+    assert v["virtual"] is None
+    assert v["insurance_posture"] is None
+    assert v["full_address"] is None
+    assert v["location_chunk"] is None
+
+
+# --- post_card_view: defensiveness --------------------------------------
+
+
+def test_view_unknown_kind_returns_base_skeleton():
+    """An unregistered kind returns the all-None skeleton — templates
+    render nothing rather than crashing on a missing detail relationship."""
+    v = post_card_view(SimpleNamespace(kind="mystery"))
+    assert v["kind"] == "mystery"
+    assert v["kind_verb"] is None
+    assert v["headline"] is None
+    assert v["services"] == []
+
+
+def test_view_cr_missing_detail_returns_base_skeleton():
+    """A CR post with no detail relationship (shouldn't happen at
+    rest, but the helper stays defensive for stub data) returns the
+    skeleton with kind/kind_verb still populated."""
+    v = post_card_view(
+        SimpleNamespace(kind="client_referral", client_referral_detail=None)
+    )
+    assert v["kind"] == "client_referral"
+    assert v["kind_verb"] == "Seeking"
+    assert v["headline"] is None
+    assert v["location_chunk"] is None
+
+
+def test_view_pa_missing_provider_returns_partial_view():
+    """PA's detail has a `provider` relationship that could be None
+    in test stubs. View-model populates the detail-row fields it can
+    and leaves provider-derived fields at None."""
+    post = SimpleNamespace(
+        kind="provider_availability",
+        provider_availability_detail=SimpleNamespace(
+            provider=None,
+            services=["psychotherapy"],
+            settings=[],
+            age_groups=[],
+            languages=[],
+            genders=[],
+            treatment_modality=None,
+            description="x",
+            schedule_text=None,
+            desired_times=[],
+            website=None,
+            referral_instructions=None,
+        ),
+    )
+    v = post_card_view(post)
+    assert v["headline"] is None
+    assert v["header_state"] is None
+    assert v["full_address"] is None
+    assert v["practice_link"] is None
+    assert v["sliding_scale"] is None
+    # Detail-row fields independent of the provider relationship still
+    # populate so the card can render whatever it can.
+    assert v["services"] == ["psychotherapy"]
+    assert v["description"] == "x"
+
+
+def test_view_returns_dict_for_jinja_attribute_access():
+    """Templates use ``view.field_name`` syntax — Jinja resolves this
+    to ``view['field_name']`` on a dict. Pin that the function returns
+    a dict (not a NamedTuple or dataclass) so the access pattern
+    works without surprises."""
+    v = post_card_view(_make_cr_post())
+    assert isinstance(v, dict)
+    assert v["kind"] == "client_referral"

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -26,9 +26,24 @@ multi for forward-compat but only the first drives the title).
 Genders that don't slot in naturally — `prefer_not_to_say`,
 `gender_diverse` — drop the gender word entirely.
 
-Both helpers are exposed as Jinja globals by
+`post_card_view(post)` is the unified view-model that both the listing
+card (`_item.html`) and the detail page (`detail.html`) read from. Each
+kind's underlying detail relationship has a different field set and
+naming — CR holds its own (city, state, zip) location and a single
+gender; PA reads location and insurance from the linked Provider;
+program reads identity from the linked Program. The function collapses
+those three shapes into one flat dict so templates iterate over keys
+rather than branching on `post.kind`. Values that don't apply to a
+kind are ``None`` (or empty lists); templates render via
+``{% if view.x %}``. Raw enum values are returned — display-label
+lookup is the template's job (it's the same label dict pattern as
+elsewhere).
+
+All three helpers are exposed as Jinja globals by
 `src/framework/rendering/templating.py`.
 """
+
+from typing import Any
 
 from src.domain.models.enums import CLIENT_AGE_GROUPS_BY_KEY
 
@@ -87,6 +102,267 @@ def insurance_posture_for_post(post) -> str | None:
         # the same.
         return None
     return None
+
+
+_KIND_VERB = {
+    "client_referral": "Seeking",
+    "provider_availability": "Providing",
+    "program_availability": "Providing",
+}
+
+
+def _location_chunk(
+    city: str | None, state: str | None, zip_code: str | None
+) -> dict | None:
+    """Return ``{city, state, zip}`` when any of the three are present,
+    otherwise ``None`` so templates can ``{% if view.location_chunk %}``."""
+    if not any((city, state, zip_code)):
+        return None
+    return {"city": city, "state": state, "zip": zip_code}
+
+
+def _full_address(
+    city: str | None, state: str | None, zip_code: str | None
+) -> str | None:
+    """Compose ``"City, ST ZIP"`` for the detail page's expanded address
+    row. Returns ``None`` when no parts are present so templates omit
+    the row entirely."""
+    if not any((city, state, zip_code)):
+        return None
+    head = ", ".join(p for p in (city, state) if p)
+    if zip_code:
+        return f"{head} {zip_code}" if head else zip_code
+    return head or None
+
+
+def _referral_or_none(website: str | None, instructions: str | None) -> dict | None:
+    """Bundle the optional PA/program "how to refer" fields. Either
+    being set lights up the section; both being empty means no section."""
+    if not (website or instructions):
+        return None
+    return {"website": website, "instructions": instructions}
+
+
+def post_card_view(post) -> dict[str, Any]:
+    """Normalize a `Post` of any kind into the flat shape both the
+    listing card and the detail page render from.
+
+    Pre-pulls every field templates need so the per-kind branching
+    happens here (once, in Python) instead of in three different
+    templates. Missing values come back as ``None`` (scalars) or
+    ``[]`` (lists) so templates render via ``{% if view.x %}`` /
+    ``{% for x in view.xs %}`` without further nullability handling.
+
+    Returns:
+        kind: the discriminator (`client_referral` /
+            `provider_availability` / `program_availability`).
+        kind_verb: ``"Seeking"`` for CR, ``"Providing"`` for the two
+            availability kinds. Mirrors the kind-chip vocabulary the
+            list card's left-edge color uses (orange = Seeking, cyan
+            = Providing).
+        headline: the card's identity line — CR is ``client_referral_headline``
+            (age + gender combo); PA is the practice's org name;
+            program is the program name.
+        header_state: the state shown next to the headline. PA reads
+            from ``provider.location_state``; program reads from
+            ``program.state_preference``; CR is ``None`` because its
+            state lives in ``location_chunk`` (the demographics-column
+            location row), not in the header line.
+        in_person / virtual: the post's in-person/virtual posture as
+            `LOCATION_AVAILABILITY_OPTIONS` values. CR reads them off
+            its own detail row; PA reads them from the linked
+            Provider's session-availability fields. Program has no
+            in-person/virtual posture and returns ``None`` for both.
+        services / settings: raw enum lists. PA + program carry
+            ``settings``; CR's ``settings`` is empty.
+        ages / languages / genders: raw enum lists. CR's single
+            ``gender`` is wrapped in a list of one so templates iterate
+            uniformly (a CR with ``gender = "prefer_not_to_say"``
+            returns ``["prefer_not_to_say"]`` — the template still has
+            the value if it wants to handle it specially).
+        insurance_posture: one of ``INSURANCE_POSTURES`` or ``None``
+            (program-availability has no posture). Same value
+            ``insurance_posture_for_post`` returns.
+        treatment_modality: free-text modality string or ``None``.
+        location_chunk: ``{city, state, zip}`` for CR's demographics
+            column; ``None`` for PA and program (PA's location is on
+            the linked Provider and surfaces via ``header_state`` and
+            ``full_address``; program has no location of its own).
+        description: free-text description or ``None``. CR's
+            description is NOT NULL on the model but the function
+            stays defensive for stubs that omit it.
+        schedule_text: PA/program optional schedule notes; ``None``
+            for CR.
+        desired_times: raw enum list of desired-time slots; empty if
+            unset.
+        practice_link: ``{id, name}`` of PA's linked Provider's org;
+            ``None`` for other kinds.
+        program_link: ``{id, name}`` of program's linked Program;
+            ``None`` for other kinds.
+        organization_name: program's owning organization name;
+            ``None`` for other kinds.
+        full_address: ``"City, ST ZIP"`` string for the detail page's
+            expanded location row. CR reads from its own location;
+            PA reads from the linked Provider; program returns
+            ``None``.
+        sliding_scale / cost: PA-only fields from the linked Provider;
+            ``None`` for other kinds.
+        network_preference / insurance_carrier: CR-only raw enum
+            values from the detail row; ``None`` for other kinds.
+        in_network_carriers / accepts_out_of_network: PA-only raw
+            values from the linked Provider. ``in_network_carriers``
+            comes back as an empty list when unset, matching the
+            list/iteration convention; ``accepts_out_of_network`` is
+            ``None`` for other kinds.
+        referral: ``{website, instructions}`` when either is set
+            (PA/program "how to refer" section); ``None`` when both
+            empty or for CR.
+    """
+    kind = getattr(post, "kind", None)
+    base: dict[str, Any] = {
+        "kind": kind,
+        "kind_verb": _KIND_VERB.get(kind),
+        "headline": None,
+        "header_state": None,
+        "in_person": None,
+        "virtual": None,
+        "services": [],
+        "settings": [],
+        "ages": [],
+        "languages": [],
+        "genders": [],
+        "insurance_posture": insurance_posture_for_post(post),
+        "treatment_modality": None,
+        "location_chunk": None,
+        "description": None,
+        "schedule_text": None,
+        "desired_times": [],
+        "practice_link": None,
+        "program_link": None,
+        "organization_name": None,
+        "full_address": None,
+        "sliding_scale": None,
+        "cost": None,
+        "network_preference": None,
+        "insurance_carrier": None,
+        "in_network_carriers": [],
+        "accepts_out_of_network": None,
+        "referral": None,
+    }
+
+    if kind == "client_referral":
+        d = getattr(post, "client_referral_detail", None)
+        if d is None:
+            return base
+        base.update(
+            headline=client_referral_headline(d),
+            in_person=getattr(d, "location_in_person", None),
+            virtual=getattr(d, "location_virtual", None),
+            services=list(getattr(d, "services", None) or []),
+            ages=list(getattr(d, "age_groups", None) or []),
+            languages=list(getattr(d, "languages", None) or []),
+            genders=([d.gender] if getattr(d, "gender", None) else []),
+            treatment_modality=getattr(d, "treatment_modality", None),
+            location_chunk=_location_chunk(
+                getattr(d, "location_city", None),
+                getattr(d, "location_state", None),
+                getattr(d, "location_zip", None),
+            ),
+            description=getattr(d, "description", None),
+            desired_times=list(getattr(d, "desired_times", None) or []),
+            full_address=_full_address(
+                getattr(d, "location_city", None),
+                getattr(d, "location_state", None),
+                getattr(d, "location_zip", None),
+            ),
+            network_preference=getattr(d, "network_preference", None),
+            insurance_carrier=getattr(d, "insurance_carrier", None),
+        )
+        return base
+
+    if kind == "provider_availability":
+        d = getattr(post, "provider_availability_detail", None)
+        if d is None:
+            return base
+        p = getattr(d, "provider", None)
+        base.update(
+            headline=(p.org.name if p and getattr(p, "org", None) else None),
+            header_state=(getattr(p, "location_state", None) if p else None),
+            in_person=(getattr(p, "in_person_sessions", None) if p else None),
+            virtual=(getattr(p, "virtual_sessions", None) if p else None),
+            services=list(getattr(d, "services", None) or []),
+            settings=list(getattr(d, "settings", None) or []),
+            ages=list(getattr(d, "age_groups", None) or []),
+            languages=list(getattr(d, "languages", None) or []),
+            genders=list(getattr(d, "genders", None) or []),
+            treatment_modality=getattr(d, "treatment_modality", None),
+            description=getattr(d, "description", None),
+            schedule_text=getattr(d, "schedule_text", None),
+            desired_times=list(getattr(d, "desired_times", None) or []),
+            practice_link=(
+                {"id": p.id, "name": p.org.name}
+                if p and getattr(p, "org", None) and getattr(p, "id", None)
+                else None
+            ),
+            full_address=(
+                _full_address(
+                    getattr(p, "location_city", None),
+                    getattr(p, "location_state", None),
+                    getattr(p, "location_zip", None),
+                )
+                if p
+                else None
+            ),
+            sliding_scale=(getattr(p, "sliding_scale", None) if p else None),
+            cost=(getattr(p, "cost", None) if p else None),
+            in_network_carriers=(
+                list(getattr(p, "in_network_carriers", None) or []) if p else []
+            ),
+            accepts_out_of_network=(
+                getattr(p, "accepts_out_of_network", None) if p else None
+            ),
+            referral=_referral_or_none(
+                getattr(d, "website", None),
+                getattr(d, "referral_instructions", None),
+            ),
+        )
+        return base
+
+    if kind == "program_availability":
+        d = getattr(post, "program_availability_detail", None)
+        if d is None:
+            return base
+        prog = getattr(d, "program", None)
+        base.update(
+            headline=(getattr(prog, "name", None) if prog else None),
+            header_state=(getattr(prog, "state_preference", None) if prog else None),
+            services=list(getattr(d, "services", None) or []),
+            settings=list(getattr(d, "settings", None) or []),
+            ages=list(getattr(d, "age_groups", None) or []),
+            languages=list(getattr(d, "languages", None) or []),
+            genders=list(getattr(d, "genders", None) or []),
+            treatment_modality=getattr(d, "treatment_modality", None),
+            description=getattr(d, "description", None),
+            schedule_text=getattr(d, "schedule_text", None),
+            desired_times=list(getattr(d, "desired_times", None) or []),
+            program_link=(
+                {"id": prog.id, "name": prog.name}
+                if prog and getattr(prog, "id", None) and getattr(prog, "name", None)
+                else None
+            ),
+            organization_name=(
+                getattr(prog.organization, "name", None)
+                if prog and getattr(prog, "organization", None)
+                else None
+            ),
+            referral=_referral_or_none(
+                getattr(d, "website", None),
+                getattr(d, "referral_instructions", None),
+            ),
+        )
+        return base
+
+    return base
 
 
 def client_referral_headline(detail) -> str:

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -23,6 +23,7 @@ from src.domain.logic.posts.schema import (
 from src.domain.logic.posts.view import (
     client_referral_headline,
     insurance_posture_for_post,
+    post_card_view,
 )
 from src.domain.models import enums
 from src.framework.rendering.form_fields import register_choice_labels
@@ -97,6 +98,10 @@ register_template_globals(
     # Post-specific view helpers.
     insurance_posture=insurance_posture_for_post,
     client_referral_headline=client_referral_headline,
+    # `post_card_view(post)` is the unified view-model both the listing
+    # card (`posts/_item.html`) and the detail page (`posts/detail.html`)
+    # read from — see its docstring in `src.domain.logic.posts.view`.
+    post_card_view=post_card_view,
 )
 
 # Register the choice-tuple → labels-dict mapping that `field_spec` uses


### PR DESCRIPTION
PR 1 of 3 toward unifying the post list-card and detail templates. **Foundation-only** — pure Python helper + tests + Jinja global registration. No template changes.

## The problem

The list card (\`posts/_item.html\`) and the detail page (\`posts/detail.html\`) today render the same data **three different ways**: list-card-shape, CR-detail-shape, PA-detail-shape — with the PA and program-availability detail branches near-duplicates of each other. Each kind has its own field set and naming (CR holds its own location and a scalar gender; PA reads location/insurance from the linked Provider; program reads identity from the linked Program), so templates inevitably grow per-kind branching.

## What this PR adds

\`post_card_view(post) -> dict[str, Any]\` collapses those three shapes into one flat dict. Templates iterate over keys instead of branching on \`post.kind\`. Values that don't apply to a kind come back as \`None\` (scalars) or \`[]\` (lists) so templates render via \`{% if view.x %}\` / \`{% for x in view.xs %}\` without further nullability handling. Raw enum values are returned — display-label lookup stays the template's job (matches the existing label-dict pattern).

24 keys covering everything both views need:

- **Identity:** \`kind\`, \`kind_verb\` (\"Seeking\"/\"Providing\"), \`headline\`, \`header_state\`
- **Session format:** \`in_person\`, \`virtual\`
- **Enum lists:** \`services\`, \`settings\`, \`ages\`, \`languages\`, \`genders\`
- **Single fields:** \`insurance_posture\`, \`treatment_modality\`, \`description\`, \`schedule_text\`, \`desired_times\`
- **Location:** \`location_chunk\`, \`full_address\`
- **Per-kind links:** \`practice_link\`, \`program_link\`, \`organization_name\`
- **PA-only insurance:** \`sliding_scale\`, \`cost\`, \`in_network_carriers\`, \`accepts_out_of_network\`
- **CR-only insurance:** \`network_preference\`, \`insurance_carrier\`
- **Optional section:** \`referral\` (\"How to refer\" — PA + program)

Registered as a Jinja global so PRs B and C can use it from templates without further wiring.

## Sequencing

- **PR A (this one):** view-model + tests, no templates touched
- **PR B (next):** extract reusable partials (\`_meta_line\`, \`_modality_chips\`, \`_services_block\`, \`_facts_block\`, \`_how_to_refer\`), migrate \`_item.html\` to read from them. Rendered HTML stays identical; existing pinning tests stay green.
- **PR C:** rewrite \`detail.html\` on the partials + view-model; re-scope CSS from \`#posts-list > article > ...\` to a \`.post-card\` class so detail picks up the same styling. User-visible HTML change.

Three small PRs read better than one large one; PR A and B are zero-visible-change refactors, PR C is the only user-visible step.

## Test plan

- [x] \`dev test src/domain/logic/posts/test_view.py\` — 46 passed (30 new \`post_card_view\` tests + 16 existing tests for the older helpers)
- [x] \`dev test\` — 1408 passed
- [x] \`dev lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)