### PR TITLE
fix(users): hide Active/Verified rows for self-view (#597)

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -303,20 +303,23 @@ async def test_detail_hides_private_fields_from_strangers(
     assert "<dt>Verified</dt>" not in body
 
 
-async def test_detail_shows_private_fields_to_self(
+async def test_detail_shows_email_but_hides_admin_fields_for_self(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
     """The user viewing their own profile (via /users/me or
-    /users/<own-id>) sees their email, active, and verified rows."""
+    /users/<own-id>) sees their email but NOT the Active or Verified
+    rows — those are admin signals (#597). Admins viewing someone
+    else still see all three (see
+    ``test_detail_shows_private_fields_to_admin``)."""
     response = await authenticated_client.get("/users/me")
 
     assert response.status_code == 200
     body = response.text
     assert logged_in_user.email in body
     assert "<dt>Email</dt>" in body
-    assert "<dt>Active</dt>" in body
-    assert "<dt>Verified</dt>" in body
+    assert "<dt>Active</dt>" not in body
+    assert "<dt>Verified</dt>" not in body
 
 
 async def test_detail_shows_private_fields_to_admin(

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -34,13 +34,22 @@
      `can_view_private`, computed in handle_get_user_detail as
      `is_self OR is_admin(viewer)`. The handler also omits these
      fields from the `target_user` projection for non-authorized
-     viewers, so a forgotten guard here cannot re-leak. #}
+     viewers, so a forgotten guard here cannot re-leak.
+
+     The Active and Verified rows are admin signals — they make
+     sense to an admin auditing someone else's account, not to the
+     user themselves (#597). Hide them on the self-view; an admin
+     viewing another user still sees both. Email stays for self
+     since users routinely glance at it to confirm which account
+     they're signed in as. #}
   {% if can_view_private %}
   <section class="entity-facts">
     <dl>
       <div><dt>Email</dt><dd>{{ target_user.email }}</dd></div>
+      {% if not is_self %}
       <div><dt>Active</dt><dd>{{ "Yes" if target_user.is_active else "No" }}</dd></div>
       <div><dt>Verified</dt><dd>{{ "Yes" if target_user.is_verified else "No" }}</dd></div>
+      {% endif %}
     </dl>
   </section>
   {% endif %}


### PR DESCRIPTION
## Summary
- /users/me no longer renders Active or Verified rows — they were admin signals that didn't help the user viewing their own profile.
- Admin viewing someone else's profile still sees all three fields.
- Email row stays for self-view.

Closes #597

## Test plan
- [x] \`test_detail_shows_email_but_hides_admin_fields_for_self\` (renamed from prior test) updated.
- [x] \`dev test\` 1447 passed.
- [x] \`dev lint\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)