### PR TITLE
fix(ui): use post title as breadcrumb leaf on /posts/{id} (#593)

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -626,10 +626,17 @@ async def test_detail_renders_breadcrumb(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """Post detail renders the Pico breadcrumb (`Posts › Post`) above
-    the page toolbar. The trailing `<li>` is marked `aria-current="page"`
-    so screen readers identify it as the current page; visual styling
-    comes from Pico's `nav[aria-label="breadcrumb"]` defaults."""
+    """Post detail renders the Pico breadcrumb (`Posts › <headline>`)
+    above the page toolbar. The trailing `<li>` is marked
+    `aria-current="page"` so screen readers identify it as the current
+    page; visual styling comes from Pico's `nav[aria-label="breadcrumb"]`
+    defaults.
+
+    The leaf reuses `post_card_view(post).headline` — the same identity
+    string the entity-card's header renders — so the breadcrumb and the
+    page heading stay in lock-step (see #593). For a default referral
+    factory post (`adults_25_64` + `prefer_not_to_say`) the headline is
+    `"Adult (25–64)"`."""
     post = _referral_post(description="crumb-x", owner_id=logged_in_user.id)
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -643,7 +650,7 @@ async def test_detail_renders_breadcrumb(
     crumb = tree.css_first('nav[aria-label="breadcrumb"]')
     assert crumb is not None
     items = crumb.css("ul > li")
-    assert [li.text(strip=True) for li in items] == ["Posts", "Post"]
+    assert [li.text(strip=True) for li in items] == ["Posts", "Adult (25–64)"]
     parent_link = items[0].css_first("a")
     assert parent_link is not None
     assert parent_link.attributes.get("href") == "/posts"
@@ -651,6 +658,31 @@ async def test_detail_renders_breadcrumb(
     assert items[-1].attributes.get("aria-current") == "page"
     # Current page has no link inside — it's the leaf.
     assert items[-1].css_first("a") is None
+
+
+async def test_detail_breadcrumb_leaf_uses_opening_practice_name(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """For `kind='opening'`, the breadcrumb leaf is the practice
+    (provider org) name — the same string the entity-card's header
+    renders. Pins the per-kind branching in `post_card_view.headline`
+    against the breadcrumb (#593)."""
+    practice_name = f"Beacon Hill Family Therapy-{uuid.uuid4()}"
+    post = _opening_post(practice_name=practice_name, owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post.opening_detail.provider)
+            session.add(post)
+        await session.refresh(post)
+        post_id = post.id
+
+    response = await authenticated_client.get(f"/posts/{post_id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    items = tree.css('nav[aria-label="breadcrumb"] ul > li')
+    assert [li.text(strip=True) for li in items] == ["Posts", practice_name]
 
 
 async def test_detail_omits_kind_chip_and_meta_line(

--- a/src/domain/templates/posts/README.md
+++ b/src/domain/templates/posts/README.md
@@ -8,6 +8,8 @@ Each kind ships a pair: a `_<kind>_form.html` macro `(hx_method, action, submit_
 
 `list.html` / `detail.html` / `_item.html` carry kind-aware branches (`{% if post.kind == "<kind>" %}`). When a new kind ships, add the branch in both. Filter and chip vocabularies come from `ChoiceFilter("kind", ...)` in [`../../specs/post.py`](../../specs/post.py).
 
+`detail.html`'s breadcrumb leaf (`current_label` block) reads `view.headline` — the same identity string the entity-card's header renders, computed once via `post_card_view(post)` at module scope so the leaf and the heading can't drift. Per-kind branching for the headline (CR age-cohort phrase / opening practice name / program name) lives in [`../../logic/posts/view.py`](../../logic/posts/view.py)`::post_card_view`; templates never re-derive it. When a new kind ships, the breadcrumb picks up automatically as long as `post_card_view` returns a non-empty `headline` for it (falls back to `"Post"`).
+
 ## Insurance posture
 
 The unified 4-state insurance posture is derived per-post by [`../../logic/posts/view.py`](../../logic/posts/view.py)`::insurance_posture_for_post` (registered as the `insurance_posture` Jinja global) — collapses the asymmetric CR (`network_preference` + nullable `insurance_carrier`) and PA (Provider's `in_network_carriers` + `accepts_out_of_network` / `sliding_scale` flags) into one labeled chunk.

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -5,9 +5,15 @@
 {%- from "posts/_how_to_refer.html" import how_to_refer -%}
 
 {% set resource_url = entity_url('post') %}
+{# `view.headline` is the same identity string the entity-card's header
+   renders ("Adult male (25–64)" for referrals, the practice org name
+   for openings, the program name for program-availability). Computing
+   it once at module scope keeps the breadcrumb leaf and the in-card
+   headline in lock-step — see #593. #}
+{%- set view = post_card_view(post) -%}
 
 {% block resource_label %}Posts{% endblock %}
-{% block current_label %}Post{% endblock %}
+{% block current_label %}{{ view.headline or 'Post' }}{% endblock %}
 
 {% block actions %}
 {% include "posts/_owner_actions.html" %}
@@ -37,7 +43,6 @@
    Per-kind branching lives in `post_card_view` (one place). Every
    visual element in the card reads from `view` (the dict view-model). #}
 {% block content %}
-{%- set view = post_card_view(post) -%}
 <article class="entity-card" data-kind="{{ post.kind }}">
   <header class="entity-header">
     <strong>{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</strong>


### PR DESCRIPTION
## Summary
- Post detail's breadcrumb leaf used the generic literal `Post` instead of the post's identity string, out of step with every other resource (`Organizations › Beacon Hill Family Therapy`, `Providers › Katie Reeves, PhD`).
- Hoist `post_card_view(post)` to module scope in `posts/detail.html` so the `current_label` block can read `view.headline` — the same string the entity-card's header already renders. Per-kind branching (CR age-cohort phrase / opening practice name / program name) stays in one place; fallback to `"Post"` is preserved if `headline` is unexpectedly missing.
- Update + add route-level breadcrumb tests (referral + opening) pinning the new leaf shape.

Closes #593.

## Test plan
- [x] `dev test src/domain/routes/test_posts.py` — 96 pass (including the updated `test_detail_renders_breadcrumb` + new `test_detail_breadcrumb_leaf_uses_opening_practice_name`).
- [x] `dev test` — 1443 pass, 80 skipped.
- [x] `dev lint` — clean.
- [ ] Manual: load `/posts/{id}` for each kind (referral / opening / program-availability); confirm breadcrumb leaf matches the in-card headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)