### PR TITLE
test(contract): introspect SQLAlchemy types for realistic make_post_stub defaults

### DIFF
--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -83,9 +83,9 @@ def insurance_posture_for_post(post) -> str | None:
         }.get(detail.network_preference)
     if kind == "provider_availability":
         detail = getattr(post, "provider_availability_detail", None)
-        if detail is None or detail.provider is None:
+        provider = getattr(detail, "provider", None) if detail is not None else None
+        if provider is None:
             return None
-        provider = detail.provider
         if provider.in_network_carriers:
             return "in_network"
         if provider.accepts_out_of_network:

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -134,37 +134,18 @@ def _setup_post_owner_actions_stub(app: FastAPI) -> None:
 
     @app.get("/posts/{post_id}")
     async def post_owner_actions_stub_page(request: Request, post_id: uuid.UUID):
-        # The detail template reads the per-kind detail relationship;
-        # `make_post_stub` populates it off `POST_KINDS`. Owner id
-        # equals post id here so the partial's owner-or-admin gate is a
-        # don't-care (current_user is a superuser).
-        #
-        # List- and enum-typed fields need realistic values rather than
-        # the `"stub <fieldname>"` defaults `make_post_stub` produces —
-        # the detail template iterates list fields and looks each item
-        # up in a display-label dict, which crashes when the field is a
-        # string ("stub age_groups" → iterating chars → KeyError on
-        # "s" in `CLIENT_AGE_GROUP_LABELS`). Scalar enum fields
-        # (location_in_person etc.) get the same treatment — the
-        # template renders their display label, which fails the
-        # lookup on a non-enum value. Hardcoding realistic values
-        # lets the detail page render so the Delete button is
-        # reachable and the contract surface (the button's HTTP shape)
-        # can be exercised.
+        # `make_post_stub` populates the per-kind detail relationship
+        # with realistic per-column defaults (JSON columns → `[]`,
+        # enum-typed Text columns → values from `_ENUM_DEFAULTS`) so
+        # the detail template renders cleanly without per-stub
+        # overrides. Owner id equals post id here so the partial's
+        # owner-or-admin gate is a don't-care (current_user is a
+        # superuser).
         post = make_post_stub(
             "client_referral",
             post_id=post_id,
             owner_id=post_id,
             owner_username="post_owner",
-            age_groups=["adults_25_64"],
-            languages=["en"],
-            services=[],
-            desired_times=[],
-            location_in_person="yes",
-            location_virtual="no",
-            gender="prefer_not_to_say",
-            network_preference="no_preference",
-            insurance_carrier=None,
         )
         # The mock auth in `run_consumer_server_process` makes current_user a
         # superuser when `posts_owner_actions=True`, so the partial's

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -7,10 +7,22 @@ monkey-patch business-logic handlers, so Pact verification exercises only the
 route layer.
 
 `make_post_stub(kind, **field_overrides)` is the registry-backed builder
