### PR TITLE
fix(deploy): prune unreferenced images before pull to bound droplet disk

### DIFF
--- a/deployment/droplet-files/deploy.sh
+++ b/deployment/droplet-files/deploy.sh
@@ -187,6 +187,16 @@ log "Deploying: $NEW (port $NEW_PORT)"
 # Clean up any existing containers for the new instance
 cleanup_containers "bedlam-connect-$NEW"
 
+# Free disk before pulling — `docker image prune -af` removes images not
+# attached to any container (running OR stopped). Blue/green keeps exactly
+# one image attached at this point (the running CURRENT-color container
+# holds a ref to its image ID via its tag), so this only deletes orphans
+# from prior deploys. Without it, every CD push accumulates one unreferenced
+# image (~hundreds of MB) and `docker pull` eventually fails with
+# "no space left on device" during layer registration.
+log "Pruning unreferenced Docker images to free disk..."
+run_cmd docker image prune -af || true
+
 # Pull latest image
 log "Pulling latest Docker image..."
 if run_cmd docker pull ghcr.io/willthefirst/bedlam-connect:latest; then


### PR DESCRIPTION
## Summary
CD periodically fails with `failed to register layer: write /usr/bin/x86_64-linux-gnu-lto-dump-14: no space left on device` because `deploy.sh` removes the old-color container but never the old image. Every push accumulates one unreferenced image (~hundreds of MB) until `docker pull` runs out of disk mid-layer-write and someone has to SSH in and manually prune.

## Fix
One `docker image prune -af` right before `docker pull` in `deployment/droplet-files/deploy.sh`. Blue/green keeps the running CURRENT-color container's image attached (Docker references the image ID, not the tag), so the prune **never touches the live image** — only orphans from prior deploys. Disk is now bounded at ~2× one image instead of growing linearly per deploy.

## Why not a watermark scheme
A `df`-threshold scheme is harder to get right and isn't needed here: only two containers ever run on the droplet (`docker-compose.blue-green.yml`), both pointed at the same tag, so at most one image is "live" at any moment. Pruning every deploy is provably bounded.

## Test plan
- [x] `bash -n deploy.sh` — syntax clean.
- [ ] Real validation lands on first post-merge deploy: the new prune step appears in the deploy log, and `docker images` on the droplet shows at most one `ghcr.io/willthefirst/bedlam-connect` image after each deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)