### PR TITLE
fix(ui): unify secondary button styles into a 4-role vocabulary (#599)

### DIFF
--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -7,7 +7,7 @@
 
 {% block actions %}
 {% if can_edit %}
-<li><a href="{{ entity_form_url('organization', id=organization.id) }}" role="button" class="outline">Edit organization</a></li>
+<li><a href="{{ entity_form_url('organization', id=organization.id) }}" role="button" class="secondary outline">Edit organization</a></li>
 {% endif %}
 {% endblock %}
 

--- a/src/domain/templates/posts/_owner_actions.html
+++ b/src/domain/templates/posts/_owner_actions.html
@@ -17,6 +17,6 @@
 #}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
 {% if can_edit %}
-<li><a href="{{ entity_form_url('post', id=post.id) }}" role="button" class="outline">Edit</a></li>
+<li><a href="{{ entity_form_url('post', id=post.id) }}" role="button" class="secondary outline">Edit</a></li>
 <li>{{ confirm_delete_button(entity_url('post', id=post.id), "Permanently delete this post? This cannot be undone.") }}</li>
 {% endif %}

--- a/src/domain/templates/programs/detail.html
+++ b/src/domain/templates/programs/detail.html
@@ -7,7 +7,7 @@
 
 {% block actions %}
 {% if can_edit %}
-<li><a href="{{ entity_form_url('program', id=program.id) }}" role="button" class="outline">Edit program</a></li>
+<li><a href="{{ entity_form_url('program', id=program.id) }}" role="button" class="secondary outline">Edit program</a></li>
 {% endif %}
 {% endblock %}
 

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -27,14 +27,14 @@
   </button></li>
   {% else %}
   <li><button type="button"
-          class="outline"
+          class="secondary outline"
           hx-post="{{ entity_url('user_favorite', id=provider.id) }}">
     Favorite
   </button></li>
   {% endif %}
 {% endif %}
 {% if can_edit %}
-<li><a href="{{ entity_form_url('provider', id=provider.id) }}" role="button" class="outline">Edit provider</a></li>
+<li><a href="{{ entity_form_url('provider', id=provider.id) }}" role="button" class="secondary outline">Edit provider</a></li>
 <li>{{ confirm_delete_button(entity_url('provider', id=provider.id), "Permanently delete this provider? Credentials attached to it will be removed too. This cannot be undone.") }}</li>
 {% endif %}
 {% endblock %}

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -14,7 +14,7 @@
    actions partial appends Deactivate / Delete after this when the
    viewer is an admin looking at someone else. #}
 {% if is_self %}
-<li><a href="{{ entity_url('user_favorite') }}" role="button" class="outline">Favorites</a></li>
+<li><a href="{{ entity_url('user_favorite') }}" role="button" class="secondary outline">Favorites</a></li>
 {% endif %}
 {% include "users/_admin_actions.html" %}
 {% endblock %}
@@ -74,7 +74,7 @@
      a user sees on the profile preview, without an extra click. #}
   {% if is_self %}
   <footer class="entity-footer">
-    <a href="{{ entity_form_url('provider') }}" role="button" class="outline">Create provider</a>
+    <a href="{{ entity_form_url('provider') }}" role="button">Create provider</a>
   </footer>
   {% endif %}
 </article>

--- a/src/domain/templates/users/providers_list.html
+++ b/src/domain/templates/users/providers_list.html
@@ -17,7 +17,7 @@
 
 {% block actions %}
 {% if is_self %}
-<li><a href="{{ entity_form_url('provider') }}" role="button" class="outline">Create provider</a></li>
+<li><a href="{{ entity_form_url('provider') }}" role="button">Create provider</a></li>
 {% endif %}
 {% endblock %}
 

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -85,6 +85,19 @@ Inline / subresource actions inside the page body (per-row delete buttons on `pr
 
 Edit forms keep a bottom `<a class="secondary outline">Cancel</a>` pointing at the resource's detail page — a deliberate "abandon this edit" affordance.
 
+### Button role vocabulary
+
+Every button or `<a role="button">` in the app picks one of four roles. The role is encoded by the CSS class on the element; the four styles are defined in [`base.html`](base.html) under the "Button role vocabulary" block.
+
+| Role        | Class                              | When to use                                                                                  |
+| ----------- | ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| Primary     | *(no class)*                       | The page's main CTA — Create, Save, Apply, Login, Register, kind-picker options.             |
+| Secondary   | `secondary outline`                | Every non-primary, non-destructive action — Cancel, Edit, Favorite/Unfavorite, Deactivate/Reactivate, Email, Favorites, inline "see related" links. |
+| Danger      | `danger` (or `danger outline`)     | Destructive actions — Delete on toolbar, Delete on form, Delete on inline subentity rows. See [`_shared/actions.html`](_shared/actions.html) and [`_shared/forms.html`](_shared/forms.html). |
+| Tertiary    | `tertiary`                         | Text-only inline reset/clear — the search page's Clear. Renders as a link with hover underline; no background, no border. |
+
+Pre-#599 the project carried three different "secondary" treatments — filled gray `.secondary`, blue-outlined bare `.outline`, and gray-outlined `.secondary outline` — for what was semantically the same role. The four-role vocabulary above replaces all three with `secondary outline`, and reserves `tertiary` for the one place a fourth visual weight is genuinely needed (Clear next to Apply in the search form).
+
 ## Partial convention
 
 Files prefixed with `_` (e.g. `_breadcrumb.html`, `_toolbar.html`, `_provider_row.html`) are partials, `{% include %}`d from full pages — never rendered directly by routes. A partial documents its required context in a `{# ... #}` comment at the top and guards visibility on a single named flag (`{% if can_edit %}`). The handler computes the flag using [`../authz.py`](../authz.py) predicates; partials never introspect `current_user` to decide visibility. Backend authorization is enforced separately in the logic layer — the template guard is presentation only.

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -371,16 +371,33 @@
         .form-actions { flex-direction: column; align-items: stretch; }
         .form-actions > .form-actions-destructive { margin-left: 0; }
       }
-      /* Destructive button style. Pico v2 ships primary (filled blue),
-         `.secondary`, `.contrast`, and the `.outline` modifier, but no
-         destructive-action color — every Delete in the app picked a
-         different style (primary blue, contrast black, secondary
-         outline) and read as the page's main CTA at the same visual
-         weight as Save/Create (#579). `.danger` is the single canonical
-         destructive class: filled red by default, red-outlined under
-         `.outline` for inline subentity deletes (credential rows) so
-         the row's main affordance doesn't shout. Reuses Pico's red
-         tokens so the color tracks the theme. */
+      /* Button role vocabulary. Pico v2 ships primary (filled blue),
+         `.secondary`, `.contrast`, and the `.outline` modifier, but the
+         project pre-#599 was using at least three different non-primary
+         treatments (filled gray `.secondary`, blue-outlined `.outline`,
+         gray-outlined `.secondary outline`) for what was semantically
+         the same "side action" role. The canonical four roles are:
+
+           * Primary — filled blue. Pico default `<button>` /
+             `<a role="button">` with no role class. Main page CTAs:
+             Create, Save, Apply, Login, Register.
+           * Secondary — `class="secondary outline"`. Single canonical
+             non-primary, non-destructive treatment. Used for Cancel,
+             Edit, Favorite/Unfavorite, Deactivate/Reactivate, Email,
+             and inline "see related" affordances.
+           * Danger — `class="danger"` (filled red) or
+             `class="danger outline"` (red-outlined, for inline
+             subentity deletes like credential rows). The single
+             canonical destructive class — closed by #579/#605.
+           * Tertiary — `class="tertiary"`. Text-only link-button for
+             inline reset/clear affordances (the search page's Clear)
+             where a third button at full button weight would compete
+             with Apply/Cancel. No background, no border; underline on
+             hover.
+
+         `.danger` reuses Pico's red tokens so the color tracks the
+         theme; `.tertiary` reuses the link/primary token so its color
+         tracks light/dark mode without per-mode overrides. */
       button.danger,
       [role="button"].danger,
       input[type="button"].danger,
@@ -406,6 +423,26 @@
         --pico-background-color: var(--pico-color-red-50);
         --pico-color: var(--pico-color-red-650);
         --pico-border-color: var(--pico-color-red-650);
+      }
+      /* Tertiary button — text-only link-button for inline reset /
+         clear affordances (the search page's Clear). Pico's `<button>`
+         baseline is filled, so this overrides the background, border,
+         and padding to render as a link with hover underline. Kept as a
+         button (vs an `<a>`) so callers don't have to switch tag when
+         the action toggles between a link target and a JS handler. */
+      button.tertiary,
+      [role="button"].tertiary {
+        --pico-background-color: transparent;
+        --pico-border-color: transparent;
+        --pico-color: var(--pico-primary);
+        padding-inline: 0;
+      }
+      button.tertiary:is(:hover, :active, :focus),
+      [role="button"].tertiary:is(:hover, :active, :focus) {
+        --pico-background-color: transparent;
+        --pico-border-color: transparent;
+        --pico-color: var(--pico-primary-hover);
+        text-decoration: underline;
       }
       /* Pico's `<fieldset>` carries a top margin that visually competes
          with the cap above — flatten the rhythm so siblings sit at a

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -425,6 +425,103 @@ def test_destructive_action_macros_emit_danger_class() -> None:
     ), "form_actions Delete button must emit class containing 'danger'"
 
 
+def test_form_actions_cancel_uses_secondary_outline() -> None:
+    """Regression for #599 — the canonical Cancel affordance on every
+    entity create/edit form must render with `class="secondary outline"`
+    (the project's single "secondary" role per the 4-role vocabulary in
+    `base.html` and the framework README). Without this pin, Cancel
+    could drift back to bare `.outline` (blue-outlined) and break
+    consistency with Cancel buttons elsewhere."""
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% from "_shared/forms.html" import form_actions %}
+        <div id="cluster">
+          {{ form_actions("Save", cancel_url="/orgs/1") }}
+        </div>
+        """,
+    )
+    html = env.get_template("stub.html").render()
+    tree = HTMLParser(html)
+    cancel = tree.css_first('#cluster a[role="button"]')
+    assert cancel is not None
+    classes = (cancel.attributes.get("class") or "").split()
+    assert "secondary" in classes and "outline" in classes, (
+        "form_actions Cancel must emit class='secondary outline' "
+        f"(got {cancel.attributes.get('class')!r})"
+    )
+
+
+def test_search_view_clear_uses_tertiary_class() -> None:
+    """Regression for #599 — Clear next to Apply on the search page must
+    render with `class="tertiary"` (text-only link-button). Pre-#599 it
+    used `class="secondary"` (filled gray), which read as a third
+    full-weight button competing with Apply."""
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/search.html" %}
+        {% block resource_label %}Posts{% endblock %}
+        """,
+    )
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+        list_action="/posts",
+        declared_filters=[],
+        filter_values={},
+    )
+    tree = HTMLParser(html)
+    clear = None
+    for a in tree.css('a[role="button"]'):
+        if (a.text() or "").strip() == "Clear":
+            clear = a
+            break
+    assert clear is not None, "search.html must render a Clear link-button"
+    classes = (clear.attributes.get("class") or "").split()
+    assert "tertiary" in classes, (
+        "Clear must emit class containing 'tertiary' "
+        f"(got {clear.attributes.get('class')!r})"
+    )
+
+
+def test_base_html_defines_tertiary_button_style() -> None:
+    """Regression for #599 — `.tertiary` button style must be defined in
+    base.html so `class="tertiary"` renders as a text-only link-button.
+    Without this rule the class is a no-op and Clear falls back to
+    Pico's filled primary."""
+    import re
+
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Posts{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+    )
+    match = re.search(
+        r"button\.tertiary,[^{]*\{[^}]*background-color:\s*transparent[^}]*\}",
+        html,
+        re.DOTALL,
+    )
+    assert (
+        match is not None
+    ), "base.html must define `button.tertiary` with transparent background"
+
+
 def test_base_html_defines_danger_button_style() -> None:
     """Regression for #579 — `.danger` button style must be defined in
     base.html with a red token. Without it, `class="danger"` falls back

--- a/src/framework/templates/views/search.html
+++ b/src/framework/templates/views/search.html
@@ -37,7 +37,7 @@ the spec.
 
   <menu>
     <li><button type="submit">Apply</button></li>
-    <li><a href="{{ list_action }}" role="button" class="secondary">Clear</a></li>
+    <li><a href="{{ list_action }}" role="button" class="tertiary">Clear</a></li>
   </menu>
 
 </form>


### PR DESCRIPTION
Closes #599.

## Summary

Pre-#599 the project carried three different visual treatments for what was semantically the same "non-primary" button role. This PR collapses every button to one of four canonical roles, defined in `src/framework/templates/base.html` and documented in `src/framework/templates/README.md`.

| Role        | Class                              | Used for                                                                                  |
| ----------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
| Primary     | *(no class)*                       | Main page CTAs — Create, Save, Apply, Login, Register.                                    |
| Secondary   | `secondary outline`                | Cancel, Edit, Favorite/Unfavorite, Deactivate/Reactivate, Email, Favorites, inline "see related" links. |
| Danger      | `danger` (or `danger outline`)     | Destructive actions. Already shipped via #605 (`.danger` token), unchanged here.          |
| Tertiary    | `tertiary` (new)                   | Text-only link-button for Clear on the search form.                                       |

## Mapping changes (per file)

- `programs/detail.html` Edit program: `outline` → `secondary outline`
- `providers/detail.html` Edit, Favorite: `outline` → `secondary outline`
- `posts/_owner_actions.html` Edit: `outline` → `secondary outline`
- `organizations/detail.html` Edit organization: `outline` → `secondary outline`
- `users/detail.html` Favorites: `outline` → `secondary outline`
- `users/detail.html` and `users/providers_list.html` Create provider: `outline` → primary (no class) so it matches the Create grammar everywhere else
- `views/search.html` Clear: `secondary` → `tertiary` (text-only link button)

## Notes on judgment calls

- **Clear → tertiary**, not secondary. The search form already has Apply (primary); a third full-weight button felt heavy. Tertiary text-link reads as "reset" without competing.
- **Create provider** on `users/detail.html` (inline footer) and `users/providers_list.html` is now primary. Other Create CTAs are primary, and the inline footer is the empty-state's main CTA, so this is the consistent pick.
- The filled-black Delete on the org edit form mentioned in the issue was already fixed by #605 (`form_actions` emits `class=\"danger\"`).

## Test plan

- [x] `dev test` passes (1451 passed, 80 skipped)
- [x] `dev lint` passes
- [x] New tests pin the canonical classes: Cancel on entity-form clusters (`secondary outline`), Clear on the search form (`tertiary`), and the `.tertiary` CSS definition (transparent background).
- [ ] Visual spot-check: render `/posts/{id}` (Edit/Delete in toolbar), `/providers/{id}` (Favorite + Edit + Delete), `/organizations/{id}/form` (Save/Cancel/Delete cluster), and `/posts/search` (Apply + Clear) to confirm the four roles read distinctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)