### PR TITLE
feat(providers): mirror per-role writes to affiliation; finalize #629 split (PR 4 of 4)

### DIFF
--- a/src/domain/models/affiliations/README.md
+++ b/src/domain/models/affiliations/README.md
@@ -1,0 +1,16 @@
+# Affiliations cluster
+
+The clinician's role at one organization — practice-role attributes that vary per (clinician × org): insurance posture, sliding-scale flag, cost, location, modality.
+
+`Affiliation` was carved out of [`../providers/provider.py`](../providers/provider.py) over the four-PR `Provider → Clinician + Affiliation` split (issue #629). PR 2 (this cluster's birth) added the table and backfilled one row per `Provider`. PR 3 switched the directory's read path onto `provider.affiliation.*` ([`../../logic/providers/view.py`](../../logic/providers/view.py) — `_role_attr` reads affiliation-first with a fallback). PR 4 added a SQLAlchemy `set`-event listener on `Provider` that mirrors per-role column writes onto the linked affiliation so the affiliation-first reads see post-edit values.
+
+See [`../clinicians/README.md`](../clinicians/README.md) for the person side and [`../providers/README.md`](../providers/README.md) for the cluster the split came out of.
+
+## Files
+
+- `affiliation.py` — `Affiliation`. Holds the per-role columns mirrored from `providers`: `(location_city, location_state, location_zip)` via `LocationMixin`, `in_person_sessions`, `virtual_sessions`, `accepts_out_of_network`, `in_network_carriers`, `sliding_scale`, `cost`. FKs: `clinician_id` (RESTRICT) is the person; `org_id` (RESTRICT) is the organization; `provider_id` (CASCADE, UNIQUE) is the transitional 1:1 link back to the legacy `providers` row — retired once the column drop on `providers` lands. `(clinician_id, org_id)` is not UNIQUE: one clinician can hold multiple affiliations at the same org with different attributes (different rate / schedule / location), and the curation rule belongs in business logic, not the schema.
+- `test_affiliation.py` — model-layer regression coverage (auto-create-on-Provider-init, skip-when-supplied, the per-role write-mirroring event, persists-via-cascade).
+
+## What still lives on `providers`
+
+Through PR 4 the per-role columns are duplicated on `providers` and `affiliations` — `provider_card_view` reads through affiliation; writes hit `providers` and mirror onto affiliation via the `set` event. The remaining cleanup (drop the duplicated columns, switch writes to land directly on affiliation, move credential sub-tables to FK on clinician, rename `Provider → Practice` or its successor) is intentionally deferred to a follow-up issue — each piece is its own contract-surface decision (template hrefs, audit-snapshot keys, URL family) that deserves its own PR.

--- a/src/domain/models/affiliations/test_affiliation.py
+++ b/src/domain/models/affiliations/test_affiliation.py
@@ -106,6 +106,35 @@ async def test_provider_construct_with_existing_affiliation_skips_auto_create():
 
 
 @pytest.mark.asyncio
+async def test_provider_per_role_writes_mirror_to_affiliation():
+    """Regression for #629 PR 4 — `setattr(provider, '<per-role>', value)`
+    must mirror the write onto `provider.affiliation` so PR 3's
+    affiliation-first reads see the post-edit value. Without the
+    mirror, `repo.patch(provider, location_city='Queens')` would
+    update `providers.location_city` but leave
+    `affiliations.location_city` stale, and the directory's
+    `provider_card_view._role_attr` would return the pre-edit
+    affiliation value."""
+    user = _make_user("dave")
+    org = _make_org("Acme", user.id)
+    provider = _make_provider(owner=user, org=org)
+    aff = provider.affiliation
+    assert aff is not None
+
+    provider.location_city = "Queens"
+    provider.in_person_sessions = "no"
+    provider.sliding_scale = True
+    provider.cost = "$300/session"
+    provider.in_network_carriers = ["bcbs", "cigna"]
+
+    assert aff.location_city == "Queens"
+    assert aff.in_person_sessions == "no"
+    assert aff.sliding_scale is True
+    assert aff.cost == "$300/session"
+    assert aff.in_network_carriers == ["bcbs", "cigna"]
+
+
+@pytest.mark.asyncio
 async def test_provider_affiliation_persists_via_cascade(session):
     """`Provider.affiliation` has `cascade="all, delete-orphan"`, so
     persisting a Provider with a transient Affiliation flushes both

--- a/src/domain/models/clinicians/README.md
+++ b/src/domain/models/clinicians/README.md
@@ -1,0 +1,14 @@
+# Clinicians cluster
+
+The person behind a directory entry — license-holder, name on NPPES, owner of credentials.
+
+`Clinician` was carved out of [`../providers/provider.py`](../providers/provider.py) over the four-PR `Provider → Clinician + Affiliation` split (issue #629). PR 1 (this cluster's birth) moved the `npi` column off `providers`; the credential sub-tables ([`../providers/provider_licensure.py`](../providers/provider_licensure.py), `provider_education.py`, `provider_certification.py`) still FK to `Provider` and move to `Clinician` in the follow-up cleanup tracked separately. See [`../providers/README.md`](../providers/README.md) for the cluster the split came out of, and [`../affiliations/README.md`](../affiliations/README.md) for the practice-role side.
+
+## Files
+
+- `clinician.py` — `Clinician`. Holds `npi` (`Text`, nullable; `ck_clinicians_npi_format` CHECK enforces NULL or exactly 10 ASCII digits — defense-in-depth behind the Pydantic `_validate_npi`). `clinician.providers` is the back-relationship to `Provider` (1:many in the target model, 1:1 today through PR 4 — the FK on `providers.clinician_id` is non-UNIQUE so attaching a second provider is a data change, not a schema change). The framework's NPPES verification pipeline reads `clinician.npi` through the `Provider.clinician` join — no separate `Clinician` route surface.
+- `test_clinician.py` — model-layer regression coverage (auto-create-on-Provider-init, write-routing setter, the NPI CHECK constraint).
+
+## Why a separate cluster
+
+A `Clinician` is *the person*; a `Provider` (today) is *the person's role at one practice*. Conflating them on one table broke the multi-affiliation clinician (private practice + Tuesdays at a community clinic + telehealth contractor across two platforms). Splitting forces credentials to live with the person — so a clinician adding a second affiliation doesn't fragment their license list — and lets per-(clinician × org) attributes vary independently. The split is in progress; until it completes, `Provider` keeps the user-facing identity and surfaces person-attributes via `provider.clinician.X` proxies.

--- a/src/domain/models/providers/provider.py
+++ b/src/domain/models/providers/provider.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from sqlalchemy import JSON, Boolean, Column, ForeignKey, Text, text
+from sqlalchemy import JSON, Boolean, Column, ForeignKey, Text, event, text
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import Uuid
 
@@ -202,3 +202,48 @@ class Provider(LocationMixin, BaseModel):
         ``org`` hasn't been populated yet (pre-flush ORM constructions);
         every persisted row has a NOT NULL ``org_id``."""
         return self.org.name if self.org is not None else None
+
+
+# Per-role attributes the directory's read path reads off
+# ``provider.affiliation`` (#629 PR 3). PR 3 swapped reads but left
+# writes still landing on the `providers.X` columns — every patch via
+# `repo.patch(provider, ...)` set the provider column but left the
+# linked affiliation stale, so reads would show pre-edit data until
+# the next backfill. PR 4 closes the gap by mirroring per-role
+# attribute writes onto `provider.affiliation` via a SQLAlchemy
+# `set` attribute event. The forthcoming column-drop PR (tracked
+# in a follow-up issue) retires this sync once `providers.X`
+# columns are gone and writes target affiliation directly.
+_PER_ROLE_COLUMNS = (
+    "org_id",
+    "location_city",
+    "location_state",
+    "location_zip",
+    "in_person_sessions",
+    "virtual_sessions",
+    "accepts_out_of_network",
+    "in_network_carriers",
+    "sliding_scale",
+    "cost",
+)
+
+
+def _mirror_to_affiliation(target, value, _oldvalue, initiator):
+    """Mirror a `Provider.<per-role>` write onto the linked
+    `Affiliation.<per-role>` so PR-3's affiliation-first reads see
+    the post-edit value. Quiet no-op when the affiliation isn't
+    loaded yet (e.g. pre-construction kwarg assignment runs before
+    `__init__` finishes wiring the back-relationship)."""
+    affiliation = getattr(target, "affiliation", None)
+    if affiliation is None:
+        return
+    setattr(affiliation, initiator.key, value)
+
+
+for _attr in _PER_ROLE_COLUMNS:
+    event.listen(
+        getattr(Provider, _attr),
+        "set",
+        _mirror_to_affiliation,
+        propagate=True,
+    )


### PR DESCRIPTION
## Summary
Final PR of the 4-PR sequence splitting \`Provider\` into \`Clinician\` + \`Affiliation\`. PR 1 added Clinician; PR 2 added Affiliation; PR 3 swapped reads; this PR closes the read-write gap PR 3 created and documents the new architecture.

- SQLAlchemy \`set\` attribute event listener mirrors per-role column writes on \`Provider\` onto the linked \`affiliation\` so PR 3's affiliation-first reads see post-edit values.
- New READMEs for the \`clinicians/\` and \`affiliations/\` clusters.
- Regression test pins the mirror behavior.

## What's deferred (filed as #635)

The remaining cleanup — credential sub-table FK move to clinician, dropping the duplicated columns on \`providers\`, switching writes to land directly on affiliation, and the final naming + \`OpeningDetail.provider_id\` retarget decision — is tracked separately in #635. Each is a distinct contract-surface decision that earns its own PR. The architectural objective of #629 ("schema supports one clinician with multiple affiliations") is met today by Clinician + Affiliation + the non-UNIQUE \`clinician_id\` FK.

Closes #629

## Test plan
- [x] New \`test_provider_per_role_writes_mirror_to_affiliation\` in \`test_affiliation.py\`.
- [x] \`dev test\` 1491 passed.
- [x] \`dev lint\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)