### PR TITLE
fix(ui): parent-org picker is now a <select>, not a UUID input (#581)

### DIFF
--- a/src/domain/logic/organizations/handlers.py
+++ b/src/domain/logic/organizations/handlers.py
@@ -1,0 +1,77 @@
+"""Per-spec hook callables for the `Organization` entity.
+
+One callable today:
+
+* :func:`organization_form_extras` — driven by
+  ``ORGANIZATION_ENTITY.form_extras_path``. Loads the requesting
+  user's visible Organizations into the form context so the
+  create / edit form can render a parent-Org picker (replaces the
+  free-text UUID input — see issue #581). Mirrors
+  :mod:`src.domain.logic.programs.handlers` and
+  :mod:`src.domain.logic.providers.handlers`: owners see only their
+  own Orgs; superusers see every Org.
+
+Edit-path: the Org being edited is excluded from the picker options
+so the form can't self-loop (an Org can't be its own parent). Deeper
+cycle prevention (a descendant being chosen as the parent) is not
+attempted here — the repository's ``_resolve_root_id`` would still
+succeed in that case; a follow-up could push a CHECK or a graph walk
+if the tree starts seeing real reparent traffic.
+
+No bespoke CRUD handlers: the framework's factory-built
+``handle_create`` / ``handle_update`` / etc. consume the hook via
+the spec's dotted-path declaration, so the route file stays a single
+``mount_entity`` call.
+"""
+
+import logging
+from typing import Any
+
+from src.domain.logic.organizations.repository import OrganizationRepository
+from src.domain.models import Organization, User
+
+logger = logging.getLogger(__name__)
+
+
+async def _orgs_visible_to(
+    org_repo: OrganizationRepository, user: User
+) -> list[Organization]:
+    """Return the Organizations a user may pick as a parent.
+
+    Owners see only the Orgs they own; superusers see every Org.
+    Mirrors ``_orgs_visible_to`` on the Provider and Program sides —
+    Org ownership is the boundary for who may pick an Org in form
+    pickers.
+    """
+    if user.is_superuser:
+        return list(
+            await org_repo.list_default(
+                Organization, order_by=Organization.created_at.desc()
+            )
+        )
+    return list(await org_repo.list_for_user(user.id))
+
+
+async def organization_form_extras(
+    *,
+    target: Organization | None,
+    requesting_user: User,
+    organization_repo: OrganizationRepository,
+    **_: Any,
+) -> dict[str, Any]:
+    """Per-viewer form extras for the create + edit Organization forms.
+
+    Drives the parent-Org picker (issue #581). The framework invokes
+    this on both paths:
+
+    * Create (``target=None``): all visible Orgs are picker options;
+      the template's default "(root — no parent)" option is selected.
+    * Edit (``target=<org row>``): the same visible-Org list, minus
+      the row being edited (prevents a self-loop on submit). The
+      template pre-selects the row's current ``parent_org_id`` if it
+      still appears in the options.
+    """
+    orgs = await _orgs_visible_to(organization_repo, requesting_user)
+    if target is not None:
+        orgs = [o for o in orgs if o.id != target.id]
+    return {"parent_org_options": orgs}

--- a/src/domain/logic/organizations/test_handlers.py
+++ b/src/domain/logic/organizations/test_handlers.py
@@ -1,0 +1,112 @@
+"""Tests for `Organization` per-spec hook callables.
+
+Pins :func:`organization_form_extras` — the parent-Org picker hook
+(issue #581):
+
+* Non-superuser sees only Orgs they own.
+* Superuser sees every Org.
+* Edit path excludes the row being edited (self-loop prevention).
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.logic.organizations.handlers import organization_form_extras
+from src.domain.logic.organizations.repository import OrganizationRepository
+from src.domain.models import Organization, User
+from tests.helpers import create_test_user, make_organization_row
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- Seeding helpers -----------------------------------------------------
+
+
+async def _seed_user(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    is_superuser: bool = False,
+) -> User:
+    user = create_test_user(username=f"u-{uuid.uuid4()}", is_superuser=is_superuser)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+    return user
+
+
+async def _seed_org(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    owner_id: uuid.UUID,
+    name: str,
+) -> uuid.UUID:
+    org = make_organization_row(owner_id=owner_id, name=name)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(org)
+    return org.id
+
+
+# --- organization_form_extras --------------------------------------------
+
+
+async def test_form_extras_owner_sees_only_owned_orgs(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Create path (target=None): non-superuser sees only Orgs they own."""
+    owner = await _seed_user(db_test_session_manager)
+    stranger = await _seed_user(db_test_session_manager)
+    owned_id = await _seed_org(db_test_session_manager, owner_id=owner.id, name="Mine")
+    await _seed_org(db_test_session_manager, owner_id=stranger.id, name="Other")
+
+    async with db_test_session_manager() as session:
+        org_repo = OrganizationRepository(session)
+        result = await organization_form_extras(
+            target=None, requesting_user=owner, organization_repo=org_repo
+        )
+        ids = [o.id for o in result["parent_org_options"]]
+        assert ids == [owned_id]
+
+
+async def test_form_extras_superuser_sees_all_orgs(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Superuser sees every Org regardless of owner."""
+    admin = await _seed_user(db_test_session_manager, is_superuser=True)
+    other = await _seed_user(db_test_session_manager)
+    await _seed_org(db_test_session_manager, owner_id=admin.id, name="Admin Org")
+    await _seed_org(db_test_session_manager, owner_id=other.id, name="Other Org")
+
+    async with db_test_session_manager() as session:
+        org_repo = OrganizationRepository(session)
+        result = await organization_form_extras(
+            target=None, requesting_user=admin, organization_repo=org_repo
+        )
+        names = {o.name for o in result["parent_org_options"]}
+        assert "Admin Org" in names
+        assert "Other Org" in names
+
+
+async def test_form_extras_edit_path_excludes_self(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Edit path: the row being edited is excluded from picker options
+    so the form can't pin a self-loop on submit (an Org as its own
+    parent)."""
+    owner = await _seed_user(db_test_session_manager)
+    self_id = await _seed_org(db_test_session_manager, owner_id=owner.id, name="Self")
+    sibling_id = await _seed_org(
+        db_test_session_manager, owner_id=owner.id, name="Sibling"
+    )
+
+    async with db_test_session_manager() as session:
+        org_repo = OrganizationRepository(session)
+        target = await org_repo.get_by_model_id(Organization, self_id)
+        result = await organization_form_extras(
+            target=target, requesting_user=owner, organization_repo=org_repo
+        )
+        ids = {o.id for o in result["parent_org_options"]}
+        assert self_id not in ids
+        assert sibling_id in ids

--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -9,11 +9,13 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
+from selectolax.parser import HTMLParser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.models import Organization, User
 from src.framework.audit.repository import AuditRepository
+from tests.helpers import create_test_user, make_organization_row
 
 pytestmark = pytest.mark.asyncio
 
@@ -189,6 +191,166 @@ async def test_get_organizations_form_resolves(
     audit lands."""
     response = await authenticated_client.get("/organizations/form")
     assert response.status_code == 200
+
+
+# --- Parent-Org picker (issue #581) --------------------------------------
+
+
+async def _seed_org(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    owner_id: uuid.UUID,
+    name: str = "Acme Health",
+) -> uuid.UUID:
+    org = make_organization_row(owner_id=owner_id, name=name)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(org)
+    return org.id
+
+
+async def test_form_new_renders_parent_org_select_with_root_option(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Pins the new picker structure from issue #581: a ``<select
+    name="parent_org_id">`` with a "(root — no parent)" default option
+    plus one ``<option>`` per Org visible to the requesting user.
+    """
+    mine_a = await _seed_org(
+        db_test_session_manager, owner_id=logged_in_user.id, name="Mine A"
+    )
+    mine_b = await _seed_org(
+        db_test_session_manager, owner_id=logged_in_user.id, name="Mine B"
+    )
+
+    response = await authenticated_client.get("/organizations/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    select = tree.css_first('select[name="parent_org_id"]')
+    assert select is not None, "parent-org picker should be a <select>"
+    options = select.css("option")
+    # Root option + one option per visible Org. selectolax surfaces
+    # `value=""` as ``None`` in the attribute dict, so we test the root
+    # option by position + the absence of a value.
+    assert len(options) == 3
+    assert options[0].attributes.get("value") is None
+    assert "selected" in options[0].attributes
+    assert "root" in options[0].text().lower()
+    values = {opt.attributes.get("value") for opt in options}
+    # `None` is the root option's value (empty-string attribute).
+    assert values == {None, str(mine_a), str(mine_b)}
+    # Free-text input from the prior UI is gone.
+    assert tree.css_first('input[name="parent_org_id"]') is None
+
+
+async def test_form_new_scopes_to_owned_orgs(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Non-superusers see only Orgs they own in the picker — same scope
+    as the Program/Provider form pickers (see ``_orgs_visible_to``)."""
+    mine = await _seed_org(
+        db_test_session_manager, owner_id=logged_in_user.id, name="Mine"
+    )
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+    other_org = await _seed_org(
+        db_test_session_manager, owner_id=other.id, name="Other's"
+    )
+
+    response = await authenticated_client.get("/organizations/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    values = {
+        opt.attributes.get("value")
+        for opt in tree.css('select[name="parent_org_id"] option')
+    }
+    assert str(mine) in values
+    assert str(other_org) not in values
+
+
+async def test_form_edit_excludes_self_from_picker(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """On edit, the org being edited is excluded from the picker
+    options so the user can't pin a self-loop (org as its own parent).
+    """
+    self_id = await _seed_org(
+        db_test_session_manager, owner_id=logged_in_user.id, name="Self"
+    )
+    sibling_id = await _seed_org(
+        db_test_session_manager, owner_id=logged_in_user.id, name="Sibling"
+    )
+
+    response = await authenticated_client.get(f"/organizations/{self_id}/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    values = {
+        opt.attributes.get("value")
+        for opt in tree.css('select[name="parent_org_id"] option')
+    }
+    assert str(self_id) not in values
+    assert str(sibling_id) in values
+    # The "(root — no parent)" option remains as an explicit detach.
+    # selectolax surfaces `value=""` as `None` in the attribute dict.
+    assert None in values
+
+
+async def test_form_edit_preselects_current_parent(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Edit form pre-selects the row's current ``parent_org_id`` in the
+    picker; if the row is a root, the "(root — no parent)" option is
+    selected instead.
+    """
+    parent_resp = await authenticated_client.post(
+        "/organizations", data=_org_payload(name="Parent")
+    )
+    parent_id = uuid.UUID(parent_resp.json()["id"])
+    child_resp = await authenticated_client.post(
+        "/organizations",
+        data=_org_payload(name="Child", type="clinic", parent_org_id=str(parent_id)),
+    )
+    child_id = uuid.UUID(child_resp.json()["id"])
+
+    response = await authenticated_client.get(f"/organizations/{child_id}/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    selected = tree.css_first('select[name="parent_org_id"] option[selected]')
+    assert selected is not None
+    assert selected.attributes.get("value") == str(parent_id)
+
+
+async def test_form_edit_preselects_root_for_top_level_org(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A root org (no parent) edits with the "(root — no parent)" option
+    pre-selected."""
+    create_resp = await authenticated_client.post(
+        "/organizations", data=_org_payload(name="Top-Level")
+    )
+    org_id = uuid.UUID(create_resp.json()["id"])
+
+    response = await authenticated_client.get(f"/organizations/{org_id}/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    selected = tree.css_first('select[name="parent_org_id"] option[selected]')
+    assert selected is not None
+    # `value=""` is rendered as the root option; selectolax surfaces an
+    # empty-string attribute as ``None``.
+    assert selected.attributes.get("value") is None
+    assert "root" in selected.text().lower()
 
 
 async def test_delete_removes_org(

--- a/src/domain/specs/organization.py
+++ b/src/domain/specs/organization.py
@@ -4,7 +4,10 @@ practices, health systems, and solo-practice shells.
 
 from typing import Final
 
-from src.domain.logic.organizations.repository import get_organization_repository
+from src.domain.logic.organizations.repository import (
+    OrganizationRepository,
+    get_organization_repository,
+)
 from src.domain.logic.organizations.schema import (
     OrganizationCreate,
     OrganizationRead,
@@ -49,6 +52,16 @@ ORGANIZATION_ENTITY: Final[EntitySpec] = EntitySpec(
     list_order_by=Organization.created_at.desc(),
     create_redirect=_organization_form_redirect,
     update_redirect=_organization_form_redirect,
+    # The create/edit form's parent-Org picker is scoped per-viewer to
+    # the user's owned Organizations (superusers see all). Replaces the
+    # free-text UUID input — see issue #581. The framework invokes the
+    # extras callable on both the create path (target=None) and the
+    # edit path (target=<row>); the edit path excludes the row being
+    # edited from the options so the picker can't pin a self-loop.
+    form_extras_path=(
+        "src.domain.logic.organizations.handlers.organization_form_extras"
+    ),
+    form_extras_repos=(("organization_repo", OrganizationRepository),),
     # Templates pull dropdown labels from the spec — same pattern as
     # `PROVIDER_ENTITY.static_context` for credential vocabularies.
     static_context={

--- a/src/domain/specs/test_organization.py
+++ b/src/domain/specs/test_organization.py
@@ -60,6 +60,20 @@ def test_schemas_wired_correctly():
     assert ORGANIZATION_ENTITY.read_schema is OrganizationRead
 
 
+def test_form_extras_path_drives_parent_org_picker():
+    """Issue #581: the parent-Org picker is populated via the framework's
+    ``form_extras_path`` hook — same shape as Provider/Program."""
+    assert (
+        ORGANIZATION_ENTITY.form_extras_path
+        == "src.domain.logic.organizations.handlers.organization_form_extras"
+    )
+    from src.domain.logic.organizations.repository import OrganizationRepository
+
+    assert ORGANIZATION_ENTITY.form_extras_repos == (
+        ("organization_repo", OrganizationRepository),
+    )
+
+
 def test_static_context_carries_type_vocabulary():
     from src.domain.models.enums import (
         ORGANIZATION_TYPES,

--- a/src/domain/templates/organizations/form_edit.html
+++ b/src/domain/templates/organizations/form_edit.html
@@ -22,9 +22,24 @@
     {# `root_org_id` is server-managed — see
        src/domain/models/organizations/README.md. The form exposes
        `parent_org_id` only; the repository recomputes `root_org_id`
-       when a reparent happens. #}
-    {{ text_field("parent_org_id", "Parent organization ID", current=organization.parent_org_id, required=false) }}
-    <small>Leave blank for a root organization.</small>
+       when a reparent happens.
+
+       Parent-Org picker — replaces the free-text UUID input from
+       issue #581. `parent_org_options` is populated by
+       `organization_form_extras` (see
+       `ORGANIZATION_ENTITY.form_extras_path`) and excludes the row
+       being edited so the picker can't pin a self-loop. Empty value
+       = root organization (no parent). #}
+    <label for="parent_org_id">
+      Parent organization
+      <select id="parent_org_id" name="parent_org_id">
+        <option value=""{% if not organization.parent_org_id %} selected{% endif %}>(root — no parent)</option>
+        {%- for o in parent_org_options %}
+        <option value="{{ o.id }}"{% if o.id == organization.parent_org_id %} selected{% endif %}>{{ o.name }}</option>
+        {%- endfor %}
+      </select>
+      <small>Leave as "(root — no parent)" for a top-level organization.</small>
+    </label>
   </fieldset>
   {{ form_actions(
       "Save organization",

--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -14,8 +14,21 @@
       {{ text_field("name", "Name", maxlength=200) }}
       {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, placeholder=true) }}
     </div>
-    {{ text_field("parent_org_id", "Parent organization ID", required=false) }}
-    <small>Leave blank for a root organization. Most users do.</small>
+    {# Parent-Org picker — replaces the free-text UUID input from
+       issue #581. `parent_org_options` is populated by
+       `organization_form_extras` (see `ORGANIZATION_ENTITY.form_extras_path`).
+       Empty value = root organization (no parent); blank-string is
+       coerced to None by the schema's `OptionalUuid`. #}
+    <label for="parent_org_id">
+      Parent organization
+      <select id="parent_org_id" name="parent_org_id">
+        <option value="" selected>(root — no parent)</option>
+        {%- for o in parent_org_options %}
+        <option value="{{ o.id }}">{{ o.name }}</option>
+        {%- endfor %}
+      </select>
+      <small>Leave as "(root — no parent)" for a top-level organization. Most users do.</small>
+    </label>
   </fieldset>
 
   {{ form_actions("Create organization", cancel_url=entity_url('organization')) }}


### PR DESCRIPTION
Closes #581.

## Summary
- Replaces the free-text "Parent organization ID" input on `/organizations/form` and `/organizations/{id}/form` with a native `<select name="parent_org_id">`, populated via the framework's existing `form_extras_path` hook (same shape as the Provider/Program Org-pickers).
- New `organization_form_extras` callable returns the requesting user's visible Orgs (owned for non-superusers; all for superusers) as `parent_org_options`. Edit form excludes the row being edited from picker options so the form can't pin a self-loop.
- Wire contract preserved: `<option value="">(root — no parent)</option>` keeps "blank = root" semantics (`OptionalUuid` already coerces empty strings to `None`), so create/update payloads are unchanged.

## Test plan
- [x] `dev test` passes (1458 / 78 skipped) — includes new colocated tests in `src/domain/logic/organizations/test_handlers.py`, `src/domain/routes/test_organizations.py`, `src/domain/specs/test_organization.py`.
- [x] `dev lint` passes.
- [ ] Manual: visit `/organizations/form` and `/organizations/{id}/form` as a non-superuser and a superuser; confirm the picker lists the right Orgs and excludes self on edit.

## Notes / follow-ups
- Deeper cycle prevention (a *descendant* picked as the parent) is not attempted here — the repository's `_resolve_root_id` would still succeed in that case. Filing a small follow-up audit if this surfaces in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)