### PR TITLE
fix(entity-card): wrap header band so badges + date don't clip on mobile (#577)

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -86,9 +86,13 @@
       .entity-card[data-kind="program_availability"] { border-left-color: darkcyan; }
       /* Header band: Pico provides the background tint + bottom
          border; we only configure the in-row flex layout (headline,
-         modality chips, right-aligned date). */
+         modality chips, right-aligned date). `flex-wrap: wrap` keeps
+         the modality chip + right-aligned `<small>` date visible on
+         narrow viewports — without it they clip past the card's right
+         edge at ≤375px (#577). */
       .entity-card > header.entity-header {
         display: flex;
+        flex-wrap: wrap;
         align-items: baseline;
         gap: 0.5rem;
       }

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -200,6 +200,40 @@ def test_form_new_view_appends_new_segment() -> None:
     assert '<form id="x"></form>' in html
 
 
+def test_entity_card_header_wraps_on_narrow_viewports() -> None:
+    """Regression for #577 — `.entity-card > header.entity-header` must
+    set `flex-wrap: wrap` so the modality chip + right-aligned `<small>`
+    date stay visible at ≤375px viewports. Without it the chip and date
+    clip past the card's right edge on mobile."""
+    import re
+
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Posts{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+    )
+
+    match = re.search(
+        r"\.entity-card\s*>\s*header\.entity-header\s*\{[^}]*\}",
+        html,
+    )
+    assert match is not None, "entity-header rule missing from base.html"
+    assert "flex-wrap: wrap" in match.group(
+        0
+    ), "entity-header must set `flex-wrap: wrap` to avoid #577 clipping"
+
+
 def test_form_edit_view_renders_three_segment_breadcrumb() -> None:
     env = _make_env()
     _add_child(


### PR DESCRIPTION
## Summary
- `.entity-card > header.entity-header` was `display: flex` with no `flex-wrap`, so at ≤375px the modality chip and the right-aligned `<small>` date clipped past the card's right edge.
- Added `flex-wrap: wrap` (single declaration) so the chips/date drop to a second line while the headline keeps the first.
- Affects every entity-card consumer (posts list/detail, providers/programs/orgs/users detail) since they all share `base.html`.

## Test plan
- [x] `dev test src/framework/templates/test_views.py` — new regression `test_entity_card_header_wraps_on_narrow_viewports` passes; substring-checks the rule in the rendered `<style>` block.
- [x] `dev lint` — clean.
- [x] `dev test` — all existing post-card DOM assertions in `src/domain/routes/test_posts.py` still pass.

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)