### PR TITLE
feat(dev): auto-login route + Playwright MCP wiring

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,11 @@
         ]
       }
     ]
+  },
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest", "--headless"]
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ dev test                  # runs the test suite
 
 `dev --help` lists every command. See [`scripts/README.md`](scripts/README.md) for what's there.
 
+### Dev auto-login
+
+After `dev seed` populates the seed admin user, bookmark:
+
+```
+http://localhost:8000/dev/login-as-seed-user
+```
+
+Hitting it issues the same session cookie a real login would (for the user named by `DEV_LOGIN_EMAIL`, defaulting to `admin@example.com`) and redirects to `/posts`. Saves a form submission every time you reopen the browser to the dev server. The route is only mounted when `ENVIRONMENT=development` — production never registers it. See [`src/domain/routes/dev_auth.py`](src/domain/routes/dev_auth.py) for the security guards.
+
+### Playwright MCP for design review <!-- title-case-ignore: "MCP" is the Anthropic acronym (Model Context Protocol) -->
+
+Claude Code can drive a real browser against the dev server to navigate, click, resize, and screenshot — useful for "load `/posts` at iPhone width and check the location row" tasks. The MCP entry is pre-configured in [`.claude/settings.json`](.claude/settings.json); the one-time browser install is:
+
+```bash
+dev playwright-setup      # installs Chromium (~150MB)
+```
+
+After that, restart Claude Code. The agent navigates to `/dev/login-as-seed-user` as its first tool call and proceeds authenticated.
+
 ## Documentation map
 
 Each fact lives in the README closest to the code that defines it; other docs link to it. See [`CLAUDE.md`](CLAUDE.md) for the contract.

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -19,8 +19,14 @@ DATABASE_URL=sqlite+aiosqlite:///./data/app.db
 SECRET=dev-only-do-not-use-in-prod-aaaaaaaa
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 
-# Development — enables template auto-reload
+# Development — enables template auto-reload AND mounts the
+# `/dev/login-as-seed-user` shortcut (see README "Dev auto-login").
 ENVIRONMENT=development
