### PR TITLE
fix(ui): cap auth-page form card width on tablet/desktop (#584)

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -155,6 +155,10 @@ async def test_get_register_page(test_client: AsyncClient):
     # Page-title text is no longer wrapped in an `<h1>` (per app-wide
     # H1 removal); the form's submit button still says "Register".
     assert "Register" in response.text
+    # Card wrapper — `.auth-page` caps the form at 28rem and centers it
+    # so it doesn't stretch to the `<main class="container">` width on
+    # tablet/desktop (#584). The `.auth-page` rule lives in `base.html`.
+    assert '<article class="auth-page">' in response.text
 
 
 async def test_get_login_page(test_client: AsyncClient):
@@ -162,6 +166,8 @@ async def test_get_login_page(test_client: AsyncClient):
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
     assert "Login" in response.text
+    # See `test_get_register_page` for `.auth-page` rationale (#584).
+    assert '<article class="auth-page">' in response.text
 
 
 async def test_get_forgot_password_page(test_client: AsyncClient):
@@ -173,6 +179,8 @@ async def test_get_forgot_password_page(test_client: AsyncClient):
     # identify the page.
     assert "/auth/forgot-password" in response.text
     assert "Send reset link" in response.text
+    # See `test_get_register_page` for `.auth-page` rationale (#584).
+    assert '<article class="auth-page">' in response.text
 
 
 async def test_get_reset_password_page(test_client: AsyncClient):
@@ -185,6 +193,8 @@ async def test_get_reset_password_page(test_client: AsyncClient):
         f'value="{reset_token}"' in response.text
         or f'data-token="{reset_token}"' in response.text
     )
+    # See `test_get_register_page` for `.auth-page` rationale (#584).
+    assert '<article class="auth-page">' in response.text
 
 
 async def test_unauthorized_redirect_for_browser_requests(test_client: AsyncClient):

--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -20,6 +20,8 @@ Subresource lists (e.g. `/users/{id}/providers`) override `{% block breadcrumb %
 
 Pages that don't fit the resource grammar — the `/auth/*` flow's centered single-card layout, the `/posts/*` polymorphic create/edit forms — extend `base.html` directly and compose the `_shared/` macros by hand. See [`posts/README.md`](posts/README.md) for the two-layer `_<variant>_form.html` + `new_<variant>.html` pattern used for polymorphic intake.
 
+The auth-flow pages (`auth/login.html`, `auth/register.html`, `auth/forgot_password.html`, `auth/reset_password.html`) each render a single `<article class="auth-page">` card. The `.auth-page` rule in [`../../framework/templates/base.html`](../../framework/templates/base.html) caps the card at 28rem and centers it horizontally — without the class the card stretches to the full `<main class="container">` width on tablet/desktop.
+
 ## Tests
 
 Exercised indirectly via route tests under [`../routes/`](../routes/). Selector and fixture conventions live in [`../../../tests/README.md`](../../../tests/README.md).

--- a/src/domain/templates/auth/forgot_password.html
+++ b/src/domain/templates/auth/forgot_password.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article>
+<article class="auth-page">
   <header>
   </header>
   <p>

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article>
+<article class="auth-page">
   <header>
   </header>
   <!-- FastAPI Users JWT login endpoint expects 'username' (which is email) and 'password' as form data. -->

--- a/src/domain/templates/auth/register.html
+++ b/src/domain/templates/auth/register.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article>
+<article class="auth-page">
   <header>
   </header>
   <form hx-post="/auth/register" hx-ext="json-enc">

--- a/src/domain/templates/auth/reset_password.html
+++ b/src/domain/templates/auth/reset_password.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article>
+<article class="auth-page">
   <header>
   </header>
   <!-- POSTs to the FastAPI Users reset-password endpoint.

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -368,6 +368,23 @@
         color: var(--pico-muted-color);
       }
       .credential-row > button { margin: 0; flex: 0 0 auto; }
+      /* Auth-page form card — `/auth/login`, `/auth/register`,
+         `/auth/forgot-password`, `/auth/reset-password/<token>`. Each
+         page extends `base.html` directly (not the entity-form grammar)
+         and renders a single `<article class="auth-page">` card. The
+         article sits inside the `<main class="container">` which Pico
+         already centers and caps; without the rules below the card
+         itself still stretches to the container's full width (~720px
+         on tablet, ~1300px on desktop, #584). Cap at 28rem (~448px) —
+         narrower than `--form-max-width` since the auth forms are
+         visually dense (2–3 short fields) and a tighter card reads as
+         a clear focal point on landing. Centered via `margin-inline:
+         auto`. Mobile (< 28rem) is unchanged since the cap is wider
+         than the viewport. */
+      .auth-page {
+        max-width: 28rem;
+        margin-inline: auto;
+      }
     </style>
     <script
       src="https://unpkg.com/htmx.org@2.0.4"


### PR DESCRIPTION
## Summary
- Adds a `.auth-page` CSS rule in `base.html` (`max-width: 28rem; margin-inline: auto`) and applies it to the `<article>` wrapper on `login.html`, `register.html`, `forgot_password.html`, and `reset_password.html`.
- 28rem (~448px) sits inside the 420–480px range called out in the issue and is tighter than the entity-form 720px cap — auth forms are visually dense (2–3 short fields) and a tighter card reads as a clearer focal point.
- Mobile is unchanged since the cap is wider than narrow viewports.

## Why
The form card previously stretched to the full `<main class="container">` width (~720px tablet, ~1300px desktop). The Login button alone became ~1300px wide. The auth-flow's "centered single-card layout" is already called out as an exception in `src/domain/templates/README.md`; this PR makes that promise literal.

## Test plan
- [x] `dev test` (1444 passed, 80 skipped)
- [x] `dev lint`
- [x] `test_get_register_page`, `test_get_login_page`, `test_get_forgot_password_page`, `test_get_reset_password_page` now assert the `<article class="auth-page">` wrapper is present — regression in the wrapper class or its removal from any of the four templates fails the test.
- [ ] Visual verification at 375×812 (mobile), 768×1024 (tablet), 1440×900 (desktop).

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)