### PR TITLE
feat(directory): listing row reflects all affiliations of a provider (#642 PR 3)

### DIFF
--- a/src/domain/logic/providers/test_view.py
+++ b/src/domain/logic/providers/test_view.py
@@ -119,6 +119,97 @@ def test_insurance_summary_both():
     assert _insurance_summary(p) == "In-network (Aetna) · Out-of-network"
 
 
+# --- _insurance_summary across multiple affiliations -------------------
+#
+# After #642 PR 3 the directory listing reads `_insurance_summary` and
+# expects it to union across every affiliation the Provider holds.
+
+
+def test_insurance_summary_unions_carriers_across_affiliations():
+    """Two affiliations each with their own in-network carrier roll up
+    into one ``In-network (...)`` clause with both carriers listed.
+    Order is first-seen-per-affiliation, then within-affiliation order."""
+    a = _stub_affiliation(in_network_carriers=["aetna"], accepts_out_of_network=False)
+    b = _stub_affiliation(
+        in_network_carriers=["anthem_bcbs"], accepts_out_of_network=False
+    )
+    p = _stub_provider(affiliations=[a, b])
+    assert _insurance_summary(p) == "In-network (Aetna, Anthem / BCBS)"
+
+
+def test_insurance_summary_dedupes_repeated_carriers():
+    """A clinician with two affiliations that both take Aetna shouldn't
+    show ``Aetna, Aetna`` — carrier codes dedupe across the union."""
+    a = _stub_affiliation(in_network_carriers=["aetna"], accepts_out_of_network=False)
+    b = _stub_affiliation(in_network_carriers=["aetna"], accepts_out_of_network=False)
+    p = _stub_provider(affiliations=[a, b])
+    assert _insurance_summary(p) == "In-network (Aetna)"
+
+
+def test_insurance_summary_oon_if_any_affiliation_accepts():
+    """Mixed posture: one affiliation accepts OON, the other doesn't.
+    The roll-up still says Out-of-network (``any``, not ``all``)."""
+    a = _stub_affiliation(in_network_carriers=[], accepts_out_of_network=True)
+    b = _stub_affiliation(in_network_carriers=[], accepts_out_of_network=False)
+    p = _stub_provider(affiliations=[a, b])
+    assert _insurance_summary(p) == "Out-of-network"
+
+
+def test_insurance_summary_self_pay_when_all_affiliations_self_pay():
+    """Every affiliation is self-pay-only → roll-up is ``Self-pay only``."""
+    a = _stub_affiliation(in_network_carriers=[], accepts_out_of_network=False)
+    b = _stub_affiliation(in_network_carriers=[], accepts_out_of_network=False)
+    p = _stub_provider(affiliations=[a, b])
+    assert _insurance_summary(p) == "Self-pay only"
+
+
+def test_insurance_summary_appends_sliding_when_any_affiliation_has_it():
+    """Any affiliation offering sliding scale surfaces in the row as a
+    trailing ``· sliding`` so the cell carries the full posture in one
+    string (the row macro no longer renders sliding as a separate
+    badge)."""
+    a = _stub_affiliation(
+        in_network_carriers=["aetna"], accepts_out_of_network=False, sliding_scale=False
+    )
+    b = _stub_affiliation(
+        in_network_carriers=[], accepts_out_of_network=False, sliding_scale=True
+    )
+    p = _stub_provider(affiliations=[a, b])
+    assert _insurance_summary(p) == "In-network (Aetna) · sliding"
+
+
+def test_insurance_summary_full_combination():
+    """The "everything on" case: in-network carriers from each
+    affiliation, at least one accepts OON, at least one has sliding
+    scale. All three clauses appear, joined by ``· `` in order."""
+    a = _stub_affiliation(
+        in_network_carriers=["aetna"],
+        accepts_out_of_network=False,
+        sliding_scale=False,
+    )
+    b = _stub_affiliation(
+        in_network_carriers=["anthem_bcbs"],
+        accepts_out_of_network=True,
+        sliding_scale=True,
+    )
+    p = _stub_provider(affiliations=[a, b])
+    assert (
+        _insurance_summary(p)
+        == "In-network (Aetna, Anthem / BCBS) · Out-of-network · sliding"
+    )
+
+
+def test_insurance_summary_sliding_alone_with_self_pay():
+    """A clinician whose only insurance posture across affiliations is
+    sliding-scale-only self-pay still surfaces sliding. ``Self-pay only``
+    sits in the base; ``· sliding`` trails."""
+    a = _stub_affiliation(
+        in_network_carriers=[], accepts_out_of_network=False, sliding_scale=True
+    )
+    p = _stub_provider(affiliations=[a])
+    assert _insurance_summary(p) == "Self-pay only · sliding"
+
+
 # --- provider_card_view ------------------------------------------------
 
 

--- a/src/domain/logic/providers/view.py
+++ b/src/domain/logic/providers/view.py
@@ -52,42 +52,76 @@ def _role_attr(provider, attr, default=None):
 
 
 def _insurance_summary(provider) -> str:
-    """Compose a single-string insurance phrase from the provider's
-    in-network / out-of-network / self-pay posture.
+    """Compose a single-string insurance phrase that unions a Provider's
+    insurance posture across **every** affiliation it holds.
+
+    After #642 PR 3 the directory listing shows one row per Provider that
+    reflects all affiliations (not just the primary). The Insurance cell
+    reads this phrase, so the summary unions across rows:
+
+      - ``in_network_carriers``: union of carrier codes across all
+        affiliations (first-seen order preserved, deduped).
+      - ``accepts_out_of_network``: ``True`` if **any** affiliation
+        accepts OON.
+      - ``sliding_scale``: ``True`` if **any** affiliation offers sliding
+        scale — surfaces in the row as a trailing ``"· sliding"`` so
+        callers don't need to render it as a separate badge.
 
     Returns one of:
-      - ``"In-network (Aetna, BCBS) · Out-of-network"``  (both)
-      - ``"In-network (Aetna)"``                         (in-network only)
-      - ``"Out-of-network"``                             (oon only)
-      - ``"Self-pay only"``                              (neither)
+      - ``"In-network (Aetna, Anthem / BCBS) · Out-of-network · sliding"``
+      - ``"In-network (Aetna) · sliding"``
+      - ``"Out-of-network"``
+      - ``"Self-pay only"``  (no carriers, no OON anywhere)
 
-    Collapses the three nested conditionals the old detail template
-    inlined; the template now reads a single ``view.insurance_summary``
-    string. The display-label lookup
+    Falls back to the legacy single-record path (``_role_attr``) when
+    ``provider.affiliations`` is empty/absent — covers ``SimpleNamespace``
+    test stubs that don't wire the 1:N relationship.
+
+    Display-label lookup
     (:data:`src.domain.models.enums.INSURANCE_CARRIER_LABELS`) happens
     here so the template doesn't need to know about it. Importing the
     label dict at module top would close a cluster-boundary import
     chain back into `models`; deferring to call time keeps the
     dependency graph quiet.
-
-    Reads source from ``provider.primary_affiliation`` — the single
-    source of truth after #635 PR B dropped the duplicated columns,
-    and the directory listing's per-row dereferencing rule after #642
-    PR 1 introduced multi-affiliation Providers.
     """
     from src.domain.models.enums import INSURANCE_CARRIER_LABELS
 
-    carriers = list(_role_attr(provider, "in_network_carriers", []) or [])
-    accepts_oon = bool(_role_attr(provider, "accepts_out_of_network", False))
-    if not carriers and not accepts_oon:
-        return "Self-pay only"
+    affiliations = list(getattr(provider, "affiliations", None) or [])
+    if affiliations:
+        carriers: list[str] = []
+        seen: set[str] = set()
+        for aff in affiliations:
+            for c in list(getattr(aff, "in_network_carriers", None) or []):
+                if c not in seen:
+                    seen.add(c)
+                    carriers.append(c)
+        accepts_oon = any(
+            bool(getattr(aff, "accepts_out_of_network", False)) for aff in affiliations
+        )
+        sliding = any(
+            bool(getattr(aff, "sliding_scale", False)) for aff in affiliations
+        )
+    else:
+        # No affiliations on the row — fall through to the legacy
+        # single-record path so test stubs that set the columns on the
+        # provider stub (or via `primary_affiliation`) keep working.
+        carriers = list(_role_attr(provider, "in_network_carriers", []) or [])
+        accepts_oon = bool(_role_attr(provider, "accepts_out_of_network", False))
+        sliding = bool(_role_attr(provider, "sliding_scale", False))
+
     parts: list[str] = []
     if carriers:
         labels = ", ".join(INSURANCE_CARRIER_LABELS[c] for c in carriers)
         parts.append(f"In-network ({labels})")
     if accepts_oon:
         parts.append("Out-of-network")
-    return " · ".join(parts)
+    if not parts:
+        base = "Self-pay only"
+    else:
+        base = " · ".join(parts)
+    if sliding:
+        base = f"{base} · sliding"
+    return base
 
 
 def _affiliation_insurance_summary(affiliation) -> str:

--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -416,7 +416,15 @@ async def test_list_providers_renders_html(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
     """`GET /providers` renders an HTML page with one entry per
-    persisted provider, regardless of which user owns it."""
+    persisted provider, regardless of which user owns it.
+
+    After #642 PR 3 the Practice cell no longer wraps in an
+    `a[href="/providers/{id}"]` anchor — each org name is its own
+    link to the owning Organization. The Provider id still rides on
+    the row via `data-row-id` so per-row chrome (and tests) can scope
+    to it; the next-PR clinician name column will surface the
+    provider-detail link. The headline assertion here pins the org
+    link shape and the row's `data-row-id`."""
     other = create_test_user(username=f"other-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -432,8 +440,161 @@ async def test_list_providers_renders_html(
     tree = HTMLParser(response.text)
     rows = tree.css("#providers-table tbody tr")
     assert len(rows) == 1
-    assert tree.css_first(f'a[href="/providers/{provider_id}"]') is not None
-    assert "Open House" in response.text
+    assert rows[0].attributes.get("data-row-id") == str(provider_id)
+    # Org name renders as a link to the owning Organization.
+    practice_cell = rows[0].css_first('td[data-label="Practice"]')
+    assert practice_cell is not None
+    org_anchor = practice_cell.css_first("a[href^='/organizations/']")
+    assert org_anchor is not None
+    assert org_anchor.text(strip=True) == "Open House"
+
+
+async def test_list_providers_row_shows_all_affiliations(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """After #642 PR 3 each Provider row reflects **every** affiliation
+    it holds, not just the primary. Seed a Provider with two
+    affiliations at different Orgs / cities and assert both org names
+    and both city/state pairs render inside the single row's Practice
+    and Location cells. The Insurance cell unions in-network carriers
+    across affiliations — pin one carrier per side and assert both
+    show up."""
+    from src.domain.models import Affiliation
+
+    provider_id = await _seed_provider_for(
+        db_test_session_manager,
+        user_id=logged_in_user.id,
+        practice_name="Bedlam Health",
+        location_city="Brooklyn",
+        location_state="NY",
+        location_zip="11201",
+        in_network_carriers=["aetna"],
+    )
+    second_org_id = await _seed_org(
+        db_test_session_manager,
+        owner_id=logged_in_user.id,
+        name="Wellspring",
+    )
+    clinician_id = await _clinician_id_for(db_test_session_manager, provider_id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                Affiliation(
+                    provider_id=provider_id,
+                    clinician_id=clinician_id,
+                    org_id=second_org_id,
+                    location_city="Queens",
+                    location_state="NY",
+                    location_zip="11101",
+                    in_person_sessions="yes",
+                    virtual_sessions="please_contact",
+                    accepts_out_of_network=True,
+                    in_network_carriers=["anthem_bcbs"],
+                    sliding_scale=False,
+                    cost=None,
+                )
+            )
+
+    response = await authenticated_client.get("/providers")
+
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    rows = tree.css(f'tr[data-row-id="{provider_id}"]')
+    assert (
+        len(rows) == 1
+    ), "expected a single row per Provider (not one per affiliation)"
+    practice_cell = rows[0].css_first('td[data-label="Practice"]')
+    location_cell = rows[0].css_first('td[data-label="Location"]')
+    insurance_cell = rows[0].css_first('td[data-label="Insurance"]')
+    assert practice_cell is not None
+    assert location_cell is not None
+    assert insurance_cell is not None
+    practice_text = practice_cell.text(strip=True)
+    location_text = location_cell.text(strip=True)
+    insurance_text = insurance_cell.text(strip=True)
+    assert "Bedlam Health" in practice_text
+    assert "Wellspring" in practice_text
+    assert "Brooklyn" in location_text
+    assert "Queens" in location_text
+    # Each org chip is its own link to the owning Organization.
+    org_links = practice_cell.css("a[href^='/organizations/']")
+    org_hrefs = {a.attributes.get("href") for a in org_links}
+    assert f"/organizations/{second_org_id}" in org_hrefs
+    assert len(org_links) == 2, "expected one anchor per affiliation"
+    # Insurance cell unions in-network carriers from both affiliations.
+    assert "Aetna" in insurance_text
+    # `anthem_bcbs` renders as "Anthem / BCBS" via INSURANCE_CARRIER_LABELS.
+    assert "Anthem" in insurance_text or "BCBS" in insurance_text
+    # The second affiliation accepts OON → roll-up surfaces Out-of-network.
+    assert "Out-of-network" in insurance_text
+
+
+async def test_list_providers_row_dedupes_identical_locations(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Two affiliations in the same city+state collapse to one chip in
+    the Location cell — guards against "Brooklyn, NY · Brooklyn, NY"
+    when a clinician holds two affiliations at different Orgs in the
+    same city. Org chips intentionally don't dedupe (each Org is its
+    own link)."""
+    from src.domain.models import Affiliation
+
+    provider_id = await _seed_provider_for(
+        db_test_session_manager,
+        user_id=logged_in_user.id,
+        practice_name="Bedlam Health",
+        location_city="Brooklyn",
+        location_state="NY",
+        location_zip="11201",
+    )
+    second_org_id = await _seed_org(
+        db_test_session_manager,
+        owner_id=logged_in_user.id,
+        name="Wellspring",
+    )
+    clinician_id = await _clinician_id_for(db_test_session_manager, provider_id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                Affiliation(
+                    provider_id=provider_id,
+                    clinician_id=clinician_id,
+                    org_id=second_org_id,
+                    location_city="Brooklyn",
+                    location_state="NY",
+                    location_zip="11201",
+                    in_person_sessions="yes",
+                    virtual_sessions="please_contact",
+                    accepts_out_of_network=False,
+                    in_network_carriers=[],
+                    sliding_scale=False,
+                    cost=None,
+                )
+            )
+
+    response = await authenticated_client.get("/providers")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    location_cell = tree.css_first(
+        f'tr[data-row-id="{provider_id}"] td[data-label="Location"]'
+    )
+    assert location_cell is not None
+    location_text = location_cell.text(strip=True)
+    # "Brooklyn, NY" appears exactly once after the dedupe.
+    assert (
+        location_text.count("Brooklyn") == 1
+    ), f"expected one Brooklyn chip, got: {location_text!r}"
+    # Both org chips still render (org_id dedup is intentionally
+    # off — two affiliations at different Orgs both get a link).
+    practice_cell = tree.css_first(
+        f'tr[data-row-id="{provider_id}"] td[data-label="Practice"]'
+    )
+    assert practice_cell is not None
+    assert len(practice_cell.css("a[href^='/organizations/']")) == 2
 
 
 async def test_list_providers_shows_licensure_states(
@@ -575,8 +736,10 @@ async def test_list_providers_filters_by_license_type(
     tree = HTMLParser(response.text)
     rows = tree.css("#providers-table tbody tr")
     assert len(rows) == 1
-    assert tree.css_first(f'a[href="/providers/{provider_a}"]') is not None
-    assert tree.css_first(f'a[href="/providers/{provider_b}"]') is None
+    # After #642 PR 3 the row scopes by `data-row-id` (the Provider id);
+    # the row's Practice cell anchors out to Orgs, not to the provider.
+    assert tree.css_first(f'tr[data-row-id="{provider_a}"]') is not None
+    assert tree.css_first(f'tr[data-row-id="{provider_b}"]') is None
     # The toolbar's filter link summarizes the active filter inline.
     link = tree.css_first("a.toolbar-filter-link")
     assert link is not None

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -491,8 +491,12 @@ async def test_detail_lists_owned_providers(
     assert tree.css_first("#user-detail-providers-empty") is None
     rows = tree.css("#user-detail-providers tbody tr")
     assert len(rows) == 2
-    hrefs = {a.attributes.get("href") for a in tree.css("#user-detail-providers a")}
-    assert hrefs == {f"/providers/{first.id}", f"/providers/{second.id}"}
+    # After #642 PR 3 the Practice cell anchors to the owning Org per
+    # affiliation (each Provider here has its own auto-built Org via
+    # `make_provider_with_org`). The Provider id rides on the row's
+    # `data-row-id`; assert both Providers surface via that attribute.
+    row_ids = {row.attributes.get("data-row-id") for row in rows}
+    assert row_ids == {str(first.id), str(second.id)}
 
 
 def _inline_create_provider_link(tree: HTMLParser):

--- a/src/framework/templates/_shared/_provider_row.html
+++ b/src/framework/templates/_shared/_provider_row.html
@@ -12,10 +12,29 @@ Filters for the `/providers` index are declared on
 `/providers/search` page (via `views/search.html`) — there's no
 provider-specific filter partial to maintain.
 
-The Insurance cell composes the same posture summary used on the
-provider detail card (#449): "In-net" / "Out-net" / "Self-pay", with
-optional "· sliding" when sliding scale is on. Folded into one column
-so the table stays narrow.
+After #642 PR 3 each cell reflects **every** affiliation the Provider
+holds — not just the primary one.
+
+  - Practice cell: one anchor per affiliation pointing at the owning
+    Organization (`/organizations/{aff.org_id}`), joined by `" · "`.
+    Two affiliations at the same Org keep both chips (they may be
+    different locations); the cell intentionally does not dedupe by
+    `org_id`. The `<td>` keeps `class="primary"` so the responsive
+    mobile-stack pattern (see `_shared/index_table.html` and
+    `base.html` #578) still treats the cell as the row's headline.
+  - Location cell: `"City, ST"` per affiliation, joined by `" · "`,
+    with adjacent duplicate strings deduped (a clinician with two
+    affiliations both in Brooklyn, NY renders one chip — see the
+    `seen` set below).
+  - Insurance cell: rendered from
+    `src.domain.logic.providers.view._insurance_summary`, which unions
+    in-network carriers, out-of-network acceptance, and sliding-scale
+    posture across every affiliation.
+
+PR 4 will introduce a per-Clinician identity column (with a link to
+the provider/clinician detail page); for now the row links out to
+its Orgs only and the `data-row-id` carries the Provider id for
+tests / future per-row chrome.
 #}
 
 {% macro provider_headers() -%}
@@ -26,12 +45,42 @@ so the table stays narrow.
 {%- endmacro %}
 
 {% macro provider_row(provider) -%}
+{%- set view = provider_card_view(provider) -%}
 {%- set issuing_states = provider.licensures | map(attribute='issuing_state') | unique | sort | list -%}
+{%- set affiliations = provider.affiliations | list -%}
+{# Dedupe identical "City, ST" strings (e.g. two affiliations in
+   Brooklyn, NY shouldn't render "Brooklyn, NY · Brooklyn, NY"). Org
+   chips intentionally don't dedupe — two affiliations at the same
+   Org may be different physical locations and both deserve a link. #}
+{%- set locations = [] -%}
+{%- for aff in affiliations -%}
+  {%- set loc -%}
+    {%- if aff.location_city or aff.location_state -%}
+      {{ aff.location_city }}{% if aff.location_city and aff.location_state %}, {% endif %}{{ aff.location_state }}
+    {%- endif -%}
+  {%- endset -%}
+  {%- set loc = loc | trim -%}
+  {%- if loc and loc not in locations -%}
+    {%- set _ = locations.append(loc) -%}
+  {%- endif -%}
+{%- endfor -%}
 <tr data-row-id="{{ provider.id }}">
   <td data-label="Practice" class="primary">
-    <a href="{{ entity_url('provider', id=provider.id) }}">{{ provider.org.name }}</a>
+    {%- if affiliations -%}
+      {%- for aff in affiliations -%}
+        <a href="{{ entity_url('organization', id=aff.org_id) }}">{{ aff.org.name }}</a>{% if not loop.last %} · {% endif %}
+      {%- endfor -%}
+    {%- else -%}
+      &mdash;
+    {%- endif -%}
   </td>
-  <td data-label="Location">{{ provider.location_city }}, {{ provider.location_state }}</td>
+  <td data-label="Location">
+    {%- if locations -%}
+      {{ locations | join(' · ') }}
+    {%- else -%}
+      &mdash;
+    {%- endif -%}
+  </td>
   <td data-label="Licensed in">
     {%- if issuing_states -%}
       {{ issuing_states | join(', ') }}
@@ -39,17 +88,6 @@ so the table stays narrow.
       &mdash;
     {%- endif -%}
   </td>
-  <td data-label="Insurance">
-    {%- if provider.in_network_carriers and provider.accepts_out_of_network -%}
-      In-net &amp; out-net
-    {%- elif provider.in_network_carriers -%}
-      In-net
-    {%- elif provider.accepts_out_of_network -%}
-      Out-net
-    {%- else -%}
-      Self-pay
-    {%- endif -%}
-    {%- if provider.sliding_scale %} <small>· sliding</small>{% endif -%}
-  </td>
+  <td data-label="Insurance">{{ view.insurance_summary }}</td>
 </tr>
 {%- endmacro %}


### PR DESCRIPTION
## Summary

Third and final UI PR for issue #642: the `/providers` directory listing now reads through **every** affiliation a Provider holds, not just the primary.

- **Practice cell** — one anchor per affiliation pointing at the owning Organization, joined by ` · `. Two affiliations at the same Org both render (they may be different physical locations).
- **Location cell** — `"City, ST"` per affiliation, joined by ` · `, with adjacent duplicate strings deduped (no `"Brooklyn, NY · Brooklyn, NY"`).
- **Licensed in cell** — unchanged (clinician-level licensures).
- **Insurance cell** — `_insurance_summary` now unions across all affiliations:
  - in-network carriers: union, deduped, first-seen order;
  - `Out-of-network` if **any** affiliation accepts OON;
  - `· sliding` if **any** affiliation has sliding scale;
  - `Self-pay only` only when NO carriers across all affiliations AND none accepts OON.

Each Provider still occupies a single row (`data-row-id` carries the Provider id). The Practice-cell anchor swap means the row no longer carries an `a[href="/providers/{id}"]` shortcut; PR 4 will introduce the clinician-name column and surface the provider-detail link there.

Design call: https://github.com/willthefirst/bedlam-connect/issues/642#issuecomment-4492090479

### Before / after row rendering

Provider with two affiliations: Bedlam Health (Brooklyn, NY, Aetna in-network) and Wellspring (Queens, NY, OON, sliding).

**Before (post-PR-2):**
```
Practice: <a href="/providers/{id}">Bedlam Health</a>
Location: Brooklyn, NY
Insurance: In-network (Aetna)
```

**After:**
```
Practice: <a href="/organizations/{a}">Bedlam Health</a> · <a href="/organizations/{b}">Wellspring</a>
Location: Brooklyn, NY · Queens, NY
Insurance: In-network (Aetna) · Out-of-network · sliding
```

### Out of scope (PR 4)

- Provider→Clinician rename.
- Changes to `/providers/` URLs.
- Filter SQL (the `?license_type=` / `?issuing_state=` filters still target Provider, not the affiliation list).

## Test plan

- [x] `dev test` passes (1514 passed, 106 skipped).
- [x] `dev lint` passes.
- [x] `dev test contract` passes (34 passed, 1 skipped — none new vs. main).
- [x] `test_view.py` pins combined-insurance semantics (Aetna+BCBS → both; both self-pay → self-pay; OON+self-pay → Out-of-network).
- [x] `test_providers.py::test_list_providers_row_shows_all_affiliations` seeds a two-affiliation Provider and asserts both org names + both cities + unioned carriers render.
- [x] `test_providers.py::test_list_providers_row_dedupes_identical_locations` guards against `Brooklyn, NY · Brooklyn, NY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)