### PR TITLE
feat(posts): openings carry location in the body row like referrals do

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -322,12 +322,15 @@ def test_view_pa_basics():
 
 
 def test_view_pa_headline_is_org_name_state_from_provider():
-    """PA's identity is the practice — `provider.org.name` — with
-    state shown in the header line (the provider's `location_state`).
-    Unlike CR, the state isn't demoted to the demographics column."""
+    """PA's identity is the practice — `provider.org.name`. State
+    surfaces via `location_chunk` (the demographics-column icon-only
+    row), matching the CR treatment so referral + opening cards
+    consistently locate their location in the same place. The header
+    line stays uncluttered for both kinds."""
     v = post_card_view(_make_pa_post())
     assert v["headline"] == "Acme Counseling"
-    assert v["header_state"] == "NY"
+    assert v["header_state"] is None
+    assert v["location_chunk"] == {"city": "Brooklyn", "state": "NY", "zip": "11201"}
 
 
 def test_view_pa_in_person_virtual_come_from_provider():
@@ -381,12 +384,39 @@ def test_view_pa_referral_none_when_both_empty():
     assert v["referral"] is None
 
 
-def test_view_pa_no_location_chunk():
-    """PA's location lives on the linked Provider and surfaces via
-    `header_state` + `full_address`. The CR-shaped `location_chunk`
-    is intentionally None for PA so the demographics column doesn't
-    render the icon-only row."""
+def test_view_pa_location_chunk_pulled_from_provider():
+    """PA's `location_chunk` reads city/state/zip from the linked
+    Provider so the listing card renders the same icon-only
+    `entity-location` row referral cards do. Detail page still gets
+    the full address via `full_address` for the expanded rows."""
     v = post_card_view(_make_pa_post())
+    assert v["location_chunk"] == {"city": "Brooklyn", "state": "NY", "zip": "11201"}
+    assert v["full_address"] == "Brooklyn, NY 11201"
+
+
+def test_view_pa_no_location_chunk_when_provider_missing():
+    """Defensive — a PA stub without a `provider` relationship returns
+    `location_chunk=None` instead of crashing. Mirrors the same
+    defensive path the existing PA-missing-provider test covers for
+    other provider-derived fields."""
+    post = SimpleNamespace(
+        kind="opening",
+        opening_detail=SimpleNamespace(
+            provider=None,
+            services=[],
+            settings=[],
+            age_groups=[],
+            languages=[],
+            genders=[],
+            treatment_modality=None,
+            description=None,
+            schedule_text=None,
+            desired_times=[],
+            website=None,
+            referral_instructions=None,
+        ),
+    )
+    v = post_card_view(post)
     assert v["location_chunk"] is None
 
 

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -163,11 +163,13 @@ def post_card_view(post) -> dict[str, Any]:
         headline: the card's identity line — CR is ``referral_headline``
             (age + gender combo); PA is the practice's org name;
             program is the program name.
-        header_state: the state shown next to the headline. PA reads
-            from ``provider.location_state``; program reads from
-            ``program.state_preference``; CR is ``None`` because its
-            state lives in ``location_chunk`` (the demographics-column
-            location row), not in the header line.
+        header_state: the state shown next to the headline. Program
+            reads from ``program.state_preference``; CR and PA leave
+            this ``None`` and surface their state via the
+            demographics-column ``location_chunk`` row instead — that
+            keeps the header line uncluttered and makes the two
+            availability-vs-seeker kinds consistent on where location
+            appears in the card.
         in_person / virtual: the post's in-person/virtual posture as
             `LOCATION_AVAILABILITY_OPTIONS` values. CR reads them off
             its own detail row; PA reads them from the linked
@@ -184,10 +186,11 @@ def post_card_view(post) -> dict[str, Any]:
             (program-availability has no posture). Same value
             ``insurance_posture_for_post`` returns.
         treatment_modality: free-text modality string or ``None``.
-        location_chunk: ``{city, state, zip}`` for CR's demographics
-            column; ``None`` for PA and program (PA's location is on
-            the linked Provider and surfaces via ``header_state`` and
-            ``full_address``; program has no location of its own).
+        location_chunk: ``{city, state, zip}`` for CR (from the
+            detail row) and PA (from the linked Provider) — the
+            demographics-column icon-only row both render. ``None``
+            for program (no location of its own; ``state_preference``
+            still surfaces via ``header_state``).
         description: free-text description or ``None``. CR's
             description is NOT NULL on the model but the function
             stays defensive for stubs that omit it.
