### PR TITLE
fix(ui): consistent active-tab state in global nav (#589)

### DIFF
--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -65,6 +65,8 @@ Every page extending `base.html` lands the same three-strip chrome above its con
 
 **Primary nav** lives in `base.html` and renders on every screen (authed *and* anonymous). The left-side slot carries the brand link plus (when authed) section shortcuts: Referrals (`/posts?kind=referral`), Openings (`/posts?kind=opening`), Directory (`/providers`). The right-side slot (`#primary-nav`) swaps the profile icon for a Login link depending on `is_authenticated`. Active state is matched against `request.url.path` plus `request.query_params['kind']` for the kind-partitioned Posts links. Pages don't extend it.
 
+The active tab carries `aria-current="page"` plus `class="contrast"`, and `base.html` styles `nav[aria-label="Primary"] a[aria-current="page"]` with a bottom underline + font-weight bump so the section reads at a glance — Pico's default `aria-current` tint alone was too subtle (#589). The rule scopes to the primary nav so breadcrumb / pagination links that also set `aria-current` keep their lighter treatment. Bare `/posts` and post detail / form URLs intentionally don't light any section tab — the canonical Referrals/Openings URLs are the filtered `/posts?kind=…` pages, and an unfiltered list is ambiguous between the two. `test_views.py` pins the URL → active-tab mapping.
+
 **Breadcrumb zone bar** (`{% block breadcrumb %}`, macro in `_shared/_breadcrumb.html`) renders Pico's native breadcrumb above the toolbar. Every authenticated page extends the block — chrome consistency is the goal. The shape follows the resource hierarchy `list > detail > edit/new`, each level appending one segment:
 
 | Page type        | URL example                    | Breadcrumb                            |

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -532,6 +532,23 @@
         max-width: 28rem;
         margin-inline: auto;
       }
+      /* Primary-nav active tab. Pico styles `aria-current="page"` only
+         subtly (a faint background tint); on a horizontal nav the cue
+         is easy to miss, and the issue audit (#589) flagged the
+         inconsistency. The rule below targets links carrying
+         `aria-current="page"` inside the `<nav aria-label="Primary">`
+         strip and adds a thicker bottom border + weight bump so the
+         active section reads at a glance on every page. Scoped to
+         the primary nav so breadcrumb / pagination links that also
+         set `aria-current` (single-segment trail, current page in
+         pager) keep their lighter treatment. */
+      nav[aria-label="Primary"] a[aria-current="page"] {
+        font-weight: 600;
+        border-bottom: 2px solid currentColor;
+        /* Compensate for the border so the text baseline doesn't
+           jump between active and inactive tabs. */
+        padding-bottom: calc(var(--pico-nav-link-spacing-vertical, 0.5rem) - 2px);
+      }
     </style>
     <script
       src="https://unpkg.com/htmx.org@2.0.4"

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -539,15 +539,43 @@ class _RequestStub:
     query_params: dict[str, str] = {}
 
 
-def _request_stub() -> _RequestStub:
-    return _RequestStub()
-
-
-def _request_stub_at(path: str) -> _RequestStub:
+def _request_stub(path: str = "/", query: dict[str, str] | None = None) -> _RequestStub:
     stub = _RequestStub()
     stub.url = _RequestStub._Url()
     stub.url.path = path
+    stub.query_params = query or {}
     return stub
+
+
+def _render_chrome(path: str, query: dict[str, str] | None = None) -> str:
+    """Render the primary-nav chrome from `base.html` (via any view-type
+    template) at a given URL + query string. Authenticated path — the
+    section shortcuts are gated on `is_authenticated`."""
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Stub{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+    return env.get_template("stub.html").render(
+        request=_request_stub(path=path, query=query),
+        is_authenticated=True,
+        is_development=False,
+    )
+
+
+def _active_tab_labels(html: str) -> list[str]:
+    """Extract the link text of every primary-nav anchor carrying
+    `aria-current="page"`. Returns labels (e.g. ``["Directory"]``) so
+    assertions read naturally."""
+    tree = HTMLParser(html)
+    nav = tree.css_first('nav[aria-label="Primary"]')
+    assert nav is not None, "primary nav missing"
+    return [a.text(strip=True) for a in nav.css("a[aria-current='page']")]
 
 
 def test_login_link_color_is_consistent_across_auth_pages() -> None:
@@ -556,7 +584,12 @@ def test_login_link_color_is_consistent_across_auth_pages() -> None:
     link black) while the same link on `/auth/register` and
     `/auth/forgot-password` rendered blue. Drop the contrast class so
     the link's color stays the same color anywhere it's still rendered
