### PR TITLE
feat(providers): credential lists render as flat rows

### DIFF
--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -914,6 +914,50 @@ async def test_owner_can_open_edit_form(
     )
 
 
+async def test_owner_edit_form_renders_credentials_as_rows(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Credential lists render as `.credential-row` blocks (not raw
+    `<li>`s) — bold type label, muted meta line, owner-side Delete
+    button. The owning `<section>` already provides the framing; rows
+    stay flat to avoid the card-on-card look."""
+    provider_id = await _seed_provider_for(
+        db_test_session_manager,
+        user_id=logged_in_user.id,
+        practice_name="Acme Counseling",
+    )
+    licensure = make_provider_licensure(
+        provider_id=provider_id,
+        license_type="lcsw",
+        license_number="L-12345",
+        issuing_state="CA",
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(licensure)
+
+    response = await authenticated_client.get(f"/providers/{provider_id}/form")
+    tree = HTMLParser(response.text)
+    rows = tree.css(".credential-list .credential-row")
+    assert len(rows) >= 1
+    first = rows[0]
+    assert (
+        first.css_first("strong").text(strip=True)
+        == "Licensed Clinical Social Worker (LCSW)"
+    )
+    meta = first.css_first(".credential-row-text small")
+    assert meta is not None
+    assert "L-12345" in meta.text()
+    assert "CA" in meta.text()
+    delete = first.css_first(
+        f'button[hx-delete="/providers/{provider_id}/licensures/{licensure.id}"]'
+    )
+    assert delete is not None
+    assert delete.text(strip=True) == "Delete"
+
+
 async def test_admin_can_open_edit_form_for_any_provider(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/providers/_credential_row.html
+++ b/src/domain/templates/providers/_credential_row.html
@@ -1,0 +1,45 @@
+{# Single row shape for a provider credential (licensure / education /
+   certification). Shared across `providers/form_edit.html` (owner edit
+   page, includes Delete button) and `providers/detail.html` (read view,
+   read-only).
+
+   Why a flat row, not a card-shaped `<article>`: the credentials list
+   sits inside an outer `<section>` (form_edit) or `<article>` (detail).
+   Nesting cards inside cards reads as visual noise; a flat row with a
+   hairline divider between entries keeps the credential lists legible
+   in either container without competing chrome.
+
+   Visual:
+
+     ┌──────────────────────────────────────────────────────────┐
+     │ <strong>Licensed Professional Counselor</strong>  [Delete] │
+     │ <small>#L-12345 · CA · Expires 2028-03-03</small>          │
+     └──────────────────────────────────────────────────────────┘
+
+   Meta parts are passed as a list; falsy entries (None / empty string)
+   are filtered out so callers can include conditional fields inline
+   without explicit `{% if %}` plumbing.
+
+   Args:
+     label — bold primary text (the credential type, e.g.
+       "Licensed Professional Counselor").
+     meta_parts — iterable of strings rendered as the muted second line,
+       joined by `·`. Falsy entries dropped.
+     delete_url, delete_confirm — optional; when both set, render an
+       hx-delete confirm button on the right. Read-only callers omit
+       both.
+#}
+{% macro credential_row(label, meta_parts, delete_url=None, delete_confirm=None) -%}
+{%- set parts = meta_parts | select | list -%}
+<div class="credential-row">
+  <div class="credential-row-text">
+    <strong>{{ label }}</strong>
+    {%- if parts %}
+    <small>{{ parts | join(' · ') }}</small>
+    {%- endif %}
+  </div>
+  {%- if delete_url and delete_confirm %}
+  <button type="button" class="secondary outline" hx-delete="{{ delete_url }}" hx-confirm="{{ delete_confirm }}">Delete</button>
+  {%- endif %}
+</div>
+{%- endmacro %}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -1,5 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
+{%- from "providers/_credential_row.html" import credential_row -%}
 
 {% set resource_url = entity_url('provider') %}
 
@@ -70,14 +71,14 @@
   <section>
     <h2>Licensures</h2>
     {% if provider.licensures %}
-    <ul>
+    <div class="credential-list">
       {%- for lic in provider.licensures %}
-      <li>
-        <strong>{{ LICENSE_TYPES_LABELS[lic.license_type] }}</strong>
-        <small>{{ lic.license_number }} ({{ lic.issuing_state }}){% if lic.expiration_date %}, expires {{ lic.expiration_date }}{% endif %}</small>
-      </li>
+      {{ credential_row(
+          LICENSE_TYPES_LABELS[lic.license_type],
+          ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None],
+      ) }}
       {%- endfor %}
-    </ul>
+    </div>
     {% else %}
     <p>No licensures listed.</p>
     {% endif %}
@@ -86,14 +87,14 @@
   <details>
     <summary><strong>Education</strong></summary>
     {% if provider.educations %}
-    <ul>
+    <div class="credential-list">
       {%- for edu in provider.educations %}
-      <li>
-        <strong>{{ EDUCATION_TYPES_LABELS[edu.education_type] }}</strong>
-        <small>{{ edu.institution }}{% if edu.month_completed %}, {{ edu.month_completed }}{% endif %}</small>
-      </li>
+      {{ credential_row(
+          EDUCATION_TYPES_LABELS[edu.education_type],
+          [edu.institution, edu.month_completed],
+      ) }}
       {%- endfor %}
-    </ul>
+    </div>
     {% else %}
     <p>No education entries listed.</p>
     {% endif %}
@@ -102,14 +103,14 @@
   <details>
     <summary><strong>Certifications</strong></summary>
     {% if provider.certifications %}
-    <ul>
+    <div class="credential-list">
       {%- for cert in provider.certifications %}
-      <li>
-        <strong>{{ CERTIFICATION_TYPES_LABELS[cert.certification_type] }}</strong>
-        <small>{{ cert.certifying_body }}{% if cert.expiration_date %}, expires {{ cert.expiration_date }}{% endif %}</small>
-      </li>
+      {{ credential_row(
+          CERTIFICATION_TYPES_LABELS[cert.certification_type],
+          [cert.certifying_body, ("Expires " ~ cert.expiration_date) if cert.expiration_date else None],
+      ) }}
       {%- endfor %}
-    </ul>
+    </div>
     {% else %}
     <p>No certifications listed.</p>
     {% endif %}

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -1,8 +1,7 @@
 {% extends "views/form_edit.html" %}
 {%- from "_shared/form_fields.html" import text_field, select_field, radio_bool_field, multi_select_field -%}
 {%- from "_shared/forms.html" import inline_add_form, form_actions -%}
-{%- from "_shared/sections.html" import list_or_empty -%}
-{%- from "_shared/actions.html" import confirm_delete_button -%}
+{%- from "providers/_credential_row.html" import credential_row -%}
 
 {% set resource_url = entity_url('provider') %}
 {% set resource_detail_url = entity_url('provider', id=provider.id) %}
@@ -66,13 +65,20 @@
 
 <section>
   <h2>Licensures</h2>
-  {% call(lic) list_or_empty(provider.licensures, "No licensures yet.") %}
-  <li>
-    <strong>{{ LICENSE_TYPES_LABELS[lic.license_type] }}</strong>
-    &mdash; {{ lic.license_number }} ({{ lic.issuing_state }}){% if lic.expiration_date %}, expires {{ lic.expiration_date }}{% endif %}
-    {{ confirm_delete_button(entity_url('provider', id=provider.id) ~ "/licensures/" ~ lic.id, "Remove this licensure?") }}
-  </li>
-  {% endcall %}
+  {% if provider.licensures %}
+  <div class="credential-list">
+    {%- for lic in provider.licensures %}
+    {{ credential_row(
+        LICENSE_TYPES_LABELS[lic.license_type],
+        ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None],
+        delete_url=entity_url('provider', id=provider.id) ~ "/licensures/" ~ lic.id|string,
+        delete_confirm="Remove this licensure?",
+    ) }}
+    {%- endfor %}
+  </div>
+  {% else %}
+  <p>No licensures yet.</p>
+  {% endif %}
 
   {% call inline_add_form(entity_url('provider', id=provider.id) ~ "/licensures", "Add licensure", "Add licensure") %}
     {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
@@ -84,13 +90,20 @@
 
 <section>
   <h2>Education</h2>
-  {% call(edu) list_or_empty(provider.educations, "No education entries yet.") %}
-  <li>
-    <strong>{{ EDUCATION_TYPES_LABELS[edu.education_type] }}</strong>
-    &mdash; {{ edu.institution }}{% if edu.month_completed %}, {{ edu.month_completed }}{% endif %}
-    {{ confirm_delete_button(entity_url('provider', id=provider.id) ~ "/educations/" ~ edu.id, "Remove this education entry?") }}
-  </li>
-  {% endcall %}
+  {% if provider.educations %}
+  <div class="credential-list">
+    {%- for edu in provider.educations %}
+    {{ credential_row(
+        EDUCATION_TYPES_LABELS[edu.education_type],
+        [edu.institution, edu.month_completed],
+        delete_url=entity_url('provider', id=provider.id) ~ "/educations/" ~ edu.id|string,
+        delete_confirm="Remove this education entry?",
+    ) }}
+    {%- endfor %}
+  </div>
+  {% else %}
+  <p>No education entries yet.</p>
+  {% endif %}
 
   {% call inline_add_form(entity_url('provider', id=provider.id) ~ "/educations", "Add education", "Add education") %}
     {{ select_field("education_type", "Education type", EDUCATION_TYPES, labels=EDUCATION_TYPES_LABELS, placeholder=true) }}
@@ -101,13 +114,20 @@
 
 <section>
   <h2>Certifications</h2>
-  {% call(cert) list_or_empty(provider.certifications, "No certifications yet.") %}
-  <li>
-    <strong>{{ CERTIFICATION_TYPES_LABELS[cert.certification_type] }}</strong>
-    &mdash; {{ cert.certifying_body }}{% if cert.expiration_date %}, expires {{ cert.expiration_date }}{% endif %}
-    {{ confirm_delete_button(entity_url('provider', id=provider.id) ~ "/certifications/" ~ cert.id, "Remove this certification?") }}
-  </li>
-  {% endcall %}
+  {% if provider.certifications %}
+  <div class="credential-list">
+    {%- for cert in provider.certifications %}
+    {{ credential_row(
+        CERTIFICATION_TYPES_LABELS[cert.certification_type],
+        [cert.certifying_body, ("Expires " ~ cert.expiration_date) if cert.expiration_date else None],
+        delete_url=entity_url('provider', id=provider.id) ~ "/certifications/" ~ cert.id|string,
+        delete_confirm="Remove this certification?",
+    ) }}
+    {%- endfor %}
+  </div>
+  {% else %}
+  <p>No certifications yet.</p>
+  {% endif %}
 
   {% call inline_add_form(entity_url('provider', id=provider.id) ~ "/certifications", "Add certification", "Add certification") %}
     {{ select_field("certification_type", "Certification type", CERTIFICATION_TYPES, labels=CERTIFICATION_TYPES_LABELS, placeholder=true) }}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -294,6 +294,37 @@
          with the cap above — flatten the rhythm so siblings sit at a
          consistent gap inside the capped form. */
       .entity-form-page form > fieldset { margin-block-start: var(--pico-spacing); }
+      /* Credential rows (provider licensures / education / certifications)
+         render as flat rows inside an outer `<section>` (edit) or
+         `<article>` (detail), so a card-on-card pattern would read as
+         visual noise. The row's vocabulary is just a stacked
+         `<strong>` + muted `<small>` on the left, optional Delete on
+         the right, with a hairline divider between entries. */
+      .credential-list {
+        display: flex;
+        flex-direction: column;
+        margin-block: var(--pico-spacing);
+      }
+      .credential-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding-block: 0.5rem;
+      }
+      .credential-row + .credential-row {
+        border-top: 1px solid var(--pico-muted-border-color);
+      }
+      .credential-row-text {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1rem;
+        min-width: 0;
+      }
+      .credential-row-text > small {
+        color: var(--pico-muted-color);
+      }
+      .credential-row > button { margin: 0; flex: 0 0 auto; }
     </style>
     <script
       src="https://unpkg.com/htmx.org@2.0.4"


### PR DESCRIPTION
## Summary

Licensures / Education / Certifications on the provider edit + detail pages used to render as raw \`<ul>\`s with \`<strong>\` + \`<small>\` crammed into one \`<li>\` and an unstyled Delete button hanging off the end. This PR replaces them with a shared row vocabulary.

\`\`\`
┌──────────────────────────────────────────────────────┐
│ Licensed Professional Counselor              [Delete] │
│ #L-12345 · CA · Expires 2028-03-03                    │
└──────────────────────────────────────────────────────┘
\`\`\`

## What changed

- **New** \`providers/_credential_row.html\` — \`credential_row(label, meta_parts, delete_url=None, delete_confirm=None)\` macro. \`meta_parts\` is a list; falsy entries are filtered, the rest joined by \`·\`. Both edit and detail call into it.
- **\`providers/form_edit.html\`** — Licensures/Education/Certifications sections use the macro with the Delete button.
- **\`providers/detail.html\`** — same three sections, read-only (no delete).
- **\`base.html\`** — adds \`.credential-list\` (vertical stack) and \`.credential-row\` (flex row with hairline dividers between entries) CSS.
- **One new test** pins the row shape — \`.credential-row\` with bold label, muted meta, hx-delete button.

## Why not a Pico card?

The credential lists already live inside an outer \`<section>\` (form_edit) or \`<article>\` (detail). Putting each entry in its own \`<article>\` card would read as card-on-card — visual noise. A flat row with hairline dividers fits both containers cleanly and matches the project's preference for not over-framing.

## Test plan
- [x] \`dev test\` passes (1411 passed, 80 skipped — 1 new test, all prior credential-list tests still pass)
- [x] \`dev lint\` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)