@@ -287,7 +290,21 @@ def post_card_view(post) -> dict[str, Any]:
         p = getattr(d, "provider", None)
         base.update(
             headline=(p.org.name if p and getattr(p, "org", None) else None),
-            header_state=(getattr(p, "location_state", None) if p else None),
+            # `header_state` stays None — opening's location lives in
+            # the demographics column via `location_chunk` (same row
+            # treatment as referral). Both kinds match on where
+            # location surfaces, so the list card's header line stays
+            # uncluttered for both.
+            header_state=None,
+            location_chunk=(
+                _location_chunk(
+                    getattr(p, "location_city", None),
+                    getattr(p, "location_state", None),
+                    getattr(p, "location_zip", None),
+                )
+                if p
+                else None
+            ),
             in_person=(getattr(p, "in_person_sessions", None) if p else None),
             virtual=(getattr(p, "virtual_sessions", None) if p else None),
             services=list(getattr(d, "services", None) or []),

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -216,13 +216,13 @@ async def test_list_opening_item_shape(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """A `opening` card header is `{practice_name},
-    {state} ({format})` — PA posts identify by their practice, so the
-    practice name fills the title slot (the `Provider Availability`
-    kind label would be redundant noise). Kind is signaled by the
-    `data-kind` left-edge color, not a text chip. Insurance posture
-    is rendered in the demographics column, derived from the linked
-    provider's `in_network_carriers` (non-empty wins the badge)."""
+    """An `opening` card header is just the practice name —
+    location surfaces via the icon-only `entity-location` row in the
+    demographics column (same treatment referral cards use), not in
+    the header line. Kind is signaled by the `data-kind` left-edge
+    color, not a text chip. Insurance posture is rendered in the
+    demographics column, derived from the linked provider's
+    `in_network_carriers` (non-empty wins the badge)."""
     author = create_test_user(username=f"author-{uuid.uuid4()}")
     practice_name = f"Practice-{uuid.uuid4()}"
     post = _opening_post(
@@ -256,12 +256,16 @@ async def test_list_opening_item_shape(
     # No text kind-chip in the listing row.
     assert item.css_first("[data-kind-chip]") is None
 
-    # Header link text: practice name + state. The in-person posture
-    # renders as a `<span.post-modality>` chip (icon + label) next to
-    # the link; virtual=no, so no virtual chip.
+    # Header link text: just the practice name (location moves to the
+    # demographics column via `entity-location`). The in-person
+    # posture renders as a `<span.post-modality>` chip (icon + label)
+    # next to the link; virtual=no, so no virtual chip.
     lead = item.css_first("header.entity-header a")
     assert lead is not None
-    assert lead.text(strip=True) == f"{practice_name}, OR"
+    assert lead.text(strip=True) == practice_name
+    location_row = item.css_first("section.entity-facts dl > div.entity-location")
+    assert location_row is not None
+    assert "Portland, OR" in location_row.text()
     modality_chips = [
         chip.text(strip=True)
         for chip in item.css("header.entity-header > .post-modality")
@@ -413,9 +417,13 @@ async def test_list_demographics_diverge_by_kind(
     assert (
         cr_card.css_first("section.entity-facts dl > div.entity-location") is not None
     )
-    # PA carries the cohort chunk; no location row.
+    # PA carries the cohort chunk AND the icon-only location row
+    # (same shape as CR's location chunk) — both kinds locate their
+    # location in the demographics column for visual consistency.
     assert "Ages" in pa_labels and "Age" not in pa_labels
-    assert pa_card.css_first("section.entity-facts dl > div.entity-location") is None
+    assert (
+        pa_card.css_first("section.entity-facts dl > div.entity-location") is not None
+    )
 
 
 async def test_list_pa_footer_carries_email_cta_only(

--- a/src/domain/templates/posts/_facts_block.html
+++ b/src/domain/templates/posts/_facts_block.html
@@ -1,9 +1,12 @@
 {# Demographics fact `<dl>` — the post card's right column.
 
 Each fact is wrapped in a `<div>` so CSS can style chunks
-individually (e.g. the CR location chunk gets an icon-only `<dt>`
-via `div.entity-location`, suppressing the trailing colon the generic
-`dt::after` rule applies to other rows).
+individually (e.g. the location chunk gets an icon-only `<dt>` via
+`div.entity-location`, suppressing the trailing colon the generic
+`dt::after` rule applies to other rows). Both referral and opening
+posts surface their location via this row — referral reads it from
+the post's own detail row, opening reads it from the linked
+Provider; the rendering treatment is identical.
 
 Two modes:
 
@@ -38,18 +41,22 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
 <section class="entity-facts">
   <dl>
     {%- if view.location_chunk and not expanded %}
-    {#- Compact mode: icon-only "City, ST". The icon-only treatment
-        is a list-density choice; expanded mode uses the labeled
+    {#- Compact mode: icon-only "City, ST". Both referral and opening
+        kinds populate `location_chunk` so the row renders with the
+        same icon/treatment on both cards. The icon-only treatment is
+        a list-density choice; expanded mode uses the labeled
         "Address" row below instead so the row reads consistently
         with its siblings. -#}
     <div class="entity-location"><dt aria-label="Location"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>
       {%- if view.location_chunk.city -%}{{ view.location_chunk.city }}, {% endif -%}{{ view.location_chunk.state }}
     </dd></div>
-    {%- elif view.ages %}
-    {#- Label is kind-aware: a `referral` post represents a single
-        seeker (one Age), while `opening` and `program_availability`
-        describe a cohort the practice/program accepts (Ages, plural). -#}
-    <div><dt>{% if view.kind == "referral" %}Age{% else %}Ages{% endif %}</dt><dd>
+    {%- endif %}
+    {%- if view.ages and view.kind != "referral" %}
+    {#- `opening` and `program_availability` describe a cohort the
+        practice/program accepts — labeled `Ages` (plural). Referral
+        skips this row because its age lives in the headline; the
+        `expanded` block below repeats it for the detail page. -#}
+    <div><dt>Ages</dt><dd>
       {%- set ages = [] -%}
       {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
       {{ ages | join(", ") }}
@@ -82,6 +89,18 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
         compact card omits — practice/program identity, full address,
         scheduling, and per-kind insurance details. -#}
     {%- if expanded %}
+      {%- if view.ages and view.kind == "referral" %}
+      {#- Referral expanded-only Age row: the headline already carries
+          the age + gender combo, so the compact list-card body skips
+          this. The detail page is detail-y enough to repeat it as a
+          labeled row (singular `Age` — a referral describes one
+          seeker). -#}
+      <div><dt>Age</dt><dd>
+        {%- set ages = [] -%}
+        {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
+        {{ ages | join(", ") }}
+      </dd></div>
+      {%- endif %}
       {%- if view.practice_link %}
       <div><dt>Practice</dt><dd><a href="{{ entity_url('provider', id=view.practice_link.id) }}">{{ view.practice_link.name }}</a></dd></div>
       {%- endif %}


### PR DESCRIPTION
Opening (provider availability) cards previously surfaced location as \" State\" appended to the practice name in the header line, while referral cards rendered \"City, State\" in the demographics column via the icon-only \`entity-location\` row. The two kinds disagreed on where location appears.

This PR unifies them on the body row.

## What changes

- **\`post_card_view\` for opening** populates \`location_chunk\` ({city, state, zip}) from the linked Provider and sets \`header_state = None\`. Same shape referral already produces, so the existing \`_facts_block.html\` icon-only \`<div class=\"entity-location\">\` row fires for both kinds with the same icon (\`icon-map-pinned\`), the same dt aria-label, and the same \"City, State\" rendering.

- **\`_facts_block.html\` row logic split**: the location row and the cohort-Ages row used to be \`if/elif\` (mutually exclusive), which worked when only referral populated \`location_chunk\`. Now both render independently — opening's card shows both the location icon-row and the labeled \"Ages\" cohort row. Referral still skips the Ages row in compact mode (its age lives in the headline); the expanded detail-page block now carries a dedicated CR-only \`Age\` row to preserve the singular label.

- **Header line cleanup**: the listing card's \`<header>\` for opening reads as just the practice name (e.g. \"Acme Counseling\") — no \", OR\" state suffix. Matches referral, which has always had a clean header line.

## What's unaffected

- **Programs** stay as-is — \`state_preference\` is conceptually an intake preference, not a physical location, so it keeps surfacing in the header line and \`location_chunk\` remains None for programs.
- **Detail pages** unchanged for opening — the expanded \"Address\" row already showed the full address; that's still there.

## Test plan

- [x] \`dev test\` — 1430 passed (was 1429; +1 PA location_chunk test, with updated assertions on the inverted PA card behavior)
- [x] \`dev test contract\` — 36 passed
- [x] \`dev lint\` — clean
- [ ] After merge, visit \`/posts?kind=opening\` — opening cards should show \"📍 Brooklyn, NY\" in the right column (matching the referral cards' treatment) and the header should read just the practice name

🤖 Generated with [Claude Code](https://claude.com/claude-code)