-    (orthogonal to #591 which may hide the link entirely)."""
+    (orthogonal to #591 which may hide the link entirely).
+
+    Anonymous path — the primary-nav active-state logic (#618) adds
+    `class="contrast"` to authenticated nav links, but the Login link
+    in the top-right zone is anonymous-only, so the two rules don't
+    cross."""
     env = _make_env()
     _add_child(
         env,
@@ -569,7 +602,7 @@ def test_login_link_color_is_consistent_across_auth_pages() -> None:
     )
     for path in ("/auth/login", "/auth/register", "/auth/forgot-password"):
         html = env.get_template("stub.html").render(
-            request=_request_stub_at(path),
+            request=_request_stub(path=path),
             is_authenticated=False,
             is_development=False,
         )
@@ -582,3 +615,58 @@ def test_login_link_color_is_consistent_across_auth_pages() -> None:
             assert (
                 "contrast" not in classes
             ), f"on {path}, Login link must not use `class='contrast'`: got {classes!r}"
+
+
+def test_primary_nav_directory_active_on_providers_list() -> None:
+    """`/providers` is the canonical Directory URL — its tab is active."""
+    assert _active_tab_labels(_render_chrome("/providers")) == ["Directory"]
+
+
+def test_primary_nav_directory_active_on_provider_detail() -> None:
+    """Subpaths under `/providers` (detail, edit) keep Directory lit so
+    the chrome stays consistent through the full provider drill-down."""
+    assert _active_tab_labels(_render_chrome("/providers/42")) == ["Directory"]
+    assert _active_tab_labels(_render_chrome("/providers/42/form")) == ["Directory"]
+
+
+def test_primary_nav_referrals_active_on_posts_kind_referral() -> None:
+    """`/posts?kind=referral` is the canonical Referrals URL."""
+    assert _active_tab_labels(_render_chrome("/posts", query={"kind": "referral"})) == [
+        "Referrals"
+    ]
+
+
+def test_primary_nav_openings_active_on_posts_kind_opening() -> None:
+    """`/posts?kind=opening` is the canonical Openings URL."""
+    assert _active_tab_labels(_render_chrome("/posts", query={"kind": "opening"})) == [
+        "Openings"
+    ]
+
+
+def test_primary_nav_no_section_tab_on_bare_posts_list() -> None:
+    """Bare `/posts` (no `?kind=`) is ambiguous between Referrals and
+    Openings — neither tab claims it. The toolbar/list-page content
+    carries the context instead."""
+    assert _active_tab_labels(_render_chrome("/posts")) == []
+
+
+def test_primary_nav_no_section_tab_on_post_detail() -> None:
+    """Post detail URLs (`/posts/<id>`) drop the `?kind=` query param,
+    so the section tabs intentionally don't light up — the post's own
+    breadcrumb carries the context instead. Keeps the rule simple:
+    only the canonical filtered list lights a section tab."""
+    assert _active_tab_labels(_render_chrome("/posts/42")) == []
+
+
+def test_primary_nav_active_link_carries_strong_style_hook() -> None:
+    """The active link adds `class="contrast"` so the Pico color cue
+    fires alongside the CSS rule that thickens the underline. Pinning
+    both attributes ensures a future refactor that drops one notices
+    the other."""
+    html = _render_chrome("/providers")
+    tree = HTMLParser(html)
+    nav = tree.css_first('nav[aria-label="Primary"]')
+    assert nav is not None
+    active = nav.css_first("a[aria-current='page']")
+    assert active is not None
+    assert "contrast" in (active.attributes.get("class") or "")


### PR DESCRIPTION
## Summary

Closes #589.

- Strengthen the primary-nav active-tab style. Pico's default `aria-current="page"` tint was too subtle on a horizontal nav — adds a thicker bottom underline + font-weight bump, scoped to `nav[aria-label="Primary"]` so breadcrumb / pagination links that also set `aria-current` keep their lighter treatment.
- Pin the URL → active-tab mapping in `src/framework/templates/test_views.py` (`/providers` → Directory, `/providers/42` → Directory, `/posts?kind=referral` → Referrals, `/posts?kind=opening` → Openings, bare `/posts` and `/posts/42` → no tab). The matching logic in `base.html` already implemented this; the tests pin it.
- Document the styling rule and the "bare `/posts` lights no tab" decision in `src/framework/templates/README.md`.

## URL → tab mapping

- Referrals = `/posts?kind=referral` (canonical filtered list, already filterable via `ChoiceFilter` on the `Post` spec)
- Openings = `/posts?kind=opening`
- Directory = `/providers`

Bare `/posts` (no filter) is ambiguous between Referrals and Openings, so no section tab claims it — list page content carries the context instead. Post detail / form URLs likewise don't light a tab; the post's breadcrumb is the location cue.

## Test plan
- [x] `dev test src/framework/templates/test_views.py` — 13 passed (7 new, 6 pre-existing)
- [x] `dev lint` — all checks pass
- [x] `dev test` — 1448 passed, 1 failed (`scripts/dev/test_migrate.py::test_roundtrip_default_scratch`, unrelated sqlite-readonly-db flake)
- [ ] Manual smoke: visit `/providers`, `/providers/<id>`, `/posts?kind=referral`, `/posts?kind=opening`, `/posts` and confirm the underline + weight cue is visible on the active tab in both light and dark color schemes