### PR TITLE
refactor(posts): extract list-card partials + migrate _item.html (PR 2 of 3)

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -7,6 +7,7 @@ import pytest
 from src.domain.logic.posts.view import (
     client_referral_headline,
     insurance_posture_for_post,
+    post_card_view,
 )
 
 
@@ -124,3 +125,377 @@ def test_client_referral_headline_falls_back_when_age_groups_empty():
     gracefully if a future code path hands us an empty list."""
     detail = SimpleNamespace(age_groups=[], gender="male")
     assert client_referral_headline(detail) == "Client Referral"
+
+
+# --- post_card_view -----------------------------------------------------
+#
+# The view-model collapses three kind-specific detail shapes (CR has its
+# own location + a scalar gender; PA reads location + insurance off the
+# linked Provider; program reads identity off the linked Program) into
+# one flat dict that templates iterate over. Tests below build a stub
+# post per kind and pin the dict's shape end-to-end. Templates are
+# tested separately at the route level.
+
+
+def _make_cr_post(**detail_overrides):
+    """Realistic CR stub. Defaults populate every field with a sensible
+    value so tests can override only what they care about."""
+    defaults = dict(
+        location_city="Brooklyn",
+        location_state="NY",
+        location_zip="11201",
+        location_in_person="yes",
+        location_virtual="no",
+        desired_times=["weekday_morning"],
+        age_groups=["adults_25_64"],
+        languages=["en", "es"],
+        gender="female",
+        description="Looking for a therapist who takes BCBS.",
+        services=["psychotherapy", "medication_management"],
+        treatment_modality="CBT",
+        network_preference="in_network_required",
+        insurance_carrier="bcbs",
+    )
+    defaults.update(detail_overrides)
+    return SimpleNamespace(
+        kind="client_referral",
+        client_referral_detail=SimpleNamespace(**defaults),
+    )
+
+
+def _make_pa_post(*, provider_attrs=None, **detail_overrides):
+    """Realistic PA stub. Defaults populate provider + detail fields."""
+    p = dict(
+        id="prov-1",
+        org=SimpleNamespace(name="Acme Counseling"),
+        location_city="Brooklyn",
+        location_state="NY",
+        location_zip="11201",
+        in_person_sessions="yes",
+        virtual_sessions="please_contact",
+        in_network_carriers=["aetna"],
+        accepts_out_of_network=False,
+        sliding_scale=True,
+        cost="$150/session",
+    )
+    if provider_attrs:
+        p.update(provider_attrs)
+    d = dict(
+        services=["psychotherapy"],
+        settings=["individual"],
+        age_groups=["adults_25_64"],
+        languages=["en"],
+        genders=["female", "non_binary"],
+        treatment_modality="DBT",
+        description="Accepting new clients.",
+        schedule_text="Mon-Wed 9-5",
+        desired_times=["weekday_morning"],
+        website="https://example.com",
+        referral_instructions="Email intake@example.com",
+    )
+    d.update(detail_overrides)
+    return SimpleNamespace(
+        kind="provider_availability",
+        provider_availability_detail=SimpleNamespace(
+            provider=SimpleNamespace(**p),
+            **d,
+        ),
+    )
+
+
+def _make_program_post(*, program_attrs=None, **detail_overrides):
+    p = dict(
+        id="prog-1",
+        name="RISE IOP",
+        state_preference="CT",
+        organization=SimpleNamespace(name="Acme Health"),
+    )
+    if program_attrs:
+        p.update(program_attrs)
+    d = dict(
+        services=["psychotherapy"],
+        settings=["group"],
+        age_groups=["adolescents_14_18"],
+        languages=["en"],
+        genders=[],
+        treatment_modality="DBT",
+        description="Intake cohort opens June 1.",
+        schedule_text="M-F 9-3",
+        desired_times=["weekday_morning"],
+        website="https://riseiop.example.com",
+        referral_instructions=None,
+    )
+    d.update(detail_overrides)
+    return SimpleNamespace(
+        kind="program_availability",
+        program_availability_detail=SimpleNamespace(
+            program=SimpleNamespace(**p),
+            **d,
+        ),
+    )
+
+
+# --- post_card_view: client_referral ------------------------------------
+
+
+def test_view_cr_basics():
+    """Per-kind discriminators map to the unified verb vocabulary the
+    card's left-edge color and `_services_block` H4 both read from."""
+    v = post_card_view(_make_cr_post())
+    assert v["kind"] == "client_referral"
+    assert v["kind_verb"] == "Seeking"
+
+
+def test_view_cr_headline_from_age_and_gender():
+    v = post_card_view(_make_cr_post(age_groups=["adults_25_64"], gender="male"))
+    assert v["headline"] == "Adult male (25–64)"
+
+
+def test_view_cr_header_state_is_none_state_lives_in_location_chunk():
+    """CR shows state in the demographics column (`location_chunk`),
+    not in the header line — the headline already carries the
+    identity. Pin `header_state` is intentionally None for CR."""
+    v = post_card_view(_make_cr_post())
+    assert v["header_state"] is None
+    assert v["location_chunk"] == {"city": "Brooklyn", "state": "NY", "zip": "11201"}
+
+
+def test_view_cr_in_person_and_virtual_pull_from_detail_row():
+    v = post_card_view(_make_cr_post(location_in_person="yes", location_virtual="no"))
+    assert v["in_person"] == "yes"
+    assert v["virtual"] == "no"
+
+
+def test_view_cr_settings_always_empty():
+    """CR has no `settings` field on its detail row; the view-model
+    returns an empty list so templates can iterate uniformly."""
+    v = post_card_view(_make_cr_post())
+    assert v["settings"] == []
+
+
+def test_view_cr_gender_wraps_to_single_element_list():
+    """CR holds a scalar `gender`; PA/program hold a `genders` list.
+    Wrapping into a list keeps templates' iteration shape uniform —
+    the `{% for g in view.genders %}` block works for both kinds."""
+    v = post_card_view(_make_cr_post(gender="female"))
+    assert v["genders"] == ["female"]
+
+
+def test_view_cr_missing_gender_yields_empty_list():
+    v = post_card_view(_make_cr_post(gender=None))
+    assert v["genders"] == []
+
+
+def test_view_cr_full_address_composes_city_state_zip():
+    v = post_card_view(_make_cr_post())
+    assert v["full_address"] == "Brooklyn, NY 11201"
+
+
+def test_view_cr_cr_only_fields_set_pa_only_fields_none():
+    """CR populates `network_preference` / `insurance_carrier`; the
+    PA-only fields stay at their None/empty defaults."""
+    v = post_card_view(_make_cr_post())
+    assert v["network_preference"] == "in_network_required"
+    assert v["insurance_carrier"] == "bcbs"
+    assert v["sliding_scale"] is None
+    assert v["cost"] is None
+    assert v["in_network_carriers"] == []
+    assert v["accepts_out_of_network"] is None
+    assert v["practice_link"] is None
+    assert v["program_link"] is None
+
+
+def test_view_cr_no_referral_section():
+    """CR has no `website` / `referral_instructions` fields. The
+    detail page's "How to refer" section is PA/program-only."""
+    v = post_card_view(_make_cr_post())
+    assert v["referral"] is None
+
+
+# --- post_card_view: provider_availability ------------------------------
+
+
+def test_view_pa_basics():
+    v = post_card_view(_make_pa_post())
+    assert v["kind"] == "provider_availability"
+    assert v["kind_verb"] == "Providing"
+
+
+def test_view_pa_headline_is_org_name_state_from_provider():
+    """PA's identity is the practice — `provider.org.name` — with
+    state shown in the header line (the provider's `location_state`).
+    Unlike CR, the state isn't demoted to the demographics column."""
+    v = post_card_view(_make_pa_post())
+    assert v["headline"] == "Acme Counseling"
+    assert v["header_state"] == "NY"
+
+
+def test_view_pa_in_person_virtual_come_from_provider():
+    """PA's session availability lives on the linked Provider, not on
+    the post's detail row. The view-model normalizes both kinds onto
+    the same `in_person`/`virtual` keys so the card's modality chips
+    read from one source."""
+    v = post_card_view(
+        _make_pa_post(
+            provider_attrs={"in_person_sessions": "no", "virtual_sessions": "yes"}
+        )
+    )
+    assert v["in_person"] == "no"
+    assert v["virtual"] == "yes"
+
+
+def test_view_pa_practice_link_carries_id_and_org_name():
+    v = post_card_view(_make_pa_post())
+    assert v["practice_link"] == {"id": "prov-1", "name": "Acme Counseling"}
+
+
+def test_view_pa_full_address_from_provider():
+    v = post_card_view(_make_pa_post())
+    assert v["full_address"] == "Brooklyn, NY 11201"
+
+
+def test_view_pa_insurance_fields_from_provider():
+    v = post_card_view(_make_pa_post())
+    assert v["in_network_carriers"] == ["aetna"]
+    assert v["accepts_out_of_network"] is False
+    assert v["sliding_scale"] is True
+    assert v["cost"] == "$150/session"
+
+
+def test_view_pa_settings_populated_genders_as_list():
+    v = post_card_view(_make_pa_post())
+    assert v["settings"] == ["individual"]
+    assert v["genders"] == ["female", "non_binary"]
+
+
+def test_view_pa_referral_set_when_either_field_present():
+    v = post_card_view(_make_pa_post())
+    assert v["referral"] == {
+        "website": "https://example.com",
+        "instructions": "Email intake@example.com",
+    }
+
+
+def test_view_pa_referral_none_when_both_empty():
+    v = post_card_view(_make_pa_post(website=None, referral_instructions=None))
+    assert v["referral"] is None
+
+
+def test_view_pa_no_location_chunk():
+    """PA's location lives on the linked Provider and surfaces via
+    `header_state` + `full_address`. The CR-shaped `location_chunk`
+    is intentionally None for PA so the demographics column doesn't
+    render the icon-only row."""
+    v = post_card_view(_make_pa_post())
+    assert v["location_chunk"] is None
+
+
+# --- post_card_view: program_availability -------------------------------
+
+
+def test_view_program_basics():
+    v = post_card_view(_make_program_post())
+    assert v["kind"] == "program_availability"
+    assert v["kind_verb"] == "Providing"
+
+
+def test_view_program_headline_is_program_name_state_from_program():
+    v = post_card_view(_make_program_post())
+    assert v["headline"] == "RISE IOP"
+    assert v["header_state"] == "CT"
+
+
+def test_view_program_link_carries_id_and_name():
+    v = post_card_view(_make_program_post())
+    assert v["program_link"] == {"id": "prog-1", "name": "RISE IOP"}
+
+
+def test_view_program_organization_name_exposed_separately():
+    """Detail page surfaces the owning Org's name as a separate row
+    below the Program link. The view-model exposes it as a flat
+    field so the template doesn't reach for `prog.organization.name`."""
+    v = post_card_view(_make_program_post())
+    assert v["organization_name"] == "Acme Health"
+
+
+def test_view_program_no_in_person_virtual_no_insurance_no_address():
+    """Program-availability has no in-person/virtual posture (the
+    Program doesn't track session format today), no insurance posture
+    (insurance lives on Provider, not Program), and no location of
+    its own (the linked Program's `state_preference` surfaces via
+    `header_state` instead)."""
+    v = post_card_view(_make_program_post())
+    assert v["in_person"] is None
+    assert v["virtual"] is None
+    assert v["insurance_posture"] is None
+    assert v["full_address"] is None
+    assert v["location_chunk"] is None
+
+
+# --- post_card_view: defensiveness --------------------------------------
+
+
+def test_view_unknown_kind_returns_base_skeleton():
+    """An unregistered kind returns the all-None skeleton — templates
+    render nothing rather than crashing on a missing detail relationship."""
+    v = post_card_view(SimpleNamespace(kind="mystery"))
+    assert v["kind"] == "mystery"
+    assert v["kind_verb"] is None
+    assert v["headline"] is None
+    assert v["services"] == []
+
+
+def test_view_cr_missing_detail_returns_base_skeleton():
+    """A CR post with no detail relationship (shouldn't happen at
+    rest, but the helper stays defensive for stub data) returns the
+    skeleton with kind/kind_verb still populated."""
+    v = post_card_view(
+        SimpleNamespace(kind="client_referral", client_referral_detail=None)
+    )
+    assert v["kind"] == "client_referral"
+    assert v["kind_verb"] == "Seeking"
+    assert v["headline"] is None
+    assert v["location_chunk"] is None
+
+
+def test_view_pa_missing_provider_returns_partial_view():
+    """PA's detail has a `provider` relationship that could be None
+    in test stubs. View-model populates the detail-row fields it can
+    and leaves provider-derived fields at None."""
+    post = SimpleNamespace(
+        kind="provider_availability",
+        provider_availability_detail=SimpleNamespace(
+            provider=None,
+            services=["psychotherapy"],
+            settings=[],
+            age_groups=[],
+            languages=[],
+            genders=[],
+            treatment_modality=None,
+            description="x",
+            schedule_text=None,
+            desired_times=[],
+            website=None,
+            referral_instructions=None,
+        ),
+    )
+    v = post_card_view(post)
+    assert v["headline"] is None
+    assert v["header_state"] is None
+    assert v["full_address"] is None
+    assert v["practice_link"] is None
+    assert v["sliding_scale"] is None
+    # Detail-row fields independent of the provider relationship still
+    # populate so the card can render whatever it can.
+    assert v["services"] == ["psychotherapy"]
+    assert v["description"] == "x"
+
+
+def test_view_returns_dict_for_jinja_attribute_access():
+    """Templates use ``view.field_name`` syntax — Jinja resolves this
+    to ``view['field_name']`` on a dict. Pin that the function returns
+    a dict (not a NamedTuple or dataclass) so the access pattern
+    works without surprises."""
+    v = post_card_view(_make_cr_post())
+    assert isinstance(v, dict)
+    assert v["kind"] == "client_referral"

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -26,9 +26,24 @@ multi for forward-compat but only the first drives the title).
 Genders that don't slot in naturally — `prefer_not_to_say`,
 `gender_diverse` — drop the gender word entirely.
 
