### PR TITLE
fix(ui): clean parent-org empty rendering on org detail (#595)

### DIFF
--- a/src/domain/models/organizations/README.md
+++ b/src/domain/models/organizations/README.md
@@ -25,6 +25,12 @@ root_org_id = (id if parent_org_id IS NULL else parent.root_org_id)
 
 Today only `Organization` itself writes the table, so the invariant is enforced in `src/domain/logic/organizations/repository.py` (`create`). When PR 2+ widens write paths, every writer MUST apply the same rule — or move the rule into a DB trigger. There is no `CHECK` constraint enforcing the equation today (SQLite CHECKs can't express the self-join), so the rule is convention enforced by the repository.
 
+## Self-referential `parent` is `lazy="selectin"` with `join_depth=1`
+
+`Organization.parent` is a self-referential relationship (the parent of an Org is another Org). The detail template dereferences `organization.parent.name` to render the parent's display name; under FastAPI's async sessions, an implicit lazy-load at template-render time fails with `MissingGreenlet`.
+
+The fix is `lazy="selectin"` so the parent is loaded at the same session boundary as the target row. `join_depth=1` is required on a self-referential `selectin` — without it SQLAlchemy's cycle guard suppresses the eager-load and the strategy silently falls back to plain lazy-load (the exact failure mode that prompted this configuration). One hop is enough for the template; deeper ancestry is not used.
+
 ## Why this cluster, not flat siblings
 
 `organizations/` matches the per-entity cluster grammar in [`../README.md`](../README.md) — every entity with at least one model file gets its own directory. The Program entity (PR 4 of the Org/Program roadmap, #537) is owned by Organization but lives in its own [`../programs/`](../programs/) cluster — same parent-cluster grammar applied recursively, not nested inside `organizations/`.

--- a/src/domain/models/organizations/organization.py
+++ b/src/domain/models/organizations/organization.py
@@ -49,10 +49,17 @@ class Organization(BaseModel):
     )
 
     user = relationship("User")
+    # ``lazy="selectin"`` so the detail template can resolve the parent's
+    # *name* without re-issuing IO inside Jinja (async sessions disallow
+    # implicit lazy-loads). Same pattern as ``Provider.org`` — any
+    # relationship a template dereferences must be eagerly loaded at the
+    # session boundary.
     parent = relationship(
         "Organization",
         remote_side="Organization.id",
         foreign_keys=[parent_org_id],
+        lazy="selectin",
+        join_depth=1,
     )
     # FK-side ``RESTRICT`` on both relationships — deleting an Org with
     # Providers or Programs fails loudly rather than silently orphaning.

--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -136,6 +136,53 @@ async def test_detail_renders(
     assert "<dt>Name</dt>" not in detail_resp.text
 
 
+async def test_detail_root_org_omits_parent_organization_row(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """Issue #595 — root organizations rendered `Parent organization: —
+    (root)`, a mixed empty-state convention. Root orgs now omit the
+    parent row entirely (matches the optional-field grammar used by
+    posts/providers/programs detail templates)."""
+    create_resp = await authenticated_client.post(
+        "/organizations", data=_org_payload(name="Root-Org")
+    )
+    new_id = uuid.UUID(create_resp.json()["id"])
+    detail_resp = await authenticated_client.get(f"/organizations/{new_id}")
+    assert detail_resp.status_code == 200
+    # The row is dropped — neither the placeholder text nor the dt label
+    # appears for a root org.
+    assert "Parent organization" not in detail_resp.text
+    assert "(root)" not in detail_resp.text
+
+
+async def test_detail_child_org_renders_parent_link(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """Counterpart to the root-omits test: when the org has a parent,
+    the parent row renders with the parent's name as the link text."""
+    parent_resp = await authenticated_client.post(
+        "/organizations", data=_org_payload(name="Parent-Org")
+    )
+    parent_id = uuid.UUID(parent_resp.json()["id"])
+
+    child_resp = await authenticated_client.post(
+        "/organizations",
+        data=_org_payload(
+            name="Child-Org", type="clinic", parent_org_id=str(parent_id)
+        ),
+    )
+    child_id = uuid.UUID(child_resp.json()["id"])
+
+    detail_resp = await authenticated_client.get(f"/organizations/{child_id}")
+    assert detail_resp.status_code == 200
+    assert "Parent organization" in detail_resp.text
+    # Parent name resolved as the link text (not the raw UUID).
+    assert "Parent-Org" in detail_resp.text
+    assert f"/organizations/{parent_id}" in detail_resp.text
+
+
 async def test_patch_updates_name(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -19,7 +19,14 @@
 
    The name does NOT appear as a `<dt>Name</dt>` row in the facts list
    because the header `<strong>` already carries it — duplicating the
-   primary identifier inside the body was filed as #594. #}
+   primary identifier inside the body was filed as #594.
+
+   Root organizations (no `parent_org_id`) omit the parent row entirely
+   rather than rendering placeholder text — matching the optional-field
+   grammar used by posts/providers/programs detail templates (e.g.
+   `{% if view.cost %}` in providers/detail.html). The root status is
+   already conveyed by absence; a "— (root)" placeholder mixed two
+   empty-state conventions (em-dash + parenthetical). #}
 {% block content %}
 <article class="entity-card">
   <header class="entity-header">
@@ -30,15 +37,15 @@
   <section class="entity-facts">
     <dl>
       <div><dt>Type</dt><dd>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</dd></div>
+      {%- if organization.parent_org_id %}
       <div><dt>Parent organization</dt><dd>
-        {%- if organization.parent_org_id and organization.parent -%}
+        {%- if organization.parent -%}
         <a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent.name }}</a>
-        {%- elif organization.parent_org_id -%}
-        <a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent_org_id }}</a>
         {%- else -%}
-        — (root)
+        <a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent_org_id }}</a>
         {%- endif -%}
       </dd></div>
+      {%- endif %}
     </dl>
   </section>
 </article>


### PR DESCRIPTION
## Summary
- Root organizations now omit the `Parent organization` row entirely instead of rendering the mixed-convention placeholder `— (root)` — matches the optional-field grammar used by posts/providers/programs detail templates.
- Child orgs continue to render the parent-name link (unchanged behavior).
- Eager-loaded the self-referential `Organization.parent` relationship (`lazy="selectin"`, `join_depth=1`) so the template's `organization.parent.name` dereference doesn't trigger an implicit lazy-load inside Jinja under async sessions. Documented the cycle-guard caveat in the org-models README.

Closes #595

## Test plan
- [x] `dev test src/domain/routes/test_organizations.py` — 10 passed, including new `test_detail_root_org_omits_parent_organization_row` and `test_detail_child_org_renders_parent_link`.
- [x] `dev lint` — clean.
- [x] `dev test` — 1443 passed (one flaky `scripts/dev/test_migrate.py::test_roundtrip_default_scratch` that passes in isolation and is unrelated).
- [x] `dev test contract` — same 13 failed / 23 passed result on this branch as on `main` (Pact mock-service infrastructure errors, pre-existing and unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)