### PR TITLE
fix(index-table): stack rows on mobile so off-screen columns stay visible (#578)

### DIFF
--- a/src/framework/templates/_shared/index_table.html
+++ b/src/framework/templates/_shared/index_table.html
@@ -44,7 +44,12 @@ scope to it.
    wide row doesn't blow out the page width. Applied here so every list
    that goes through `index_table` gets the same treatment — bespoke
    tables outside this macro (e.g. organizations/programs) wrap
-   themselves. #}
+   themselves. On ≤640px viewports, `.overflow-auto table[role="grid"]`
+   rows with `data-label` cells stack vertically into "Label: value"
+   lines (see base.html — #578), so row macros should put a
+   `data-label="..."` on every `<td>` whose meaning isn't already
+   carried by the cell content. The `class="primary"` cell suppresses
+   its label since the headline link is self-describing. #}
 <div class="overflow-auto">
   <table{% if id %} id="{{ id }}"{% endif %} role="grid">
     <thead><tr>{{ headers(**header_kwargs) }}</tr></thead>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -194,6 +194,38 @@
       .entity-card > .entity-how-to-refer { margin: 0; }
       .entity-card > .entity-how-to-refer h4 { margin: 0 0 0.4rem 0; font-size: 1rem; }
       .entity-card > .entity-how-to-refer p { margin: 0.25rem 0; }
+      /* Responsive index tables. Pico's `.overflow-auto` wrapper gives
+         every `index_table` table a horizontal scroll container, but
+         on narrow viewports the right-edge columns still slide past
+         the viewport with no affordance that they exist (#578). When
+         the row macro emits `data-label` on each `<td>` (the
+         convention documented in `_shared/index_table.html`), stack
+         the row into "Label: value" lines on ≤640px so every column
+         stays visible without horizontal scroll. The `.primary` cell
+         (canonically the row's headline link) suppresses its label —
+         the headline carries its own context. Tables without
+         `data-label` (organizations, programs) fall back to the
+         existing horizontal scroll. */
+      @media (max-width: 640px) {
+        .overflow-auto table[role="grid"] thead { display: none; }
+        .overflow-auto table[role="grid"] tr {
+          display: block;
+          padding: 0.5rem 0;
+          border-bottom: var(--pico-border-width) solid var(--pico-muted-border-color);
+        }
+        .overflow-auto table[role="grid"] tbody tr:last-child { border-bottom: 0; }
+        .overflow-auto table[role="grid"] td[data-label] {
+          display: block;
+          padding: 0.15rem 0;
+          border: 0;
+        }
+        .overflow-auto table[role="grid"] td[data-label]::before {
+          content: attr(data-label) ": ";
+          font-weight: 600;
+          margin-inline-end: 0.25rem;
+        }
+        .overflow-auto table[role="grid"] td[data-label].primary::before { content: ""; }
+      }
       /* Lucide icons — single source of truth for sizing AND
          spacing. `color: inherit` lets each icon pick up the
          surrounding text color (so an icon inside a `<small>` or a

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -234,6 +234,56 @@ def test_entity_card_header_wraps_on_narrow_viewports() -> None:
     ), "entity-header must set `flex-wrap: wrap` to avoid #577 clipping"
 
 
+def test_index_table_rows_stack_on_narrow_viewports() -> None:
+    """Regression for #578 — every `index_table` row whose `<td>` cells
+    carry `data-label` must stack into "Label: value" lines on ≤640px
+    viewports so off-screen columns (e.g. `/providers` Insurance) stay
+    visible without horizontal scroll. Pin the CSS rule's presence by
+    matching the stacking rules under a `max-width: 640px` `@media`
+    block scoped to `.overflow-auto table[role="grid"]`."""
+    import re
+
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Providers{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+    )
+
+    # Two `@media (max-width: 640px)` blocks exist in base.html (the
+    # entity-grid collapse and this one); concatenate every match body
+    # and assert the stacking rules appear in at least one. Bespoke
+    # tables (organizations/programs) that don't emit `data-label`
+    # stay on the horizontal-scroll path because the rules scope to
+    # `.overflow-auto table[role="grid"] td[data-label]`.
+    all_640_blocks = re.findall(
+        r"@media\s*\(\s*max-width:\s*640px\s*\)\s*\{(.*?)\n      \}",
+        html,
+        re.DOTALL,
+    )
+    assert all_640_blocks, "no @media (max-width: 640px) block in base.html"
+    combined = "\n".join(all_640_blocks)
+    assert (
+        '.overflow-auto table[role="grid"] thead' in combined
+    ), "missing thead hide rule for responsive index-table stacking"
+    assert (
+        "td[data-label]" in combined
+    ), "missing td[data-label] rule for responsive index-table stacking"
+    assert (
+        "content: attr(data-label)" in combined
+    ), "missing data-label ::before content rule"
+
+
 def test_form_edit_view_renders_three_segment_breadcrumb() -> None:
     env = _make_env()
     _add_child(


### PR DESCRIPTION
## Summary
- `.overflow-auto table[role="grid"]` rows with `data-label` cells stack into "Label: value" lines on ≤640px so off-screen columns (e.g. `/providers` Insurance) stay visible without horizontal scroll.
- Row macros already emit `data-label` (per `_shared/index_table.html`'s mobile-stack note), so `/providers` and `/users` pick up the responsive treatment without per-page edits.
- Bespoke tables (organizations, programs) that don't emit `data-label` keep their existing horizontal-scroll behavior via Pico's `.overflow-auto` wrapper.

Closes #578

## Test plan
- [x] New regression test in `src/framework/templates/test_views.py` pins the `@media (max-width: 640px)` stacking rules.
- [x] \`dev test\` green (1444 passed, 80 skipped).
- [x] \`dev lint\` green.
- [ ] Visual check on /providers at 375px viewport once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)