### PR TITLE
fix(nav): normalize top-right Login link color across auth pages (#592)

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -529,7 +529,12 @@
           </li>
           {% else %}
           <li>
-            <a href="/auth/login"{% if _on_login %} aria-current="page" class="contrast"{% endif %}>Login</a>
+            {# `class="contrast"` is dropped on the active state so the
+               Login link color stays consistent across /auth/login vs
+               /auth/register / /auth/forgot-password (#592). The
+               aria-current semantics still convey the active state to
+               assistive tech. #}
+            <a href="/auth/login"{% if _on_login %} aria-current="page"{% endif %}>Login</a>
           </li>
           {% endif %}
         </ul>

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -488,3 +488,44 @@ class _RequestStub:
 
 def _request_stub() -> _RequestStub:
     return _RequestStub()
+
+
+def _request_stub_at(path: str) -> _RequestStub:
+    stub = _RequestStub()
+    stub.url = _RequestStub._Url()
+    stub.url.path = path
+    return stub
+
+
+def test_login_link_color_is_consistent_across_auth_pages() -> None:
+    """Regression for #592 — the top-right Login link must not carry
+    `class="contrast"` on `/auth/login` (which previously rendered the
+    link black) while the same link on `/auth/register` and
+    `/auth/forgot-password` rendered blue. Drop the contrast class so
+    the link's color stays the same color anywhere it's still rendered
+    (orthogonal to #591 which may hide the link entirely)."""
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Login{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+    for path in ("/auth/login", "/auth/register", "/auth/forgot-password"):
+        html = env.get_template("stub.html").render(
+            request=_request_stub_at(path),
+            is_authenticated=False,
+            is_development=False,
+        )
+        tree = HTMLParser(html)
+        login_links = [
+            a for a in tree.css('a[href="/auth/login"]') if a.text().strip() == "Login"
+        ]
+        for link in login_links:
+            classes = (link.attributes.get("class") or "").split()
+            assert (
+                "contrast" not in classes
+            ), f"on {path}, Login link must not use `class='contrast'`: got {classes!r}"


### PR DESCRIPTION
## Summary
- Drop \`class="contrast"\` from the top-right Login link's active state. Pico's default blue link color now renders consistently on /auth/login, /auth/register, and /auth/forgot-password.
- \`aria-current="page"\` preserved so assistive tech still knows it's the current page.
- Orthogonal to #591 — if that lands first and hides Login on /auth/login, this is a no-op on the visible color but the test still pins the rule.

Closes #592

## Test plan
- [x] New parametrized regression test in \`test_views.py\` covers /auth/login, /auth/register, /auth/forgot-password.
- [x] \`dev test\` 1449 passed.
- [x] \`dev lint\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)