### PR TITLE
fix(ui): hide self-referential Login link on /auth/login (#591)

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -89,7 +89,19 @@ async def test_base_template_renders_primary_nav_for_anonymous_visitors(
     Anonymous visitors get the brand link plus a Login shortcut on the
     right (no `/users/me` link, which would 401). The `{% if
     is_authenticated %}` branch lives inside `#primary-nav` so the
-    nav scaffold is always present and only its right-side item swaps."""
+    nav scaffold is always present and only its right-side item swaps.
+
+    On `/auth/login` itself the Login shortcut is rendered as a
+    non-link `<span aria-current="page">` so the chrome doesn't offer a
+    self-referential click target (see issue #591); that branch is
+    pinned in ``test_primary_nav_suppresses_self_referential_login_link``
+    below.
+    """
+    # Every anonymous-accessible page in production is under
+    # `/auth/...`, and the issue-#591 suppression covers all of them,
+    # so there is no end-to-end path that exercises the clickable-`<a>`
+    # branch — that branch is pinned by the isolation-level unit test
+    # in ``src/framework/templates/test_views.py``.
     response = await test_client.get("/auth/login")
 
     assert response.status_code == 200
@@ -99,14 +111,46 @@ async def test_base_template_renders_primary_nav_for_anonymous_visitors(
     # Brand link is present on the left.
     brand = nav.css_first('a[href="/"]')
     assert brand is not None
-    # Right-side slot has the Login link; no profile link.
-    nav_items = tree.css("#primary-nav > li > a")
-    hrefs = {a.attributes.get("href") for a in nav_items}
-    assert hrefs == {"/auth/login"}
-    # The current Login link is marked aria-current="page".
-    login_link = tree.css_first('#primary-nav a[href="/auth/login"]')
-    assert login_link is not None
-    assert login_link.attributes.get("aria-current") == "page"
+    # Right-side slot has the Login indicator (rendered as a non-link
+    # span on auth-flow pages); no profile link.
+    profile_link = tree.css_first('#primary-nav a[href="/users/me"]')
+    assert profile_link is None
+    # No clickable `<a href="/auth/login">` on the login page itself.
+    assert tree.css_first('#primary-nav a[href="/auth/login"]') is None
+    # The Login indicator is a `<span aria-current="page">`.
+    login_indicator = tree.css_first('#primary-nav span[aria-current="page"]')
+    assert login_indicator is not None
+    assert login_indicator.text().strip() == "Login"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/auth/login",
+        "/auth/register",
+        "/auth/forgot-password",
+    ],
+)
+async def test_primary_nav_suppresses_self_referential_login_link(
+    test_client: AsyncClient,
+    path: str,
+):
+    """On every anonymous-accessible auth-flow page the top-right
+    Login shortcut must not link to `/auth/login` — clicking a header
+    link that points where you already are (or to a sibling auth page
+    that has the same chrome) is the bug filed in issue #591. The
+    suppression covers `/auth/login`, `/auth/register`, and
+    `/auth/forgot-password` so the chrome reads consistently across
+    the public auth flow."""
+    response = await test_client.get(path)
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first('#primary-nav a[href="/auth/login"]') is None
+    login_indicator = tree.css_first('#primary-nav span[aria-current="page"]')
+    assert (
+        login_indicator is not None
+    ), f"expected #primary-nav to carry a non-link Login indicator on {path}"
+    assert login_indicator.text().strip() == "Login"
 
 
 # --- Listing -------------------------------------------------------------

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -67,6 +67,8 @@ Every page extending `base.html` lands the same three-strip chrome above its con
 
 The active tab carries `aria-current="page"` plus `class="contrast"`, and `base.html` styles `nav[aria-label="Primary"] a[aria-current="page"]` with a bottom underline + font-weight bump so the section reads at a glance — Pico's default `aria-current` tint alone was too subtle (#589). The rule scopes to the primary nav so breadcrumb / pagination links that also set `aria-current` keep their lighter treatment. Bare `/posts` and post detail / form URLs intentionally don't light any section tab — the canonical Referrals/Openings URLs are the filtered `/posts?kind=…` pages, and an unfiltered list is ambiguous between the two. `test_views.py` pins the URL → active-tab mapping.
 
+On the public auth-flow pages (`/auth/login`, `/auth/register`, `/auth/forgot-password`, `/auth/reset-password/...`) the right-side Login shortcut is rendered as a non-link `<span aria-current="page">Login</span>` instead of an `<a>` — the chrome must not offer a self-referential click target on the page the visitor is already on (or on a sibling auth page where the same Login link would still be a no-op). Pinned by ``test_views.py::test_primary_nav_suppresses_login_link_on_auth_flow_paths``.
+
 **Breadcrumb zone bar** (`{% block breadcrumb %}`, macro in `_shared/_breadcrumb.html`) renders Pico's native breadcrumb above the toolbar. Every authenticated page extends the block — chrome consistency is the goal. The shape follows the resource hierarchy `list > detail > edit/new`, each level appending one segment:
 
 | Page type        | URL example                    | Breadcrumb                            |

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -576,10 +576,18 @@
        `/users/me`); anonymous visitors see a Login link. The brand
        link goes to `/`, which redirects authed users to `/posts` and
        unauthed users to the login page — safe on either side of the
