### PR TITLE
fix(ui): render /users row actions inline instead of stacked (#580)

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -225,6 +225,41 @@ async def test_list_shows_reactivate_for_deactivated_user(
     assert activation_button.text().strip() == "Reactivate"
 
 
+async def test_list_row_actions_render_inline(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Row-action buttons share a single `<menu class="row-actions">`
+    container so they render inline rather than stacked (#580). The
+    class is the hook for the `menu.row-actions` flex rule in
+    `base.html`; without it Pico's default block-level `<button>`
+    stacks Deactivate above Delete and doubles row height."""
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    other = create_test_user(username=f"target-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+
+    response = await authenticated_client.get("/users")
+    tree = HTMLParser(response.text)
+    row = tree.css_first(f"tr[data-row-id='{other.id}']")
+    assert row is not None, "Expected the target user's row in the table"
+    actions_menu = row.css_first("td[data-label='Actions'] menu.row-actions")
+    assert actions_menu is not None, (
+        "Actions cell must wrap row-action buttons in `menu.row-actions` "
+        "for the inline flex layout to apply"
+    )
+    # Both buttons live inside the same menu — confirms they share one
+    # flex container rather than being split into separate stacks.
+    activation_button = actions_menu.css_first(
+        f"button[hx-put='/users/{other.id}/activation']"
+    )
+    delete_button = actions_menu.css_first(f"button[hx-delete='/users/{other.id}']")
+    assert activation_button is not None
+    assert delete_button is not None
+
+
 # --- Detail page ---------------------------------------------------------
 
 

--- a/src/domain/templates/users/_columns.html
+++ b/src/domain/templates/users/_columns.html
@@ -10,6 +10,13 @@ the user detail page; the same `<li>` shape needs a `<menu>` parent
 here to stay valid HTML). The cell `<menu>` is a list of commands —
 same semantics as the toolbar, different layout context.
 
+The `class="row-actions"` on the `<menu>` flips the cluster to an
+inline flex row at every viewport (#580). Without it, Pico's default
+`<button>` is `display: block; width: 100%` (form-shaped), so each
+action stacks vertically and doubles row height. See `base.html` for
+the `menu.row-actions` rule — single source of truth for in-row
+action clusters.
+
 Macros isolate `{% include %}` from the page-level rendering
 context, so `can_admin_actions` is threaded through as a `row_kwargs`
 arg by `users/list.html` and re-bound via `{% with %}` here. The
@@ -36,7 +43,7 @@ renders nothing when the viewer is not an admin (its existing guard).
     {%- endif -%}
   </td>
   <td data-label="Actions">
-    <menu>
+    <menu class="row-actions">
     {%- with target_user = user, can_admin_actions = can_admin_actions -%}
       {%- include "users/_admin_actions.html" -%}
     {%- endwith -%}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -283,6 +283,16 @@
          visual weight. The `.toolbar button` rule above reaches each
          action via descendant selector. */
       menu { list-style: none; padding: 0; margin: 0; }
+      /* In-row action clusters (e.g. the Actions cell on `/users`). Pico's
+         default `<button>` is `display: block; width: 100%` (form-shaped),
+         so a `<menu>` of `<li><button>` children stacks vertically and
+         doubles the row height (#580). `menu.row-actions` flips the
+         cluster to an inline flex row with a small gap, and forces each
+         child button back to natural width. Mirrors the `.toolbar`
+         override pattern above — same problem, different container. */
+      menu.row-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+      menu.row-actions > li { display: contents; }
+      menu.row-actions button, menu.row-actions [role="button"] { width: auto; margin: 0; }
       /* Breadcrumb zone bar. Pico already styles the markup
          (`nav[aria-label="breadcrumb"] ul` becomes an inline list
          with a separator via `li + li::before`); the only thing this


### PR DESCRIPTION
## Summary
- The Actions cell on `/users` rendered Deactivate above Delete (block-level buttons inside a `<menu>`), doubling row height at every viewport.
- Add `class="row-actions"` on the cell `<menu>` and a `menu.row-actions` rule in `base.html` that flips the cluster to an inline flex row with natural-width buttons. Mirrors the existing `.toolbar` override that already solves the same problem for the page toolbar.
- Pure layout fix. Destructive styling on Delete is tracked separately (#579 / #599) and is intentionally untouched here.

Closes #580

## Test plan
- [x] `dev test` (1447 passed)
- [x] `dev lint`
- [x] New `test_list_row_actions_render_inline` pins both buttons inside one `menu.row-actions` container in the Actions cell
- [ ] Visual check at 375 / 768 / 1440 widths via `/dev/login-as-seed-user` → `/users` as an admin