### PR TITLE
fix(ui): inline location pin icon on detail pages (closes #587)

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -155,28 +155,35 @@
         padding: 0.1rem 0;
       }
       /* Demographics `<dl>`: one `<div>` per fact, "Label: value"
-         layout — `<dt>` inline with a colon, `<dd>` inline after. */
-      .entity-card > .entity-grid section.entity-facts > dl {
+         layout — `<dt>` inline with a colon, `<dd>` inline after.
+         Scoped to `.entity-card section.entity-facts` (not
+         `.entity-card > .entity-grid section.entity-facts`) so the
+         inline `<dt>`/`<dd>` rules apply on detail pages that don't
+         use the 2-column `.entity-grid` wrapper (org, program, user,
+         provider). Without this, the icon-only `<dt>` in
+         `<div class="entity-location">` falls back to block layout
+         and renders on its own line above the value. */
+      .entity-card section.entity-facts > dl {
         margin: 0;
         padding: 0;
       }
-      .entity-card > .entity-grid section.entity-facts > dl > div {
+      .entity-card section.entity-facts > dl > div {
         padding: 0.1rem 0;
       }
-      .entity-card > .entity-grid section.entity-facts dt {
+      .entity-card section.entity-facts dt {
         display: inline;
         font-weight: 600;
       }
-      .entity-card > .entity-grid section.entity-facts dt::after { content: ": "; }
+      .entity-card section.entity-facts dt::after { content: ": "; }
       /* CR location chunk: `<dt>` is icon-only (`aria-label` carries
          meaning for screen readers), so suppress the trailing colon
          that the generic rule above adds to every `<dt>`. Icon →
          `<dd>` spacing comes from the icon's own `margin-inline-end`
          (set in the global icon rule below), which extends past
          the inline `<dt>` into the inline flow. */
-      .entity-card > .entity-grid section.entity-facts dl > div.entity-location > dt::after { content: ""; }
-      .entity-card > .entity-grid section.entity-facts dl > div.entity-location > dt { font-weight: normal; }
-      .entity-card > .entity-grid section.entity-facts dd { display: inline; margin: 0; }
+      .entity-card section.entity-facts dl > div.entity-location > dt::after { content: ""; }
+      .entity-card section.entity-facts dl > div.entity-location > dt { font-weight: normal; }
+      .entity-card section.entity-facts dd { display: inline; margin: 0; }
       /* Detail-only "how to refer" section — sits below the body
          grid, before the footer. Margin-top echoes the grid's
          vertical rhythm; the heading is the standard `<h4>`. */


### PR DESCRIPTION
## Summary
- Closes #587 — provider detail's map-pin icon was rendering on its own line above the address.
- Root cause: `entity-facts` inline-`dt`/`dd` rules were scoped to `.entity-card > .entity-grid section.entity-facts`. Only post cards use `.entity-grid` (the 2-column body layout); org/program/user/provider detail pages use `.entity-card` directly, so the inline-`dt` rules never matched and the icon-only `<dt>` fell back to block layout.
- Fix: drop the `> .entity-grid` from the selector chain. The `.entity-grid` class still owns the 2-column grid layout itself; only the demographics-`<dl>` styling no longer depends on it.

## Test plan
- [x] `dev lint` passes.
- [x] `dev test` — 1441 passed, 1 pre-existing flake (`test_roundtrip_default_scratch`, sqlite scratch-DB lock unrelated to CSS).
- [x] Manual: `dev up`, `/dev/login-as-seed-user`, `/providers/{id}` — pin icon now renders inline with the address text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)