-for Post-shaped `SimpleNamespace` stubs — the per-kind detail
-relationship name and field tuple come from `POST_KINDS` in
-`src/domain/models/posts/post_kinds.py`, so adding/renaming a kind's fields does not
-require touching contract test code.
+for Post-shaped `SimpleNamespace` stubs. The per-kind detail relationship
+name and field tuple come from `POST_KINDS`, and the per-column default
+values are inferred from the SQLAlchemy column type (JSON → ``[]``,
+Boolean → ``False``, Uuid → ``uuid4()``, DateTime → ``now()``) so the
+detail page renders without crashing on list-typed fields. For Text
+columns that hold enum values (CHECK-constrained), `_ENUM_DEFAULTS`
+supplies a per-kind realistic value so the template's display-label
+lookup resolves.
+
+Adding or renaming a column on a detail model is a one-place change —
+the spec's `detail_fields` picks it up, and the type-introspecting
+default picks the right primitive. New enum-typed columns need a
+matching entry in `_ENUM_DEFAULTS`; the test
+`test_mock_data_factory.test_make_post_stub_renders_detail_html` is
+the canary that catches a missing entry by surfacing the template
+crash at test time rather than waiting for a contract pair to fail.
 """
 
 from datetime import datetime, timezone
@@ -18,8 +30,92 @@ from types import SimpleNamespace
 from typing import Any, Dict
 from uuid import UUID, uuid4
 
+import sqlalchemy
+
 from src.domain.logic.users.schema import UserRead
 from src.domain.models import POST_KINDS
+from src.domain.models.posts.client_referral_detail import ClientReferralDetail
+from src.domain.models.posts.program_availability_detail import (
+    ProgramAvailabilityDetail,
+)
+from src.domain.models.posts.provider_availability_detail import (
+    ProviderAvailabilityDetail,
+)
+
+# Per-kind detail model — keyed by the same discriminator that
+# `POST_KINDS` uses. Lives in test code (not the production spec) so
+# the test-only stub factory doesn't push its concerns onto the
+# production registry. Adding a new kind: add an entry here and an
+# entry to `_ENUM_DEFAULTS` (if the new detail row has CHECK-Text
+# columns).
+_DETAIL_MODELS: dict[str, type] = {
+    "client_referral": ClientReferralDetail,
+    "provider_availability": ProviderAvailabilityDetail,
+    "program_availability": ProgramAvailabilityDetail,
+}
+
+
+# Per-kind defaults for Text columns that hold enum values
+# (CHECK-constrained to a vocabulary in `src.domain.models.enums`).
+# Without these, columns like `gender` would default to `"stub gender"`
+# — a string the detail template's display-label lookup
+# (`GENDER_LABELS["stub gender"]`) can't resolve, which crashes the
+# render. Values chosen here are *valid* enum members, picked for
+# neutrality where possible (`gender = "prefer_not_to_say"` rather
+# than the alphabetical first option).
+#
+# An empty dict for a kind means "no enum-typed Text columns on this
+# detail row" — PA and program-availability hold their enum values
+# on the linked Provider / Program rather than on the detail row
+# itself.
+_ENUM_DEFAULTS: dict[str, dict[str, Any]] = {
+    "client_referral": {
+        "location_in_person": "no",
+        "location_virtual": "no",
+        "gender": "prefer_not_to_say",
+        "network_preference": "no_preference",
+        "location_state": "NY",
+        # `insurance_carrier` is nullable and only meaningful when
+        # `network_preference != "no_preference"`. Default to None so
+        # the detail template's gating (`if d.insurance_carrier and
+        # ...`) renders nothing.
+        "insurance_carrier": None,
+    },
+    "provider_availability": {},
+    "program_availability": {},
+}
+
+
+def _column_default(col: sqlalchemy.Column, kind: str) -> Any:
+    """Pick a realistic default for a detail-row column.
+
+    Type-dispatch table:
+
+      JSON         → ``[]`` (template iterates these as lists; a
+                     string default would iterate chars and crash
+                     label-dict lookups)
+      Boolean      → ``False``
+      Uuid         → ``uuid4()`` (one fresh id per stub instance)
+      DateTime     → ``datetime.now(timezone.utc)`` (no DateTime
+                     columns on detail rows today; included for
+                     forward-compat)
+      Text         → ``_ENUM_DEFAULTS[kind][col.name]`` if the column
+                     is registered there (enum-typed); else
+                     ``f"stub {col.name}"``.
+    """
+    col_type = col.type
+    if isinstance(col_type, sqlalchemy.JSON):
+        return []
+    if isinstance(col_type, sqlalchemy.Boolean):
+        return False
+    if isinstance(col_type, sqlalchemy.types.Uuid):
+        return uuid4()
+    if isinstance(col_type, (sqlalchemy.DateTime, sqlalchemy.types.DateTime)):
+        return datetime.now(timezone.utc)
+    kind_enum_defaults = _ENUM_DEFAULTS.get(kind, {})
+    if col.name in kind_enum_defaults:
+        return kind_enum_defaults[col.name]
+    return f"stub {col.name}"
 
 
 def make_post_stub(
@@ -36,13 +132,24 @@ def make_post_stub(
     `POST_KINDS[kind]`); the other kinds' detail relationships are
     set to `None` so template `{% if post.X %}` checks behave correctly.
 
-    Detail fields default to `f"stub {field}"`; override individually
-    via `**field_overrides`. Unknown overrides for the kind are passed
-    through onto the detail `SimpleNamespace` (caller's responsibility
-    not to send cross-kind fields).
+    Detail fields default per their SQLAlchemy column type via
+    :func:`_column_default` — list-typed fields get ``[]``, enum-typed
+    Text fields get the registry value from :data:`_ENUM_DEFAULTS`,
+    other Text fields get ``f"stub {name}"``. Override individually
+    via ``**field_overrides``. Unknown overrides for the kind are
+    passed through onto the detail `SimpleNamespace` (caller's
+    responsibility not to send cross-kind fields).
     """
     spec = POST_KINDS[kind]