+
+# Seed user the dev-only `/dev/login-as-seed-user` route logs in as.
+# Defaults to the admin user `dev seed` creates; uncomment + override
+# to log in as a different seed-data user.
+# DEV_LOGIN_EMAIL=admin@example.com
 """
 
 
@@ -420,6 +426,50 @@ class RoutesCommands:
         return 0
 
 
+class PlaywrightCommands:
+    """One-time setup for the Playwright MCP server.
+
+    The MCP entry in `.claude/settings.json` invokes
+    `npx @playwright/mcp@latest`; that fetches and runs the server
+    fresh each time without a pre-install step. The browser binary
+    (Chromium) is the only thing that needs to be installed locally.
+    This command runs `npx playwright install chromium` and prints
+    the bookmark URL + a pointer to the auto-login route.
+    """
+
+    def __init__(self, runner: CLIRunner):
+        self.runner = runner
+
+    def setup(self) -> int:
+        print("🎭 Installing Chromium for Playwright (one-time, ~150MB)...")
+        result = self.runner.run_command(
+            ["npx", "--yes", "playwright", "install", "chromium"]
+        )
+        if result != 0:
+            print(
+                "❌ Chromium install failed. Confirm Node + npm are installed; "
+                "see https://nodejs.org/."
+            )
+            return result
+
+        print("\n✅ Playwright Chromium installed.")
+        print("\nNext steps:")
+        print("  1. Start the dev server:    dev up")
+        print("  2. Seed the dev DB:         dev seed")
+        print("  3. Log in (bookmark this):")
+        print("       http://localhost:8000/dev/login-as-seed-user")
+        print(
+            "     Visiting it sets the session cookie for the seed admin user "
+            "and redirects to /posts."
+        )
+        print(
+            "\nClaude Code's Playwright MCP entry is already configured in "
+            "`.claude/settings.json`. After restarting Claude Code, the agent "
+            "can navigate / click / screenshot via the same auto-login URL."
+        )
+        return 0
+
+
 class SetupCommands:
     def __init__(self, runner: CLIRunner):
         self.runner = runner
@@ -470,6 +520,7 @@ class DevCLI:
         self.routes_cmd = RoutesCommands(self.runner)
         self.promote_admin_cmd = PromoteAdminCommands(self.runner)
         self.migrate_cmd = MigrateCommands(self.runner)
+        self.playwright_cmd = PlaywrightCommands(self.runner)
 
     def create_parser(self) -> argparse.ArgumentParser:
         """Create the argument parser with all commands."""
@@ -505,6 +556,7 @@ Examples:
         self._add_routes_parser(subparsers)
         self._add_promote_admin_parser(subparsers)
         self._add_migrate_parser(subparsers)
+        self._add_playwright_setup_parser(subparsers)
 
         return parser
 
@@ -611,6 +663,19 @@ Examples:
             ),
         )
         parser.set_defaults(func=lambda args: self.setup.setup())
+
+    def _add_playwright_setup_parser(self, subparsers):
+        parser = subparsers.add_parser(
+            "playwright-setup",
+            help="Install Chromium for the Playwright MCP server",
+            description=(
+                "One-time browser install for the Playwright MCP entry "
+                "wired up in `.claude/settings.json`. Also prints the "
+                "auto-login bookmark URL (`/dev/login-as-seed-user`) so "
+                "the dev knows where to point their browser."
+            ),
+        )
+        parser.set_defaults(func=lambda args: self.playwright_cmd.setup())
 
     def _add_seed_parser(self, subparsers):
         parser = subparsers.add_parser(

--- a/src/domain/routes/dev_auth.py
+++ b/src/domain/routes/dev_auth.py
@@ -1,0 +1,86 @@
+"""Dev-only auto-login route.
+
+Visiting ``GET /dev/login-as-seed-user`` issues the same session
+cookie a production login would (via ``auth_backend.login`` with the
+JWT strategy from :mod:`src.auth_config`) for the user named by
+``settings.DEV_LOGIN_EMAIL``, then 302s to ``/posts``. Useful in two
+places:
+
+  * Manual development — bookmark the URL. One click after starting
+    the dev server and you're authenticated; no form to fill.
+  * Playwright MCP agent — first tool call of a session navigates here,
+    then every subsequent navigate happens with the auth cookie set.
+
+Security guards (defense in depth — both must pass):
+
+  1. The route is only mounted on the FastAPI app when
+     ``settings.ENVIRONMENT == "development"`` — see
+     :func:`mount_dev_routes`. In production the route doesn't exist
+     and 404s without ever reaching this module.
+  2. The handler additionally raises 404 if ``settings.ENVIRONMENT``
+     somehow drifts out of "development" at request time. Belt-and-
+     suspenders against a future code path that toggles the env flag
+     after app boot.
+
+The route never accepts user input — the seed-user identifier comes
+from the server-side ``DEV_LOGIN_EMAIL`` setting, not from query
+params — so it can't be tricked into authenticating as an arbitrary
+user. The seed user must already exist in the database; otherwise the
+handler 404s.
+
+Tested in `test_dev_auth.py` (the colocated route test).
+"""
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi.responses import Response
+from fastapi_users.manager import BaseUserManager
+
+from src.auth_config import auth_backend, get_strategy, get_user_manager
+from src.domain.models import User
+from src.framework.config import settings
+
+router = APIRouter(tags=["dev"])
+
+
+@router.get("/dev/login-as-seed-user")
+async def login_as_seed_user(
+    user_manager: BaseUserManager[User, object] = Depends(get_user_manager),
+) -> Response:
+    """Issue a session cookie for the configured seed user and 302 to
+    ``/posts``."""
+    if settings.ENVIRONMENT != "development":
+        raise HTTPException(status_code=404)
+
+    try:
+        user = await user_manager.get_by_email(settings.DEV_LOGIN_EMAIL)
+    except Exception as exc:  # fastapi-users raises UserNotExists
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Seed user not found: {settings.DEV_LOGIN_EMAIL}. "
+                "Run `dev seed` to populate the dev database."
+            ),
+        ) from exc
+
+    # `auth_backend.login(strategy, user)` builds a Response with the
+    # cookie set by the transport (CookieTransport in our config). We
+    # then swap the status + Location header so the agent / browser
+    # lands on `/posts` carrying the freshly-set cookie.
+    response = await auth_backend.login(get_strategy(), user)
+    response.status_code = 302
+    response.headers["Location"] = "/posts"
+    return response
+
+
+def mount_dev_routes(app: FastAPI, *, environment: str) -> None:
+    """Mount the dev-only routes on ``app`` iff ``environment`` is
+    ``"development"``.
+
+    Called from :mod:`src.main` with ``settings.ENVIRONMENT`` so the
+    mount decision happens once, at app boot. Production never sees
+    these routes registered. Pulled into a function so the
+    ``test_mount_dev_routes_*`` tests can pin the gating behavior
+    without monkeypatching the global ``app`` instance.
+    """
+    if environment == "development":
+        app.include_router(router)

--- a/src/domain/routes/test_dev_auth.py
+++ b/src/domain/routes/test_dev_auth.py
@@ -1,0 +1,124 @@
+"""Tests for the dev-only auto-login route.
+
+Two layers of guarding:
+
+  1. ``mount_dev_routes`` only registers the router when the
+     ``environment`` argument is ``"development"``. Tested with a
+     fresh ``FastAPI()`` instance per case so the global
+     ``src.main:app`` isn't mutated.
+  2. The handler additionally raises 404 if
+     ``settings.ENVIRONMENT`` doesn't read ``"development"`` at
+     request time (defense in depth).
+
+The happy-path test goes through the test client's already-mounted
+``app`` (which runs with ``ENVIRONMENT="development"`` via
+``.env.test``) and pins the contract a Playwright agent or a manual
+bookmark relies on: 302 + ``Location: /posts`` + ``Set-Cookie:
+fastapiusersauth=...``.
+"""
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.auth_config import get_user_manager
+from src.domain.logic.users.schema import UserCreate
+from src.domain.routes import dev_auth
+from src.framework.config import settings
+from tests.fixtures import create_test_user
+
+# --- mount_dev_routes: env-gated router registration --------------------
+
+
+def test_mount_dev_routes_registers_when_environment_is_development():
+    """A fresh app + `mount_dev_routes(env="development")` produces a
+    `/dev/login-as-seed-user` route on `app.routes`. Pins the dev-
+    mode mount."""
+    app = FastAPI()
+    dev_auth.mount_dev_routes(app, environment="development")
+    paths = {getattr(r, "path", None) for r in app.routes}
+    assert "/dev/login-as-seed-user" in paths
+
+
+def test_mount_dev_routes_skips_when_environment_is_production():
+    """The production mount path MUST NOT register the dev route.
+    This is the canary against an accidental env-flag flip leaking the
+    auto-login backdoor into prod."""
+    app = FastAPI()
+    dev_auth.mount_dev_routes(app, environment="production")
+    paths = {getattr(r, "path", None) for r in app.routes}
+    assert "/dev/login-as-seed-user" not in paths
+
+
+def test_mount_dev_routes_skips_when_environment_is_arbitrary_other():
+    """Any non-`development` value (staging, test, empty string, etc.)
+    is treated as "not dev" — the mount is strict-equality, not a
+    truthy/falsy check."""
+    app = FastAPI()
+    for env in ("staging", "test", "PRODUCTION", "Development", ""):
+        dev_auth.mount_dev_routes(app, environment=env)
+    paths = {getattr(r, "path", None) for r in app.routes}
+    assert "/dev/login-as-seed-user" not in paths
+
+
+# --- Handler: happy path ------------------------------------------------
+
+
+async def test_dev_login_issues_session_cookie_and_redirects(
+    test_client: AsyncClient,
+    test_app: FastAPI,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Hitting the route with a seed user in the DB issues the same
+    `fastapiusersauth` cookie a production login would, and 302s to
+    `/posts`. This is the contract a Playwright MCP agent's
+    first-tool-call relies on."""
+    # Seed the DEV_LOGIN_EMAIL user. Use the standard fastapi-users
+    # user-manager dependency so the password is hashed correctly.
+    seed_email = "dev-login-seed@example.com"
+    monkeypatch.setattr(settings, "DEV_LOGIN_EMAIL", seed_email)
+    user_data = UserCreate(email=seed_email, password="anything", username="dev-seed")
+    await create_test_user(db_test_session_manager, user_data, get_user_manager)
+
+    response = await test_client.get("/dev/login-as-seed-user", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/posts"
+    set_cookie = response.headers.get("Set-Cookie", "")
+    assert "fastapiusersauth=" in set_cookie, (
+        "expected the session cookie to be set on the response — "
+        "fastapi-users' CookieTransport.login() puts it on Set-Cookie"
+    )
+
+
+async def test_dev_login_404s_when_seed_user_missing(
+    test_client: AsyncClient,
+    test_app: FastAPI,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If `DEV_LOGIN_EMAIL` points at a user that doesn't exist (no
+    seed yet), the route 404s with a hint to run `dev seed` rather
+    than crashing or silently authenticating as a non-user."""
+    monkeypatch.setattr(
+        settings, "DEV_LOGIN_EMAIL", "nobody-at-this-address@example.com"
+    )
+    response = await test_client.get("/dev/login-as-seed-user", follow_redirects=False)
+    assert response.status_code == 404
+    assert "dev seed" in response.text
+
+
+async def test_dev_login_404s_when_environment_is_not_development(
+    test_client: AsyncClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """In-handler defense-in-depth: even if the route is mounted (it
+    is in the test app, which runs with `ENVIRONMENT=development`), a
+    request-time check against the live setting 404s when the env
+    flag isn't `"development"`. Belt-and-suspenders against a future
+    code path that toggles the env at runtime."""
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    response = await test_client.get("/dev/login-as-seed-user", follow_redirects=False)
+    assert response.status_code == 404

--- a/src/framework/config.py
+++ b/src/framework/config.py
@@ -11,6 +11,14 @@ class Settings(BaseSettings):
     DATABASE_URL: str
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
     ENVIRONMENT: str = "production"
+    # Seed-user email the dev-only auto-login route logs in as. Read
+    # by `src.domain.routes.dev_auth` when `ENVIRONMENT="development"`
+    # — the route is not mounted in any other environment so this
+    # value is inert in production. Defaults to the admin user
+    # `seed.py` creates so a fresh `dev seed` + `dev up` lands the
+    # developer (or the Playwright MCP agent) authenticated without
+    # extra config.
+    DEV_LOGIN_EMAIL: str = "admin@example.com"
 
     model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,8 @@ from src.db import check_database_health
 from src.domain import routes  # noqa: F401  # populates entity_registry
 from src.domain import template_globals  # noqa: F401  # populates Jinja env globals
 from src.domain.logic.users.schema import UserRead
-from src.domain.routes import auth_pages, auth_routes, verifications
+from src.domain.routes import auth_pages, auth_routes, dev_auth, verifications
+from src.framework.config import settings
 from src.framework.dispatch.registry import entity_registry
 from src.framework.http.middleware import StripEmptyQueryParamsMiddleware
 from src.jobs.scheduler import make_scheduler, register_jobs
@@ -124,6 +125,13 @@ app.include_router(verifications.verifications_api_router)
 # repeat them on `include_router`.
 for _, _router in entity_registry.entries():
     app.include_router(_router)
+
+# Dev-only routes. Mounted iff `ENVIRONMENT == "development"`; the
+# `/dev/login-as-seed-user` shortcut doesn't exist in production. The
+# `mount_dev_routes` indirection makes the gating behavior testable
+# without monkeypatching the global `app` instance. See
+# `src/domain/routes/dev_auth.py` for the full security rationale.
+dev_auth.mount_dev_routes(app, environment=settings.ENVIRONMENT)
 
 
 @app.get("/health")


### PR DESCRIPTION
Two changes that together unblock browser-driven design review and cut the per-session login friction:

## 1. \`GET /dev/login-as-seed-user\`

A dev-only route that issues the same session cookie a production login would (via \`auth_backend.login\` with the JWT strategy from \`auth_config\`) for the user named by \`settings.DEV_LOGIN_EMAIL\` (default: \`admin@example.com\`), then 302s to \`/posts\`. Same path serves two clients:

- **Manual development**: bookmark \`http://localhost:8000/dev/login-as-seed-user\`. One click after \`dev up\` and you're authenticated — no form to fill.
- **Playwright MCP agent**: first tool call of a session navigates here, then every subsequent navigate happens with the auth cookie set.

### Security guards (defense in depth)

- The route is only registered on the app when \`settings.ENVIRONMENT == \"development\"\` — see \`dev_auth.mount_dev_routes(app, environment=...)\`. In production the route literally doesn't exist; \`/dev/...\` 404s.
- The handler additionally raises 404 if \`settings.ENVIRONMENT\` drifts out of \`\"development\"\` at request time.
- The seed-user identifier is read from a server-side setting (no query-param input), so the route can't be tricked into authenticating as an arbitrary user.

Six colocated tests in \`test_dev_auth.py\` pin both the mount-gating (development mounts, production / staging / arbitrary / empty don't) and the handler contract (302 + \`Location: /posts\` + \`Set-Cookie: fastapiusersauth=...\`; 404 when seed user missing; 404 when env isn't dev).

## 2. Playwright MCP entry in \`.claude/settings.json\`

Wired up so Claude Code can drive a headless Chromium against the dev server (navigate, click, screenshot, set viewport size). The agent's first tool call hits \`/dev/login-as-seed-user\` and proceeds authenticated. Same bookmark serves manual development.

\`dev playwright-setup\` is the one-time browser install (runs \`npx playwright install chromium\`, ~150MB) plus a printout of the bookmark URL and next-steps.

## Knobs added

- \`Settings.DEV_LOGIN_EMAIL\` (default \`admin@example.com\`) — override via \`.env\` to log in as a different seed-data user.
- \`ENV_TEMPLATE\` (the \`.env\` scaffold \`dev setup\` writes) picks up the new setting (commented; default works) plus a comment noting \`ENVIRONMENT=development\` is what gates the route mount.
- README's Quick start picks up two new sections: \"Dev auto-login\" and \"Playwright MCP for design review\".

## Test plan

- [x] \`dev test\` — 1442 passed (+6 new tests for the route)
- [x] \`dev test contract\` — 36 passed
- [x] \`dev lint\` — clean
- [ ] After merge: \`dev playwright-setup\` once locally, restart Claude Code, ask the agent to take a screenshot of \`/posts\` at mobile width — should work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)