### PR TITLE
fix(buttons): introduce .danger class and standardize Delete styling (#579)

### DIFF
--- a/src/domain/templates/providers/_credential_row.html
+++ b/src/domain/templates/providers/_credential_row.html
@@ -39,7 +39,7 @@
     {%- endif %}
   </div>
   {%- if delete_url and delete_confirm %}
-  <button type="button" class="secondary outline" hx-delete="{{ delete_url }}" hx-confirm="{{ delete_confirm }}">Delete</button>
+  <button type="button" class="danger outline" hx-delete="{{ delete_url }}" hx-confirm="{{ delete_confirm }}">Delete</button>
   {%- endif %}
 </div>
 {%- endmacro %}

--- a/src/framework/templates/_shared/actions.html
+++ b/src/framework/templates/_shared/actions.html
@@ -2,7 +2,11 @@
 
 {# Confirm-then-delete button. Renders an `hx-delete` button with an
 `hx-confirm` dialog. Used by owner/admin action partials and by inline
-sub-resource list rows (e.g. providers/form_edit.html licensure delete). #}
+sub-resource list rows (e.g. providers/form_edit.html licensure delete).
+`class="danger"` (defined in base.html — #579) gives every Delete the
+same red destructive-action style; without it Pico defaults to the
+filled primary blue, which read as the page's main CTA and let
+destructive clicks happen at the same visual weight as Save/Create. #}
 {% macro confirm_delete_button(url, confirm_message, label="Delete") -%}
-<button type="button" hx-delete="{{ url }}" hx-confirm="{{ confirm_message }}">{{ label }}</button>
+<button type="button" class="danger" hx-delete="{{ url }}" hx-confirm="{{ confirm_message }}">{{ label }}</button>
 {%- endmacro %}

--- a/src/framework/templates/_shared/forms.html
+++ b/src/framework/templates/_shared/forms.html
@@ -51,7 +51,7 @@ without submitting the enclosing form. #}
   <a href="{{ cancel_url }}" role="button" class="secondary outline">Cancel</a>
   {%- endif %}
   {%- if delete_url and delete_confirm %}
-  <button type="button" class="contrast form-actions-destructive" hx-delete="{{ delete_url }}" hx-confirm="{{ delete_confirm }}">Delete</button>
+  <button type="button" class="danger form-actions-destructive" hx-delete="{{ delete_url }}" hx-confirm="{{ delete_confirm }}">Delete</button>
   {%- endif %}
 </div>
 {%- endmacro %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -333,6 +333,42 @@
         .form-actions { flex-direction: column; align-items: stretch; }
         .form-actions > .form-actions-destructive { margin-left: 0; }
       }
+      /* Destructive button style. Pico v2 ships primary (filled blue),
+         `.secondary`, `.contrast`, and the `.outline` modifier, but no
+         destructive-action color — every Delete in the app picked a
+         different style (primary blue, contrast black, secondary
+         outline) and read as the page's main CTA at the same visual
+         weight as Save/Create (#579). `.danger` is the single canonical
+         destructive class: filled red by default, red-outlined under
+         `.outline` for inline subentity deletes (credential rows) so
+         the row's main affordance doesn't shout. Reuses Pico's red
+         tokens so the color tracks the theme. */
+      button.danger,
+      [role="button"].danger,
+      input[type="button"].danger,
+      input[type="reset"].danger,
+      input[type="submit"].danger {
+        --pico-background-color: var(--pico-color-red-550);
+        --pico-border-color: var(--pico-color-red-550);
+        --pico-color: var(--pico-color-azure-50);
+      }
+      button.danger:is(:hover, :active, :focus),
+      [role="button"].danger:is(:hover, :active, :focus) {
+        --pico-background-color: var(--pico-color-red-600);
+        --pico-border-color: var(--pico-color-red-600);
+      }
+      button.danger.outline,
+      [role="button"].danger.outline {
+        --pico-background-color: transparent;
+        --pico-color: var(--pico-color-red-550);
+        --pico-border-color: var(--pico-color-red-550);
+      }
+      button.danger.outline:is(:hover, :active, :focus),
+      [role="button"].danger.outline:is(:hover, :active, :focus) {
+        --pico-background-color: var(--pico-color-red-50);
+        --pico-color: var(--pico-color-red-650);
+        --pico-border-color: var(--pico-color-red-650);
+      }
       /* Pico's `<fieldset>` carries a top margin that visually competes
          with the cap above — flatten the rhythm so siblings sit at a
          consistent gap inside the capped form. */

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -311,6 +311,79 @@ def test_form_edit_view_renders_three_segment_breadcrumb() -> None:
     assert ">Edit</li>" in html or ">Edit<" in html
 
 
+def test_destructive_action_macros_emit_danger_class() -> None:
+    """Regression for #579 — every Delete affordance must carry
+    `class="danger"` (defined in base.html). Pins the two macros that
+    own the destructive-button vocabulary:
+
+    1. `_shared/actions.html::confirm_delete_button` — used by toolbar
+       owner/admin actions and inline subentity rows.
+    2. `_shared/forms.html::form_actions` — the standard
+       Save/Cancel/Delete cluster at the bottom of every entity form.
+    """
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% from "_shared/actions.html" import confirm_delete_button %}
+        {% from "_shared/forms.html" import form_actions %}
+        <div id="toolbar-delete">
+          {{ confirm_delete_button("/posts/1", "Sure?") }}
+        </div>
+        <div id="form-delete">
+          {{ form_actions("Save", cancel_url="/posts/1", delete_url="/posts/1", delete_confirm="Sure?") }}
+        </div>
+        """,
+    )
+    html = env.get_template("stub.html").render()
+
+    tree = HTMLParser(html)
+    toolbar = tree.css_first("#toolbar-delete button")
+    assert toolbar is not None
+    assert "danger" in (
+        toolbar.attributes.get("class") or ""
+    ), "confirm_delete_button must emit class containing 'danger'"
+
+    form_delete = tree.css_first("#form-delete .form-actions-destructive")
+    assert form_delete is not None
+    assert "danger" in (
+        form_delete.attributes.get("class") or ""
+    ), "form_actions Delete button must emit class containing 'danger'"
+
+
+def test_base_html_defines_danger_button_style() -> None:
+    """Regression for #579 — `.danger` button style must be defined in
+    base.html with a red token. Without it, `class="danger"` falls back
+    to Pico's primary blue and the destructive button looks like the
+    page's main CTA."""
+    import re
+
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Posts{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+    )
+    match = re.search(
+        r"button\.danger,[^{]*\{[^}]*--pico-color-red-[^}]*\}",
+        html,
+        re.DOTALL,
+    )
+    assert (
+        match is not None
+    ), "base.html must define `button.danger` with a Pico red token"
+
+
 class _RequestStub:
     """Minimal stand-in for the FastAPI ``Request`` that `base.html`
     references via `request.url.path` in the primary-nav section."""


### PR DESCRIPTION
## Summary
- New `.danger` button class in `base.html` (red filled default, red-outlined under `.outline`) keyed off Pico's `--pico-color-red-*` tokens.
- Every Delete affordance switches to `.danger`: toolbar/inline (`confirm_delete_button`), entity form (`form_actions`), credential row (`_credential_row.html`).
- Previously Delete was rendered three different ways (primary blue, contrast black, secondary outline) and competed with Save/Edit as the page's main CTA.

Closes #579

## Test plan
- [x] New regression tests in \`test_views.py\` pin both the macro emits \`class="danger"\` and base.html defines the \`.danger\` style.
- [x] \`dev test\` green (1445 passed, 80 skipped).
- [x] \`dev lint\` green.
- [ ] Visual smoke on /posts/{id}, /users, /providers/{id}/form once CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)