-    detail_values: dict[str, Any] = {f: f"stub {f}" for f in spec.detail_fields}
+    detail_model = _DETAIL_MODELS[kind]
+    spec_field_names = set(spec.detail_fields)
+    detail_values: dict[str, Any] = {}
+    for col in detail_model.__table__.columns:
+        if col.name not in spec_field_names:
+            # `spec.detail_fields` excludes `post_id` — skip anything
+            # the spec wouldn't consider a user-facing field.
+            continue
+        detail_values[col.name] = _column_default(col, kind)
     detail_values.update(field_overrides)
     detail = SimpleNamespace(**detail_values)
 

--- a/tests/test_contract/tests/shared/test_mock_data_factory.py
+++ b/tests/test_contract/tests/shared/test_mock_data_factory.py
@@ -1,0 +1,250 @@
+"""Tests for ``make_post_stub`` — the contract-test Post-stub factory.
+
+The stub's per-column default values are inferred from the SQLAlchemy
+column type. These tests pin the type-dispatch rules (JSON → ``[]``,
+Boolean → ``False``, Uuid → fresh ``UUID``, Text → enum default or
+``"stub <name>"``) so future detail-model changes can't silently
+re-introduce the "stub age_groups" crashes that motivated the
+introspection rewrite.
+
+The acceptance test at the bottom (`test_stub_renders_detail_html`)
+renders the real ``posts/detail.html`` template against each kind's
+stub — that's the canary: if a future detail-model column needs
+special treatment (e.g. a new enum-typed Text column with no
+``_ENUM_DEFAULTS`` entry), the canary fails at test time rather
+than waiting for the next contract pair to surface it.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from src.domain.models import POST_KINDS
+from tests.test_contract.tests.shared.mock_data_factory import make_post_stub
+
+_KINDS = ["client_referral", "provider_availability", "program_availability"]
+
+
+# --- Defaults: per-column type-dispatch --------------------------------
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+def test_json_columns_default_to_empty_list(kind):
+    """JSON columns (`age_groups`, `languages`, `services`, etc.) are
+    iterated in the detail template. An empty list is the safe default
+    — the template's `{% for x in ... %}` blocks render nothing
+    without crashing."""
+    post = make_post_stub(kind, owner_id=uuid.uuid4())
+    detail = getattr(post, POST_KINDS[kind].detail_relationship)
+    # Every kind carries at least these JSON columns.
+    for json_field in ("age_groups", "languages", "services", "desired_times"):
+        if hasattr(detail, json_field):
+            assert (
+                getattr(detail, json_field) == []
+            ), f"{kind}.{json_field} expected []; got {getattr(detail, json_field)!r}"
+
+
+def test_pa_and_program_settings_default_to_empty_list():
+    """PA + program detail rows carry `settings`; CR does not. The
+    default applies wherever the column exists."""
+    for kind in ("provider_availability", "program_availability"):
+        post = make_post_stub(kind, owner_id=uuid.uuid4())
+        detail = getattr(post, POST_KINDS[kind].detail_relationship)
+        assert detail.settings == []
+
+
+def test_pa_and_program_genders_default_to_empty_list():
+    """PA + program hold `genders` as a list; CR has a scalar `gender`."""
+    for kind in ("provider_availability", "program_availability"):
+        post = make_post_stub(kind, owner_id=uuid.uuid4())
+        detail = getattr(post, POST_KINDS[kind].detail_relationship)
+        assert detail.genders == []
+
+
+def test_uuid_columns_get_fresh_uuids():
+    """PA's `provider_id` and program's `program_id` are Uuid columns
+    — the stub generates a fresh UUID per call so two consecutive
+    stubs don't share an id."""
+    pa1 = make_post_stub("provider_availability", owner_id=uuid.uuid4())
+    pa2 = make_post_stub("provider_availability", owner_id=uuid.uuid4())
+    pid1 = pa1.provider_availability_detail.provider_id
+    pid2 = pa2.provider_availability_detail.provider_id
+    assert isinstance(pid1, uuid.UUID)
+    assert isinstance(pid2, uuid.UUID)
+    assert pid1 != pid2
+
+
+def test_text_columns_get_stub_string():
+    """Free-text columns (CR's `description`, PA's `schedule_text`,
+    etc.) fall through to the readable ``"stub <name>"`` placeholder."""
+    cr = make_post_stub("client_referral", owner_id=uuid.uuid4())
+    assert cr.client_referral_detail.description == "stub description"
+    assert cr.client_referral_detail.location_city == "stub location_city"
+    assert cr.client_referral_detail.treatment_modality == "stub treatment_modality"
+
+    pa = make_post_stub("provider_availability", owner_id=uuid.uuid4())
+    assert pa.provider_availability_detail.description == "stub description"
+    assert pa.provider_availability_detail.schedule_text == "stub schedule_text"
+    assert pa.provider_availability_detail.website == "stub website"
+
+
+# --- Defaults: enum-typed Text columns (per-kind registry) -------------
+
+
+def test_cr_enum_defaults_render_via_label_dict():
+    """CR's enum-typed Text columns must default to valid enum
+    members so the detail template's display-label lookup resolves.
+    Pin each column to its `_ENUM_DEFAULTS["client_referral"]` value."""
+    cr = make_post_stub("client_referral", owner_id=uuid.uuid4())
+    d = cr.client_referral_detail
+    assert d.location_in_person == "no"
+    assert d.location_virtual == "no"
+    assert d.gender == "prefer_not_to_say"
+    assert d.network_preference == "no_preference"
+    assert d.location_state == "NY"
+    # `insurance_carrier` is nullable + gated on
+    # `network_preference != "no_preference"`. None keeps the detail
+    # template's gating clean.
+    assert d.insurance_carrier is None
+
+
+def test_pa_has_no_enum_text_columns_on_detail_row():
+    """PA's enum-typed fields (in_person_sessions, virtual_sessions,
+    in_network_carriers, ...) live on the linked Provider, not on the
+    detail row itself. The detail row has no CHECK-constrained Text
+    columns, so the enum-defaults registry for PA is empty."""
+    pa = make_post_stub("provider_availability", owner_id=uuid.uuid4())
+    # All fields on the detail row are list-typed JSON, Uuid, or
+    # plain Text — none are enum-checked.
+    assert isinstance(pa.provider_availability_detail.services, list)
+    assert isinstance(pa.provider_availability_detail.provider_id, uuid.UUID)
+    assert pa.provider_availability_detail.description == "stub description"
+
+
+# --- Overrides ---------------------------------------------------------
+
+
+def test_field_overrides_replace_defaults():
+    """Callers passing ``**field_overrides`` win over the per-column
+    default — gives stubs an escape hatch for fields the default
+    doesn't fit (e.g. supplying a populated services list to render
+    multiple icon rows)."""
+    post = make_post_stub(
+        "client_referral",
+        owner_id=uuid.uuid4(),
+        services=["psychotherapy", "medication_management"],
+        gender="female",
+        description="Looking for a therapist.",
+    )
+    d = post.client_referral_detail
+    assert d.services == ["psychotherapy", "medication_management"]
+    assert d.gender == "female"
+    assert d.description == "Looking for a therapist."
+
+
+def test_field_overrides_for_unknown_field_are_passed_through():
+    """The factory doesn't filter overrides against the spec — a
+    caller can attach an unrelated attribute (e.g. a relationship that
+    isn't a column) and it ends up on the `SimpleNamespace`. Useful
+    for adding `provider` (PA) / `program` (program) relationships
+    that the column-driven defaults can't populate."""
+    post = make_post_stub(
+        "provider_availability",
+        owner_id=uuid.uuid4(),
+        provider=object(),  # arbitrary stand-in for the relationship
+    )
+    assert post.provider_availability_detail.provider is not None
+
+
+# --- Acceptance: template render canary --------------------------------
+
+
+def test_stub_renders_detail_html_without_errors():
+    """The canary test for the whole factory: render the real
+    ``posts/detail.html`` template against each kind's stub. If a
+    future detail-model column needs special treatment (e.g. a new
+    enum-typed Text column) and someone forgot to add an
+    `_ENUM_DEFAULTS` entry, the template crashes here at test time
+    rather than waiting for a contract pair to fail with a Playwright
+    timeout."""
+    from src.framework.rendering.templating import templates
+
+    env = templates.env
+    template = env.get_template("posts/detail.html")
+
+    for kind in _KINDS:
+        post = make_post_stub(kind, owner_id=uuid.uuid4())
+        # `views/detail.html` needs `request`, but for a smoke
+        # render the chrome accepts a minimal mock. The point isn't
+        # to verify chrome — it's to render the kind-specific body
+        # without exception.
+
+        class _RequestStub:
+            class _Url:
+                path = "/posts/stub"
+
+            url = _Url()
+
+            class _QueryParams:
+                @staticmethod
+                def get(_):
+                    return None
+
+            query_params = _QueryParams()
+
+        html = template.render(
+            post=post,
+            request=_RequestStub(),
+            can_edit=True,
+            is_authenticated=True,
+            is_admin=False,
+            current_username="tester",
+            current_user_id=uuid.uuid4(),
+            is_development=False,
+        )
+        # Sanity: the kind chip lands in the output. If a render
+        # error caused a stack trace partway through, the chip would
+        # be absent.
+        assert f'data-kind-chip="{kind}"' in html, (
+            f"detail.html for kind={kind!r} did not render the kind chip; "
+            f"either the template crashed or the meta-line partial regressed"
+        )
+
+
+# --- Meta: stub shape sanity -------------------------------------------
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+def test_stub_populates_only_its_kind_detail_relationship(kind):
+    """The stub sets `<kind>_detail` on the post and leaves the other
+    kinds' detail relationships at None so template
+    `{% if post.X_detail %}` checks behave the way they would for a
+    real persisted post."""
+    post = make_post_stub(kind, owner_id=uuid.uuid4())
+    own_rel = POST_KINDS[kind].detail_relationship
+    assert getattr(post, own_rel) is not None
+    for other_kind, other_spec in POST_KINDS.items():
+        if other_kind == kind:
+            continue
+        assert getattr(post, other_spec.detail_relationship) is None
+
+
+def test_stub_sets_post_metadata():
+    """Every stub carries `id`, `kind`, `owner_id`, `owner`,
+    `created_at`, `updated_at` — the fields any template reads
+    regardless of kind."""
+    pid = uuid.uuid4()
+    oid = uuid.uuid4()
+    post = make_post_stub(
+        "client_referral",
+        post_id=pid,
+        owner_id=oid,
+        owner_username="alice",
+    )
+    assert post.id == pid
+    assert post.kind == "client_referral"
+    assert post.owner_id == oid
+    assert post.owner.username == "alice"
+    assert isinstance(post.created_at, datetime)
+    assert post.created_at.tzinfo == timezone.utc