-       auth gate. #}
+       auth gate.
+
+       Self-reference suppression: when an anonymous visitor is already
+       on an auth-flow page (`/auth/login`, `/auth/register`,
+       `/auth/forgot-password`, `/auth/reset-password`), the right-side
+       Login shortcut renders as a non-link `<span>` so the chrome
+       doesn't offer a click target that points where the user already
+       is. The `<span>` keeps `aria-current="page"` for assistive tech.
+    #}
     {%- set _profile_path = entity_url('user', id='me') -%}
     {%- set _on_profile = is_authenticated and (request.url.path == _profile_path or request.url.path.startswith(_profile_path + '/')) -%}
-    {%- set _on_login = request.url.path == '/auth/login' -%}
+    {%- set _on_auth_flow = request.url.path == '/auth/login' or request.url.path == '/auth/register' or request.url.path == '/auth/forgot-password' or request.url.path.startswith('/auth/reset-password') -%}
     {# Section shortcuts. Posts is one route partitioned by `?kind=`, so
        Referrals/Openings disambiguate via the query param; Directory is
        its own route under `/providers`. Active-state matching keeps
@@ -636,12 +644,17 @@
           </li>
           {% else %}
           <li>
-            {# `class="contrast"` is dropped on the active state so the
-               Login link color stays consistent across /auth/login vs
-               /auth/register / /auth/forgot-password (#592). The
-               aria-current semantics still convey the active state to
-               assistive tech. #}
-            <a href="/auth/login"{% if _on_login %} aria-current="page"{% endif %}>Login</a>
+            {# When the visitor is already on the auth flow (login /
+               register / forgot-password) we render Login as a
+               non-clickable `<span>` instead of a self-referential
+               link (#591). When it *is* rendered as a link, it carries
+               no `class="contrast"` so the link color stays consistent
+               across the auth pages (#592). #}
+            {% if _on_auth_flow %}
+            <span aria-current="page" class="contrast">Login</span>
+            {% else %}
+            <a href="/auth/login">Login</a>
+            {% endif %}
           </li>
           {% endif %}
         </ul>

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -578,18 +578,32 @@ def _active_tab_labels(html: str) -> list[str]:
     return [a.text(strip=True) for a in nav.css("a[aria-current='page']")]
 
 
+def _render_base_for_path(path: str) -> str:
+    """Render ``base.html`` for an anonymous visitor at the given path.
+
+    The base template only differs from a child render in that nothing
+    fills `{% block content %}`; we still get the full nav scaffold.
+    """
+    env = _make_env()
+    return env.get_template("base.html").render(
+        request=_request_stub(path),
+        is_authenticated=False,
+        is_development=False,
+    )
+
+
 def test_login_link_color_is_consistent_across_auth_pages() -> None:
     """Regression for #592 — the top-right Login link must not carry
     `class="contrast"` on `/auth/login` (which previously rendered the
     link black) while the same link on `/auth/register` and
     `/auth/forgot-password` rendered blue. Drop the contrast class so
-    the link's color stays the same color anywhere it's still rendered
-    (orthogonal to #591 which may hide the link entirely).
+    the link's color stays the same color anywhere it's still rendered.
 
-    Anonymous path — the primary-nav active-state logic (#618) adds
-    `class="contrast"` to authenticated nav links, but the Login link
-    in the top-right zone is anonymous-only, so the two rules don't
-    cross."""
+    After #591 lands, the Login link is replaced by a `<span>` on
+    auth-flow paths so there's no `<a href="/auth/login">` to check on
+    those paths — the assertion-on-the-empty-set still holds, and the
+    test stays useful as a guard against re-introducing a colored link
+    if the suppression rule is ever loosened."""
     env = _make_env()
     _add_child(
         env,
@@ -615,6 +629,9 @@ def test_login_link_color_is_consistent_across_auth_pages() -> None:
             assert (
                 "contrast" not in classes
             ), f"on {path}, Login link must not use `class='contrast'`: got {classes!r}"
+
+
+# --- Primary nav: section active-state + Login shortcut --------------
 
 
 def test_primary_nav_directory_active_on_providers_list() -> None:
@@ -670,3 +687,45 @@ def test_primary_nav_active_link_carries_strong_style_hook() -> None:
     active = nav.css_first("a[aria-current='page']")
     assert active is not None
     assert "contrast" in (active.attributes.get("class") or "")
+
+
+def test_primary_nav_renders_login_link_off_auth_flow() -> None:
+    """When an anonymous visitor is *not* on an auth-flow page, the
+    top-right Login shortcut renders as a clickable `<a
+    href="/auth/login">` — the default chrome state."""
+    html = _render_base_for_path("/")
+    tree = HTMLParser(html)
+    link = tree.css_first('#primary-nav a[href="/auth/login"]')
+    assert link is not None
+    # No `<span aria-current="page">` on a non-auth path.
+    assert tree.css_first('#primary-nav span[aria-current="page"]') is None
+    # When rendered as a link, no `class="contrast"` — keeps color
+    # consistent with how the link would render anywhere else in the
+    # chrome (#592). The auth-flow `<span>` variant carries `contrast`
+    # because it's a non-link indicator, not a navigation target.
+    classes = (link.attributes.get("class") or "").split()
+    assert (
+        "contrast" not in classes
+    ), f"Login link must not use `class='contrast'`: got {classes!r}"
+
+
+def test_primary_nav_suppresses_login_link_on_auth_flow_paths() -> None:
+    """Issue #591: on `/auth/login`, `/auth/register`,
+    `/auth/forgot-password`, and any `/auth/reset-password/...` path,
+    the top-right Login shortcut renders as a non-link
+    `<span aria-current="page">Login</span>` so the chrome doesn't
+    offer a self-referential click target."""
+    for path in (
+        "/auth/login",
+        "/auth/register",
+        "/auth/forgot-password",
+        "/auth/reset-password/some-token",
+    ):
+        html = _render_base_for_path(path)
+        tree = HTMLParser(html)
+        assert (
+            tree.css_first('#primary-nav a[href="/auth/login"]') is None
+        ), f"expected no /auth/login link on {path}"
+        indicator = tree.css_first('#primary-nav span[aria-current="page"]')
+        assert indicator is not None, f"expected Login indicator on {path}"
+        assert indicator.text().strip() == "Login"


### PR DESCRIPTION
## Summary
- On `/auth/login` (and every sibling auth-flow page) the top-right Login shortcut now renders as a non-link `<span aria-current="page">Login</span>` instead of a clickable `<a href="/auth/login">`, so the chrome doesn't offer a self-referential click target.
- Suppression covers `/auth/login`, `/auth/register`, `/auth/forgot-password`, and `/auth/reset-password/...` — all anonymous-accessible pages where the Login link would be a no-op self-reference or a sibling-page redirect-trap.
- Pinned by a parametrized end-to-end test (`src/domain/routes/test_users.py`) plus two template-isolation unit tests (`src/framework/templates/test_views.py`). Primary-nav contract in `src/framework/templates/README.md` updated accordingly.

Closes #591

## Test plan
- [x] `dev lint` clean
- [x] `dev test` clean (1447 passed, 80 skipped)
- [x] New tests fail before the template change and pass after
- [x] Contract failures (12) pre-exist on `main` — verified by stashing and re-running

🤖 Generated with [Claude Code](https://claude.com/claude-code)