### PR TITLE
fix(css): strip all entity-card-specific CSS

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -66,120 +66,15 @@
         --pico-font-size-h3: 1.125rem;
         --pico-font-size-h4: 1rem;
       }
-      /* Entity cards — `<article class="entity-card">` is the canonical
-         shape for posts (list + detail) and the entity detail pages
-         (provider, organization, program, user). Pico's default article
-         framing (background, border, padding, rounded corners) gives
-         the chrome; the only post-specific override below is the
-         kind-colored left edge, kept as a documented exception so the
-         visual kind-anchor doesn't require touching markup per kind.
-
-         Everything else — header band hierarchy, body flow, footer
-         band — leans on Pico defaults and semantic HTML (`<hgroup>`,
-         `<h3>`, `<small>`, `<dl>`) so the chrome stays portable if
-         we ever swap CSS frameworks. The header on non-post detail
-         pages (provider / org / program / user) still uses
-         `<header class="entity-header">` with inline name+subtitle;
-         see the `.entity-header` rules further down. */
-      #posts-list { padding: 0; margin: 0; display: flex; flex-direction: column; gap: 1rem; }
-      .entity-card {
-        margin: 0;
-        border-left: 4px solid var(--pico-muted-border-color);
-      }
-      .entity-card[data-kind="referral"] { border-left-color: darkorange; }
-      .entity-card[data-kind="opening"] { border-left-color: darkcyan; }
-      .entity-card[data-kind="intake"] { border-left-color: darkcyan; }
-      /* Non-post detail pages still pair name + subtitle inline in
-         the card header via the `entity-header` class. Posts use a
-         `<hgroup>` pattern instead and intentionally drop this class
-         so Pico's default block flow applies. */
-      .entity-card > header.entity-header {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        gap: 0.5rem;
-      }
-      .entity-card > header.entity-header > strong { flex: 0 0 auto; }
-      .entity-card > header.entity-header > strong > a { color: inherit; text-decoration: none; }
-      .entity-card > header.entity-header > strong > a:hover { text-decoration: underline; }
-      .entity-card > header.entity-header > small {
-        margin-left: auto;
-        color: var(--pico-muted-color);
-      }
-      /* Footer band for the one detail page that still right-aligns
-         its CTA (users). Posts and other detail pages use the default
-         Pico footer flow (left-aligned). */
-      .entity-card > footer.entity-footer {
-        display: flex;
-        justify-content: flex-end;
-      }
-      .entity-card > footer.entity-footer > [role="button"] {
-        font-size: 0.875rem;
-      }
-      /* Services-with-icons list inside the post card body. `list-style:
-         none` lets the inline Lucide icon serve as the bullet; the
-         `display: flex` row aligns the icon vertically with its label. */
-      .entity-card section.entity-icon-list > ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-      }
-      .entity-card section.entity-icon-list > ul > li {
-        display: flex;
-        align-items: center;
-        padding: 0.1rem 0;
-      }
-      /* Demographics `<dl>`: one `<div>` per fact, "Label: value"
-         layout — `<dt>` inline with a colon, `<dd>` inline after.
-         Used by every entity-card body (posts and non-post detail
-         pages). Without these rules the default `<dl>` would stack
-         each label above its value on a separate line, doubling
-         the body height. The icon-only `<dt>` in
-         `<div class="entity-location">` would also fall back to
-         block layout and render on its own line above the value. */
-      .entity-card section.entity-facts > dl {
-        margin: 0;
-        padding: 0;
-      }
-      .entity-card section.entity-facts > dl > div {
-        padding: 0.1rem 0;
-      }
-      /* Two-column dl on desktop for non-post detail cards (org,
-         program, user, provider). Without this the facts list packs
-         into the left third of the card and wastes the right two
-         thirds (#586). Scoped via `:not([data-kind])` — only posts
-         carry `data-kind` for their kind-colored left edge — so post
-         cards keep their single-column body (they're already
-         tighter, and the user-facing design calls for stacked
-         services + facts per card). */
-      @media (min-width: 768px) {
-        .entity-card:not([data-kind]) > section.entity-facts > dl {
-          display: grid;
-          grid-template-columns: 1fr 1fr;
-          column-gap: 1.5rem;
-        }
-      }
-      .entity-card section.entity-facts dt {
-        display: inline;
-        font-weight: 600;
-      }
-      .entity-card section.entity-facts dt::after { content: ": "; }
-      /* CR location chunk: `<dt>` is icon-only (`aria-label` carries
-         meaning for screen readers), so suppress the trailing colon
-         that the generic rule above adds to every `<dt>`. Icon →
-         `<dd>` spacing comes from the icon's own `margin-inline-end`
-         (set in the global icon rule below), which extends past
-         the inline `<dt>` into the inline flow. */
-      .entity-card section.entity-facts dl > div.entity-location > dt::after { content: ""; }
-      .entity-card section.entity-facts dl > div.entity-location > dt { font-weight: normal; }
-      .entity-card section.entity-facts dd { display: inline; margin: 0; }
-      /* Detail-only "how to refer" section — sits below the body
-         sections, before the footer. The heading is the standard
-         `<h4>`; vertical rhythm comes from Pico's typography
-         spacing on the wrapping `<section>`. */
-      .entity-card > .entity-how-to-refer { margin: 0; }
-      .entity-card > .entity-how-to-refer h4 { margin: 0 0 0.4rem 0; font-size: 1rem; }
-      .entity-card > .entity-how-to-refer p { margin: 0.25rem 0; }
+      /* Entity cards (`<article class="entity-card">`) intentionally
+         carry no custom CSS — they rely on Pico's default `<article>`
+         framing (background, border, padding, rounded corners) plus
+         semantic HTML inside (`<hgroup>`, `<h3>`, `<small>`, `<dl>`,
+         etc.) so the chrome stays framework-portable. The
+         `entity-card` / `entity-header` / `entity-facts` / etc.
+         class names are kept on the markup as DOM hooks (tests query
+         them and they may pick up styles if Pico ever needs to be
+         supplemented), but no rule below targets them. */
       /* Responsive index tables. Pico's `.overflow-auto` wrapper gives
          every `index_table` table a horizontal scroll container, but
          on narrow viewports the right-edge columns still slide past
@@ -359,7 +254,7 @@
          clicks to enter the kind-specific create form: Lucide icon on
          the left, two-line text stack (title + 1-line description) on
          the right. The `data-kind` attribute mirrors the convention
-         used on `.entity-card` so the kind palette stays consistent
+         used on the entity-card markup so the kind reads the same
          across post surfaces. Pico styles `<a>` as inline text; the
          rules here promote each option to a block-level card with
          border, padding, and a hover/focus accent. The cap reuses

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -200,40 +200,6 @@ def test_form_new_view_appends_new_segment() -> None:
     assert '<form id="x"></form>' in html
 
 
-def test_entity_card_header_wraps_on_narrow_viewports() -> None:
-    """Regression for #577 — `.entity-card > header.entity-header` must
-    set `flex-wrap: wrap` so the modality chip + right-aligned `<small>`
-    date stay visible at ≤375px viewports. Without it the chip and date
-    clip past the card's right edge on mobile."""
-    import re
-
-    env = _make_env()
-    _add_child(
-        env,
-        "stub.html",
-        """
-        {% extends "views/list.html" %}
-        {% block resource_label %}Posts{% endblock %}
-        {% block content %}body{% endblock %}
-        """,
-    )
-
-    html = env.get_template("stub.html").render(
-        request=_request_stub(),
-        is_authenticated=False,
-        is_development=False,
-    )
-
-    match = re.search(
-        r"\.entity-card\s*>\s*header\.entity-header\s*\{[^}]*\}",
-        html,
-    )
-    assert match is not None, "entity-header rule missing from base.html"
-    assert "flex-wrap: wrap" in match.group(
-        0
-    ), "entity-header must set `flex-wrap: wrap` to avoid #577 clipping"
-
-
 def test_index_table_rows_stack_on_narrow_viewports() -> None:
     """Regression for #578 — every `index_table` row whose `<td>` cells
     carry `data-label` must stack into "Label: value" lines on ≤640px


### PR DESCRIPTION
## Summary
Per the direction "remove all entity-card specific CSS, we don't want any of it." Drops every rule targeting `.entity-card` and its descendant classes; the chrome now relies exclusively on Pico's default `<article>` framing + semantic HTML (`<hgroup>`, `<h3>`, `<small>`, `<dl>`).

## Removed CSS
- `.entity-card` border + `[data-kind="…"]` kind-colored left edge
- `.entity-card > header.entity-header` flex layout (and the `flex-wrap: wrap` rule that was the #577 mobile-clip fix)
- `.entity-card > footer.entity-footer` right-aligned CTA band
- `.entity-card section.entity-icon-list` ul/li flex + no-bullets
- `.entity-card section.entity-facts` dl/dt/dd inline-rendering rules
- `.entity-card:not([data-kind]) > section.entity-facts > dl` 2-col facts grid
- `.entity-card > .entity-how-to-refer` margin/heading rules
- `#posts-list` flex column with gap

## What stays
Class names remain on the markup as DOM hooks — tests still query them and Pico can be supplemented later if needed — but no rule below targets them.

## Test plan
- [x] Dropped `test_entity_card_header_wraps_on_narrow_viewports` (pinned the removed flex-wrap rule).
- [x] `dev test` — 1444 passed, 98 skipped.
- [x] `dev lint` — clean.
- [ ] Visual: confirm Pico's default `<article>` rendering produces acceptable cards on `/referrals`, `/openings`, `/intakes`, `/providers`, `/organizations`, `/programs`, `/users` detail and list pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)