### PR TITLE
fix(ui): add inline Create CTA to /programs empty state (#598)

### DIFF
--- a/src/domain/routes/test_programs.py
+++ b/src/domain/routes/test_programs.py
@@ -218,6 +218,28 @@ async def test_list_programs_renders(
     assert "Listable Program" in response.text
 
 
+async def test_list_programs_empty_state_has_inline_create_cta(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """When no programs exist for the viewer, the empty state itself
+    pulls the eye to the next action — a "Create program" button inline,
+    not just the toolbar one above. Pins #598 so the CTA can't silently
+    regress to a bare "No programs found." paragraph.
+    """
+    response = await authenticated_client.get("/programs")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    empty = tree.css_first("#programs-empty-state")
+    assert empty is not None, "empty-state container missing"
+
+    cta = empty.css_first("a[role='button']")
+    assert cta is not None, "inline Create CTA missing from empty state"
+    assert "Create program" in cta.text()
+    assert cta.attributes.get("href") == "/programs/form"
+
+
 async def test_detail_renders(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/programs/list.html
+++ b/src/domain/templates/programs/list.html
@@ -31,6 +31,16 @@
   </table>
 </div>
 {% else %}
-<p>No programs found.</p>
+{# Empty state owns its own CTA so the next action is in the eye-line of
+   the user, not buried in the toolbar above. The toolbar's "Create
+   program" still renders (this branch fires only when the list itself
+   is empty) — the inline button is a second affordance, not a
+   replacement. #}
+<div id="programs-empty-state">
+  <p>No programs yet.</p>
+  <p>
+    <a href="{{ entity_form_url('program') }}" role="button">Create program</a>
+  </p>
+</div>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- `/programs` empty state was a bare "No programs found." paragraph; the only "Create program" affordance lived in the toolbar above, off the eye-line for a brand-new user.
- Replaced with short copy + an inline primary "Create program" button inside a `#programs-empty-state` container. The toolbar action is unaffected; this is a second (more visible) affordance, not a replacement.
- Added a route test pinning the CTA's presence and `href` so the empty state can't silently regress.

The pattern is the one the framework's `_shared/index_table.html` README already prescribes for rich empty states; this is a deliberate application to the bespoke `programs/list.html` (which doesn't go through `index_table`).

Closes #598

## Test plan
- [x] `dev test src/domain/routes/test_programs.py` passes (new + existing tests)
- [x] `dev test` (full suite): 1444 passed, 80 skipped
- [x] `dev lint` clean
- [ ] Manual: `dev` server, visit `/programs` as a user with no programs — empty state shows headline + inline "Create program" button that navigates to `/programs/form`

## Notes for reviewer
- Contract tests (`dev test contract`) hit pre-existing port-8990 / Pact mock teardown failures unrelated to this change; the program-specific contract test (`program-create-form-with_programs_api_mocks`) passes.
- No README change: the empty-state-with-CTA pattern is already documented in `src/framework/templates/README.md` under `index_table.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)