### PR TITLE
refactor(chrome): rename .post-card family → .entity-card (PR 1 of 3 detail-view unification)

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -120,14 +120,14 @@ async def test_list_referral_item_shape(
     # Header line: link text is the age + gender combo (no state —
     # state moved to the demographics column for CR). Modality chips
     # (icon + short label) sit next to the headline.
-    header_link = item.css_first("header.post-header a")
+    header_link = item.css_first("header.entity-header a")
     assert header_link is not None
     assert header_link.attributes.get("href") == f"/posts/{post.id}"
     # `age_groups[0]` = adolescents_14_18 + gender=male.
     assert header_link.text(strip=True) == "Adolescent male (14–18)"
     modality_chips = [
         chip.text(strip=True)
-        for chip in item.css("header.post-header > .post-modality")
+        for chip in item.css("header.entity-header > .post-modality")
     ]
     assert modality_chips == ["Virtual", "In-person"]
 
@@ -138,7 +138,7 @@ async def test_list_referral_item_shape(
     assert description not in item.text()
 
     # Services column lists each service with an inline icon and label.
-    service_items = item.css("section.post-services > ul > li")
+    service_items = item.css("section.entity-icon-list > ul > li")
     service_labels = [li.text(strip=True) for li in service_items]
     assert "Psychotherapy" in service_labels
     assert "Medication management" in service_labels
@@ -148,8 +148,8 @@ async def test_list_referral_item_shape(
     # Demographics column: location chunk (City, ST) + languages +
     # insurance posture. CR's age + gender live in the headline, not
     # here.
-    facts_text = item.css_first("section.post-facts").text()
-    location = item.css_first("section.post-facts dl > div.post-location")
+    facts_text = item.css_first("section.entity-facts").text()
+    location = item.css_first("section.entity-facts dl > div.entity-location")
     assert location is not None
     assert location.css_first("dt > i[class^=icon-]") is not None
     assert location.css_first("dd").text(strip=True) == "Seattle, WA"
@@ -159,10 +159,10 @@ async def test_list_referral_item_shape(
     assert "Adolescent" not in facts_text
     assert "Adult" not in facts_text
 
-    # Contact band lives in `<footer class="post-footer">` — just the
+    # Contact band lives in `<footer class="entity-footer">` — just the
     # Email CTA. The username + practice name no longer render in the
     # footer; the headline already identifies who you're contacting.
-    footer = item.css_first("footer.post-footer")
+    footer = item.css_first("footer.entity-footer")
     assert author.username not in footer.text()
     mailto = footer.css_first("a")
     assert mailto is not None
@@ -200,13 +200,13 @@ async def test_list_referral_header_is_age_gender_combo(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     item = tree.css_first("#posts-list > article")
-    lead = item.css_first("header.post-header a")
+    lead = item.css_first("header.entity-header a")
     assert lead is not None
     assert lead.text(strip=True) == "Young adult female (19–24)"
     # State is *not* in the header anymore.
-    assert "ID" not in item.css_first("header.post-header").text()
+    assert "ID" not in item.css_first("header.entity-header").text()
     # ...but it does appear in the demographics column's location chunk.
-    location = item.css_first("section.post-facts dl > div.post-location")
+    location = item.css_first("section.entity-facts dl > div.entity-location")
     assert location is not None
     assert location.css_first("dd").text(strip=True) == "Boise, ID"
 
@@ -259,23 +259,23 @@ async def test_list_opening_item_shape(
     # Header link text: practice name + state. The in-person posture
     # renders as a `<span.post-modality>` chip (icon + label) next to
     # the link; virtual=no, so no virtual chip.
-    lead = item.css_first("header.post-header a")
+    lead = item.css_first("header.entity-header a")
     assert lead is not None
     assert lead.text(strip=True) == f"{practice_name}, OR"
     modality_chips = [
         chip.text(strip=True)
-        for chip in item.css("header.post-header > .post-modality")
+        for chip in item.css("header.entity-header > .post-modality")
     ]
     assert modality_chips == ["In-person"]
 
     # Demographics column shows the posture; non-empty in_network_carriers
     # wins the priority even though sliding_scale is also set.
-    facts_text = item.css_first("section.post-facts").text()
+    facts_text = item.css_first("section.entity-facts").text()
     assert "In-network" in facts_text
 
-    # Contact band lives in `<footer class="post-footer">` — just the
+    # Contact band lives in `<footer class="entity-footer">` — just the
     # Email CTA. Practice name is in the headline, not duplicated here.
-    footer = item.css_first("footer.post-footer")
+    footer = item.css_first("footer.entity-footer")
     footer_text = footer.text()
     assert practice_name not in footer_text
     assert author.username not in footer_text
@@ -320,8 +320,8 @@ async def test_list_services_column_heading_is_kind_aware(
     cards = {
         a.attributes.get("data-row-id"): a for a in tree.css("#posts-list > article")
     }
-    cr_heading = cards[str(cr_post.id)].css_first("section.post-services h4")
-    pa_heading = cards[str(pa_post.id)].css_first("section.post-services h4")
+    cr_heading = cards[str(cr_post.id)].css_first("section.entity-icon-list h4")
+    pa_heading = cards[str(pa_post.id)].css_first("section.entity-icon-list h4")
     assert cr_heading is not None and cr_heading.text(strip=True) == "Seeking"
     assert pa_heading is not None and pa_heading.text(strip=True) == "Providing"
 
@@ -357,7 +357,7 @@ async def test_list_services_priority_sorted_psychotherapy_and_medmgmt_first(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    items = tree.css("#posts-list > article section.post-services > ul > li")
+    items = tree.css("#posts-list > article section.entity-icon-list > ul > li")
     labels = [li.text(strip=True) for li in items]
     assert labels[:2] == ["Psychotherapy", "Medication management"]
     # The non-priority items keep enum declaration order.
@@ -401,15 +401,21 @@ async def test_list_demographics_diverge_by_kind(
     }
     cr_card = cards[str(cr_post.id)]
     pa_card = cards[str(pa_post.id)]
-    cr_labels = [dt.text(strip=True) for dt in cr_card.css("section.post-facts dl dt")]
-    pa_labels = [dt.text(strip=True) for dt in pa_card.css("section.post-facts dl dt")]
+    cr_labels = [
+        dt.text(strip=True) for dt in cr_card.css("section.entity-facts dl dt")
+    ]
+    pa_labels = [
+        dt.text(strip=True) for dt in pa_card.css("section.entity-facts dl dt")
+    ]
     # CR omits Age + Gender (they're in the headline) and adds a
     # location chunk whose `<dt>` is icon-only (empty text).
     assert "Age" not in cr_labels and "Gender" not in cr_labels
-    assert cr_card.css_first("section.post-facts dl > div.post-location") is not None
+    assert (
+        cr_card.css_first("section.entity-facts dl > div.entity-location") is not None
+    )
     # PA carries the cohort chunk; no location row.
     assert "Ages" in pa_labels and "Age" not in pa_labels
-    assert pa_card.css_first("section.post-facts dl > div.post-location") is None
+    assert pa_card.css_first("section.entity-facts dl > div.entity-location") is None
 
 
 async def test_list_pa_footer_carries_email_cta_only(
@@ -437,7 +443,7 @@ async def test_list_pa_footer_carries_email_cta_only(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    footer = tree.css_first("#posts-list > article footer.post-footer")
+    footer = tree.css_first("#posts-list > article footer.entity-footer")
     assert footer is not None
     text = footer.text()
     # Neither name renders in the footer — only the Email CTA.
@@ -494,7 +500,7 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
 ):
     """Each metadata fact is a `<dt>`/`<dd>` pair (wrapped in a
     `<div>`, the HTML5 grouping construct inside `<dl>`) in the
-    demographics column (`section.post-facts`). For CR the first
+    demographics column (`section.entity-facts`). For CR the first
     chunk is a location row: an icon-only `<dt>` (`aria-label`
     carries the meaning) + `City, ST` value. Other chunks have a
     visible text `<dt>` label (e.g. "Insurance"). Modality lives in
@@ -532,13 +538,13 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
     # Demographics `<dl>` chunks for CR. English-only languages are
     # dropped (default); insurance posture renders; age + gender are
     # absent (they're in the headline).
-    meta_chunks = item.css("section.post-facts dl > div")
+    meta_chunks = item.css("section.entity-facts dl > div")
     # Location + Insurance = 2 chunks.
     assert len(meta_chunks) == 2
     labels = [chunk.css_first("dt").text(strip=True) for chunk in meta_chunks]
     # First `<dt>` is icon-only (no visible text); second is "Insurance".
     assert labels == ["", "Insurance"]
-    assert meta_chunks[0].attributes.get("class") == "post-location"
+    assert meta_chunks[0].attributes.get("class") == "entity-location"
     assert meta_chunks[0].css_first("dt").attributes.get("aria-label") == "Location"
     assert meta_chunks[0].css_first("dt > i[class^=icon-]") is not None
     values = [chunk.css_first("dd").text(strip=True) for chunk in meta_chunks]
@@ -548,12 +554,12 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
     # (virtual=no). The fixture's gender default is `prefer_not_to_say`,
     # so the gender word drops out. State lives in the location chunk
     # of the demographics column, not in the header.
-    header_text = item.css_first("header.post-header").text()
+    header_text = item.css_first("header.entity-header").text()
     assert "Adolescent (14–18)" in header_text
     assert "WA" not in header_text
     modality_chips = [
         chip.text(strip=True)
-        for chip in item.css("header.post-header > .post-modality")
+        for chip in item.css("header.entity-header > .post-modality")
     ]
     assert modality_chips == ["In-person"]
 
@@ -561,10 +567,10 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
     # the Email CTA in the footer. The footer carries only the CTA;
     # the name (username for CR, practice for PA) lives in the
     # headline, not duplicated here.
-    header_link = item.css_first("header.post-header a")
+    header_link = item.css_first("header.entity-header a")
     assert header_link is not None
     assert header_link.attributes.get("href") == f"/posts/{post.id}"
-    footer = item.css_first("footer.post-footer")
+    footer = item.css_first("footer.entity-footer")
     assert author.username not in footer.text()
     mailto = footer.css_first("a")
     assert mailto is not None
@@ -598,7 +604,7 @@ async def test_list_renders_readable_date_format(
     tree = HTMLParser(response.text)
     item = tree.css_first("#posts-list > article")
     assert item is not None
-    date_cell = item.css_first("header.post-header small")
+    date_cell = item.css_first("header.entity-header small")
     assert date_cell is not None
     rendered = date_cell.text(strip=True)
     # `May 15` for current-year posts; `May 15, 2025` once we cross a
@@ -670,7 +676,7 @@ async def test_detail_omits_kind_chip_and_meta_line(
         assert response.status_code == 200
         tree = HTMLParser(response.text)
         assert tree.css_first("article [data-kind-chip]") is None
-        assert tree.css_first("article .post-meta") is None
+        assert tree.css_first("article .entity-meta") is None
 
 
 async def test_detail_age_label_is_singular_for_cr_and_appears_once(
@@ -698,7 +704,7 @@ async def test_detail_age_label_is_singular_for_cr_and_appears_once(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     labels = [
-        dt.text(strip=True) for dt in tree.css("article section.post-facts dl dt")
+        dt.text(strip=True) for dt in tree.css("article section.entity-facts dl dt")
     ]
     assert labels.count("Age") == 1
     assert "Ages" not in labels
@@ -728,7 +734,7 @@ async def test_detail_ages_label_is_plural_for_pa_and_appears_once(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     labels = [
-        dt.text(strip=True) for dt in tree.css("article section.post-facts dl dt")
+        dt.text(strip=True) for dt in tree.css("article section.entity-facts dl dt")
     ]
     assert labels.count("Ages") == 1
     assert "Age" not in labels
@@ -770,7 +776,7 @@ async def test_list_posts_one_post(
     assert len(items) == 1
     # The description doesn't appear in the listing row (lives on the
     # detail page); the card header link is what we look for.
-    assert items[0].css_first("header.post-header a") is not None
+    assert items[0].css_first("header.entity-header a") is not None
     assert "No posts found" not in tree.body.text()
 
 
@@ -1772,7 +1778,7 @@ async def test_list_renders_referral_row(
     assert item.attributes.get("data-kind") == "referral"
     # Default fixture: age_groups=["adults_25_64"], gender="prefer_not_to_say".
     # State (IL) lives in the demographics location chunk, not the header.
-    assert item.css_first("header.post-header a").text().strip() == "Adult (25–64)"
+    assert item.css_first("header.entity-header a").text().strip() == "Adult (25–64)"
 
 
 async def test_get_referral_detail_renders(
@@ -2226,7 +2232,7 @@ async def test_list_renders_opening_row(
     item = tree.css_first("#posts-list > article")
     assert item is not None
     assert item.attributes.get("data-kind") == "opening"
-    assert practice_name in item.css_first("header.post-header a").text()
+    assert practice_name in item.css_first("header.entity-header a").text()
 
 
 async def test_get_opening_detail_renders(

--- a/src/domain/templates/posts/_facts_block.html
+++ b/src/domain/templates/posts/_facts_block.html
@@ -2,7 +2,7 @@
 
 Each fact is wrapped in a `<div>` so CSS can style chunks
 individually (e.g. the CR location chunk gets an icon-only `<dt>`
-via `div.post-location`, suppressing the trailing colon the generic
+via `div.entity-location`, suppressing the trailing colon the generic
 `dt::after` rule applies to other rows).
 
 Two modes:
@@ -35,14 +35,14 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
 `INSURANCE_CARRIER_LABELS`, `NETWORK_PREFERENCE_LABELS`,
 `DESIRED_TIME_SLOT_LABELS`) are Jinja globals. #}
 {% macro facts_block(view, expanded=False) -%}
-<section class="post-facts">
+<section class="entity-facts">
   <dl>
     {%- if view.location_chunk and not expanded %}
     {#- Compact mode: icon-only "City, ST". The icon-only treatment
         is a list-density choice; expanded mode uses the labeled
         "Address" row below instead so the row reads consistently
         with its siblings. -#}
-    <div class="post-location"><dt aria-label="Location"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>
+    <div class="entity-location"><dt aria-label="Location"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>
       {%- if view.location_chunk.city -%}{{ view.location_chunk.city }}, {% endif -%}{{ view.location_chunk.state }}
     </dd></div>
     {%- elif view.ages %}

--- a/src/domain/templates/posts/_how_to_refer.html
+++ b/src/domain/templates/posts/_how_to_refer.html
@@ -11,7 +11,7 @@ Reads from `view.referral`, which is ``{website, instructions}`` or
 ``None``. The caller has already gated on `view.referral` so the
 macro doesn't re-check. #}
 {% macro how_to_refer(view) -%}
-<section class="post-how-to-refer">
+<section class="entity-how-to-refer">
   <h4>How to refer</h4>
   {%- if view.referral.website %}
   <p><a href="{{ view.referral.website }}" target="_blank" rel="noopener noreferrer">{{ view.referral.website }}</a></p>

--- a/src/domain/templates/posts/_item.html
+++ b/src/domain/templates/posts/_item.html
@@ -45,13 +45,13 @@ per-kind, so a single-kind filter doesn't need to suppress anything. #}
 
 {% macro post_item(post, active_kind=None) -%}
 {%- set view = post_card_view(post) -%}
-<article class="post-card" data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
-  <header class="post-header">
+<article class="entity-card" data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
+  <header class="entity-header">
     <strong><a href="{{ entity_url('post', id=post.id) }}">{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</a></strong>
     {{ modality_chips(view.in_person, view.virtual) }}
     <small>{{ post.created_at | format_post_date }}</small>
   </header>
-  <div class="post-grid">
+  <div class="entity-grid">
     {{ services_block(view) }}
     {{ facts_block(view) }}
   </div>
@@ -61,7 +61,7 @@ per-kind, so a single-kind filter doesn't need to suppress anything. #}
       address lives only in the `href`. `target="_blank" rel="noopener
       noreferrer"` is harmless on `mailto:` URLs and matches the
       pattern used for the PA `website` link on the detail page. -#}
-  <footer class="post-footer">
+  <footer class="entity-footer">
     <a href="mailto:{{ post.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>
 </article>

--- a/src/domain/templates/posts/_services_block.html
+++ b/src/domain/templates/posts/_services_block.html
@@ -22,7 +22,7 @@ globals (`REFERRAL_SERVICE_LABELS` / `_ICONS`, same for
 {%- endmacro %}
 
 {% macro services_block(view) -%}
-<section class="post-services">
+<section class="entity-icon-list">
   {%- if view.services or view.settings %}
   <h4>{{ view.kind_verb }}</h4>
   {%- set _priority = ["psychotherapy", "medication_management"] %}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -13,7 +13,7 @@
 {% include "posts/_owner_actions.html" %}
 {% endblock %}
 
-{# Detail-page layout: same `.post-card` shape the list cards use
+{# Detail-page layout: same `.entity-card` shape the list cards use
    (kind-colored left edge, Pico's article framing, header band,
    two-column body grid, footer band), with detail-only sections
    appended in reading order between the header and the body grid:
@@ -38,8 +38,8 @@
    visual element in the card reads from `view` (the dict view-model). #}
 {% block content %}
 {%- set view = post_card_view(post) -%}
-<article class="post-card" data-kind="{{ post.kind }}">
-  <header class="post-header">
+<article class="entity-card" data-kind="{{ post.kind }}">
+  <header class="entity-header">
     <strong>{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</strong>
     {{ modality_chips(view.in_person, view.virtual) }}
     <small>{{ post.created_at | format_post_date }}</small>
@@ -49,7 +49,7 @@
   <p>{{ view.description }}</p>
   {%- endif %}
 
-  <div class="post-grid">
+  <div class="entity-grid">
     {{ services_block(view) }}
     {{ facts_block(view, expanded=True) }}
   </div>
@@ -58,7 +58,7 @@
   {{ how_to_refer(view) }}
   {%- endif %}
 
-  <footer class="post-footer">
+  <footer class="entity-footer">
     <a href="mailto:{{ post.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>
 </article>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -66,10 +66,10 @@
         --pico-font-size-h3: 1.125rem;
         --pico-font-size-h4: 1rem;
       }
-      /* Post cards — `<article class="post-card">` is the canonical
+      /* Post cards — `<article class="entity-card">` is the canonical
          shape for a single post anywhere on the site: the list page
-         (`#posts-list` of `.post-card` articles) and the detail page
-         (one `.post-card` standing alone). Pico's default article
+         (`#posts-list` of `.entity-card` articles) and the detail page
+         (one `.entity-card` standing alone). Pico's default article
          framing (background, border, padding, rounded corners) gives
          the chrome; the rules below add the kind-colored left edge,
          the header/footer band layouts, and the two-column body grid.
@@ -77,28 +77,28 @@
          render between the header and the body grid styled by Pico
          defaults — no post-specific overrides. */
       #posts-list { padding: 0; margin: 0; display: flex; flex-direction: column; gap: 1rem; }
-      .post-card {
+      .entity-card {
         margin: 0;
         border-left: 4px solid var(--pico-muted-border-color);
       }
-      .post-card[data-kind="referral"] { border-left-color: darkorange; }
-      .post-card[data-kind="opening"] { border-left-color: darkcyan; }
-      .post-card[data-kind="program_availability"] { border-left-color: darkcyan; }
+      .entity-card[data-kind="referral"] { border-left-color: darkorange; }
+      .entity-card[data-kind="opening"] { border-left-color: darkcyan; }
+      .entity-card[data-kind="program_availability"] { border-left-color: darkcyan; }
       /* Header band: Pico provides the background tint + bottom
          border; we only configure the in-row flex layout (headline,
          modality chips, right-aligned date). */
-      .post-card > header.post-header {
+      .entity-card > header.entity-header {
         display: flex;
         align-items: baseline;
         gap: 0.5rem;
       }
-      .post-card > header.post-header > strong { flex: 0 0 auto; }
-      .post-card > header.post-header > strong > a { color: inherit; text-decoration: none; }
-      .post-card > header.post-header > strong > a:hover { text-decoration: underline; }
+      .entity-card > header.entity-header > strong { flex: 0 0 auto; }
+      .entity-card > header.entity-header > strong > a { color: inherit; text-decoration: none; }
+      .entity-card > header.entity-header > strong > a:hover { text-decoration: underline; }
       /* Date sits at the right edge regardless of headline + modality
          width; the chips between strong and small stay attached to
          the headline on the left. */
-      .post-card > header.post-header > small {
+      .entity-card > header.entity-header > small {
         margin-left: auto;
         color: var(--pico-muted-color);
       }
@@ -107,7 +107,7 @@
          header gap pick up the parent's 0.5rem separation. Icon →
          label spacing comes from the global icon rule below, not
          a local `gap`. */
-      .post-card > header.post-header > .post-modality {
+      .entity-card > header.entity-header > .post-modality {
         display: inline-flex;
         align-items: center;
         color: var(--pico-muted-color);
@@ -115,7 +115,7 @@
       }
       /* Two-column grid for the body. Columns auto-fit narrow
          viewports by collapsing to one column under 640px. */
-      .post-card > .post-grid {
+      .entity-card > .entity-grid {
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 1.5rem;
@@ -128,61 +128,61 @@
          header (Pico's button padding is em-based, so font-size
          shrinks the whole button proportionally — no padding override
          needed). */
-      .post-card > footer.post-footer {
+      .entity-card > footer.entity-footer {
         display: flex;
         justify-content: flex-end;
       }
-      .post-card > footer.post-footer > [role="button"] {
+      .entity-card > footer.entity-footer > [role="button"] {
         font-size: 0.875rem;
       }
       @media (max-width: 640px) {
-        .post-card > .post-grid { grid-template-columns: 1fr; gap: 1rem; }
+        .entity-card > .entity-grid { grid-template-columns: 1fr; gap: 1rem; }
       }
       /* Column tweaks: kill default vertical margins on `h4`, `<ul>`,
          `<dl>`, `<p>` so columns line up at the top. */
-      .post-card > .post-grid h4 {
+      .entity-card > .entity-grid h4 {
         margin: 0 0 0.4rem 0;
         font-size: 1rem;
       }
-      .post-card > .post-grid section.post-services > ul {
+      .entity-card > .entity-grid section.entity-icon-list > ul {
         list-style: none;
         padding: 0;
         margin: 0;
       }
-      .post-card > .post-grid section.post-services > ul > li {
+      .entity-card > .entity-grid section.entity-icon-list > ul > li {
         display: flex;
         align-items: center;
         padding: 0.1rem 0;
       }
       /* Demographics `<dl>`: one `<div>` per fact, "Label: value"
          layout — `<dt>` inline with a colon, `<dd>` inline after. */
-      .post-card > .post-grid section.post-facts > dl {
+      .entity-card > .entity-grid section.entity-facts > dl {
         margin: 0;
         padding: 0;
       }
-      .post-card > .post-grid section.post-facts > dl > div {
+      .entity-card > .entity-grid section.entity-facts > dl > div {
         padding: 0.1rem 0;
       }
-      .post-card > .post-grid section.post-facts dt {
+      .entity-card > .entity-grid section.entity-facts dt {
         display: inline;
         font-weight: 600;
       }
-      .post-card > .post-grid section.post-facts dt::after { content: ": "; }
+      .entity-card > .entity-grid section.entity-facts dt::after { content: ": "; }
       /* CR location chunk: `<dt>` is icon-only (`aria-label` carries
          meaning for screen readers), so suppress the trailing colon
          that the generic rule above adds to every `<dt>`. Icon →
          `<dd>` spacing comes from the icon's own `margin-inline-end`
          (set in the global icon rule below), which extends past
          the inline `<dt>` into the inline flow. */
-      .post-card > .post-grid section.post-facts dl > div.post-location > dt::after { content: ""; }
-      .post-card > .post-grid section.post-facts dl > div.post-location > dt { font-weight: normal; }
-      .post-card > .post-grid section.post-facts dd { display: inline; margin: 0; }
+      .entity-card > .entity-grid section.entity-facts dl > div.entity-location > dt::after { content: ""; }
+      .entity-card > .entity-grid section.entity-facts dl > div.entity-location > dt { font-weight: normal; }
+      .entity-card > .entity-grid section.entity-facts dd { display: inline; margin: 0; }
       /* Detail-only "how to refer" section — sits below the body
          grid, before the footer. Margin-top echoes the grid's
          vertical rhythm; the heading is the standard `<h4>`. */
-      .post-card > .post-how-to-refer { margin: 0; }
-      .post-card > .post-how-to-refer h4 { margin: 0 0 0.4rem 0; font-size: 1rem; }
-      .post-card > .post-how-to-refer p { margin: 0.25rem 0; }
+      .entity-card > .entity-how-to-refer { margin: 0; }
+      .entity-card > .entity-how-to-refer h4 { margin: 0 0 0.4rem 0; font-size: 1rem; }
+      .entity-card > .entity-how-to-refer p { margin: 0.25rem 0; }
       /* Lucide icons — single source of truth for sizing AND
          spacing. `color: inherit` lets each icon pick up the
          surrounding text color (so an icon inside a `<small>` or a


### PR DESCRIPTION
PR 1 of the detail-view standardization. **Pure CSS class rename — zero behavior change.** Renames the post-card chrome to an entity-card vocabulary so non-post detail pages (provider, org, program, user) can adopt the same chrome in PRs 2 + 3 without inheriting post-prefixed names that no longer describe their use.

## Renames

| Before | After | Notes |
| --- | --- | --- |
| \`.post-card\` | \`.entity-card\` | wrapper article |
| \`.post-header\` | \`.entity-header\` | top band |
| \`.post-grid\` | \`.entity-grid\` | 2-col body |
| \`.post-facts\` | \`.entity-facts\` | right-column \`<dl>\` |
| \`.post-services\` | \`.entity-icon-list\` | renamed to describe the style (icon-prefixed list) rather than the post concept |
| \`.post-footer\` | \`.entity-footer\` | bottom band |
| \`.post-meta\` | \`.entity-meta\` | kind chip + byline (currently unused after earlier meta-line drop) |
| \`.post-description\` | \`.entity-description\` | lead prose |
| \`.post-how-to-refer\` | \`.entity-how-to-refer\` | post-specific in use, vocabulary-consistent in name |
| \`.post-location\` | \`.entity-location\` | icon-only location row variant |

**Kept as-is:**
- \`.post-modality\` — chip with video / map-pin icon for the post's in-person / virtual posture; truly post-specific.
- \`data-kind\` / \`data-kind-chip\` attributes — kind colorization stays post-only.

## Test plan

- [x] \`dev test\` — 1411 passed (test selectors in \`test_posts.py\` updated to new class names; no assertion semantics changed)
- [x] \`dev test contract\` — 36 passed
- [x] \`dev lint\` — clean

## Next

- **PR 2:** rewrite \`providers/detail.html\` on the new chrome (\`provider_card_view\` + drop the collapsible \`<details>\` sections per UX decision to use collapsibles sparingly).
- **PR 3:** apply the same chrome to organizations / programs / users detail pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)