### PR TITLE
fix(nav): drop class="contrast" + custom active-tab CSS, rely on Pico defaults

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -582,23 +582,6 @@
         max-width: 28rem;
         margin-inline: auto;
       }
-      /* Primary-nav active tab. Pico styles `aria-current="page"` only
-         subtly (a faint background tint); on a horizontal nav the cue
-         is easy to miss, and the issue audit (#589) flagged the
-         inconsistency. The rule below targets links carrying
-         `aria-current="page"` inside the `<nav aria-label="Primary">`
-         strip and adds a thicker bottom border + weight bump so the
-         active section reads at a glance on every page. Scoped to
-         the primary nav so breadcrumb / pagination links that also
-         set `aria-current` (single-segment trail, current page in
-         pager) keep their lighter treatment. */
-      nav[aria-label="Primary"] a[aria-current="page"] {
-        font-weight: 600;
-        border-bottom: 2px solid currentColor;
-        /* Compensate for the border so the text baseline doesn't
-           jump between active and inactive tabs. */
-        padding-bottom: calc(var(--pico-nav-link-spacing-vertical, 0.5rem) - 2px);
-      }
     </style>
     <script
       src="https://unpkg.com/htmx.org@2.0.4"
@@ -670,25 +653,25 @@
       <nav aria-label="Primary">
         <ul>
           {# title-case-ignore: "Bedlam Connect" is a brand name #}
-          <li><strong><a href="/" class="contrast">Bedlam Connect</a></strong></li>
+          <li><strong><a href="/">Bedlam Connect</a></strong></li>
           {% if is_authenticated %}
-          <li><a href="{{ entity_url('post') }}?kind=referral"{% if _on_referrals %} aria-current="page" class="contrast"{% endif %}>Referrals</a></li>
-          <li><a href="{{ entity_url('post') }}?kind=opening"{% if _on_openings %} aria-current="page" class="contrast"{% endif %}>Openings</a></li>
-          <li><a href="{{ entity_url('provider') }}"{% if _on_directory %} aria-current="page" class="contrast"{% endif %}>Directory</a></li>
+          <li><a href="{{ entity_url('post') }}?kind=referral"{% if _on_referrals %} aria-current="page"{% endif %}>Referrals</a></li>
+          <li><a href="{{ entity_url('post') }}?kind=opening"{% if _on_openings %} aria-current="page"{% endif %}>Openings</a></li>
+          <li><a href="{{ entity_url('provider') }}"{% if _on_directory %} aria-current="page"{% endif %}>Directory</a></li>
           {% if is_admin %}
-          <li><a href="{{ entity_url('organization') }}"{% if _on_orgs %} aria-current="page" class="contrast"{% endif %}>Organizations</a></li>
-          <li><a href="{{ entity_url('program') }}"{% if _on_programs %} aria-current="page" class="contrast"{% endif %}>Programs</a></li>
-          <li><a href="{{ entity_url('user') }}"{% if _on_users %} aria-current="page" class="contrast"{% endif %}>Users</a></li>
+          <li><a href="{{ entity_url('organization') }}"{% if _on_orgs %} aria-current="page"{% endif %}>Organizations</a></li>
+          <li><a href="{{ entity_url('program') }}"{% if _on_programs %} aria-current="page"{% endif %}>Programs</a></li>
+          <li><a href="{{ entity_url('user') }}"{% if _on_users %} aria-current="page"{% endif %}>Users</a></li>
           {% endif %}
           {% endif %}
         </ul>
         <ul id="primary-nav">
           {% if is_authenticated %}
           <li>
-            <a href="{{ entity_url('user', id='me') }}" aria-label="Profile"{% if _on_profile %} aria-current="page" class="contrast"{% endif %}>
+            <a href="{{ entity_url('user', id='me') }}" aria-label="Profile"{% if _on_profile %} aria-current="page"{% endif %}>
               {# Lucide `user` icon, inlined. `currentColor` makes it
-                 inherit the link color (including Pico's `.contrast`
-                 active state). #}
+                 inherit the link color, including Pico's default
+                 `aria-current="page"` treatment. #}
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
             </a>
           </li>
@@ -697,11 +680,12 @@
             {# When the visitor is already on the auth flow (login /
                register / forgot-password) we render Login as a
                non-clickable `<span>` instead of a self-referential
-               link (#591). When it *is* rendered as a link, it carries
-               no `class="contrast"` so the link color stays consistent
-               across the auth pages (#592). #}
+               link (#591). The `<span>` keeps `aria-current="page"`
+               so assistive tech still hears it as the current section;
+               Pico styles the indicator using its default current-page
+               treatment. #}
             {% if _on_auth_flow %}
-            <span aria-current="page" class="contrast">Login</span>
+            <span aria-current="page">Login</span>
             {% else %}
             <a href="/auth/login">Login</a>
             {% endif %}

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -749,20 +749,6 @@ def test_primary_nav_no_section_tab_on_post_detail() -> None:
     assert _active_tab_labels(_render_chrome("/posts/42")) == []
 
 
-def test_primary_nav_active_link_carries_strong_style_hook() -> None:
-    """The active link adds `class="contrast"` so the Pico color cue
-    fires alongside the CSS rule that thickens the underline. Pinning
-    both attributes ensures a future refactor that drops one notices
-    the other."""
-    html = _render_chrome("/providers")
-    tree = HTMLParser(html)
-    nav = tree.css_first('nav[aria-label="Primary"]')
-    assert nav is not None
-    active = nav.css_first("a[aria-current='page']")
-    assert active is not None
-    assert "contrast" in (active.attributes.get("class") or "")
-
-
 def test_primary_nav_renders_login_link_off_auth_flow() -> None:
     """When an anonymous visitor is *not* on an auth-flow page, the
     top-right Login shortcut renders as a clickable `<a
@@ -773,10 +759,10 @@ def test_primary_nav_renders_login_link_off_auth_flow() -> None:
     assert link is not None
     # No `<span aria-current="page">` on a non-auth path.
     assert tree.css_first('#primary-nav span[aria-current="page"]') is None
-    # When rendered as a link, no `class="contrast"` — keeps color
-    # consistent with how the link would render anywhere else in the
-    # chrome (#592). The auth-flow `<span>` variant carries `contrast`
-    # because it's a non-link indicator, not a navigation target.
+    # No `class="contrast"` anywhere in the nav — Pico styles the
+    # link with its default chrome treatment and the active-section
+    # cue with its default `aria-current="page"` treatment, no custom
+    # contrast utility needed (#592 + nav-pico-defaults cleanup).
     classes = (link.attributes.get("class") or "").split()
     assert (
         "contrast" not in classes


### PR DESCRIPTION
## Summary
The primary nav was layering two pieces of custom styling on top of what Pico already does for `aria-current="page"`:

1. `class="contrast"` on the brand link, every section link's active state, the profile icon's active state, and the Login `<span>` on auth-flow paths.
2. A `nav[aria-label=\"Primary\"] a[aria-current=\"page\"]` rule that bumped font-weight and added a `border-bottom: 2px solid currentColor` plus a padding compensation hack.

Both broke Pico's intended nav-link rendering. Pico already styles `aria-current=\"page\"` natively — the framework's chosen current-section cue. Stack-on customization wasn't needed.

## Change
- Remove all `class=\"contrast\"` from `<nav aria-label=\"Primary\">` links and the auth-flow Login `<span>`.
- Remove the `nav[aria-label=\"Primary\"] a[aria-current=\"page\"]` CSS block.
- Drop `test_primary_nav_active_link_carries_strong_style_hook` (it pinned the now-removed class).
- Update one comment on `test_login_link_color_is_consistent_across_auth_pages` to match the broader cleanup; the assertion itself stays as a regression guard.

## Test plan
- [x] `dev test` — 1490 passed, 78 skipped.
- [x] `dev lint` — clean.
- [ ] Visual: confirm the active section reads correctly with Pico's default `aria-current` treatment on `/posts?kind=referral`, `/providers`, `/organizations`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)