-Both helpers are exposed as Jinja globals by
+`post_card_view(post)` is the unified view-model that both the listing
+card (`_item.html`) and the detail page (`detail.html`) read from. Each
+kind's underlying detail relationship has a different field set and
+naming — CR holds its own (city, state, zip) location and a single
+gender; PA reads location and insurance from the linked Provider;
+program reads identity from the linked Program. The function collapses
+those three shapes into one flat dict so templates iterate over keys
+rather than branching on `post.kind`. Values that don't apply to a
+kind are ``None`` (or empty lists); templates render via
+``{% if view.x %}``. Raw enum values are returned — display-label
+lookup is the template's job (it's the same label dict pattern as
+elsewhere).
+
+All three helpers are exposed as Jinja globals by
 `src/framework/rendering/templating.py`.
 """
+
+from typing import Any
 
 from src.domain.models.enums import CLIENT_AGE_GROUPS_BY_KEY
 
@@ -87,6 +102,267 @@ def insurance_posture_for_post(post) -> str | None:
         # the same.
         return None
     return None
+
+
+_KIND_VERB = {
+    "client_referral": "Seeking",
+    "provider_availability": "Providing",
+    "program_availability": "Providing",
+}
+
+
+def _location_chunk(
+    city: str | None, state: str | None, zip_code: str | None
+) -> dict | None:
+    """Return ``{city, state, zip}`` when any of the three are present,
+    otherwise ``None`` so templates can ``{% if view.location_chunk %}``."""
+    if not any((city, state, zip_code)):
+        return None
+    return {"city": city, "state": state, "zip": zip_code}
+
+
+def _full_address(
+    city: str | None, state: str | None, zip_code: str | None
+) -> str | None:
+    """Compose ``"City, ST ZIP"`` for the detail page's expanded address
+    row. Returns ``None`` when no parts are present so templates omit
+    the row entirely."""
+    if not any((city, state, zip_code)):
+        return None
+    head = ", ".join(p for p in (city, state) if p)
+    if zip_code:
+        return f"{head} {zip_code}" if head else zip_code
+    return head or None
+
+
+def _referral_or_none(website: str | None, instructions: str | None) -> dict | None:
+    """Bundle the optional PA/program "how to refer" fields. Either
+    being set lights up the section; both being empty means no section."""
+    if not (website or instructions):
+        return None
+    return {"website": website, "instructions": instructions}
+
+
+def post_card_view(post) -> dict[str, Any]:
+    """Normalize a `Post` of any kind into the flat shape both the
+    listing card and the detail page render from.
+
+    Pre-pulls every field templates need so the per-kind branching
+    happens here (once, in Python) instead of in three different
+    templates. Missing values come back as ``None`` (scalars) or
+    ``[]`` (lists) so templates render via ``{% if view.x %}`` /
+    ``{% for x in view.xs %}`` without further nullability handling.
+
+    Returns:
+        kind: the discriminator (`client_referral` /
+            `provider_availability` / `program_availability`).
+        kind_verb: ``"Seeking"`` for CR, ``"Providing"`` for the two
+            availability kinds. Mirrors the kind-chip vocabulary the
+            list card's left-edge color uses (orange = Seeking, cyan
+            = Providing).
+        headline: the card's identity line — CR is ``client_referral_headline``
+            (age + gender combo); PA is the practice's org name;
+            program is the program name.
+        header_state: the state shown next to the headline. PA reads
+            from ``provider.location_state``; program reads from
+            ``program.state_preference``; CR is ``None`` because its
+            state lives in ``location_chunk`` (the demographics-column
+            location row), not in the header line.
+        in_person / virtual: the post's in-person/virtual posture as
+            `LOCATION_AVAILABILITY_OPTIONS` values. CR reads them off
+            its own detail row; PA reads them from the linked
+            Provider's session-availability fields. Program has no
+            in-person/virtual posture and returns ``None`` for both.
+        services / settings: raw enum lists. PA + program carry
+            ``settings``; CR's ``settings`` is empty.
+        ages / languages / genders: raw enum lists. CR's single
+            ``gender`` is wrapped in a list of one so templates iterate
+            uniformly (a CR with ``gender = "prefer_not_to_say"``
+            returns ``["prefer_not_to_say"]`` — the template still has
+            the value if it wants to handle it specially).
+        insurance_posture: one of ``INSURANCE_POSTURES`` or ``None``
+            (program-availability has no posture). Same value
+            ``insurance_posture_for_post`` returns.
+        treatment_modality: free-text modality string or ``None``.
+        location_chunk: ``{city, state, zip}`` for CR's demographics
+            column; ``None`` for PA and program (PA's location is on
+            the linked Provider and surfaces via ``header_state`` and
+            ``full_address``; program has no location of its own).
+        description: free-text description or ``None``. CR's
+            description is NOT NULL on the model but the function
+            stays defensive for stubs that omit it.
+        schedule_text: PA/program optional schedule notes; ``None``
+            for CR.
+        desired_times: raw enum list of desired-time slots; empty if
+            unset.
+        practice_link: ``{id, name}`` of PA's linked Provider's org;
+            ``None`` for other kinds.
+        program_link: ``{id, name}`` of program's linked Program;
+            ``None`` for other kinds.
+        organization_name: program's owning organization name;
+            ``None`` for other kinds.
+        full_address: ``"City, ST ZIP"`` string for the detail page's
+            expanded location row. CR reads from its own location;
+            PA reads from the linked Provider; program returns
+            ``None``.
+        sliding_scale / cost: PA-only fields from the linked Provider;
+            ``None`` for other kinds.
+        network_preference / insurance_carrier: CR-only raw enum
+            values from the detail row; ``None`` for other kinds.
+        in_network_carriers / accepts_out_of_network: PA-only raw
+            values from the linked Provider. ``in_network_carriers``
+            comes back as an empty list when unset, matching the
+            list/iteration convention; ``accepts_out_of_network`` is
+            ``None`` for other kinds.
+        referral: ``{website, instructions}`` when either is set
+            (PA/program "how to refer" section); ``None`` when both
+            empty or for CR.
+    """
+    kind = getattr(post, "kind", None)
+    base: dict[str, Any] = {
+        "kind": kind,
+        "kind_verb": _KIND_VERB.get(kind),
+        "headline": None,
+        "header_state": None,
+        "in_person": None,
+        "virtual": None,
+        "services": [],
+        "settings": [],
+        "ages": [],
+        "languages": [],
+        "genders": [],
+        "insurance_posture": insurance_posture_for_post(post),
+        "treatment_modality": None,
+        "location_chunk": None,
+        "description": None,
+        "schedule_text": None,
+        "desired_times": [],
+        "practice_link": None,
+        "program_link": None,
+        "organization_name": None,
+        "full_address": None,
+        "sliding_scale": None,
+        "cost": None,
+        "network_preference": None,
+        "insurance_carrier": None,
+        "in_network_carriers": [],
+        "accepts_out_of_network": None,
+        "referral": None,
+    }
+
+    if kind == "client_referral":
+        d = getattr(post, "client_referral_detail", None)
+        if d is None:
+            return base
+        base.update(
+            headline=client_referral_headline(d),
+            in_person=getattr(d, "location_in_person", None),
+            virtual=getattr(d, "location_virtual", None),
+            services=list(getattr(d, "services", None) or []),
+            ages=list(getattr(d, "age_groups", None) or []),
+            languages=list(getattr(d, "languages", None) or []),
+            genders=([d.gender] if getattr(d, "gender", None) else []),
+            treatment_modality=getattr(d, "treatment_modality", None),
+            location_chunk=_location_chunk(
+                getattr(d, "location_city", None),
+                getattr(d, "location_state", None),
+                getattr(d, "location_zip", None),
+            ),
+            description=getattr(d, "description", None),
+            desired_times=list(getattr(d, "desired_times", None) or []),
+            full_address=_full_address(
+                getattr(d, "location_city", None),
+                getattr(d, "location_state", None),
+                getattr(d, "location_zip", None),
+            ),
+            network_preference=getattr(d, "network_preference", None),
+            insurance_carrier=getattr(d, "insurance_carrier", None),
+        )
+        return base
+
+    if kind == "provider_availability":
+        d = getattr(post, "provider_availability_detail", None)
+        if d is None:
+            return base
+        p = getattr(d, "provider", None)
+        base.update(
+            headline=(p.org.name if p and getattr(p, "org", None) else None),
+            header_state=(getattr(p, "location_state", None) if p else None),
+            in_person=(getattr(p, "in_person_sessions", None) if p else None),
+            virtual=(getattr(p, "virtual_sessions", None) if p else None),
+            services=list(getattr(d, "services", None) or []),
+            settings=list(getattr(d, "settings", None) or []),
+            ages=list(getattr(d, "age_groups", None) or []),
+            languages=list(getattr(d, "languages", None) or []),
+            genders=list(getattr(d, "genders", None) or []),
+            treatment_modality=getattr(d, "treatment_modality", None),
+            description=getattr(d, "description", None),
+            schedule_text=getattr(d, "schedule_text", None),
+            desired_times=list(getattr(d, "desired_times", None) or []),
+            practice_link=(
+                {"id": p.id, "name": p.org.name}
+                if p and getattr(p, "org", None) and getattr(p, "id", None)
+                else None
+            ),
+            full_address=(
+                _full_address(
+                    getattr(p, "location_city", None),
+                    getattr(p, "location_state", None),
+                    getattr(p, "location_zip", None),
+                )
+                if p
+                else None
+            ),
+            sliding_scale=(getattr(p, "sliding_scale", None) if p else None),
+            cost=(getattr(p, "cost", None) if p else None),
+            in_network_carriers=(
+                list(getattr(p, "in_network_carriers", None) or []) if p else []
+            ),
+            accepts_out_of_network=(
+                getattr(p, "accepts_out_of_network", None) if p else None
+            ),
+            referral=_referral_or_none(
+                getattr(d, "website", None),
+                getattr(d, "referral_instructions", None),
+            ),
+        )
+        return base
+
+    if kind == "program_availability":
+        d = getattr(post, "program_availability_detail", None)
+        if d is None:
+            return base
+        prog = getattr(d, "program", None)
+        base.update(
+            headline=(getattr(prog, "name", None) if prog else None),
+            header_state=(getattr(prog, "state_preference", None) if prog else None),
+            services=list(getattr(d, "services", None) or []),
+            settings=list(getattr(d, "settings", None) or []),
+            ages=list(getattr(d, "age_groups", None) or []),
+            languages=list(getattr(d, "languages", None) or []),
+            genders=list(getattr(d, "genders", None) or []),
+            treatment_modality=getattr(d, "treatment_modality", None),
+            description=getattr(d, "description", None),
+            schedule_text=getattr(d, "schedule_text", None),
+            desired_times=list(getattr(d, "desired_times", None) or []),
+            program_link=(
+                {"id": prog.id, "name": prog.name}
+                if prog and getattr(prog, "id", None) and getattr(prog, "name", None)
+                else None
+            ),
+            organization_name=(
+                getattr(prog.organization, "name", None)
+                if prog and getattr(prog, "organization", None)
+                else None
+            ),
+            referral=_referral_or_none(
+                getattr(d, "website", None),
+                getattr(d, "referral_instructions", None),
+            ),
+        )
+        return base
+
+    return base
 
 
 def client_referral_headline(detail) -> str:

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -23,6 +23,7 @@ from src.domain.logic.posts.schema import (
 from src.domain.logic.posts.view import (
     client_referral_headline,
     insurance_posture_for_post,
+    post_card_view,
 )
 from src.domain.models import enums
 from src.framework.rendering.form_fields import register_choice_labels
@@ -97,6 +98,10 @@ register_template_globals(
     # Post-specific view helpers.
     insurance_posture=insurance_posture_for_post,
     client_referral_headline=client_referral_headline,
+    # `post_card_view(post)` is the unified view-model both the listing
+    # card (`posts/_item.html`) and the detail page (`posts/detail.html`)
+    # read from — see its docstring in `src.domain.logic.posts.view`.
+    post_card_view=post_card_view,
 )
 
 # Register the choice-tuple → labels-dict mapping that `field_spec` uses

--- a/src/domain/templates/posts/_facts_block.html
+++ b/src/domain/templates/posts/_facts_block.html
@@ -1,0 +1,62 @@
+{# Demographics fact `<dl>` — the post card's right column.
+
+Each fact is wrapped in a `<div>` so CSS can style chunks
+individually (e.g. the CR location chunk gets an icon-only `<dt>`
+via `div.post-location`, suppressing the trailing colon the generic
+`dt::after` rule applies to other rows).
+
+Chunks shown depend on what the view has:
+
+  - location_chunk: CR only — the icon-only row with "City, ST".
+    PA/program return `None` here (PA's location surfaces via the
+    header line's `header_state`; program has no location of its
+    own).
+  - ages: PA + program (when set). CR's age + gender combo lives in
+    the headline so the column omits it for CR.
+  - genders: PA + program only. CR's gender lives in the headline.
+  - languages: any kind, but suppressed when the value is `["en"]`
+    alone — English-only isn't a worthwhile chunk on a card.
+  - insurance_posture: any kind that produces a posture. Program-
+    availability returns `None` here so the row hides.
+  - treatment_modality: free-text modality string when present.
+
+Reads from `view` (the `post_card_view` dict). Display-label dicts
+(`CLIENT_AGE_GROUP_LABELS`, `GENDER_LABELS`, `LANGUAGE_LABELS`,
+`INSURANCE_POSTURE_LABELS`) are Jinja globals. #}
+{% macro facts_block(view) -%}
+<section class="post-facts">
+  <dl>
+    {%- if view.location_chunk %}
+    <div class="post-location"><dt aria-label="Location"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>
+      {%- if view.location_chunk.city -%}{{ view.location_chunk.city }}, {% endif -%}{{ view.location_chunk.state }}
+    </dd></div>
+    {%- elif view.ages %}
+    <div><dt>Ages</dt><dd>
+      {%- set ages = [] -%}
+      {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
+      {{ ages | join(", ") }}
+    </dd></div>
+    {%- endif %}
+    {%- if view.kind != "client_referral" and view.genders %}
+    <div><dt>Genders</dt><dd>
+      {%- set gs = [] -%}
+      {%- for g in view.genders -%}{%- set _ = gs.append(GENDER_LABELS[g]) -%}{%- endfor -%}
+      {{ gs | join(", ") }}
+    </dd></div>
+    {%- endif %}
+    {%- if view.languages and not (view.languages | length == 1 and view.languages[0] == "en") %}
+    <div><dt>Languages</dt><dd>
+      {%- set langs = [] -%}
+      {%- for l in view.languages -%}{%- set _ = langs.append(LANGUAGE_LABELS[l]) -%}{%- endfor -%}
+      {{ langs | join(", ") }}
+    </dd></div>
+    {%- endif %}
+    {%- if view.insurance_posture %}
+    <div><dt>Insurance</dt><dd>{{ INSURANCE_POSTURE_LABELS[view.insurance_posture] }}</dd></div>
+    {%- endif %}
+    {%- if view.treatment_modality %}
+    <div><dt>Modality</dt><dd>{{ view.treatment_modality }}</dd></div>
+    {%- endif %}
+  </dl>
+</section>
+{%- endmacro %}

--- a/src/domain/templates/posts/_item.html
+++ b/src/domain/templates/posts/_item.html
@@ -22,198 +22,45 @@ Layout per card:
 
 The card is `<article>` with `<header>`, two-column body, and
 `<footer>` — Pico's automatic styling tints header and footer as
-the top/bottom bands of the card, so we don't restyle them. The
-header line carries the headline link, one or two modality chips
-(icon + short label) describing the post's in-person/virtual
-posture, and a right-aligned date. The headline shape varies by
-kind: CR is the age + gender combo from `client_referral_headline`
-("Adult male (25–64)"); PA is "{org.name}, ST". CR's state is
-demoted to a location chunk in the demographics column (icon-only
-`<dt>` + "City, ST"); PA still carries state in the header. Each
-modality is a separate chip so each glyph anchors a single fact;
-the muted color keeps the headline as the visual lead. The body is
-a two-column grid: services (left), demographics (right). The
-footer carries one element — the "Email" CTA (Pico `secondary
-outline` button) — right-aligned so it reads as the action
-landing at the natural eye-end of the card.
-The reader already knows who they're contacting from the headline
-(PA: practice name; CR: the post itself implies the author), so
-the raw address stays inside the `href`.
+the top/bottom bands of the card. The header line carries the
+headline link, modality chips, and a right-aligned date. The body
+is two `<section>`s side-by-side: services with inline icons
+(left), demographics `<dl>` (right). The footer carries one element
+— the Email CTA — right-aligned.
 
-The left-column heading is kind-aware — "Seeking" for `client_referral`,
-"Providing" for `provider_availability`. The generic "Services" label was
-ambiguous (both kinds carried it with opposite meaning); the verb forms
-reuse the chip vocabulary documented for the colored left edge (orange =
-Seeking, cyan = Providing). Service order is priority-sorted, not enum
-order: `psychotherapy` and `medication_management` lead the list (the
-two services a reader is overwhelmingly likeliest to be scanning for);
-the rest follow in `CLIENT_REFERRAL_SERVICES` declaration order. PA
-`settings` render under the same heading after services, unsorted.
-
-Per-service icons render inline next to each service name in the
-left column. The icons come from `CLIENT_REFERRAL_SERVICE_ICONS` and
-`TREATMENT_SETTINGS_ICONS` in `src/domain/models/enums.py`; the
-Lucide font CSS in `base.html` renders the glyphs. Icons next to a
-labeled item are unambiguous — the reader sees "pill | Medication
-management" together — unlike the earlier icon-only experiment.
-
-Footer carries just the Email CTA — Pico-styled `role="button"
-class="secondary outline"` with the label "Email". The raw address
-lives only in the `href`. `target="_blank" rel="noopener noreferrer"`
-is harmless on `mailto:` URLs (most clients open the mail handler
-regardless) and matches the pattern used for the PA `website` link
-on the detail page.
+Per-kind branching and field selection live in
+`src.domain.logic.posts.view.post_card_view`, which collapses CR /
+PA / program-availability detail shapes into one flat `view` dict.
+The three blocks (modality chips, services, facts) are partials
+that read from `view`; this file composes them into the card frame.
+PR C of the list/detail unification reuses the same partials on the
+detail page so both views share the same visual vocabulary.
 
 `active_kind` accepted for backward compatibility with `list.html`
 but ignored — the cards' `data-kind` left-edge color is constant
-per-kind, so a single-kind filter doesn't need to suppress anything.
-#}
-
-{% macro _modality_chips(in_person, virtual) -%}
-{#- Header-line in-person/virtual posture as one or two icon+label
-    chips. `please_contact` on either arm collapses to a single
-    "Contact for format" chip (no icon — the posture is unknown,
-    so neither glyph applies). Empty when neither arm is `yes`. -#}
-{%- if in_person == "please_contact" or virtual == "please_contact" -%}
-<span class="post-modality">Contact for format</span>
-{%- else -%}
-{%- if virtual == "yes" %}<span class="post-modality"><i class="icon-video" aria-hidden="true"></i>Virtual</span>{% endif -%}
-{%- if in_person == "yes" %}<span class="post-modality"><i class="icon-map-pin" aria-hidden="true"></i>In-person</span>{% endif -%}
-{%- endif -%}
-{%- endmacro %}
-
-{% macro _service_item(value, label_dict, icon_dict) -%}
-{#- One `<li>` for a service or setting: icon + label. The icon is
-    decorative; the label carries the meaning for screen readers. -#}
-<li><i class="icon-{{ icon_dict[value] }}" aria-hidden="true"></i>{{ label_dict[value] }}</li>
-{%- endmacro %}
+per-kind, so a single-kind filter doesn't need to suppress anything. #}
+{%- from "posts/_modality_chips.html" import modality_chips -%}
+{%- from "posts/_services_block.html" import services_block -%}
+{%- from "posts/_facts_block.html" import facts_block -%}
 
 {% macro post_item(post, active_kind=None) -%}
-{%- if post.kind == "client_referral" -%}
-  {%- set d = post.client_referral_detail -%}
-  {#- CR posts have no client name; the age + gender combo (e.g.
-      "Adult male (25–64)") is the identity. `client_referral_headline`
-      composes it from `age_groups[0]` + `gender`. State is intentionally
-      omitted from the header — it lives in the demographics column as
-      a labeled location chunk (`📍 City, ST`). -#}
-  {%- set headline_text = client_referral_headline(d) -%}
-  {%- set state = None -%}
-  {%- set in_person = d.location_in_person -%}
-  {%- set virtual = d.location_virtual -%}
-  {%- set services = d.services or [] -%}
-  {%- set settings_list = [] -%}
-{%- elif post.kind == "program_availability" -%}
-  {%- set d = post.program_availability_detail -%}
-  {%- set prog = d.program -%}
-  {#- Program-availability posts identify as their Program; the Program
-      name is the lead, the owning Org's name follows as a small
-      qualifier (#541). State comes from the Program's
-      `state_preference` (Programs may serve a state distinct from the
-      Org's primary state). In-person/virtual posture isn't tracked at
-      the Program level today, so the modality-chip pair is empty. -#}
-  {%- set headline_text = prog.name -%}
-  {%- set state = prog.state_preference if prog else None -%}
-  {%- set in_person = None -%}
-  {%- set virtual = None -%}
-  {%- set services = d.services or [] -%}
-  {%- set settings_list = d.settings or [] -%}
-{%- else -%}
-  {%- set d = post.provider_availability_detail -%}
-  {%- set p = d.provider -%}
-  {#- PA posts identify as their practice. The practice name is the
-      identity; "Provider Availability" as a label adds nothing. -#}
-  {%- set headline_text = p.org.name -%}
-  {%- set state = p.location_state if p else None -%}
-  {%- set in_person = p.in_person_sessions if p else None -%}
-  {%- set virtual = p.virtual_sessions if p else None -%}
-  {%- set services = d.services or [] -%}
-  {%- set settings_list = d.settings or [] -%}
-{%- endif -%}
-{%- set posture = insurance_posture(post) -%}
+{%- set view = post_card_view(post) -%}
 <article data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
   <header class="post-header">
-    <strong><a href="{{ entity_url('post', id=post.id) }}">{{ headline_text }}{% if state %}, {{ state }}{% endif %}</a></strong>
-    {{ _modality_chips(in_person, virtual) }}
+    <strong><a href="{{ entity_url('post', id=post.id) }}">{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</a></strong>
+    {{ modality_chips(view.in_person, view.virtual) }}
     <small>{{ post.created_at | format_post_date }}</small>
   </header>
   <div class="post-grid">
-    <section class="post-services">
-      {%- if services or settings_list %}
-      {#- "Seeking" / "Providing" mirrors the kind-chip vocabulary
-          (see this file's top doc-comment). Priority services
-          ("psychotherapy", "medication_management") render first so a
-          scanner finds the two most-asked-for items at the top. -#}
-      <h4>{% if post.kind == "client_referral" %}Seeking{% else %}Providing{% endif %}</h4>
-      {%- set _priority = ["psychotherapy", "medication_management"] %}
-      <ul>
-        {%- for s in _priority if s in services %}
-        {{ _service_item(s, CLIENT_REFERRAL_SERVICE_LABELS, CLIENT_REFERRAL_SERVICE_ICONS) }}
-        {%- endfor %}
-        {%- for s in services if s not in _priority %}
-        {{ _service_item(s, CLIENT_REFERRAL_SERVICE_LABELS, CLIENT_REFERRAL_SERVICE_ICONS) }}
-        {%- endfor %}
-        {%- for s in settings_list %}
-        {{ _service_item(s, TREATMENT_SETTINGS_LABELS, TREATMENT_SETTINGS_ICONS) }}
-        {%- endfor %}
-      </ul>
-      {%- endif %}
-    </section>
-
-    <section class="post-facts">
-      <dl>
-        {%- if post.kind == "client_referral" %}
-        {#- CR: location chunk replaces the state-in-header treatment.
-            City + state inline (city always present per LocationMixin
-            NOT NULL; falls back to state alone if absent). The `<dt>`
-            is icon-only — `aria-label` carries the meaning for screen
-            readers; CSS suppresses the trailing colon for this row.
-            Age + gender are intentionally not surfaced here — the
-            headline already carries both. -#}
-        <div class="post-location"><dt aria-label="Location"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>
-          {%- if d.location_city -%}{{ d.location_city }}, {% endif -%}{{ d.location_state }}
-        </dd></div>
-        {%- elif d.age_groups %}
-        {#- PA: "Ages" — the cohort of clients the practice accepts.
-            Plural `CLIENT_AGE_GROUP_LABELS`. -#}
-        <div><dt>Ages</dt><dd>
-          {%- set ages = [] -%}
-          {%- for g in d.age_groups -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
-          {{ ages | join(", ") }}
-        </dd></div>
-        {%- endif %}
-        {#- PA / program-availability gender chunk: `genders` is a list
-            (may be empty, which means "no restriction stated" — omit
-            the chunk entirely). CR's gender lives in the headline, so
-            no CR branch here. -#}
-        {%- if post.kind in ("provider_availability", "program_availability") and d.genders %}
-        <div><dt>Genders</dt><dd>
-          {%- set gs = [] -%}
-          {%- for g in d.genders -%}{%- set _ = gs.append(GENDER_LABELS[g]) -%}{%- endfor -%}
-          {{ gs | join(", ") }}
-        </dd></div>
-        {%- endif %}
-        {%- if d.languages and not (d.languages | length == 1 and d.languages[0] == "en") %}
-        <div><dt>Languages</dt><dd>
-          {%- set langs = [] -%}
-          {%- for l in d.languages -%}{%- set _ = langs.append(LANGUAGE_LABELS[l]) -%}{%- endfor -%}
-          {{ langs | join(", ") }}
-        </dd></div>
-        {%- endif %}
-        {%- if posture %}
-        <div><dt>Insurance</dt><dd>{{ INSURANCE_POSTURE_LABELS[posture] }}</dd></div>
-        {%- endif %}
-        {%- if d.treatment_modality %}
-        <div><dt>Modality</dt><dd>{{ d.treatment_modality }}</dd></div>
-        {%- endif %}
-      </dl>
-    </section>
+    {{ services_block(view) }}
+    {{ facts_block(view) }}
   </div>
 
-  {#- Footer contains only the Email CTA, right-aligned by the
-      `.post-footer` rule. The headline already identifies the
-      contact (PA: practice name; CR: implicit in the post), so the
-      footer is just the action. Pico-styled `role="button"
-      class="secondary outline"`. -#}
+  {#- Footer carries just the Email CTA — Pico-styled `role="button"
+      class="secondary outline"` with the label "Email". The raw
+      address lives only in the `href`. `target="_blank" rel="noopener
+      noreferrer"` is harmless on `mailto:` URLs and matches the
+      pattern used for the PA `website` link on the detail page. -#}
   <footer class="post-footer">
     <a href="mailto:{{ post.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>

--- a/src/domain/templates/posts/_modality_chips.html
+++ b/src/domain/templates/posts/_modality_chips.html
@@ -1,0 +1,19 @@
+{# Two-chip modality posture for the post card's header line.
+
+`in_person` and `virtual` are `LOCATION_AVAILABILITY_OPTIONS` values
+(`yes` / `no` / `please_contact`). A `please_contact` on either arm
+collapses to a single "Contact for format" chip — the posture is
+unknown so neither glyph applies. When both are `no` (or None), no
+chip renders.
+
+Used by `posts/_item.html` (the list card) and `posts/detail.html`
+(the detail page, post PR C). Same visual treatment in both views
+so the modality posture reads the same wherever it appears. #}
+{% macro modality_chips(in_person, virtual) -%}
+{%- if in_person == "please_contact" or virtual == "please_contact" -%}
+<span class="post-modality">Contact for format</span>
+{%- else -%}
+{%- if virtual == "yes" %}<span class="post-modality"><i class="icon-video" aria-hidden="true"></i>Virtual</span>{% endif -%}
+{%- if in_person == "yes" %}<span class="post-modality"><i class="icon-map-pin" aria-hidden="true"></i>In-person</span>{% endif -%}
+{%- endif -%}
+{%- endmacro %}

--- a/src/domain/templates/posts/_services_block.html
+++ b/src/domain/templates/posts/_services_block.html
@@ -1,0 +1,42 @@
+{# Services-with-icons block — the post card's left column.
+
+`<h4>` carries the kind-aware verb (`Seeking` for CR, `Providing` for
+PA/program); the `<ul>` items combine a Lucide icon with the service's
+display label. Priority sort puts `psychotherapy` and
+`medication_management` first since those are the two services
+scanners most often look for; the rest follow in
+`CLIENT_REFERRAL_SERVICES` declaration order. PA+program `settings`
+render under the same `<ul>` after the services.
+
+Reads from `view` (the `post_card_view` dict):
+  - view.kind_verb — H4 heading text
+  - view.services — service enum values
+  - view.settings — setting enum values (PA + program; empty for CR)
+
+Renders nothing when both lists are empty so the H4 doesn't stand
+alone. The display-label and icon-name dicts come in via Jinja
+globals (`CLIENT_REFERRAL_SERVICE_LABELS` / `_ICONS`, same for
+`TREATMENT_SETTINGS_*`) registered in `src/domain/template_globals.py`. #}
+{% macro _service_item(value, label_dict, icon_dict) -%}
+<li><i class="icon-{{ icon_dict[value] }}" aria-hidden="true"></i>{{ label_dict[value] }}</li>
+{%- endmacro %}
+
+{% macro services_block(view) -%}
+<section class="post-services">
+  {%- if view.services or view.settings %}
+  <h4>{{ view.kind_verb }}</h4>
+  {%- set _priority = ["psychotherapy", "medication_management"] %}
+  <ul>
+    {%- for s in _priority if s in view.services %}
+    {{ _service_item(s, CLIENT_REFERRAL_SERVICE_LABELS, CLIENT_REFERRAL_SERVICE_ICONS) }}
+    {%- endfor %}
+    {%- for s in view.services if s not in _priority %}
+    {{ _service_item(s, CLIENT_REFERRAL_SERVICE_LABELS, CLIENT_REFERRAL_SERVICE_ICONS) }}
+    {%- endfor %}
+    {%- for s in view.settings %}
+    {{ _service_item(s, TREATMENT_SETTINGS_LABELS, TREATMENT_SETTINGS_ICONS) }}
+    {%- endfor %}
+  </ul>
+  {%- endif %}
+</section>
+{%- endmacro %}


### PR DESCRIPTION
PR 2 of 3 toward unifying the post list-card and detail templates.

**Pure refactor** — rendered HTML is identical to before this PR, so all 94 existing pinning tests in \`test_posts.py\` stay green without modification. PR C will reuse these partials on the detail page.

## What moved

- \`posts/_modality_chips.html\` — \`modality_chips(in_person, virtual)\` macro, extracted from the private \`_modality_chips\` macro that was inside \`_item.html\`. Same chip output (video / map-pin icons + label, \"Contact for format\" collapse for \`please_contact\`).
- \`posts/_services_block.html\` — \`services_block(view)\` macro for the \`<section class=\"post-services\">\` H4-and-icon-list left column. H4 verb (\`Seeking\` / \`Providing\`) reads from \`view.kind_verb\`. Priority sort (\`psychotherapy\` + \`medication_management\` first) and PA/program \`settings\` append are preserved.
- \`posts/_facts_block.html\` — \`facts_block(view)\` macro for the \`<section class=\"post-facts\">\` demographics \`<dl>\`. Each chunk (location / ages / genders / languages / insurance / modality) reads from \`view\`. The CR-specific rules — \`location_chunk\` replaces the ages row; genders omitted for CR; English-only languages suppressed — are preserved.

## What \`_item.html\` looks like now

Goes from ~200 lines (with embedded 4-branch per-kind preamble) to ~60 lines composing the card frame from three partials, reading from \`post_card_view(post)\` (the dict view-model added in PR A). The kind-branching that used to live in two places (\`_item.html\` and \`detail.html\`) now lives in one: \`post_card_view\`.

## Why pure-refactor matters

CSS hooks (\`header.post-header\`, \`section.post-services\`, \`section.post-facts\`, \`div.post-location\`, \`data-kind\`) are preserved exactly, which is why \`test_posts.py\`'s ~30 selectors-on-rendered-HTML assertions stay green. PR C is the one that changes user-visible HTML (re-scoping CSS from \`#posts-list > article > ...\` to a \`.post-card\` class so detail picks up the same styling and detail.html itself gets rewritten on these partials).

## Test plan

- [x] \`dev test src/domain/routes/test_posts.py\` — 94 passed (no selector or assertion changed)
- [x] \`dev test\` — 1408 passed
- [x] \`dev test contract\` — 20 passed (the \`post-owner-actions\` contract pair uses the unchanged-shape detail template)
- [x] \`dev lint\` — clean

## Dependencies

Stacks on top of #562 (PR A — \`post_card_view\` view-model + Jinja global). Now that #562 is merged this branch rebases cleanly onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)