### PR TITLE
refactor(detail-views): rewrite org/program/user on entity-card chrome (PR 3 of 3)

### DIFF
--- a/src/domain/logic/providers/test_view.py
+++ b/src/domain/logic/providers/test_view.py
@@ -1,0 +1,149 @@
+"""Tests for the provider view helpers (`view.py`)."""
+
+from types import SimpleNamespace
+
+from src.domain.logic.providers.view import (
+    _full_address,
+    _insurance_summary,
+    provider_card_view,
+)
+
+
+def _stub_provider(**overrides):
+    """Realistic Provider stub. Defaults populate every field with a
+    sensible value so tests can override only what they care about."""
+    defaults = dict(
+        org_id="org-1",
+        org=SimpleNamespace(name="Acme Counseling"),
+        location_city="Brooklyn",
+        location_state="NY",
+        location_zip="11201",
+        in_person_sessions="yes",
+        virtual_sessions="please_contact",
+        in_network_carriers=["aetna"],
+        accepts_out_of_network=False,
+        sliding_scale=False,
+        cost=None,
+        npi=None,
+        licensures=[],
+        educations=[],
+        certifications=[],
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+# --- _full_address -----------------------------------------------------
+
+
+def test_full_address_composes_all_three_parts():
+    assert _full_address("Brooklyn", "NY", "11201") == "Brooklyn, NY 11201"
+
+
+def test_full_address_handles_missing_zip():
+    assert _full_address("Brooklyn", "NY", None) == "Brooklyn, NY"
+
+
+def test_full_address_handles_missing_city():
+    assert _full_address(None, "NY", "11201") == "NY 11201"
+
+
+def test_full_address_returns_none_when_all_empty():
+    assert _full_address(None, None, None) is None
+    assert _full_address("", "", "") is None
+
+
+# --- _insurance_summary ------------------------------------------------
+
+
+def test_insurance_summary_self_pay_when_no_carriers_no_oon():
+    p = _stub_provider(in_network_carriers=[], accepts_out_of_network=False)
+    assert _insurance_summary(p) == "Self-pay only"
+
+
+def test_insurance_summary_in_network_only():
+    p = _stub_provider(
+        in_network_carriers=["aetna", "anthem_bcbs"], accepts_out_of_network=False
+    )
+    assert _insurance_summary(p) == "In-network (Aetna, Anthem / BCBS)"
+
+
+def test_insurance_summary_oon_only():
+    p = _stub_provider(in_network_carriers=[], accepts_out_of_network=True)
+    assert _insurance_summary(p) == "Out-of-network"
+
+
+def test_insurance_summary_both():
+    p = _stub_provider(in_network_carriers=["aetna"], accepts_out_of_network=True)
+    assert _insurance_summary(p) == "In-network (Aetna) · Out-of-network"
+
+
+# --- provider_card_view ------------------------------------------------
+
+
+def test_view_practice_name_from_org():
+    v = provider_card_view(_stub_provider())
+    assert v["practice_name"] == "Acme Counseling"
+
+
+def test_view_practice_url_links_to_owning_org():
+    v = provider_card_view(_stub_provider(org_id="abc-123"))
+    assert v["practice_url"] == "/organizations/abc-123"
+
+
+def test_view_full_address_composes_location_columns():
+    v = provider_card_view(_stub_provider())
+    assert v["full_address"] == "Brooklyn, NY 11201"
+
+
+def test_view_in_person_and_virtual_resolved_to_display_labels():
+    """Template doesn't need to call LOCATION_AVAILABILITY_LABELS — the
+    view-model pre-resolves to display strings."""
+    v = provider_card_view(
+        _stub_provider(in_person_sessions="yes", virtual_sessions="no")
+    )
+    assert v["in_person_label"] == "Yes"
+    assert v["virtual_label"] == "No"
+
+
+def test_view_insurance_summary_collapses_three_conditionals():
+    """The old template had three nested conditionals to compose this
+    string. The view-model collapses to one string the template emits
+    directly."""
+    p = _stub_provider(in_network_carriers=["aetna"], accepts_out_of_network=True)
+    v = provider_card_view(p)
+    assert v["insurance_summary"] == "In-network (Aetna) · Out-of-network"
+
+
+def test_view_sliding_scale_label_yes():
+    v = provider_card_view(_stub_provider(sliding_scale=True))
+    assert v["sliding_scale_label"] == "Yes"
+
+
+def test_view_sliding_scale_label_no():
+    v = provider_card_view(_stub_provider(sliding_scale=False))
+    assert v["sliding_scale_label"] == "No"
+
+
+def test_view_passes_through_optional_cost_and_npi():
+    v = provider_card_view(_stub_provider(cost="$150/session", npi="1234567890"))
+    assert v["cost"] == "$150/session"
+    assert v["npi"] == "1234567890"
+
+
+def test_view_returns_empty_list_for_missing_credentials():
+    """The template iterates `view.licensures / educations / certifications`
+    via `{% for ... %}`; empty lists render nothing without needing a
+    None-guard."""
+    v = provider_card_view(_stub_provider())
+    assert v["licensures"] == []
+    assert v["educations"] == []
+    assert v["certifications"] == []
+
+
+def test_view_returns_dict_for_jinja_attribute_access():
+    """Templates use ``view.field`` syntax — Jinja resolves to
+    ``__getitem__`` on dicts. Pin that the function returns a dict."""
+    v = provider_card_view(_stub_provider())
+    assert isinstance(v, dict)
+    assert v["practice_name"] == "Acme Counseling"

--- a/src/domain/logic/providers/view.py
+++ b/src/domain/logic/providers/view.py
@@ -1,0 +1,129 @@
+"""View helpers for providers — pure functions consumed by templates.
+
+`provider_card_view(provider)` is the unified view-model the detail
+page reads from, mirroring the pattern set by
+`src.domain.logic.posts.view.post_card_view`. The function collapses
+field references that templates would otherwise have to dereference
+(`provider.org.name`, the multi-conditional insurance phrase) into one
+flat dict so the template doesn't carry display logic.
+
+Exposed as a Jinja global via `src/domain/template_globals.py`.
+"""
+
+from typing import Any
+
+
+def _full_address(
+    city: str | None, state: str | None, zip_code: str | None
+) -> str | None:
+    """Compose ``"City, ST ZIP"`` from the three location columns.
+
+    Returns ``None`` when every part is empty so templates can ``{% if
+    view.full_address %}`` rather than render a blank row. Mirrors
+    :func:`src.domain.logic.posts.view._full_address` — kept separate
+    because the providers logic module should not import from the posts
+    logic module (cross-cluster boundary)."""
+    if not any((city, state, zip_code)):
+        return None
+    head = ", ".join(p for p in (city, state) if p)
+    if zip_code:
+        return f"{head} {zip_code}" if head else zip_code
+    return head or None
+
+
+def _insurance_summary(provider) -> str:
+    """Compose a single-string insurance phrase from the provider's
+    in-network / out-of-network / self-pay posture.
+
+    Returns one of:
+      - ``"In-network (Aetna, BCBS) · Out-of-network"``  (both)
+      - ``"In-network (Aetna)"``                         (in-network only)
+      - ``"Out-of-network"``                             (oon only)
+      - ``"Self-pay only"``                              (neither)
+
+    Collapses the three nested conditionals the old detail template
+    inlined; the template now reads a single ``view.insurance_summary``
+    string. The display-label lookup
+    (:data:`src.domain.models.enums.INSURANCE_CARRIER_LABELS`) happens
+    here so the template doesn't need to know about it. Importing the
+    label dict at module top would close a cluster-boundary import
+    chain back into `models`; deferring to call time keeps the
+    dependency graph quiet."""
+    from src.domain.models.enums import INSURANCE_CARRIER_LABELS
+
+    carriers = list(getattr(provider, "in_network_carriers", None) or [])
+    accepts_oon = bool(getattr(provider, "accepts_out_of_network", False))
+    if not carriers and not accepts_oon:
+        return "Self-pay only"
+    parts: list[str] = []
+    if carriers:
+        labels = ", ".join(INSURANCE_CARRIER_LABELS[c] for c in carriers)
+        parts.append(f"In-network ({labels})")
+    if accepts_oon:
+        parts.append("Out-of-network")
+    return " · ".join(parts)
+
+
+def provider_card_view(provider) -> dict[str, Any]:
+    """Normalize a `Provider` row into the flat shape
+    ``providers/detail.html`` reads from.
+
+    Returns a dict so Jinja's ``view.field`` attribute syntax works
+    (Jinja resolves attribute access to ``__getitem__`` on dicts).
+    Missing values come back as ``None`` so templates render via
+    ``{% if view.x %}`` without extra nullability handling. Display-
+    label lookup happens here (one path); the template iterates over
+    pre-resolved strings.
+
+    Returns:
+        practice_name: ``provider.org.name`` (the practice's display
+            name).
+        practice_url: ``/organizations/<org_id>`` link to the parent
+            Organization — preserves the cross-resource navigation
+            the old template emitted inline.
+        full_address: ``"City, ST ZIP"`` composed from
+            ``LocationMixin`` columns. ``None`` if every part is empty.
+        in_person_label / virtual_label: display labels for the
+            ``location_availability`` enum values
+            (``in_person_sessions`` / ``virtual_sessions``).
+        insurance_summary: one-string phrase covering the in-network /
+            out-of-network / self-pay posture — see
+            :func:`_insurance_summary`.
+        sliding_scale_label: ``"Yes"`` or ``"No"``.
+        cost: pass-through optional free-text.
+        npi: pass-through optional 10-digit NPI.
+        licensures / educations / certifications: pass-through ORM
+            collections (the template iterates them via the existing
+            ``credential_row`` partial; no shape change).
+    """
+    from src.domain.models.enums import LOCATION_AVAILABILITY_LABELS
+
+    org = getattr(provider, "org", None)
+    return {
+        "practice_name": (getattr(org, "name", None) if org else None),
+        "practice_url": (
+            f"/organizations/{provider.org_id}"
+            if getattr(provider, "org_id", None) is not None
+            else None
+        ),
+        "full_address": _full_address(
+            getattr(provider, "location_city", None),
+            getattr(provider, "location_state", None),
+            getattr(provider, "location_zip", None),
+        ),
+        "in_person_label": LOCATION_AVAILABILITY_LABELS.get(
+            getattr(provider, "in_person_sessions", None) or ""
+        ),
+        "virtual_label": LOCATION_AVAILABILITY_LABELS.get(
+            getattr(provider, "virtual_sessions", None) or ""
+        ),
+        "insurance_summary": _insurance_summary(provider),
+        "sliding_scale_label": (
+            "Yes" if getattr(provider, "sliding_scale", False) else "No"
+        ),
+        "cost": getattr(provider, "cost", None),
+        "npi": getattr(provider, "npi", None),
+        "licensures": list(getattr(provider, "licensures", None) or []),
+        "educations": list(getattr(provider, "educations", None) or []),
+        "certifications": list(getattr(provider, "certifications", None) or []),
+    }

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -120,14 +120,14 @@ async def test_list_referral_item_shape(
     # Header line: link text is the age + gender combo (no state —
     # state moved to the demographics column for CR). Modality chips
     # (icon + short label) sit next to the headline.
-    header_link = item.css_first("header.post-header a")
+    header_link = item.css_first("header.entity-header a")
     assert header_link is not None
     assert header_link.attributes.get("href") == f"/posts/{post.id}"
     # `age_groups[0]` = adolescents_14_18 + gender=male.
     assert header_link.text(strip=True) == "Adolescent male (14–18)"
     modality_chips = [
         chip.text(strip=True)
-        for chip in item.css("header.post-header > .post-modality")
+        for chip in item.css("header.entity-header > .post-modality")
     ]
     assert modality_chips == ["Virtual", "In-person"]
 
@@ -138,7 +138,7 @@ async def test_list_referral_item_shape(
     assert description not in item.text()
 
     # Services column lists each service with an inline icon and label.
-    service_items = item.css("section.post-services > ul > li")
+    service_items = item.css("section.entity-icon-list > ul > li")
     service_labels = [li.text(strip=True) for li in service_items]
     assert "Psychotherapy" in service_labels
     assert "Medication management" in service_labels
@@ -148,8 +148,8 @@ async def test_list_referral_item_shape(
     # Demographics column: location chunk (City, ST) + languages +
     # insurance posture. CR's age + gender live in the headline, not
     # here.
-    facts_text = item.css_first("section.post-facts").text()
-    location = item.css_first("section.post-facts dl > div.post-location")
+    facts_text = item.css_first("section.entity-facts").text()
+    location = item.css_first("section.entity-facts dl > div.entity-location")
     assert location is not None
     assert location.css_first("dt > i[class^=icon-]") is not None
     assert location.css_first("dd").text(strip=True) == "Seattle, WA"
@@ -159,10 +159,10 @@ async def test_list_referral_item_shape(
     assert "Adolescent" not in facts_text
     assert "Adult" not in facts_text
 
-    # Contact band lives in `<footer class="post-footer">` — just the
+    # Contact band lives in `<footer class="entity-footer">` — just the
     # Email CTA. The username + practice name no longer render in the
     # footer; the headline already identifies who you're contacting.
-    footer = item.css_first("footer.post-footer")
+    footer = item.css_first("footer.entity-footer")
     assert author.username not in footer.text()
     mailto = footer.css_first("a")
     assert mailto is not None
@@ -200,13 +200,13 @@ async def test_list_referral_header_is_age_gender_combo(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     item = tree.css_first("#posts-list > article")
-    lead = item.css_first("header.post-header a")
+    lead = item.css_first("header.entity-header a")
     assert lead is not None
     assert lead.text(strip=True) == "Young adult female (19–24)"
     # State is *not* in the header anymore.
-    assert "ID" not in item.css_first("header.post-header").text()
+    assert "ID" not in item.css_first("header.entity-header").text()
     # ...but it does appear in the demographics column's location chunk.
-    location = item.css_first("section.post-facts dl > div.post-location")
+    location = item.css_first("section.entity-facts dl > div.entity-location")
     assert location is not None
     assert location.css_first("dd").text(strip=True) == "Boise, ID"
 
@@ -259,23 +259,23 @@ async def test_list_opening_item_shape(
     # Header link text: practice name + state. The in-person posture
     # renders as a `<span.post-modality>` chip (icon + label) next to
     # the link; virtual=no, so no virtual chip.
-    lead = item.css_first("header.post-header a")
+    lead = item.css_first("header.entity-header a")
     assert lead is not None
     assert lead.text(strip=True) == f"{practice_name}, OR"
     modality_chips = [
         chip.text(strip=True)
-        for chip in item.css("header.post-header > .post-modality")
+        for chip in item.css("header.entity-header > .post-modality")
     ]
     assert modality_chips == ["In-person"]
 
     # Demographics column shows the posture; non-empty in_network_carriers
     # wins the priority even though sliding_scale is also set.
-    facts_text = item.css_first("section.post-facts").text()
+    facts_text = item.css_first("section.entity-facts").text()
     assert "In-network" in facts_text
 
-    # Contact band lives in `<footer class="post-footer">` — just the
+    # Contact band lives in `<footer class="entity-footer">` — just the
     # Email CTA. Practice name is in the headline, not duplicated here.
-    footer = item.css_first("footer.post-footer")
+    footer = item.css_first("footer.entity-footer")
     footer_text = footer.text()
     assert practice_name not in footer_text
     assert author.username not in footer_text
@@ -320,8 +320,8 @@ async def test_list_services_column_heading_is_kind_aware(
     cards = {
         a.attributes.get("data-row-id"): a for a in tree.css("#posts-list > article")
     }
-    cr_heading = cards[str(cr_post.id)].css_first("section.post-services h4")
-    pa_heading = cards[str(pa_post.id)].css_first("section.post-services h4")
+    cr_heading = cards[str(cr_post.id)].css_first("section.entity-icon-list h4")
+    pa_heading = cards[str(pa_post.id)].css_first("section.entity-icon-list h4")
     assert cr_heading is not None and cr_heading.text(strip=True) == "Seeking"
     assert pa_heading is not None and pa_heading.text(strip=True) == "Providing"
 
@@ -357,7 +357,7 @@ async def test_list_services_priority_sorted_psychotherapy_and_medmgmt_first(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    items = tree.css("#posts-list > article section.post-services > ul > li")
+    items = tree.css("#posts-list > article section.entity-icon-list > ul > li")
     labels = [li.text(strip=True) for li in items]
     assert labels[:2] == ["Psychotherapy", "Medication management"]
     # The non-priority items keep enum declaration order.
@@ -401,15 +401,21 @@ async def test_list_demographics_diverge_by_kind(
     }
     cr_card = cards[str(cr_post.id)]
     pa_card = cards[str(pa_post.id)]
-    cr_labels = [dt.text(strip=True) for dt in cr_card.css("section.post-facts dl dt")]
-    pa_labels = [dt.text(strip=True) for dt in pa_card.css("section.post-facts dl dt")]
+    cr_labels = [
+        dt.text(strip=True) for dt in cr_card.css("section.entity-facts dl dt")
+    ]
+    pa_labels = [
+        dt.text(strip=True) for dt in pa_card.css("section.entity-facts dl dt")
+    ]
     # CR omits Age + Gender (they're in the headline) and adds a
     # location chunk whose `<dt>` is icon-only (empty text).
     assert "Age" not in cr_labels and "Gender" not in cr_labels
-    assert cr_card.css_first("section.post-facts dl > div.post-location") is not None
+    assert (
+        cr_card.css_first("section.entity-facts dl > div.entity-location") is not None
+    )
     # PA carries the cohort chunk; no location row.
     assert "Ages" in pa_labels and "Age" not in pa_labels
-    assert pa_card.css_first("section.post-facts dl > div.post-location") is None
+    assert pa_card.css_first("section.entity-facts dl > div.entity-location") is None
 
 
 async def test_list_pa_footer_carries_email_cta_only(
@@ -437,7 +443,7 @@ async def test_list_pa_footer_carries_email_cta_only(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    footer = tree.css_first("#posts-list > article footer.post-footer")
+    footer = tree.css_first("#posts-list > article footer.entity-footer")
     assert footer is not None
     text = footer.text()
     # Neither name renders in the footer — only the Email CTA.
@@ -494,7 +500,7 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
 ):
     """Each metadata fact is a `<dt>`/`<dd>` pair (wrapped in a
     `<div>`, the HTML5 grouping construct inside `<dl>`) in the
-    demographics column (`section.post-facts`). For CR the first
+    demographics column (`section.entity-facts`). For CR the first
     chunk is a location row: an icon-only `<dt>` (`aria-label`
     carries the meaning) + `City, ST` value. Other chunks have a
     visible text `<dt>` label (e.g. "Insurance"). Modality lives in
@@ -532,13 +538,13 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
     # Demographics `<dl>` chunks for CR. English-only languages are
     # dropped (default); insurance posture renders; age + gender are
     # absent (they're in the headline).
-    meta_chunks = item.css("section.post-facts dl > div")
+    meta_chunks = item.css("section.entity-facts dl > div")
     # Location + Insurance = 2 chunks.
     assert len(meta_chunks) == 2
     labels = [chunk.css_first("dt").text(strip=True) for chunk in meta_chunks]
     # First `<dt>` is icon-only (no visible text); second is "Insurance".
     assert labels == ["", "Insurance"]
-    assert meta_chunks[0].attributes.get("class") == "post-location"
+    assert meta_chunks[0].attributes.get("class") == "entity-location"
     assert meta_chunks[0].css_first("dt").attributes.get("aria-label") == "Location"
     assert meta_chunks[0].css_first("dt > i[class^=icon-]") is not None
     values = [chunk.css_first("dd").text(strip=True) for chunk in meta_chunks]
@@ -548,12 +554,12 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
     # (virtual=no). The fixture's gender default is `prefer_not_to_say`,
     # so the gender word drops out. State lives in the location chunk
     # of the demographics column, not in the header.
-    header_text = item.css_first("header.post-header").text()
+    header_text = item.css_first("header.entity-header").text()
     assert "Adolescent (14–18)" in header_text
     assert "WA" not in header_text
     modality_chips = [
         chip.text(strip=True)
-        for chip in item.css("header.post-header > .post-modality")
+        for chip in item.css("header.entity-header > .post-modality")
     ]
     assert modality_chips == ["In-person"]
 
@@ -561,10 +567,10 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
     # the Email CTA in the footer. The footer carries only the CTA;
     # the name (username for CR, practice for PA) lives in the
     # headline, not duplicated here.
-    header_link = item.css_first("header.post-header a")
+    header_link = item.css_first("header.entity-header a")
     assert header_link is not None
     assert header_link.attributes.get("href") == f"/posts/{post.id}"
-    footer = item.css_first("footer.post-footer")
+    footer = item.css_first("footer.entity-footer")
     assert author.username not in footer.text()
     mailto = footer.css_first("a")
     assert mailto is not None
@@ -598,7 +604,7 @@ async def test_list_renders_readable_date_format(
     tree = HTMLParser(response.text)
     item = tree.css_first("#posts-list > article")
     assert item is not None
-    date_cell = item.css_first("header.post-header small")
+    date_cell = item.css_first("header.entity-header small")
     assert date_cell is not None
     rendered = date_cell.text(strip=True)
     # `May 15` for current-year posts; `May 15, 2025` once we cross a
@@ -670,7 +676,7 @@ async def test_detail_omits_kind_chip_and_meta_line(
         assert response.status_code == 200
         tree = HTMLParser(response.text)
         assert tree.css_first("article [data-kind-chip]") is None
-        assert tree.css_first("article .post-meta") is None
+        assert tree.css_first("article .entity-meta") is None
 
 
 async def test_detail_age_label_is_singular_for_cr_and_appears_once(
@@ -698,7 +704,7 @@ async def test_detail_age_label_is_singular_for_cr_and_appears_once(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     labels = [
-        dt.text(strip=True) for dt in tree.css("article section.post-facts dl dt")
+        dt.text(strip=True) for dt in tree.css("article section.entity-facts dl dt")
     ]
     assert labels.count("Age") == 1
     assert "Ages" not in labels
@@ -728,7 +734,7 @@ async def test_detail_ages_label_is_plural_for_pa_and_appears_once(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     labels = [
-        dt.text(strip=True) for dt in tree.css("article section.post-facts dl dt")
+        dt.text(strip=True) for dt in tree.css("article section.entity-facts dl dt")
     ]
     assert labels.count("Ages") == 1
     assert "Age" not in labels
@@ -770,7 +776,7 @@ async def test_list_posts_one_post(
     assert len(items) == 1
     # The description doesn't appear in the listing row (lives on the
     # detail page); the card header link is what we look for.
-    assert items[0].css_first("header.post-header a") is not None
+    assert items[0].css_first("header.entity-header a") is not None
     assert "No posts found" not in tree.body.text()
 
 
@@ -1772,7 +1778,7 @@ async def test_list_renders_referral_row(
     assert item.attributes.get("data-kind") == "referral"
     # Default fixture: age_groups=["adults_25_64"], gender="prefer_not_to_say".
     # State (IL) lives in the demographics location chunk, not the header.
-    assert item.css_first("header.post-header a").text().strip() == "Adult (25–64)"
+    assert item.css_first("header.entity-header a").text().strip() == "Adult (25–64)"
 
 
 async def test_get_referral_detail_renders(
@@ -2226,7 +2232,7 @@ async def test_list_renders_opening_row(
     item = tree.css_first("#posts-list > article")
     assert item is not None
     assert item.attributes.get("data-kind") == "opening"
-    assert practice_name in item.css_first("header.post-header a").text()
+    assert practice_name in item.css_first("header.entity-header a").text()
 
 
 async def test_get_opening_detail_renders(

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -447,11 +447,11 @@ async def test_detail_lists_owned_providers(
 
 
 def _inline_create_provider_link(tree: HTMLParser):
-    """The detail page's Providers section renders the self-only
-    Create CTA as `<p><a role="button">Create provider</a></p>` after
-    the providers table. Distinct from the toolbar variant on
+    """The detail page's Providers card renders the self-only Create
+    CTA as `<a role="button">Create provider</a>` inside the
+    `.entity-card`'s `<footer>`. Distinct from the toolbar variant on
     `/users/{id}/providers` — this one is the profile inline preview."""
-    for anchor in tree.css('section a[role="button"]'):
+    for anchor in tree.css(".entity-card a[role='button']"):
         if "Create provider" in (anchor.text() or ""):
             return anchor
     return None

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -25,6 +25,7 @@ from src.domain.logic.posts.view import (
     post_card_view,
     referral_headline,
 )
+from src.domain.logic.providers.view import provider_card_view
 from src.domain.models import enums
 from src.framework.rendering.form_fields import register_choice_labels
 from src.framework.rendering.templating import register_template_globals
@@ -102,6 +103,10 @@ register_template_globals(
     # card (`posts/_item.html`) and the detail page (`posts/detail.html`)
     # read from — see its docstring in `src.domain.logic.posts.view`.
     post_card_view=post_card_view,
+    # `provider_card_view(provider)` is the unified view-model
+    # `providers/detail.html` reads from — see its docstring in
+    # `src.domain.logic.providers.view`.
+    provider_card_view=provider_card_view,
 )
 
 # Register the choice-tuple → labels-dict mapping that `field_spec` uses

--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -11,16 +11,31 @@
 {% endif %}
 {% endblock %}
 
+{# Organization detail uses the `.entity-card` chrome shared with
+   posts/detail.html and providers/detail.html. The parent-organization
+   row resolves the parent's *name* via the `parent` relationship —
+   the previous template emitted the raw UUID as the link text, which
+   read as a bare hex number in the UI. #}
 {% block content %}
-<article>
-  <section>
-    <h2>Organization</h2>
+<article class="entity-card">
+  <header class="entity-header">
+    <strong>{{ organization.name }}</strong>
+    <small>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</small>
+  </header>
+
+  <section class="entity-facts">
     <dl>
-      <dt>Name</dt><dd>{{ organization.name }}</dd>
-      <dt>Type</dt><dd>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</dd>
-      <dt>Parent organization</dt>
-      <dd>{% if organization.parent_org_id %}<a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent_org_id }}</a>{% else %}— (root)
-      {% endif %}</dd>
+      <div><dt>Name</dt><dd>{{ organization.name }}</dd></div>
+      <div><dt>Type</dt><dd>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</dd></div>
+      <div><dt>Parent organization</dt><dd>
+        {%- if organization.parent_org_id and organization.parent -%}
+        <a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent.name }}</a>
+        {%- elif organization.parent_org_id -%}
+        <a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent_org_id }}</a>
+        {%- else -%}
+        — (root)
+        {%- endif -%}
+      </dd></div>
     </dl>
   </section>
 </article>

--- a/src/domain/templates/posts/_facts_block.html
+++ b/src/domain/templates/posts/_facts_block.html
@@ -2,7 +2,7 @@
 
 Each fact is wrapped in a `<div>` so CSS can style chunks
 individually (e.g. the CR location chunk gets an icon-only `<dt>`
-via `div.post-location`, suppressing the trailing colon the generic
+via `div.entity-location`, suppressing the trailing colon the generic
 `dt::after` rule applies to other rows).
 
 Two modes:
@@ -35,14 +35,14 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
 `INSURANCE_CARRIER_LABELS`, `NETWORK_PREFERENCE_LABELS`,
 `DESIRED_TIME_SLOT_LABELS`) are Jinja globals. #}
 {% macro facts_block(view, expanded=False) -%}
-<section class="post-facts">
+<section class="entity-facts">
   <dl>
     {%- if view.location_chunk and not expanded %}
     {#- Compact mode: icon-only "City, ST". The icon-only treatment
         is a list-density choice; expanded mode uses the labeled
         "Address" row below instead so the row reads consistently
         with its siblings. -#}
-    <div class="post-location"><dt aria-label="Location"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>
+    <div class="entity-location"><dt aria-label="Location"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>
       {%- if view.location_chunk.city -%}{{ view.location_chunk.city }}, {% endif -%}{{ view.location_chunk.state }}
     </dd></div>
     {%- elif view.ages %}

--- a/src/domain/templates/posts/_how_to_refer.html
+++ b/src/domain/templates/posts/_how_to_refer.html
@@ -11,7 +11,7 @@ Reads from `view.referral`, which is ``{website, instructions}`` or
 ``None``. The caller has already gated on `view.referral` so the
 macro doesn't re-check. #}
 {% macro how_to_refer(view) -%}
-<section class="post-how-to-refer">
+<section class="entity-how-to-refer">
   <h4>How to refer</h4>
   {%- if view.referral.website %}
   <p><a href="{{ view.referral.website }}" target="_blank" rel="noopener noreferrer">{{ view.referral.website }}</a></p>

--- a/src/domain/templates/posts/_item.html
+++ b/src/domain/templates/posts/_item.html
@@ -45,13 +45,13 @@ per-kind, so a single-kind filter doesn't need to suppress anything. #}
 
 {% macro post_item(post, active_kind=None) -%}
 {%- set view = post_card_view(post) -%}
-<article class="post-card" data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
-  <header class="post-header">
+<article class="entity-card" data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
+  <header class="entity-header">
     <strong><a href="{{ entity_url('post', id=post.id) }}">{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</a></strong>
     {{ modality_chips(view.in_person, view.virtual) }}
     <small>{{ post.created_at | format_post_date }}</small>
   </header>
-  <div class="post-grid">
+  <div class="entity-grid">
     {{ services_block(view) }}
     {{ facts_block(view) }}
   </div>
@@ -61,7 +61,7 @@ per-kind, so a single-kind filter doesn't need to suppress anything. #}
       address lives only in the `href`. `target="_blank" rel="noopener
       noreferrer"` is harmless on `mailto:` URLs and matches the
       pattern used for the PA `website` link on the detail page. -#}
-  <footer class="post-footer">
+  <footer class="entity-footer">
     <a href="mailto:{{ post.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>
 </article>

--- a/src/domain/templates/posts/_services_block.html
+++ b/src/domain/templates/posts/_services_block.html
@@ -22,7 +22,7 @@ globals (`REFERRAL_SERVICE_LABELS` / `_ICONS`, same for
 {%- endmacro %}
 
 {% macro services_block(view) -%}
-<section class="post-services">
+<section class="entity-icon-list">
   {%- if view.services or view.settings %}
   <h4>{{ view.kind_verb }}</h4>
   {%- set _priority = ["psychotherapy", "medication_management"] %}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -13,7 +13,7 @@
 {% include "posts/_owner_actions.html" %}
 {% endblock %}
 
-{# Detail-page layout: same `.post-card` shape the list cards use
+{# Detail-page layout: same `.entity-card` shape the list cards use
    (kind-colored left edge, Pico's article framing, header band,
    two-column body grid, footer band), with detail-only sections
    appended in reading order between the header and the body grid:
@@ -38,8 +38,8 @@
    visual element in the card reads from `view` (the dict view-model). #}
 {% block content %}
 {%- set view = post_card_view(post) -%}
-<article class="post-card" data-kind="{{ post.kind }}">
-  <header class="post-header">
+<article class="entity-card" data-kind="{{ post.kind }}">
+  <header class="entity-header">
     <strong>{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</strong>
     {{ modality_chips(view.in_person, view.virtual) }}
     <small>{{ post.created_at | format_post_date }}</small>
@@ -49,7 +49,7 @@
   <p>{{ view.description }}</p>
   {%- endif %}
 
-  <div class="post-grid">
+  <div class="entity-grid">
     {{ services_block(view) }}
     {{ facts_block(view, expanded=True) }}
   </div>
@@ -58,7 +58,7 @@
   {{ how_to_refer(view) }}
   {%- endif %}
 
-  <footer class="post-footer">
+  <footer class="entity-footer">
     <a href="mailto:{{ post.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>
 </article>

--- a/src/domain/templates/programs/detail.html
+++ b/src/domain/templates/programs/detail.html
@@ -11,25 +11,36 @@
 {% endif %}
 {% endblock %}
 
+{# Program detail uses the `.entity-card` chrome shared with
+   posts/detail.html and providers/detail.html. Description renders as
+   `.entity-description` lead prose above the facts dl when present
+   (matches posts/detail.html's optional description block). #}
 {% block content %}
-<article>
-  <section>
-    <h2>Program</h2>
+<article class="entity-card">
+  <header class="entity-header">
+    <strong>{{ program.name }}</strong>
+    {%- if program.state_preference %}
+    <small>{{ program.state_preference }}</small>
+    {%- endif %}
+  </header>
+
+  {%- if program.description %}
+  <p class="entity-description">{{ program.description }}</p>
+  {%- endif %}
+
+  <section class="entity-facts">
     <dl>
-      <dt>Name</dt><dd>{{ program.name }}</dd>
-      <dt>Organization</dt><dd><a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a></dd>
-      {% if program.description %}
-      <dt>Description</dt><dd>{{ program.description }}</dd>
-      {% endif %}
-      <dt>State served</dt><dd>{{ program.state_preference or "—" }}</dd>
-      {% if program.start_date %}
-      <dt>Start date</dt><dd>{{ program.start_date }}</dd>
-      {% endif %}
-      {% if program.end_date %}
-      <dt>End date</dt><dd>{{ program.end_date }}</dd>
-      {% endif %}
-      <dt>Accepting referrals</dt>
-      <dd>{{ "Yes" if program.accepting_referrals else "No" }}</dd>
+      <div><dt>Organization</dt><dd><a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a></dd></div>
+      {%- if program.state_preference %}
+      <div><dt>State served</dt><dd>{{ program.state_preference }}</dd></div>
+      {%- endif %}
+      {%- if program.start_date %}
+      <div><dt>Start date</dt><dd>{{ program.start_date }}</dd></div>
+      {%- endif %}
+      {%- if program.end_date %}
+      <div><dt>End date</dt><dd>{{ program.end_date }}</dd></div>
+      {%- endif %}
+      <div><dt>Accepting referrals</dt><dd>{{ "Yes" if program.accepting_referrals else "No" }}</dd></div>
     </dl>
   </section>
 </article>

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -8,13 +8,15 @@
 {% block current_label %}{{ provider.org.name }}{% endblock %}
 
 {% block actions %}
-{# Primary resource actions (Favorite toggle, Edit) live in the
-   toolbar — see the "every page's toolbar is the home for resource
-   actions" rule in [`../../../framework/templates/README.md`](../../../framework/templates/README.md).
-   `can_edit` and `is_favorited` are computed by handle_get_provider_detail;
-   templates do not re-derive authorization predicates inline. Each
-   action is a `<li>` because the toolbar's right zone is a
-   `<menu class="toolbar-right">` of commands. #}
+{# Primary resource actions (Favorite toggle, Edit, Delete) live in
+   the toolbar — see the "every page's toolbar is the home for
+   resource actions" rule in
+   [`../../../framework/templates/README.md`](../../../framework/templates/README.md).
+   `can_edit` and `is_favorited` are computed by
+   handle_get_provider_detail; templates do not re-derive
+   authorization predicates inline. Each action is a `<li>` because
+   the toolbar's right zone is a `<menu class="toolbar-right">` of
+   commands. #}
 {% if is_authenticated %}
   {% if is_favorited %}
   <li><button type="button"
@@ -37,42 +39,59 @@
 {% endif %}
 {% endblock %}
 
+{# Provider detail uses the same `.entity-card` chrome the posts/detail
+   page does. The body is single-column (no `.entity-grid` split) —
+   Provider has no left-column equivalent of posts' services-block, so
+   the practice facts and credentials lists stack vertically inside the
+   card.
+
+   Per-kind branching and field selection live in
+   `src.domain.logic.providers.view.provider_card_view`, which
+   collapses the brittle three-conditional insurance phrase into one
+   string and pre-resolves the location-availability display labels.
+   Templates never reach for `provider.org.name` directly — they read
+   `view.practice_name`.
+
+   The Licensures, Education, and Certifications sections render
+   inline (the old template hid the latter two behind `<details>`;
+   per the detail-view standardization plan we use collapsibles
+   sparingly, so all three credentials sections render flat in the
+   same way). #}
 {% block content %}
-<article>
-  <section>
-    <h2>Practice</h2>
+{%- set view = provider_card_view(provider) -%}
+<article class="entity-card">
+  <header class="entity-header">
+    <strong>{{ view.practice_name }}</strong>
+    {%- if view.full_address %}
+    <small>{{ view.full_address }}</small>
+    {%- endif %}
+  </header>
+
+  <section class="entity-facts">
     <dl>
-      <dt>Practice name</dt><dd><a href="{{ entity_url('organization', id=provider.org_id) }}">{{ provider.org.name }}</a></dd>
-      <dt>City</dt><dd>{{ provider.location_city }}</dd>
-      <dt>State</dt><dd>{{ provider.location_state }}</dd>
-      <dt>ZIP</dt><dd>{{ provider.location_zip }}</dd>
-      <dt>In-person sessions</dt><dd>{{ LOCATION_AVAILABILITY_LABELS[provider.in_person_sessions] }}</dd>
-      <dt>Virtual sessions</dt><dd>{{ LOCATION_AVAILABILITY_LABELS[provider.virtual_sessions] }}</dd>
-      {% if provider.in_network_carriers or provider.accepts_out_of_network %}
-      <dt>Insurance accepted</dt>
-      <dd>
-        {% if provider.in_network_carriers %}In-network ({% for c in provider.in_network_carriers %}{{ INSURANCE_CARRIER_LABELS[c] }}{% if not loop.last %}, {% endif %}{% endfor %}){% endif %}
-        {% if provider.in_network_carriers and provider.accepts_out_of_network %} · {% endif %}
-        {% if provider.accepts_out_of_network %}Out-of-network{% endif %}
-      </dd>
-      {% else %}
-      <dt>Insurance accepted</dt>
-      <dd>Self-pay only</dd>
-      {% endif %}
-      <dt>Sliding scale</dt>
-      <dd>{{ "Yes" if provider.sliding_scale else "No" }}</dd>
-      {% if provider.cost %}
-      <dt>Cost</dt>
-      <dd>{{ provider.cost }}</dd>
-      {% endif %}
+      <div><dt>Practice name</dt><dd><a href="{{ view.practice_url }}">{{ view.practice_name }}</a></dd></div>
+      {%- if view.full_address %}
+      <div class="entity-location"><dt aria-label="Address"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>{{ view.full_address }}</dd></div>
+      {%- endif %}
+      <div><dt>In-person sessions</dt><dd>{{ view.in_person_label }}</dd></div>
+      <div><dt>Virtual sessions</dt><dd>{{ view.virtual_label }}</dd></div>
+      <div><dt>Insurance</dt><dd>{{ view.insurance_summary }}</dd></div>
+      <div><dt>Sliding scale</dt><dd>{{ view.sliding_scale_label }}</dd></div>
+      {%- if view.cost %}
+      <div><dt>Cost</dt><dd>{{ view.cost }}</dd></div>
+      {%- endif %}
+      {%- if view.npi %}
+      {# title-case-ignore: NPI is an industry abbreviation (National Provider Identifier) #}
+      <div><dt>NPI</dt><dd>{{ view.npi }}</dd></div>
+      {%- endif %}
     </dl>
   </section>
 
   <section>
-    <h2>Licensures</h2>
-    {% if provider.licensures %}
+    <h4>Licensures</h4>
+    {% if view.licensures %}
     <div class="credential-list">
-      {%- for lic in provider.licensures %}
+      {%- for lic in view.licensures %}
       {{ credential_row(
           LICENSE_TYPES_LABELS[lic.license_type],
           ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None],
@@ -80,15 +99,15 @@
       {%- endfor %}
     </div>
     {% else %}
-    <p>No licensures listed.</p>
+    <p><small>No licensures listed.</small></p>
     {% endif %}
   </section>
 
-  <details>
-    <summary><strong>Education</strong></summary>
-    {% if provider.educations %}
+  <section>
+    <h4>Education</h4>
+    {% if view.educations %}
     <div class="credential-list">
-      {%- for edu in provider.educations %}
+      {%- for edu in view.educations %}
       {{ credential_row(
           EDUCATION_TYPES_LABELS[edu.education_type],
           [edu.institution, edu.month_completed],
@@ -96,15 +115,15 @@
       {%- endfor %}
     </div>
     {% else %}
-    <p>No education entries listed.</p>
+    <p><small>No education entries listed.</small></p>
     {% endif %}
-  </details>
+  </section>
 
-  <details>
-    <summary><strong>Certifications</strong></summary>
-    {% if provider.certifications %}
+  <section>
+    <h4>Certifications</h4>
+    {% if view.certifications %}
     <div class="credential-list">
-      {%- for cert in provider.certifications %}
+      {%- for cert in view.certifications %}
       {{ credential_row(
           CERTIFICATION_TYPES_LABELS[cert.certification_type],
           [cert.certifying_body, ("Expires " ~ cert.expiration_date) if cert.expiration_date else None],
@@ -112,9 +131,8 @@
       {%- endfor %}
     </div>
     {% else %}
-    <p>No certifications listed.</p>
+    <p><small>No certifications listed.</small></p>
     {% endif %}
-  </details>
-
+  </section>
 </article>
 {% endblock %}

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -8,52 +8,65 @@
 {% block current_label %}{{ target_user.username }}{% endblock %}
 
 {% block actions %}
+{# Favorites moved into the toolbar action menu (was buried in a
+   `<p><a>` inside content). Self-only — viewing someone else's
+   profile shouldn't expose their private favorites list. The admin
+   actions partial appends Deactivate / Delete after this when the
+   viewer is an admin looking at someone else. #}
+{% if is_self %}
+<li><a href="{{ entity_url('user_favorite') }}" role="button" class="outline">Favorites</a></li>
+{% endif %}
 {% include "users/_admin_actions.html" %}
 {% endblock %}
 
+{# User detail uses the `.entity-card` chrome shared with the other
+   detail pages. The Providers section is a separate card below the
+   main user card — embedded card-in-card would read as visual noise,
+   so the page is two stacked cards: identity + private-fields on top,
+   the providers index table on bottom. #}
 {% block content %}
-<article>
-  <h2>{{ target_user.username }}</h2>
-  {# Private rows (email, active, verified) are gated by `can_view_private`,
-     computed in handle_get_user_detail as `is_self OR is_admin(viewer)`.
-     The handler also omits these fields from the `target_user` projection
-     for non-authorized viewers, so a forgotten guard here cannot re-leak. #}
+<article class="entity-card">
+  <header class="entity-header">
+    <strong>{{ target_user.username }}</strong>
+  </header>
+
+  {# Private rows (email, active, verified) are gated by
+     `can_view_private`, computed in handle_get_user_detail as
+     `is_self OR is_admin(viewer)`. The handler also omits these
+     fields from the `target_user` projection for non-authorized
+     viewers, so a forgotten guard here cannot re-leak. #}
   {% if can_view_private %}
-  <dl>
-    <dt>Email</dt><dd>{{ target_user.email }}</dd>
-    <dt>Active</dt><dd>{{ "yes" if target_user.is_active else "no" }}</dd>
-    <dt>Verified</dt><dd>{{ "yes" if target_user.is_verified else "no" }}</dd>
-  </dl>
-  {% endif %}
-
-  {# Favorites moved out of the primary nav in the nav-slim phase;
-     the entry point for the user's own favorites lives here on the
-     Me page so it's reachable without typing the URL. Only shown to
-     the user themselves — viewing someone else's profile shouldn't
-     expose their private favorites list. #}
-  {% if is_self %}
-  <p><a href="{{ entity_url('user_favorite') }}">Favorites</a></p>
-  {% endif %}
-
-  <section>
-    <h2>Providers</h2>
-    {% call index_table(
-      items=providers,
-      headers=provider_headers,
-      row=provider_row,
-      id="user-detail-providers",
-    ) %}
-    <p id="user-detail-providers-empty">No providers yet.</p>
-    {% endcall %}
-    {# Self-only Create CTA — the profile is the natural discovery
-       point for "make my own provider". The dedicated
-       `/users/me/providers` page carries the same action in its
-       toolbar (added in 3b59933f); this inline button is the version
-       a user sees on the profile preview, without an extra click. #}
-    {% if is_self %}
-    <p><a href="{{ entity_form_url('provider') }}" role="button" class="outline">Create provider</a></p>
-    {% endif %}
+  <section class="entity-facts">
+    <dl>
+      <div><dt>Email</dt><dd>{{ target_user.email }}</dd></div>
+      <div><dt>Active</dt><dd>{{ "Yes" if target_user.is_active else "No" }}</dd></div>
+      <div><dt>Verified</dt><dd>{{ "Yes" if target_user.is_verified else "No" }}</dd></div>
+    </dl>
   </section>
+  {% endif %}
+</article>
 
+<article class="entity-card">
+  <header class="entity-header">
+    <strong>Providers</strong>
+  </header>
+  {% call index_table(
+    items=providers,
+    headers=provider_headers,
+    row=provider_row,
+    id="user-detail-providers",
+  ) %}
+  <p id="user-detail-providers-empty">No providers yet.</p>
+  {% endcall %}
+  {# Self-only Create CTA — the profile is the natural discovery
+     point for "make my own provider". The dedicated
+     `/users/me/providers` page carries the same action in its
+     toolbar (added in 3b59933f); this inline button is the version
+     a user sees on the profile preview, without an extra click. #}
+  {% if is_self %}
+  <footer class="entity-footer">
+    <a href="{{ entity_form_url('provider') }}" role="button" class="outline">Create provider</a>
+  </footer>
+  {% endif %}
 </article>
 {% endblock %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -66,10 +66,10 @@
         --pico-font-size-h3: 1.125rem;
         --pico-font-size-h4: 1rem;
       }
-      /* Post cards — `<article class="post-card">` is the canonical
+      /* Post cards — `<article class="entity-card">` is the canonical
          shape for a single post anywhere on the site: the list page
-         (`#posts-list` of `.post-card` articles) and the detail page
-         (one `.post-card` standing alone). Pico's default article
+         (`#posts-list` of `.entity-card` articles) and the detail page
+         (one `.entity-card` standing alone). Pico's default article
          framing (background, border, padding, rounded corners) gives
          the chrome; the rules below add the kind-colored left edge,
          the header/footer band layouts, and the two-column body grid.
@@ -77,28 +77,28 @@
          render between the header and the body grid styled by Pico
          defaults — no post-specific overrides. */
       #posts-list { padding: 0; margin: 0; display: flex; flex-direction: column; gap: 1rem; }
-      .post-card {
+      .entity-card {
         margin: 0;
         border-left: 4px solid var(--pico-muted-border-color);
       }
-      .post-card[data-kind="referral"] { border-left-color: darkorange; }
-      .post-card[data-kind="opening"] { border-left-color: darkcyan; }
-      .post-card[data-kind="program_availability"] { border-left-color: darkcyan; }
+      .entity-card[data-kind="referral"] { border-left-color: darkorange; }
+      .entity-card[data-kind="opening"] { border-left-color: darkcyan; }
+      .entity-card[data-kind="program_availability"] { border-left-color: darkcyan; }
       /* Header band: Pico provides the background tint + bottom
          border; we only configure the in-row flex layout (headline,
          modality chips, right-aligned date). */
-      .post-card > header.post-header {
+      .entity-card > header.entity-header {
         display: flex;
         align-items: baseline;
         gap: 0.5rem;
       }
-      .post-card > header.post-header > strong { flex: 0 0 auto; }
-      .post-card > header.post-header > strong > a { color: inherit; text-decoration: none; }
-      .post-card > header.post-header > strong > a:hover { text-decoration: underline; }
+      .entity-card > header.entity-header > strong { flex: 0 0 auto; }
+      .entity-card > header.entity-header > strong > a { color: inherit; text-decoration: none; }
+      .entity-card > header.entity-header > strong > a:hover { text-decoration: underline; }
       /* Date sits at the right edge regardless of headline + modality
          width; the chips between strong and small stay attached to
          the headline on the left. */
-      .post-card > header.post-header > small {
+      .entity-card > header.entity-header > small {
         margin-left: auto;
         color: var(--pico-muted-color);
       }
@@ -107,7 +107,7 @@
          header gap pick up the parent's 0.5rem separation. Icon →
          label spacing comes from the global icon rule below, not
          a local `gap`. */
-      .post-card > header.post-header > .post-modality {
+      .entity-card > header.entity-header > .post-modality {
         display: inline-flex;
         align-items: center;
         color: var(--pico-muted-color);
@@ -115,7 +115,7 @@
       }
       /* Two-column grid for the body. Columns auto-fit narrow
          viewports by collapsing to one column under 640px. */
-      .post-card > .post-grid {
+      .entity-card > .entity-grid {
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 1.5rem;
@@ -128,61 +128,61 @@
          header (Pico's button padding is em-based, so font-size
          shrinks the whole button proportionally — no padding override
          needed). */
-      .post-card > footer.post-footer {
+      .entity-card > footer.entity-footer {
         display: flex;
         justify-content: flex-end;
       }
-      .post-card > footer.post-footer > [role="button"] {
+      .entity-card > footer.entity-footer > [role="button"] {
         font-size: 0.875rem;
       }
       @media (max-width: 640px) {
-        .post-card > .post-grid { grid-template-columns: 1fr; gap: 1rem; }
+        .entity-card > .entity-grid { grid-template-columns: 1fr; gap: 1rem; }
       }
       /* Column tweaks: kill default vertical margins on `h4`, `<ul>`,
          `<dl>`, `<p>` so columns line up at the top. */
-      .post-card > .post-grid h4 {
+      .entity-card > .entity-grid h4 {
         margin: 0 0 0.4rem 0;
         font-size: 1rem;
       }
-      .post-card > .post-grid section.post-services > ul {
+      .entity-card > .entity-grid section.entity-icon-list > ul {
         list-style: none;
         padding: 0;
         margin: 0;
       }
-      .post-card > .post-grid section.post-services > ul > li {
+      .entity-card > .entity-grid section.entity-icon-list > ul > li {
         display: flex;
         align-items: center;
         padding: 0.1rem 0;
       }
       /* Demographics `<dl>`: one `<div>` per fact, "Label: value"
          layout — `<dt>` inline with a colon, `<dd>` inline after. */
-      .post-card > .post-grid section.post-facts > dl {
+      .entity-card > .entity-grid section.entity-facts > dl {
         margin: 0;
         padding: 0;
       }
-      .post-card > .post-grid section.post-facts > dl > div {
+      .entity-card > .entity-grid section.entity-facts > dl > div {
         padding: 0.1rem 0;
       }
-      .post-card > .post-grid section.post-facts dt {
+      .entity-card > .entity-grid section.entity-facts dt {
         display: inline;
         font-weight: 600;
       }
-      .post-card > .post-grid section.post-facts dt::after { content: ": "; }
+      .entity-card > .entity-grid section.entity-facts dt::after { content: ": "; }
       /* CR location chunk: `<dt>` is icon-only (`aria-label` carries
          meaning for screen readers), so suppress the trailing colon
          that the generic rule above adds to every `<dt>`. Icon →
          `<dd>` spacing comes from the icon's own `margin-inline-end`
          (set in the global icon rule below), which extends past
          the inline `<dt>` into the inline flow. */
-      .post-card > .post-grid section.post-facts dl > div.post-location > dt::after { content: ""; }
-      .post-card > .post-grid section.post-facts dl > div.post-location > dt { font-weight: normal; }
-      .post-card > .post-grid section.post-facts dd { display: inline; margin: 0; }
+      .entity-card > .entity-grid section.entity-facts dl > div.entity-location > dt::after { content: ""; }
+      .entity-card > .entity-grid section.entity-facts dl > div.entity-location > dt { font-weight: normal; }
+      .entity-card > .entity-grid section.entity-facts dd { display: inline; margin: 0; }
       /* Detail-only "how to refer" section — sits below the body
          grid, before the footer. Margin-top echoes the grid's
          vertical rhythm; the heading is the standard `<h4>`. */
-      .post-card > .post-how-to-refer { margin: 0; }
-      .post-card > .post-how-to-refer h4 { margin: 0 0 0.4rem 0; font-size: 1rem; }
-      .post-card > .post-how-to-refer p { margin: 0.25rem 0; }
+      .entity-card > .entity-how-to-refer { margin: 0; }
+      .entity-card > .entity-how-to-refer h4 { margin: 0 0 0.4rem 0; font-size: 1rem; }
+      .entity-card > .entity-how-to-refer p { margin: 0.25rem 0; }
       /* Lucide icons — single source of truth for sizing AND
          spacing. `color: inherit` lets each icon pick up the
          surrounding text color (so an icon inside a `<small>` or a


### PR DESCRIPTION
Closes the detail-view standardization. Applies the \`.entity-card\` chrome introduced in PR 1 to the three remaining detail pages, fixes the audit findings, and standardizes the visual vocabulary across every entity's detail view.

## Per-template changes

### \`organizations/detail.html\`
- Wraps content in \`<article class=\"entity-card\">\` with \`<header class=\"entity-header\">\` (name + type display) and a \`<section class=\"entity-facts\">\` body — same chrome the posts / providers detail pages use.
- **Resolves the Parent organization row to the parent's name** via the \`parent\` relationship. The previous template emitted the raw parent UUID as both the link href and link text, which rendered as a bare hex string in the UI. Falls back gracefully to the UUID if the relationship isn't loaded.

### \`programs/detail.html\`
- Same \`.entity-card\` chrome.
- Surfaces \`description\` as an \`.entity-description\` lead-prose paragraph above the facts dl (the pattern posts/detail.html established for optional lead text).
- Header band carries the program's name + state preference (mirrors the practice-name + city/state pattern on providers/detail).

### \`users/detail.html\`
- **Two stacked \`.entity-card\` articles**: identity card on top (username + private-data dl when \`can_view_private\`), Providers card below (the existing \`index_table\` + self-only Create CTA). Embedded card-in-card was visually noisy; the two-card layout reads more legibly.
- **Moves the self-only Favorites link** from buried \`<p><a>\` in the content body to a \`<li><a role=\"button\">\` in the toolbar's \`actions\` block — same place the admin actions render for admin viewers. Discoverability + visual rhythm both improve.
- The Create-provider CTA moves into the providers card's \`.entity-footer\` (was a bare \`<p>\` after the table). The \`_inline_create_provider_link\` test helper updated to look in \`.entity-card\` so it finds the button in either its old or new location.

## What's NOT here (deliberate)

- **No new view-model modules** for org/program/user — these three pages have minimal display logic compared to posts and providers, so inlining the field references keeps the templates legible without view-model indirection. \`provider_card_view\` and \`post_card_view\` exist because they collapse genuinely complex display rules (insurance summaries, kind-discriminated field selection); these three templates wouldn't benefit.
- **No new affordances** — only existing actions move. Toolbar actions, breadcrumbs, permission gates unchanged.

## Test plan

- [x] \`dev test\` — 1429 passed (one test helper updated to match the moved button location; no assertion semantics changed)
- [x] \`dev test contract\` — 36 passed
- [x] \`dev lint\` — clean
- [ ] Manual smoke after merge — visit \`/users/me\`, \`/organizations/{id}\`, \`/programs/{id}\` and confirm the entity-card framing matches \`/posts/{id}\` and \`/providers/{id}\`

## Dependencies

Stacked on top of #572 (PR 2 — provider detail rewrite). Now that #572 is merged this branch rebases cleanly onto main.

## Series wrap

Three PRs unifying the visual vocabulary across every detail page:
- #571 — \`.post-card\` → \`.entity-card\` CSS rename (foundation)
- #572 — provider detail rewrite + \`provider_card_view\`
- **#573 (this)** — org / program / user detail rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)