### PR TITLE
fix(detail): drop duplicate Name rows from org/provider detail (#594)

### DIFF
--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -128,6 +128,10 @@ async def test_detail_renders(
     detail_resp = await authenticated_client.get(f"/organizations/{new_id}")
     assert detail_resp.status_code == 200
     assert "Detail-Org" in detail_resp.text
+    # Regression for #594 — the name appears in the header `<strong>`
+    # only; the facts `<dl>` must not include a `<dt>Name</dt>` row
+    # that duplicates the same string.
+    assert "<dt>Name</dt>" not in detail_resp.text
 
 
 async def test_patch_updates_name(

--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -253,6 +253,10 @@ async def test_get_provider_renders_detail_page(
     # Owner sees an Edit link, no edit forms (read-only).
     assert tree.css_first(f'a[href="/providers/{provider_id}/form"]') is not None
     assert tree.css_first("form") is None
+    # Regression for #594 — the practice name lives in the header
+    # `<strong>` only. The facts list relabels its row "Organization"
+    # so the same string is not repeated under a "Practice name" `<dt>`.
+    assert "<dt>Practice name</dt>" not in response.text
 
 
 async def test_get_provider_hides_edit_link_for_non_owner(

--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -15,7 +15,11 @@
    posts/detail.html and providers/detail.html. The parent-organization
    row resolves the parent's *name* via the `parent` relationship —
    the previous template emitted the raw UUID as the link text, which
-   read as a bare hex number in the UI. #}
+   read as a bare hex number in the UI.
+
+   The name does NOT appear as a `<dt>Name</dt>` row in the facts list
+   because the header `<strong>` already carries it — duplicating the
+   primary identifier inside the body was filed as #594. #}
 {% block content %}
 <article class="entity-card">
   <header class="entity-header">
@@ -25,7 +29,6 @@
 
   <section class="entity-facts">
     <dl>
-      <div><dt>Name</dt><dd>{{ organization.name }}</dd></div>
       <div><dt>Type</dt><dd>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</dd></div>
       <div><dt>Parent organization</dt><dd>
         {%- if organization.parent_org_id and organization.parent -%}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -69,7 +69,12 @@
 
   <section class="entity-facts">
     <dl>
-      <div><dt>Practice name</dt><dd><a href="{{ view.practice_url }}">{{ view.practice_name }}</a></dd></div>
+      {#- The provider's name lives in the header `<strong>`; the facts
+          row labelled "Organization" preserves the link to the owning
+          org so users can still navigate from the provider to the
+          practice page. Previously a "Practice name" row repeated the
+          same text under a duplicate label (#594). -#}
+      <div><dt>Organization</dt><dd><a href="{{ view.practice_url }}">{{ view.practice_name }}</a></dd></div>
       {%- if view.full_address %}
       <div class="entity-location"><dt aria-label="Address"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>{{ view.full_address }}</dd></div>
       {%- endif %}


### PR DESCRIPTION
## Summary
- Organizations detail: remove the redundant \`<dt>Name</dt>\` row; the header \`<strong>\` already carries the name.
- Providers detail: rename "Practice name" row to "Organization" so the label describes the relationship (link to parent org) rather than duplicating the practice name. Link target unchanged.

Closes #594

## Test plan
- [x] Regression assertions added to \`test_organizations.py::test_detail_renders\` and \`test_providers.py::test_get_provider_renders_detail_page\`.
- [x] \`dev test\` green (1446 passed).
- [x] \`dev lint\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)