### PR TITLE
fix(ui): hide Active/Verified rows on user self-view (closes #597)

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -303,20 +303,22 @@ async def test_detail_hides_private_fields_from_strangers(
     assert "<dt>Verified</dt>" not in body
 
 
-async def test_detail_shows_private_fields_to_self(
+async def test_detail_shows_email_to_self_but_hides_admin_flags(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
     """The user viewing their own profile (via /users/me or
-    /users/<own-id>) sees their email, active, and verified rows."""
+    /users/<own-id>) sees their email but NOT the `Active` /
+    `Verified` rows — those are admin-facing moderation flags and
+    read as internal state on a personal profile."""
     response = await authenticated_client.get("/users/me")
 
     assert response.status_code == 200
     body = response.text
     assert logged_in_user.email in body
     assert "<dt>Email</dt>" in body
-    assert "<dt>Active</dt>" in body
-    assert "<dt>Verified</dt>" in body
+    assert "<dt>Active</dt>" not in body
+    assert "<dt>Verified</dt>" not in body
 
 
 async def test_detail_shows_private_fields_to_admin(
@@ -341,6 +343,11 @@ async def test_detail_shows_private_fields_to_admin(
     body = response.text
     assert target_email in body
     assert "<dt>Email</dt>" in body
+    # Admin viewing someone else still sees the moderation flags —
+    # they're hidden only on self-view (see
+    # `test_detail_shows_email_to_self_but_hides_admin_flags`).
+    assert "<dt>Active</dt>" in body
+    assert "<dt>Verified</dt>" in body
 
 
 async def test_detail_shows_admin_actions_for_admin(

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -30,17 +30,25 @@
     <strong>{{ target_user.username }}</strong>
   </header>
 
-  {# Private rows (email, active, verified) are gated by
-     `can_view_private`, computed in handle_get_user_detail as
-     `is_self OR is_admin(viewer)`. The handler also omits these
-     fields from the `target_user` projection for non-authorized
-     viewers, so a forgotten guard here cannot re-leak. #}
+  {# Private rows are gated by `can_view_private`, computed in
+     handle_get_user_detail as `is_self OR is_admin(viewer)`. The
+     handler also omits these fields from the `target_user`
+     projection for non-authorized viewers, so a forgotten guard
+     here cannot re-leak.
+
+     `Active` / `Verified` are admin-facing moderation flags — they
+     read as internal state, not something a user needs on their
+     own profile. They render only when an admin is viewing
+     someone else (`can_view_private and not is_self`). Email
+     stays for both self and admin-other. #}
   {% if can_view_private %}
   <section class="entity-facts">
     <dl>
       <div><dt>Email</dt><dd>{{ target_user.email }}</dd></div>
+      {% if not is_self %}
       <div><dt>Active</dt><dd>{{ "Yes" if target_user.is_active else "No" }}</dd></div>
       <div><dt>Verified</dt><dd>{{ "Yes" if target_user.is_verified else "No" }}</dd></div>
+      {% endif %}
     </dl>
   </section>
   {% endif %}


### PR DESCRIPTION
## Summary
- Closes #597 — `/users/me` was showing `Active: Yes` and `Verified: Yes` as labeled rows; these are admin-facing moderation flags and read as internal state on a user's own profile.
- Wrap the two rows in `{% if not is_self %}` so they render only when an admin is viewing someone else's profile. Email stays visible for both self and admin-other (it's a legitimate self-profile field).
- The defense-in-depth invariant (handler projection still omits the fields for non-authorized viewers) is unchanged — this is purely a display choice on top of the existing projection.

## Test plan
- [x] `dev lint` passes.
- [x] `dev test` — 1442 passed, 80 skipped.
- [x] Updated `test_detail_shows_email_to_self_but_hides_admin_flags` (formerly `test_detail_shows_private_fields_to_self`) — self sees Email but NOT Active/Verified labels.
- [x] Strengthened `test_detail_shows_private_fields_to_admin` — admin viewing someone else still sees all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)