### PR DESCRIPTION
Closes the friction that surfaced during PR #566. That PR had to add 9 per-field overrides to \`_setup_post_owner_actions_stub\` by hand to keep the detail-page render from crashing on \`\"stub age_groups\"\` strings being iterated character-by-character. Every future contract pair that renders a Post detail page would have hit the same friction.

## Fix

\`make_post_stub\` now picks per-column defaults from the SQLAlchemy column type:

| Type | Default |
| --- | --- |
| \`JSON\` | \`[]\` (safe to iterate) |
| \`Boolean\` | \`False\` |
| \`Uuid\` | \`uuid4()\` (fresh per call) |
| \`DateTime\` | \`datetime.now(timezone.utc)\` (forward-compat) |
| \`Text\` | \`_ENUM_DEFAULTS[kind][name]\` if the column is CHECK-constrained; else \`\"stub <name>\"\` |

\`_ENUM_DEFAULTS\` is the small per-kind registry of valid enum members for Text columns whose label-dict lookups would otherwise crash. Only \`client_referral\` has entries today (6 fields); PA + program detail rows have no CHECK-Text columns (their enum fields live on the linked Provider / Program).

\`_setup_post_owner_actions_stub\` simplifies back to a bare \`make_post_stub(\"client_referral\", ...)\` call — the 9 PR #566 overrides are removed. Adding a new contract pair that needs a Post stub is now a one-liner.

## Latent bug caught by the new canary

The acceptance test (render each kind's detail.html against the stub) exposed \`insurance_posture_for_post\` doing \`detail.provider is None\` instead of \`getattr(detail, \"provider\", None)\` — fine for SQLAlchemy rows but AttributeError on stub SimpleNamespaces whose detail rows don't auto-populate relationship attrs. Fixed in this PR.

## Test plan

- [x] \`dev test\` — 1408 passed
- [x] \`dev test contract\` — 36 passed (20 existing + 16 new factory tests including the acceptance canary that renders each kind's detail.html through the stub)
- [x] \`dev lint\` — clean
- [ ] After merge, any future contract pair that needs a Post stub should just call \`make_post_stub(kind, ...)\` and have detail.html render cleanly.

## Why this matters

The fix to PR #566 was a band-aid: rendering the detail page from a stub crashed because the stub provided strings where lists were expected, and my refactored \`facts_block\` propagated the resulting KeyError (the old template silently swallowed it). The band-aid was per-stub overrides. The systemic fix is per-column type-aware defaults — now any contract pair gets realistic data without thinking about it, and a future detail-model change that needs a new \`_ENUM_DEFAULTS\` entry will fail the canary test at unit-test time rather than waiting for a contract pair to time out in Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)