### PR TITLE
fix(ui): 2-column entity-facts layout on wide viewports (#586)

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -166,10 +166,31 @@
          use the 2-column `.entity-grid` wrapper (org, program, user,
          provider). Without this, the icon-only `<dt>` in
          `<div class="entity-location">` falls back to block layout
-         and renders on its own line above the value. */
+         and renders on its own line above the value.
+
+         The `<dl>` itself is a CSS grid so the per-fact `<div>`s
+         flow into two columns on tablet/desktop and reflow to a
+         single column on narrow viewports (#586 — the detail page
+         was wasting 60–70% of horizontal space because each fact's
+         `<div>` was a block-level row that filled the card width).
+         Scoped to `.entity-card > section.entity-facts > dl` (direct
+         child of the card) so the 2-column grid only applies to the
+         single-section detail pages (org, program, user, provider).
+         Posts detail wraps its `entity-facts` inside `.entity-grid`,
+         which is already a 2-column layout — letting the inner `<dl>`
+         re-split would create a sub-grid inside the right column.
+         `auto-fit, minmax(...)` is the responsive idiom: the columns
+         expand to fill the card on wide viewports and collapse to one
+         column as the available width drops below the min track size. */
       .entity-card section.entity-facts > dl {
         margin: 0;
         padding: 0;
+      }
+      .entity-card > section.entity-facts > dl {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+        column-gap: 1.5rem;
+        row-gap: 0.1rem;
       }
       .entity-card section.entity-facts > dl > div {
         padding: 0.1rem 0;

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -234,6 +234,55 @@ def test_entity_card_header_wraps_on_narrow_viewports() -> None:
     ), "entity-header must set `flex-wrap: wrap` to avoid #577 clipping"
 
 
+def test_entity_facts_dl_is_two_column_grid_on_single_section_detail() -> None:
+    """Regression for #586 — the demographics `<dl>` on single-section
+    detail pages (org, program, user, provider) was rendering as a
+    single block-stacked column, leaving 60–70% of the card's horizontal
+    space empty. The grid rule must apply only when `<section
+    class="entity-facts">` is a *direct child* of `.entity-card` — when
+    it's nested inside `.entity-grid` (posts detail), the outer 2-column
+    grid already splits the body and a second inner split would create
+    a sub-grid inside the right column."""
+    import re
+
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Providers{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+    )
+
+    # Match the direct-child grid rule. `>` between `.entity-card` and
+    # `section.entity-facts` is load-bearing — the looser descendant
+    # selector would also catch posts/detail.html where the `.dl` lives
+    # inside `.entity-grid`.
+    match = re.search(
+        r"\.entity-card\s*>\s*section\.entity-facts\s*>\s*dl\s*\{[^}]*\}",
+        html,
+    )
+    assert (
+        match is not None
+    ), "missing `.entity-card > section.entity-facts > dl` grid rule (#586)"
+    rule = match.group(0)
+    assert "display: grid" in rule, "entity-facts dl must use CSS grid (#586)"
+    assert (
+        "auto-fit" in rule
+    ), "entity-facts dl must use auto-fit so columns collapse on narrow viewports (#586)"
+    assert (
+        "minmax(" in rule
+    ), "entity-facts dl must use minmax(...) so each column has a min track size (#586)"
+
+
 def test_index_table_rows_stack_on_narrow_viewports() -> None:
     """Regression for #578 — every `index_table` row whose `<td>` cells
     carry `data-label` must stack into "Label: value" lines on ≤640px


### PR DESCRIPTION
Closes #586

## Summary
- The demographics `<dl>` on single-section detail pages (`/users/me`, `/organizations/{id}`, `/providers/{id}`, `/programs/{id}`) rendered as a single block-stacked column, leaving 60–70% of the card's horizontal space empty.
- Make `.entity-card > section.entity-facts > dl` a CSS grid with `repeat(auto-fit, minmax(18rem, 1fr))` so facts flow into two columns on tablet/desktop and reflow to one column on narrow viewports — no explicit `@media` breakpoint needed, the track size drives the collapse.
- Scope with `>` (direct child of `.entity-card`) so the rule does not also re-split the posts detail page's `entity-facts`, which already lives inside the `.entity-grid` 2-column wrapper — re-splitting there would produce a sub-grid inside the right column.

## Test plan
- [x] `dev test` passes (1448 passed)
- [x] `dev lint` passes
- [x] New regression test `test_entity_facts_dl_is_two_column_grid_on_single_section_detail` pins the direct-child grid selector and the `auto-fit` / `minmax` shape so future selector drift fails the build.
- [ ] Manual visual check at 375 / 768 / 1440 px on `/users/me`, `/organizations/{id}`, `/providers/{id}`, `/programs/{id}` (single column on mobile, two columns on tablet/desktop).
- [ ] Manual visual check on `/posts/{id}` (posts detail) — already inside `.entity-grid`, should be unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)