### PR TITLE
fix(ui): structured chooser on /posts/form post-kind picker (#582)

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -1728,17 +1728,43 @@ async def test_get_post_form_no_kind_renders_picker(
 ):
     """`GET /posts/form` without a `kind` query parameter renders the
     kind picker (`posts/form_new.html`) — not a kind-specific create
-    form. The picker has one link per kind round-tripping back with
-    `?kind=…`."""
+    form. The picker is a `.kind-picker` chooser with one option card
+    per kind: each card is an `<a class="kind-picker-option">`
+    carrying a Lucide icon, a title, and a 1-line description, and
+    its href round-trips back to `/posts/form?kind=…`."""
     response = await authenticated_client.get("/posts/form")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     # No `<input name="kind">` — that lives on the kind-specific forms,
     # not the picker.
     assert tree.css_first('input[name="kind"]') is None
-    # Each registered kind has a link on the picker.
-    assert tree.css_first('a[href="/posts/form?kind=referral"]') is not None
-    assert tree.css_first('a[href="/posts/form?kind=opening"]') is not None
+    # The chooser wrapper is the new `kind-picker` class — pin it so
+    # any future rewrite has to update this test deliberately.
+    assert tree.css_first(".kind-picker") is not None
+    # Each registered kind has an option card with the kind-specific
+    # accent (`data-kind`), title, and description.
+    referral_option = tree.css_first(
+        'a.kind-picker-option[data-kind="referral"][href="/posts/form?kind=referral"]'
+    )
+    assert referral_option is not None
+    assert referral_option.css_first(".kind-picker-icon") is not None
+    assert "Refer a client to a provider" in referral_option.text()
+    assert "needs care" in referral_option.text()
+
+    opening_option = tree.css_first(
+        'a.kind-picker-option[data-kind="opening"][href="/posts/form?kind=opening"]'
+    )
+    assert opening_option is not None
+    assert "Announce availability for new clients" in opening_option.text()
+    assert "open slots" in opening_option.text()
+
+    program_option = tree.css_first(
+        'a.kind-picker-option[data-kind="program_availability"]'
+        '[href="/posts/form?kind=program_availability"]'
+    )
+    assert program_option is not None
+    assert "Announce program intake" in program_option.text()
+    assert "cohort" in program_option.text()
 
 
 async def test_get_post_form_treats_empty_kind_as_absent(

--- a/src/domain/templates/posts/README.md
+++ b/src/domain/templates/posts/README.md
@@ -2,6 +2,10 @@
 
 Polymorphic intake (`referral` / `opening` / `program_availability`) — pages extend `base.html` directly because the kind-picker and the per-kind forms don't fit the resource grammar's single-form-page shape.
 
+## Kind picker
+
+`form_new.html` renders `GET /posts/form` (no `?kind=`) as a `.kind-picker` chooser — one `<a class="kind-picker-option" data-kind="…">` per registered kind, each with a Lucide icon + title + 1-line description, round-tripping back to the same route with `?kind=…`. Adding a kind means adding another option block here, and extending the `[data-kind="…"]` border rule in [`../../../framework/templates/base.html`](../../../framework/templates/base.html) if the new kind needs its own accent color. The chooser shares the `--form-max-width` envelope with the per-kind forms it routes to.
+
 ## Two-layer per-kind forms
 
 Each kind ships a pair: a `_<kind>_form.html` macro `(hx_method, action, submit_label, post=None)` that renders the full intake form (shared field macros from [`../../../framework/templates/_shared/form_fields.html`](../../../framework/templates/_shared/form_fields.html)), and a thin `new_<kind>.html` / `edit_<kind>.html` wrapper that calls the macro with the right method/action. Adding a kind = add the macro + two wrappers and register their paths on the kind's `PostKindSpec` in [`../../models/posts/post_kinds.py`](../../models/posts/post_kinds.py); the route layer reads `spec.create_template` / `spec.edit_template`.

--- a/src/domain/templates/posts/form_new.html
+++ b/src/domain/templates/posts/form_new.html
@@ -4,16 +4,47 @@
 
 {% block resource_label %}Posts{% endblock %}
 
-{# Kind-picker for `GET /posts/form` (no `?kind=`). Each option is a
-   stand-alone `<a role="button">` describing the post the user is
-   about to create — the button label is the entire prompt, no
-   surrounding heading or explainer copy. Wrapping each button in a
-   `<p>` stacks them vertically and gives them Pico-default block
-   spacing for free. Each link round-trips back to this route with
-   `?kind=…`, which the handler routes to the kind-specific create
-   form. Two kinds today; add another `<p><a>…</a></p>` per kind. #}
+{# Kind-picker for `GET /posts/form` (no `?kind=`). The page is a
+   chooser: one option card per registered post kind. Each card is a
+   single `<a class="kind-picker-option" data-kind="…">` whose href
+   round-trips back to this route with `?kind=…`, which the handler
+   then routes to the kind-specific create form. The card body is a
+   Lucide icon + title + 1-line description; the title is the verb
+   phrase from the bare-button era (so the call-to-action reads the
+   same), the description is a one-line "when would I pick this?"
+   hint. Adding a kind = add another `<a class="kind-picker-option">`
+   block here AND extend the `data-kind` border rule in
+   `framework/templates/base.html` if the kind needs a distinct
+   accent color. #}
+{# Per-`<li>` `title-case-ignore` markers sit on each title's source
+   line because the title-case linter walks deep text on the
+   surrounding `<a>`/`<li>` and concatenates the two `<span>`s (title
+   + description) into one logical sentence, then flags the
+   description's leading capital as a mid-sentence break. The two
+   spans are semantically distinct prose, not one sentence, so the
+   per-line escape hatch is the right tool. #}
 {% block content %}
-<p><a href="{{ entity_form_url('post') }}?kind=referral" role="button">Refer a client to a provider</a></p>
-<p><a href="{{ entity_form_url('post') }}?kind=opening" role="button">Announce availability for new clients</a></p>
-<p><a href="{{ entity_form_url('post') }}?kind=program_availability" role="button">Announce program intake</a></p>
+<ul class="kind-picker" role="list">
+  <li>
+    <a class="kind-picker-option" data-kind="referral" href="{{ entity_form_url('post') }}?kind=referral">
+      <i class="icon-corner-down-right kind-picker-icon" aria-hidden="true"></i>
+      <span class="kind-picker-title">Refer a client to a provider</span> {# title-case-ignore: title + description are two separate prose spans #}
+      <span class="kind-picker-description">You have a client who needs care and you're looking to hand them off.</span>
+    </a>
+  </li>
+  <li>
+    <a class="kind-picker-option" data-kind="opening" href="{{ entity_form_url('post') }}?kind=opening">
+      <i class="icon-door-open kind-picker-icon" aria-hidden="true"></i>
+      <span class="kind-picker-title">Announce availability for new clients</span>
+      <span class="kind-picker-description">You're a provider with open slots and want referrals to come to you.</span>
+    </a>
+  </li>
+  <li>
+    <a class="kind-picker-option" data-kind="program_availability" href="{{ entity_form_url('post') }}?kind=program_availability">
+      <i class="icon-calendar-clock kind-picker-icon" aria-hidden="true"></i>
+      <span class="kind-picker-title">Announce program intake</span> {# title-case-ignore: title + description are two separate prose spans #}
+      <span class="kind-picker-description">A program is opening intake or has cohort spots — broadcast the window.</span>
+    </a>
+  </li>
+</ul>
 {% endblock %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -333,6 +333,69 @@
         .form-actions { flex-direction: column; align-items: stretch; }
         .form-actions > .form-actions-destructive { margin-left: 0; }
       }
+      /* Kind-picker chooser — used by `posts/form_new.html` (the
+         `/posts/form` page when the request omits `?kind=`). Each
+         `<a class="kind-picker-option">` is a full-bleed card the user
+         clicks to enter the kind-specific create form: Lucide icon on
+         the left, two-line text stack (title + 1-line description) on
+         the right. The `data-kind` attribute mirrors the convention
+         used on `.entity-card` so the kind palette stays consistent
+         across post surfaces. Pico styles `<a>` as inline text; the
+         rules here promote each option to a block-level card with
+         border, padding, and a hover/focus accent. The cap reuses
+         `--form-max-width` so the chooser shares the page-width
+         envelope with the per-kind create forms it routes to. */
+      .kind-picker {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        max-width: var(--form-max-width);
+      }
+      .kind-picker-option {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        grid-template-rows: auto auto;
+        column-gap: 1rem;
+        align-items: center;
+        padding: 1rem;
+        border: var(--pico-border-width) solid var(--pico-muted-border-color);
+        border-left: 4px solid var(--pico-muted-border-color);
+        border-radius: var(--pico-border-radius);
+        background: var(--pico-card-background-color);
+        color: inherit;
+        text-decoration: none;
+      }
+      .kind-picker-option[data-kind="referral"] { border-left-color: darkorange; }
+      .kind-picker-option[data-kind="opening"] { border-left-color: darkcyan; }
+      .kind-picker-option[data-kind="program_availability"] { border-left-color: darkcyan; }
+      .kind-picker-option:is(:hover, :focus-visible) {
+        border-color: var(--pico-primary);
+        background: var(--pico-card-sectioning-background-color);
+        text-decoration: none;
+      }
+      .kind-picker-icon {
+        grid-row: 1 / span 2;
+        grid-column: 1;
+        font-size: 1.75rem;
+        margin-inline-end: 0;
+        color: var(--pico-primary);
+      }
+      .kind-picker-title {
+        grid-row: 1;
+        grid-column: 2;
+        font-weight: 600;
+        font-size: 1.05rem;
+      }
+      .kind-picker-description {
+        grid-row: 2;
+        grid-column: 2;
+        color: var(--pico-muted-color);
+        font-size: 0.9rem;
+        line-height: 1.35;
+      }
       /* Destructive button style. Pico v2 ships primary (filled blue),
          `.secondary`, `.contrast`, and the `.outline` modifier, but no
          destructive-action color — every Delete in the app picked a


### PR DESCRIPTION
## Summary
- Replaces the bare 3-button stack on `/posts/form` with a `.kind-picker` chooser: one option card per registered post kind (Refer / Announce availability / Announce program intake), each with a Lucide icon, verb-phrase title, and 1-line description.
- Each option carries `data-kind="..."` so the same orange/teal left-edge palette used on `.entity-card` carries over to the chooser — the kind identity is consistent from picker -> create form -> list -> detail.
- Picker shares `--form-max-width` with the per-kind create forms it routes to so the page-width envelope is consistent across the create flow.

Closes #582

## Test plan
- [x] `dev test src/domain/routes/test_posts.py::test_get_post_form_no_kind_renders_picker` — pins the wrapper class, each option's `data-kind` + href, title text, and description fragment.
- [x] `dev test` — full suite (1446 passed, 80 skipped).
- [x] `dev lint` — all checks passing (per-line `title-case-ignore` markers explain why on each title source line).
- [ ] Manual sanity at `/posts/form` at 375/768/1440 viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)