### PR TITLE
fix(buttons): standardize search Clear on .secondary.outline (#599)

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -1292,6 +1292,19 @@ async def test_search_page_renders_one_control_per_filter(
         "opening",
         "program_availability",
     }
+    # Regression for #599 — the search-form Clear link must use the
+    # outline variant so it shares the rest of the app's secondary
+    # button vocabulary (Cancel, Filters, Edit). Pico's filled
+    # `.secondary` (dark-gray) was a third button style with no
+    # other callers.
+    clear_links = [
+        a for a in form.css("a[role='button']") if a.text().strip() == "Clear"
+    ]
+    assert len(clear_links) == 1, "search form must render one Clear link"
+    clear_class = (clear_links[0].attributes.get("class") or "").split()
+    assert (
+        "secondary" in clear_class and "outline" in clear_class
+    ), f"Clear link must use `secondary outline`, got {clear_class!r}"
 
 
 async def test_toolbar_inline_active_filter_summary_collapses_beyond_two(

--- a/src/framework/templates/views/search.html
+++ b/src/framework/templates/views/search.html
@@ -37,7 +37,11 @@ the spec.
 
   <menu>
     <li><button type="submit">Apply</button></li>
-    <li><a href="{{ list_action }}" role="button" class="secondary">Clear</a></li>
+    {# Use the outline variant so Clear matches the rest of the
+       app's secondary-action vocabulary (Cancel, Filters, Edit,
+       Unfavorite) — Pico's filled `.secondary` was a third button
+       style with no other callers (#599). #}
+    <li><a href="{{ list_action }}" role="button" class="secondary outline">Clear</a></li>
   </menu>
 
 </form>


### PR DESCRIPTION
## Summary
- Switch \`views/search.html\` Clear link to \`class="secondary outline"\` so it shares the rest of the app's secondary-button vocabulary.
- After #579 (\`.danger\` for Delete) and this PR, the app uses exactly three button styles: primary (Pico default filled), \`.secondary.outline\` (neutral), and \`.danger\` (destructive).

Closes #599

## Test plan
- [x] Regression assertion added to \`test_search_page_renders_one_control_per_filter\`.
- [x] \`dev test\` 1448 passed.
- [x] \`dev lint\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)