### PR TITLE
refactor(entity-card): one-column post body, Pico hgroup header, drop chip CSS

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -118,18 +118,17 @@ async def test_list_referral_item_shape(
     assert item.attributes.get("data-kind") == "referral"
 
     # Header line: link text is the age + gender combo (no state —
-    # state moved to the demographics column for CR). Modality chips
-    # (icon + short label) sit next to the headline.
-    header_link = item.css_first("header.entity-header a")
+    # state moved to the demographics column for CR). Modality reads
+    # as plain text in the `<small>` meta line below the `<h3>`.
+    header_link = item.css_first("header h3 a")
     assert header_link is not None
     assert header_link.attributes.get("href") == f"/posts/{post.id}"
     # `age_groups[0]` = adolescents_14_18 + gender=male.
     assert header_link.text(strip=True) == "Adolescent male (14–18)"
-    modality_chips = [
-        chip.text(strip=True)
-        for chip in item.css("header.entity-header > .post-modality")
-    ]
-    assert modality_chips == ["Virtual", "In-person"]
+    meta_text = item.css_first("header hgroup small").text(strip=True)
+    # Both modalities ordered "Virtual · In-person" in the meta string.
+    assert "Virtual" in meta_text and "In-person" in meta_text
+    assert meta_text.index("Virtual") < meta_text.index("In-person")
 
     # No text kind-chip anywhere in the listing row.
     assert item.css_first("[data-kind-chip]") is None
@@ -162,7 +161,7 @@ async def test_list_referral_item_shape(
     # Contact band lives in `<footer class="entity-footer">` — just the
     # Email CTA. The username + practice name no longer render in the
     # footer; the headline already identifies who you're contacting.
-    footer = item.css_first("footer.entity-footer")
+    footer = item.css_first("article > footer")
     assert author.username not in footer.text()
     mailto = footer.css_first("a")
     assert mailto is not None
@@ -200,11 +199,11 @@ async def test_list_referral_header_is_age_gender_combo(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     item = tree.css_first("#posts-list > article")
-    lead = item.css_first("header.entity-header a")
+    lead = item.css_first("header h3 a")
     assert lead is not None
     assert lead.text(strip=True) == "Young adult female (19–24)"
     # State is *not* in the header anymore.
-    assert "ID" not in item.css_first("header.entity-header").text()
+    assert "ID" not in item.css_first("article > header").text()
     # ...but it does appear in the demographics column's location chunk.
     location = item.css_first("section.entity-facts dl > div.entity-location")
     assert location is not None
@@ -258,19 +257,17 @@ async def test_list_opening_item_shape(
 
     # Header link text: just the practice name (location moves to the
     # demographics column via `entity-location`). The in-person
-    # posture renders as a `<span.post-modality>` chip (icon + label)
-    # next to the link; virtual=no, so no virtual chip.
-    lead = item.css_first("header.entity-header a")
+    # posture appears as plain text in the `<small>` meta line under
+    # the `<h3>`; virtual=no, so only "In-person" shows.
+    lead = item.css_first("header h3 a")
     assert lead is not None
     assert lead.text(strip=True) == practice_name
     location_row = item.css_first("section.entity-facts dl > div.entity-location")
     assert location_row is not None
     assert "Portland, OR" in location_row.text()
-    modality_chips = [
-        chip.text(strip=True)
-        for chip in item.css("header.entity-header > .post-modality")
-    ]
-    assert modality_chips == ["In-person"]
+    meta_text = item.css_first("header hgroup small").text(strip=True)
+    assert "In-person" in meta_text
+    assert "Virtual" not in meta_text
 
     # Demographics column shows the posture; non-empty in_network_carriers
     # wins the priority even though sliding_scale is also set.
@@ -279,7 +276,7 @@ async def test_list_opening_item_shape(
 
     # Contact band lives in `<footer class="entity-footer">` — just the
     # Email CTA. Practice name is in the headline, not duplicated here.
-    footer = item.css_first("footer.entity-footer")
+    footer = item.css_first("article > footer")
     footer_text = footer.text()
     assert practice_name not in footer_text
     assert author.username not in footer_text
@@ -451,7 +448,7 @@ async def test_list_pa_footer_carries_email_cta_only(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    footer = tree.css_first("#posts-list > article footer.entity-footer")
+    footer = tree.css_first("#posts-list > article > footer")
     assert footer is not None
     text = footer.text()
     # Neither name renders in the footer — only the Email CTA.
@@ -558,27 +555,26 @@ async def test_list_meta_is_a_dl_of_labeled_key_value_chunks(
     values = [chunk.css_first("dd").text(strip=True) for chunk in meta_chunks]
     assert values == ["Seattle, WA", "In-network"]
 
-    # Header carries the age headline + an "In-person" modality chip
-    # (virtual=no). The fixture's gender default is `prefer_not_to_say`,
-    # so the gender word drops out. State lives in the location chunk
-    # of the demographics column, not in the header.
-    header_text = item.css_first("header.entity-header").text()
+    # Header carries the age headline + an "In-person" modality label
+    # in the `<small>` meta line (virtual=no). The fixture's gender
+    # default is `prefer_not_to_say`, so the gender word drops out.
+    # State lives in the location chunk of the demographics column,
+    # not in the header.
+    header_text = item.css_first("article > header").text()
     assert "Adolescent (14–18)" in header_text
     assert "WA" not in header_text
-    modality_chips = [
-        chip.text(strip=True)
-        for chip in item.css("header.entity-header > .post-modality")
-    ]
-    assert modality_chips == ["In-person"]
+    meta_text = item.css_first("header hgroup small").text(strip=True)
+    assert "In-person" in meta_text
+    assert "Virtual" not in meta_text
 
     # Two `<a>`s per card: the header link to the detail page and
     # the Email CTA in the footer. The footer carries only the CTA;
     # the name (username for CR, practice for PA) lives in the
     # headline, not duplicated here.
-    header_link = item.css_first("header.entity-header a")
+    header_link = item.css_first("header h3 a")
     assert header_link is not None
     assert header_link.attributes.get("href") == f"/posts/{post.id}"
-    footer = item.css_first("footer.entity-footer")
+    footer = item.css_first("article > footer")
     assert author.username not in footer.text()
     mailto = footer.css_first("a")
     assert mailto is not None
@@ -612,13 +608,15 @@ async def test_list_renders_readable_date_format(
     tree = HTMLParser(response.text)
     item = tree.css_first("#posts-list > article")
     assert item is not None
-    date_cell = item.css_first("header.entity-header small")
+    date_cell = item.css_first("header hgroup small")
     assert date_cell is not None
     rendered = date_cell.text(strip=True)
-    # `May 15` for current-year posts; `May 15, 2025` once we cross a
-    # year boundary. Either is acceptable — both prove the raw ISO
-    # `2025-05-15` is gone.
-    assert rendered in {"May 15", "May 15, 2025"}
+    # The meta line is `{date} · {modality?}` — split on the middot
+    # to assert just the date prefix. `May 15` for current-year
+    # posts; `May 15, 2025` once we cross a year boundary. Either is
+    # acceptable — both prove the raw ISO `2025-05-15` is gone.
+    date_prefix = rendered.split(" · ", 1)[0].strip()
+    assert date_prefix in {"May 15", "May 15, 2025"}
 
 
 async def test_detail_renders_breadcrumb(
@@ -816,7 +814,7 @@ async def test_list_posts_one_post(
     assert len(items) == 1
     # The description doesn't appear in the listing row (lives on the
     # detail page); the card header link is what we look for.
-    assert items[0].css_first("header.entity-header a") is not None
+    assert items[0].css_first("header h3 a") is not None
     assert "No posts found" not in tree.body.text()
 
 
@@ -1974,7 +1972,7 @@ async def test_list_renders_referral_row(
     assert item.attributes.get("data-kind") == "referral"
     # Default fixture: age_groups=["adults_25_64"], gender="prefer_not_to_say".
     # State (IL) lives in the demographics location chunk, not the header.
-    assert item.css_first("header.entity-header a").text().strip() == "Adult (25–64)"
+    assert item.css_first("header h3 a").text().strip() == "Adult (25–64)"
 
 
 async def test_get_referral_detail_renders(
@@ -2428,7 +2426,7 @@ async def test_list_renders_opening_row(
     item = tree.css_first("#posts-list > article")
     assert item is not None
     assert item.attributes.get("data-kind") == "opening"
-    assert practice_name in item.css_first("header.entity-header a").text()
+    assert practice_name in item.css_first("header h3 a").text()
 
 
 async def test_get_opening_detail_renders(

--- a/src/domain/templates/posts/_item.html
+++ b/src/domain/templates/posts/_item.html
@@ -9,29 +9,38 @@ id="posts-list">` of `<article>` children.
 
 Layout per card:
 
-  ┌──────────────────────────────────────────────────────────────┐
-  │ <header>  Adult male (25–64)  📹 Virtual  📍 In-person   May 17 │
-  │                                                              │
-  │ Seeking                      │  📍 City, ST                  │
-  │   • icon name                │  Languages: …                 │
-  │   • icon name                │  Insurance: …                 │
-  │                              │  Modality: …                  │
-  │                                                              │
-  │ <footer>                                     [✉ Email]        │
-  └──────────────────────────────────────────────────────────────┘
+  ┌──────────────────────────────────────────────┐
+  │ <header>  Adult male (25–64)                 │
+  │           May 17 · Virtual · In-person       │
+  │                                              │
+  │ Seeking                                      │
+  │   • icon name                                │
+  │   • icon name                                │
+  │                                              │
+  │ 📍 City, ST                                   │
+  │ Languages: …                                 │
+  │ Insurance: …                                 │
+  │ Modality: …                                  │
+  │                                              │
+  │ <footer>  [✉ Email]                          │
+  └──────────────────────────────────────────────┘
 
-The card is `<article>` with `<header>`, two-column body, and
-`<footer>` — Pico's automatic styling tints header and footer as
-the top/bottom bands of the card. The header line carries the
-headline link, modality chips, and a right-aligned date. The body
-is two `<section>`s side-by-side: services with inline icons
-(left), demographics `<dl>` (right). The footer carries one element
-— the Email CTA — right-aligned.
+The card is `<article>` with `<header>`, a stacked single-column
+body, and `<footer>` — Pico's automatic styling tints header and
+footer as the top/bottom bands of the card. The header band is a
+Pico `<hgroup>` pairing an `<h3>` headline link with a `<small>`
+meta line (date · modality, separated by middots). The `<h3>`
+anchors the card visually — Pico's heading scale gives it size +
+weight without custom CSS, which is the rule we want to lean on so
+the chrome stays framework-portable. The body stacks two
+`<section>`s vertically: services with inline icons, then the
+demographics `<dl>`. The footer carries one element — the Email
+CTA — in the default left-aligned footer flow.
 
 Per-kind branching and field selection live in
 `src.domain.logic.posts.view.post_card_view`, which collapses CR /
 PA / intake detail shapes into one flat `view` dict.
-The three blocks (modality chips, services, facts) are partials
+The three blocks (modality text, services, facts) are partials
 that read from `view`; this file composes them into the card frame.
 PR C of the list/detail unification reuses the same partials on the
 detail page so both views share the same visual vocabulary.
@@ -45,23 +54,23 @@ per-kind, so a single-kind filter doesn't need to suppress anything. #}
 
 {% macro post_item(post, active_kind=None) -%}
 {%- set view = post_card_view(post) -%}
+{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
-  <header class="entity-header">
-    <strong><a href="{{ entity_url('post', id=post.id) }}">{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</a></strong>
-    {{ modality_chips(view.in_person, view.virtual) }}
-    <small>{{ post.created_at | format_post_date }}</small>
+  <header>
+    <hgroup>
+      <h3><a href="{{ entity_url('post', id=post.id) }}">{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</a></h3>
+      <small>{{ post.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
+    </hgroup>
   </header>
-  <div class="entity-grid">
-    {{ services_block(view) }}
-    {{ facts_block(view) }}
-  </div>
+  {{ services_block(view) }}
+  {{ facts_block(view) }}
 
   {#- Footer carries just the Email CTA — Pico-styled `role="button"
       class="secondary outline"` with the label "Email". The raw
       address lives only in the `href`. `target="_blank" rel="noopener
       noreferrer"` is harmless on `mailto:` URLs and matches the
       pattern used for the PA `website` link on the detail page. -#}
-  <footer class="entity-footer">
+  <footer>
     <a href="mailto:{{ post.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>
 </article>

--- a/src/domain/templates/posts/_modality_chips.html
+++ b/src/domain/templates/posts/_modality_chips.html
@@ -1,19 +1,28 @@
-{# Two-chip modality posture for the post card's header line.
+{# Modality posture as a plain-text fragment for the post card's meta line.
+
+Replaces the legacy `<span class="post-modality">` chips. The card
+header now uses Pico's `<hgroup>` pattern (`<h3>` title + `<small>`
+meta line), and the meta line is just text — date · modality —
+separated by middots. Returning plain labels lets the caller drop
+custom CSS classes for the chips and rely on Pico defaults inside
+`<small>` for muted, smaller text.
 
 `in_person` and `virtual` are `LOCATION_AVAILABILITY_OPTIONS` values
 (`yes` / `no` / `please_contact`). A `please_contact` on either arm
-collapses to a single "Contact for format" chip — the posture is
-unknown so neither glyph applies. When both are `no` (or None), no
-chip renders.
+collapses to a single "Contact for format" label — posture is unknown
+so neither glyph applies. When both arms are `no` (or `None`), the
+macro renders nothing; the caller checks `| trim` to decide whether
+to emit a separator.
 
 Used by `posts/_item.html` (the list card) and `posts/detail.html`
-(the detail page, post PR C). Same visual treatment in both views
-so the modality posture reads the same wherever it appears. #}
+(the detail page) so modality reads the same wherever it appears. #}
 {% macro modality_chips(in_person, virtual) -%}
 {%- if in_person == "please_contact" or virtual == "please_contact" -%}
-<span class="post-modality">Contact for format</span>
+Contact for format
 {%- else -%}
-{%- if virtual == "yes" %}<span class="post-modality"><i class="icon-video" aria-hidden="true"></i>Virtual</span>{% endif -%}
-{%- if in_person == "yes" %}<span class="post-modality"><i class="icon-map-pin" aria-hidden="true"></i>In-person</span>{% endif -%}
+{%- set labels = [] -%}
+{%- if virtual == "yes" %}{%- set _ = labels.append("Virtual") -%}{% endif -%}
+{%- if in_person == "yes" %}{%- set _ = labels.append("In-person") -%}{% endif -%}
+{{ labels | join(' · ') }}
 {%- endif -%}
 {%- endmacro %}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -24,46 +24,49 @@
    two-column body grid, footer band), with detail-only sections
    appended in reading order between the header and the body grid:
 
-     1. Header band — headline + modality chips + date (same shape
-        as the list card's header, but the headline is plain text,
-        not a link to itself). The breadcrumb above the card and
-        the kind-colored left edge already convey the "kind +
-        collection" context the page used to repeat as a meta line.
+     1. Header band — Pico `<hgroup>` pairing an `<h3>` headline
+        (plain text on detail, not a link to itself) with a
+        `<small>` meta line (date · modality). Same shape as the
+        list card so modality reads the same wherever it appears.
+        The breadcrumb above the card and the kind-colored left
+        edge already convey the "kind + collection" context the
+        page used to repeat as a meta line.
      2. Description prose — the post's lead text (required for CR;
         optional for PA / program).
-     3. Body grid — services-with-icons (left) + demographics `<dl>`
-        (right) in expanded mode (the facts block surfaces
-        detail-only rows: full address, practice/program link,
-        desired times, schedule notes, network preference, sliding
-        scale, cost).
+     3. Body — services-with-icons, then the demographics `<dl>`,
+        stacked vertically (single column). The facts block surfaces
+        detail-only rows in expanded mode: full address,
+        practice/program link, desired times, schedule notes,
+        network preference, sliding scale, cost.
      4. How to refer — PA / program only, when website or
         instructions are set.
-     5. Footer — Email CTA (same as list card).
+     5. Footer — Email CTA (same as list card), left-aligned via
+        Pico's default footer flow.
 
    Per-kind branching lives in `post_card_view` (one place). Every
    visual element in the card reads from `view` (the dict view-model). #}
 {% block content %}
+{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-kind="{{ post.kind }}">
-  <header class="entity-header">
-    <strong>{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</strong>
-    {{ modality_chips(view.in_person, view.virtual) }}
-    <small>{{ post.created_at | format_post_date }}</small>
+  <header>
+    <hgroup>
+      <h3>{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</h3>
+      <small>{{ post.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
+    </hgroup>
   </header>
 
   {%- if view.description %}
   <p>{{ view.description }}</p>
   {%- endif %}
 
-  <div class="entity-grid">
-    {{ services_block(view) }}
-    {{ facts_block(view, expanded=True) }}
-  </div>
+  {{ services_block(view) }}
+  {{ facts_block(view, expanded=True) }}
 
   {%- if view.referral %}
   {{ how_to_refer(view) }}
   {%- endif %}
 
-  <footer class="entity-footer">
+  <footer>
     <a href="mailto:{{ post.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>
 </article>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -66,16 +66,21 @@
         --pico-font-size-h3: 1.125rem;
         --pico-font-size-h4: 1rem;
       }
-      /* Post cards — `<article class="entity-card">` is the canonical
-         shape for a single post anywhere on the site: the list page
-         (`#posts-list` of `.entity-card` articles) and the detail page
-         (one `.entity-card` standing alone). Pico's default article
+      /* Entity cards — `<article class="entity-card">` is the canonical
+         shape for posts (list + detail) and the entity detail pages
+         (provider, organization, program, user). Pico's default article
          framing (background, border, padding, rounded corners) gives
-         the chrome; the rules below add the kind-colored left edge,
-         the header/footer band layouts, and the two-column body grid.
-         Detail-only sections (description `<p>`, "how to refer")
-         render between the header and the body grid styled by Pico
-         defaults — no post-specific overrides. */
+         the chrome; the only post-specific override below is the
+         kind-colored left edge, kept as a documented exception so the
+         visual kind-anchor doesn't require touching markup per kind.
+
+         Everything else — header band hierarchy, body flow, footer
+         band — leans on Pico defaults and semantic HTML (`<hgroup>`,
+         `<h3>`, `<small>`, `<dl>`) so the chrome stays portable if
+         we ever swap CSS frameworks. The header on non-post detail
+         pages (provider / org / program / user) still uses
+         `<header class="entity-header">` with inline name+subtitle;
+         see the `.entity-header` rules further down. */
       #posts-list { padding: 0; margin: 0; display: flex; flex-direction: column; gap: 1rem; }
       .entity-card {
         margin: 0;
@@ -84,12 +89,10 @@
       .entity-card[data-kind="referral"] { border-left-color: darkorange; }
       .entity-card[data-kind="opening"] { border-left-color: darkcyan; }
       .entity-card[data-kind="intake"] { border-left-color: darkcyan; }
-      /* Header band: Pico provides the background tint + bottom
-         border; we only configure the in-row flex layout (headline,
-         modality chips, right-aligned date). `flex-wrap: wrap` keeps
-         the modality chip + right-aligned `<small>` date visible on
-         narrow viewports — without it they clip past the card's right
-         edge at ≤375px (#577). */
+      /* Non-post detail pages still pair name + subtitle inline in
+         the card header via the `entity-header` class. Posts use a
+         `<hgroup>` pattern instead and intentionally drop this class
+         so Pico's default block flow applies. */
       .entity-card > header.entity-header {
         display: flex;
         flex-wrap: wrap;
@@ -99,39 +102,13 @@
       .entity-card > header.entity-header > strong { flex: 0 0 auto; }
       .entity-card > header.entity-header > strong > a { color: inherit; text-decoration: none; }
       .entity-card > header.entity-header > strong > a:hover { text-decoration: underline; }
-      /* Date sits at the right edge regardless of headline + modality
-         width; the chips between strong and small stay attached to
-         the headline on the left. */
       .entity-card > header.entity-header > small {
         margin-left: auto;
         color: var(--pico-muted-color);
       }
-      /* In-person / virtual chips: icon + short label, muted color
-         so the headline stays the visual lead. Flex items in the
-         header gap pick up the parent's 0.5rem separation. Icon →
-         label spacing comes from the global icon rule below, not
-         a local `gap`. */
-      .entity-card > header.entity-header > .post-modality {
-        display: inline-flex;
-        align-items: center;
-        color: var(--pico-muted-color);
-        font-size: 0.875rem;
-      }
-      /* Two-column grid for the body. Columns auto-fit narrow
-         viewports by collapsing to one column under 640px. */
-      .entity-card > .entity-grid {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 1.5rem;
-        align-items: start;
-      }
-      /* Footer band: Pico provides the tinted background and styles
-         the Email CTA itself (role="button" class="secondary outline").
-         We right-align the CTA inside the band and scale its
-         `font-size` down so it matches the `<small>` date in the
-         header (Pico's button padding is em-based, so font-size
-         shrinks the whole button proportionally — no padding override
-         needed). */
+      /* Footer band for the one detail page that still right-aligns
+         its CTA (users). Posts and other detail pages use the default
+         Pico footer flow (left-aligned). */
       .entity-card > footer.entity-footer {
         display: flex;
         justify-content: flex-end;
@@ -139,34 +116,27 @@
       .entity-card > footer.entity-footer > [role="button"] {
         font-size: 0.875rem;
       }
-      @media (max-width: 640px) {
-        .entity-card > .entity-grid { grid-template-columns: 1fr; gap: 1rem; }
-      }
-      /* Column tweaks: kill default vertical margins on `h4`, `<ul>`,
-         `<dl>`, `<p>` so columns line up at the top. */
-      .entity-card > .entity-grid h4 {
-        margin: 0 0 0.4rem 0;
-        font-size: 1rem;
-      }
-      .entity-card > .entity-grid section.entity-icon-list > ul {
+      /* Services-with-icons list inside the post card body. `list-style:
+         none` lets the inline Lucide icon serve as the bullet; the
+         `display: flex` row aligns the icon vertically with its label. */
+      .entity-card section.entity-icon-list > ul {
         list-style: none;
         padding: 0;
         margin: 0;
       }
-      .entity-card > .entity-grid section.entity-icon-list > ul > li {
+      .entity-card section.entity-icon-list > ul > li {
         display: flex;
         align-items: center;
         padding: 0.1rem 0;
       }
       /* Demographics `<dl>`: one `<div>` per fact, "Label: value"
          layout — `<dt>` inline with a colon, `<dd>` inline after.
-         Scoped to `.entity-card section.entity-facts` (not
-         `.entity-card > .entity-grid section.entity-facts`) so the
-         inline `<dt>`/`<dd>` rules apply on detail pages that don't
-         use the 2-column `.entity-grid` wrapper (org, program, user,
-         provider). Without this, the icon-only `<dt>` in
-         `<div class="entity-location">` falls back to block layout
-         and renders on its own line above the value. */
+         Used by every entity-card body (posts and non-post detail
+         pages). Without these rules the default `<dl>` would stack
+         each label above its value on a separate line, doubling
+         the body height. The icon-only `<dt>` in
+         `<div class="entity-location">` would also fall back to
+         block layout and render on its own line above the value. */
       .entity-card section.entity-facts > dl {
         margin: 0;
         padding: 0;
@@ -174,15 +144,16 @@
       .entity-card section.entity-facts > dl > div {
         padding: 0.1rem 0;
       }
-      /* Two-column dl on desktop for non-grid detail cards (org,
+      /* Two-column dl on desktop for non-post detail cards (org,
          program, user, provider). Without this the facts list packs
          into the left third of the card and wastes the right two
-         thirds (#586). Targets `.entity-card > section.entity-facts`
-         (direct child) so post-detail — where `entity-facts` sits
-         inside `.entity-grid`'s right column already — keeps its
-         single-column layout. */
+         thirds (#586). Scoped via `:not([data-kind])` — only posts
+         carry `data-kind` for their kind-colored left edge — so post
+         cards keep their single-column body (they're already
+         tighter, and the user-facing design calls for stacked
+         services + facts per card). */
       @media (min-width: 768px) {
-        .entity-card > section.entity-facts > dl {
+        .entity-card:not([data-kind]) > section.entity-facts > dl {
           display: grid;
           grid-template-columns: 1fr 1fr;
           column-gap: 1.5rem;
@@ -203,8 +174,9 @@
       .entity-card section.entity-facts dl > div.entity-location > dt { font-weight: normal; }
       .entity-card section.entity-facts dd { display: inline; margin: 0; }
       /* Detail-only "how to refer" section — sits below the body
-         grid, before the footer. Margin-top echoes the grid's
-         vertical rhythm; the heading is the standard `<h4>`. */
+         sections, before the footer. The heading is the standard
+         `<h4>`; vertical rhythm comes from Pico's typography
+         spacing on the wrapping `<section>`. */
       .entity-card > .entity-how-to-refer { margin: 0; }
       .entity-card > .entity-how-to-refer h4 { margin: 0 0 0.4rem 0; font-size: 1rem; }
       .entity-card > .entity-how-to-refer p { margin: 0.25rem 0; }


### PR DESCRIPTION
## Summary
Strip custom CSS from the post card chrome and lean on Pico defaults + semantic HTML so the design is portable when we eventually swap CSS frameworks.

**Header band:** `<header class="entity-header">` with custom flex wrapping `<strong>` + chips + margin-auto date becomes a vanilla `<header>` containing a Pico `<hgroup>`:
- `<h3>` for the headline link — Pico's heading scale anchors the card visually with no custom font-size/weight rule.
- A single `<small>` meta line: `{date} · {modality}` joined by middots.

The `_modality_chips` macro now returns plain labels (no more `<span class="post-modality">` per chip).

**Body:** drop the `<div class="entity-grid">` two-column wrapper. Services-with-icons and the demographics `<dl>` stack vertically — no zig-zag between columns when scanning.

**Footer:** drop the right-aligning flex; Email CTA uses Pico's default left-aligned footer flow.

**CSS removed from `base.html`:**
- `.entity-card > header.entity-header > .post-modality` (chip styling — dead)
- `.entity-card > .entity-grid` + the 640px 1-col collapse + the h4 margin reset (dead)
- `.entity-card > footer.entity-footer` for posts (now Pico-default-aligned)

**CSS kept (with scope tightening):**
- `.entity-card` border + `[data-kind="…"]` colors — the kind anchor (documented exception to the no-custom-CSS rule).
- `.entity-header` flex + `.entity-footer` flex — still used by non-post detail pages (provider/org/program/user/users) that haven't migrated to `<hgroup>`.
- `.entity-icon-list` ul/li layout + `.entity-facts` dl inline rendering — needed for compact key:value cards.
- `.entity-card:not([data-kind]) > section.entity-facts > dl` 2-col grid — scoped via `:not([data-kind])` so the rule applies to non-post detail cards only; post cards (`data-kind="…"`) stay single-column.

## Test plan
- [x] `dev test` — 1486 passed, 78 skipped.
- [x] `dev test contract` — 36 passed after killing stale Pact mock services from a removed worktree.
- [x] `dev lint` — clean.
- [ ] Visual: render `/posts`, `/posts/{id}` and confirm header reads `Title` → `May 17 · Virtual · In-person`, body stacks services then facts, Email button bottom-left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)