### PR TITLE
fix(tables): lay out in-cell action menus inline (#580)

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -283,6 +283,30 @@
          visual weight. The `.toolbar button` rule above reaches each
          action via descendant selector. */
       menu { list-style: none; padding: 0; margin: 0; }
+      /* In-row action menus inside table cells render their `<li>`
+         commands inline so the actions sit on a single row instead of
+         stacking each `<li>` on its own line (#580 — the `/users`
+         table's Deactivate/Delete cluster previously doubled row
+         height). Scoped to `td > menu` so the page toolbar `<menu>`
+         (which has its own flex layout) is untouched, and so that
+         bespoke tables outside `index_table` pick up the same
+         treatment if they ever need an Actions cell. Buttons inside
+         the cell shrink to a compact size so two-or-three-action
+         clusters don't dominate the row width. */
+      td > menu {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.25rem;
+      }
+      td > menu > li { margin: 0; }
+      td > menu > li > button,
+      td > menu > li > [role="button"] {
+        margin: 0;
+        padding-block: 0.25rem;
+        padding-inline: 0.5rem;
+        font-size: 0.875rem;
+      }
       /* Breadcrumb zone bar. Pico already styles the markup
          (`nav[aria-label="breadcrumb"] ul` becomes an inline list
          with a separator via `li + li::before`); the only thing this

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -284,6 +284,40 @@ def test_index_table_rows_stack_on_narrow_viewports() -> None:
     ), "missing data-label ::before content rule"
 
 
+def test_in_cell_action_menu_lays_out_inline() -> None:
+    """Regression for #580 — `<menu>` inside a table cell must render
+    its `<li>` commands inline (single-line cluster), not stacked. The
+    `/users` table's Actions cell had Deactivate/Reactivate + Delete
+    stacking vertically and doubling row height. Scoping to `td >
+    menu` (not all `<menu>`) keeps the page toolbar `<menu>`
+    untouched."""
+    import re
+
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Users{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+    )
+    match = re.search(
+        r"td\s*>\s*menu\s*\{[^}]*\}",
+        html,
+    )
+    assert match is not None, "missing `td > menu` rule in base.html"
+    assert "display: flex" in match.group(
+        0
+    ), "`td > menu` must use flex layout so `<li>` commands sit inline (#580)"
+
+
 def test_form_edit_view_renders_three_segment_breadcrumb() -> None:
     env = _make_env()
     _add_child(


### PR DESCRIPTION
## Summary
- Scope \`display: flex; flex-wrap: wrap;\` to \`td > menu\` so the \`/users\` Actions cell (and any future in-row action cluster) lays its \`<li>\` commands inline instead of stacking each on its own line — row height was doubling before.
- Tightens button padding inside cell menus so the Actions column doesn't dominate row width.
- Page toolbar \`<menu>\` keeps its own layout (rule is scoped to \`td > menu\`).

Closes #580

## Test plan
- [x] New regression test in \`test_views.py\` pins the \`td > menu\` flex rule.
- [x] \`dev test\` green.
- [x] \`dev lint\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)