### PR TITLE
feat(providers): read per-role attrs from affiliation (#629 PR 3 of 4)

### DIFF
--- a/src/domain/logic/providers/test_view.py
+++ b/src/domain/logic/providers/test_view.py
@@ -155,3 +155,55 @@ def test_view_returns_dict_for_jinja_attribute_access():
     v = provider_card_view(_stub_provider())
     assert isinstance(v, dict)
     assert v["practice_name"] == "Acme Counseling"
+
+
+def test_view_prefers_affiliation_over_legacy_provider_columns():
+    """Regression for #629 PR 3 — per-role attrs source from
+    ``provider.affiliation`` first, falling back to the legacy
+    column on ``provider`` only when the affiliation is absent or
+    has no value for the field.
+
+    The PR 2 migration mirrored the per-role columns onto
+    ``affiliations``; PR 3 switches reads onto the new column set.
+    PR 4 will drop the legacy columns and the fallback path. The
+    test pins the precedence by giving the two sides disagreeing
+    values and asserting the affiliation value wins.
+    """
+    provider = _stub_provider(
+        # Legacy columns on `provider` carry the "old" values
+        in_person_sessions="no",
+        virtual_sessions="no",
+        sliding_scale=False,
+        cost="$50/session",
+        location_city="Old City",
+        location_state="NY",
+        location_zip="00000",
+        in_network_carriers=[],
+        accepts_out_of_network=False,
+        # `affiliation` carries the post-PR-3 source of truth
+        affiliation=SimpleNamespace(
+            in_person_sessions="yes",
+            virtual_sessions="please_contact",
+            sliding_scale=True,
+            cost="$200/session",
+            location_city="New City",
+            location_state="CA",
+            location_zip="90210",
+            in_network_carriers=["aetna"],
+            accepts_out_of_network=True,
+        ),
+    )
+    v = provider_card_view(provider)
+    assert v["in_person_label"] is not None
+    # affiliation says yes → label maps to the Yes branch, not the
+    # legacy "no" → "No" branch.
+    assert "yes" in v["in_person_label"].lower() or v["in_person_label"] == "Yes"
+    assert v["sliding_scale_label"] == "Yes"
+    assert v["cost"] == "$200/session"
+    assert "New City" in v["full_address"]
+    assert "CA" in v["full_address"]
+    assert "90210" in v["full_address"]
+    # Affiliation has both Aetna in-network and accepts_oon=True →
+    # summary mentions both.
+    assert "Aetna" in v["insurance_summary"]
+    assert "Out-of-network" in v["insurance_summary"]

--- a/src/domain/logic/providers/view.py
+++ b/src/domain/logic/providers/view.py
@@ -31,6 +31,26 @@ def _full_address(
     return head or None
 
 
+def _role_attr(provider, attr, default=None):
+    """Source a per-role attribute from `provider.affiliation` first,
+    falling back to the legacy column on `provider` itself.
+
+    The PR 2 migration populates ``provider.affiliation`` with a
+    1:1 mirror of the per-role columns currently still on
+    ``providers``; PR 3 switches the directory's read path here.
+    PR 4 will drop the duplicated columns from ``providers`` and
+    this helper's fallback path with them.
+
+    Test stubs typed as `SimpleNamespace` may set the legacy attr
+    without an affiliation — the fallback keeps those passing
+    until PR 4 retires the legacy field set.
+    """
+    affiliation = getattr(provider, "affiliation", None)
+    if affiliation is not None and getattr(affiliation, attr, None) is not None:
+        return getattr(affiliation, attr)
+    return getattr(provider, attr, default)
+
+
 def _insurance_summary(provider) -> str:
     """Compose a single-string insurance phrase from the provider's
     in-network / out-of-network / self-pay posture.
@@ -48,11 +68,15 @@ def _insurance_summary(provider) -> str:
     here so the template doesn't need to know about it. Importing the
     label dict at module top would close a cluster-boundary import
     chain back into `models`; deferring to call time keeps the
-    dependency graph quiet."""
+    dependency graph quiet.
+
+    Reads source from ``provider.affiliation`` first, falling back
+    to the legacy columns on ``provider`` itself (#629 PR 3).
+    """
     from src.domain.models.enums import INSURANCE_CARRIER_LABELS
 
-    carriers = list(getattr(provider, "in_network_carriers", None) or [])
-    accepts_oon = bool(getattr(provider, "accepts_out_of_network", False))
+    carriers = list(_role_attr(provider, "in_network_carriers", []) or [])
+    accepts_oon = bool(_role_attr(provider, "accepts_out_of_network", False))
     if not carriers and not accepts_oon:
         return "Self-pay only"
     parts: list[str] = []
@@ -99,8 +123,13 @@ def provider_card_view(provider) -> dict[str, Any]:
     from src.domain.models.enums import LOCATION_AVAILABILITY_LABELS
 
     org = getattr(provider, "org", None)
-    # `npi` moved to `clinicians.npi` in #629 PR 1 — read through the
-    # `provider.clinician` relationship (NOT NULL since the same PR).
+    # Per-role attrs come from `provider.affiliation` after #629 PR 3 —
+    # the directory's source-of-truth for "what is this clinician's
+    # role at this org." `npi` continues to come from
+    # `provider.clinician` (PR 1). Legacy columns on `providers` are
+    # the PR-2-era mirror and `_role_attr` falls back to them when
+    # affiliation is absent (test stubs); PR 4 drops both the columns
+    # and the fallback.
     clinician = getattr(provider, "clinician", None)
     return {
         "practice_name": (getattr(org, "name", None) if org else None),
@@ -110,21 +139,21 @@ def provider_card_view(provider) -> dict[str, Any]:
             else None
         ),
         "full_address": _full_address(
-            getattr(provider, "location_city", None),
-            getattr(provider, "location_state", None),
-            getattr(provider, "location_zip", None),
+            _role_attr(provider, "location_city"),
+            _role_attr(provider, "location_state"),
+            _role_attr(provider, "location_zip"),
         ),
         "in_person_label": LOCATION_AVAILABILITY_LABELS.get(
-            getattr(provider, "in_person_sessions", None) or ""
+            _role_attr(provider, "in_person_sessions") or ""
         ),
         "virtual_label": LOCATION_AVAILABILITY_LABELS.get(
-            getattr(provider, "virtual_sessions", None) or ""
+            _role_attr(provider, "virtual_sessions") or ""
         ),
         "insurance_summary": _insurance_summary(provider),
         "sliding_scale_label": (
-            "Yes" if getattr(provider, "sliding_scale", False) else "No"
+            "Yes" if _role_attr(provider, "sliding_scale", False) else "No"
         ),
-        "cost": getattr(provider, "cost", None),
+        "cost": _role_attr(provider, "cost"),
         "npi": getattr(clinician, "npi", None) if clinician is not None else None,
         "licensures": list(getattr(provider, "licensures", None) or []),
         "educations": list(getattr(provider, "educations", None) or []),


### PR DESCRIPTION
## Summary
Third of the 4 PRs splitting \`Provider\` into \`Clinician\` + \`Affiliation\` (#629). PR 1 added \`Clinician\`; PR 2 added \`Affiliation\` as a 1:1 mirror; PR 3 switches the directory's read path onto the new column set.

- \`provider_card_view\` sources per-role attrs (\`location_*\`, sessions, insurance, sliding scale, cost) from \`provider.affiliation\` first; falls back to the legacy columns on \`provider\` only when affiliation is absent. New \`_role_attr\` helper encapsulates the precedence.
- Visible behavior unchanged: PR 2 backfilled affiliations 1:1, so the data behind the swap is identical at runtime.

Out of scope for PR 3 (bundled into PR 4): credential sub-table FK move, \`OpeningDetail.provider_id\` retarget, switching writes onto affiliation, dropping the duplicated columns from \`providers\`.

## Test plan
- [x] New \`test_view_prefers_affiliation_over_legacy_provider_columns\` pins the precedence (legacy fields disagree → affiliation wins).
- [x] \`dev test\` 1490 passed.
- [x] \`dev lint\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)