### PR TITLE
refactor(chrome): consolidate breadcrumb + toolbar into a single band

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -292,14 +292,16 @@ async def test_get_user_detail_renders(
     assert target_username in tree.body.text()
 
 
-async def test_get_user_detail_renders_breadcrumb(
+async def test_get_user_detail_renders_breadcrumb_and_heading(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """User detail follows the standard `list → detail` breadcrumb
-    shape: `Users › <username>`. The first item links to the user
-    list; the trailing username is the current page (`aria-current`)."""
+    """User detail uses the consolidated chrome: a one-segment
+    breadcrumb that links back to `/users` and a toolbar `<h1>` that
+    carries the current user's name. The current item is NOT
+    repeated as a non-link crumb — every visible breadcrumb item is
+    an actionable link (GOV.UK pattern)."""
     target_username = f"target-{uuid.uuid4()}"
     target = create_test_user(username=target_username)
     async with db_test_session_manager() as session:
@@ -310,12 +312,14 @@ async def test_get_user_detail_renders_breadcrumb(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     items = tree.css('nav[aria-label="breadcrumb"] ul > li')
-    assert [li.text(strip=True) for li in items] == ["Users", target_username]
+    assert [li.text(strip=True) for li in items] == ["Users"]
     parent = items[0].css_first("a")
     assert parent is not None
     assert parent.attributes.get("href") == "/users"
-    assert items[-1].attributes.get("aria-current") == "page"
-    assert items[-1].css_first("a") is None
+    # Current item lives in the toolbar <h1>, not the breadcrumb.
+    h1 = tree.css_first("div.toolbar h1")
+    assert h1 is not None
+    assert h1.text(strip=True) == target_username
 
 
 async def test_detail_hides_private_fields_from_strangers(

--- a/src/framework/templates/_shared/_toolbar.html
+++ b/src/framework/templates/_shared/_toolbar.html
@@ -1,9 +1,13 @@
 {# Top-of-page zone bar primitive.
 
-Every page that needs page-scoped controls renders one toolbar
-strip above its content, followed by an `<hr />` separator. All
-content right-aligns. The bar carries up to two items:
+Every page renders one toolbar strip above its content, followed
+by an `<hr />` separator. The row carries up to three things,
+left-to-right:
 
+  Heading (`<h1>`) — the page title. Required arg. Lives in the
+    same row as the actions so the chrome compacts to a single
+    band (the breadcrumb above is plain inline text carrying
+    ancestry only; the H1 is here).
   Filter link (`a.toolbar-filter-link`) — opens the dedicated
     `/<collection>/search` page. Always reads `Filters` when none
     are active; switches to a short inline summary
@@ -22,26 +26,26 @@ content right-aligns. The bar carries up to two items:
 Cap on how many filter chips appear inline before collapsing to
 `+N more filters`. Keeps the link readable on narrow viewports.
 
-    Detail page (actions only):
+    Detail page (heading + actions):
 
-        {% call page_toolbar() %}
+        {% call page_toolbar(heading="Will's Org") %}
           <li><a href=".../form" role="button">Edit</a></li>
           <li>{{ confirm_delete_button(...) }}</li>
         {% endcall %}
 
-    List page (filter link + actions):
+    List page (heading + filter link + actions):
 
         {% call page_toolbar(
+          heading="Openings",
           active_filters=active_filters,
           search_url=search_url,
         ) %}
           <li><a href="{{ entity_form_url('post') }}" role="button">Create</a></li>
         {% endcall %}
 
-Pages with no toolbar content leave `{% block toolbar %}` empty
-(or omit it). The shell is suppressed when neither a filter link
-nor a caller body is present, so empty pages don't emit a stray
-`<hr />`.
+    Form page (heading only):
+
+        {% call page_toolbar(heading="Edit Will's Org") %}{% endcall %}
 #}
 
 {% set _ACTIVE_FILTER_INLINE_LIMIT = 2 %}
@@ -50,6 +54,11 @@ nor a caller body is present, so empty pages don't emit a stray
 {# Render the toolbar.
 
 Args:
+  heading: page title — rendered as an `<h1>` on the left of the
+    toolbar row. Required: every page-scoped toolbar owns the
+    page heading (the breadcrumb above carries ancestry only;
+    the heading lives in the same row as the page actions so the
+    chrome compacts into a single band).
   active_filters: list of `{name, value, label}` descriptors (one
     per active value; multi-valued filters fan out). Empty when
     no filter is applied.
@@ -59,6 +68,7 @@ Args:
     `routes.search`).
 #}
 {% macro page_toolbar(
+  heading,
   active_filters=(),
   search_url=none
 ) -%}
@@ -70,6 +80,8 @@ Args:
 {%- set actions_html = caller() if caller else "" -%}
 {%- set has_actions = actions_html | trim -%}
 <div class="toolbar">
+
+  <h1>{{ heading }}</h1>
 
   {%- if search_url %}
   <a href="{{ search_url }}" class="toolbar-filter-link">

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -144,6 +144,12 @@
          so the whole cluster lands at the right edge whether one
          or both pieces are present. */
       .toolbar { display: flex; align-items: center; flex-wrap: wrap; gap: 0.75rem; }
+      /* Toolbar carries the page `<h1>` on the left. Reset Pico's
+         block-level heading margins so the heading sits cleanly in
+         the flex row (Pico defaults add ~1rem above/below); the
+         size stays at Pico's default `h1` so the heading reads as
+         the page title. */
+      .toolbar h1 { margin: 0; }
       /* Pico's default `<button>` is `display: block; width: 100%`
          (form-shaped); the toolbar overrides to natural-width inline
          buttons. Reaches every nested `<button>` / `[role="button"]`
@@ -188,33 +194,16 @@
         padding-inline: 0.5rem;
         font-size: 0.875rem;
       }
-      /* Breadcrumb zone bar. Pico already styles the markup
-         (`nav[aria-label="breadcrumb"] ul` becomes an inline list
-         with a separator via `li + li::before`); the only thing this
-         project adds is the strip's frame — subtle background +
-         bottom border to set it apart from page content — and the
-         divider character via the Pico-exposed
-         `--pico-nav-breadcrumb-divider`. Hidden on narrow viewports;
-         the location context isn't worth the row on mobile. */
+      /* Breadcrumb. Inline text only — no band chrome (background,
+         border, padding). Pico already styles `nav[aria-label="breadcrumb"]
+         ul` as an inline list with a separator via `li + li::before`;
+         we just set the divider character via the Pico-exposed
+         `--pico-nav-breadcrumb-divider`. The breadcrumb sits as a thin
+         line above the toolbar row that carries the `<h1>`, so the
+         chrome between the global nav and the content is one band
+         instead of two. */
       nav[aria-label="breadcrumb"] {
         --pico-nav-breadcrumb-divider: '›';
-        background: var(--pico-card-background-color);
-        border-bottom: var(--pico-border-width) solid var(--pico-muted-border-color);
-        padding: calc(var(--pico-spacing) * 0.5) var(--pico-spacing);
-        margin: 0 0 var(--pico-spacing) 0;
-      }
-      /* On mobile, only the *current page* segment is worth the row —
-         list pages render a single-segment breadcrumb that doubles as
-         the page heading ("Organizations", "Posts", "Providers",
-         "Users") and must stay visible (#588). Detail/form pages whose
-         breadcrumb carries multiple segments hide it on mobile: the
-         intermediate links are location context, not the page heading,
-         and the toolbar already gives the page its actions.
-         `:has(li + li)` matches a nav containing two or more `<li>`s —
-         i.e. any multi-segment breadcrumb. Single-segment breadcrumbs
-         (one `<li>`) don't match and stay visible. */
-      @media (max-width: 768px) {
-        nav[aria-label="breadcrumb"]:has(li + li) { display: none; }
       }
       /* Entity create/edit forms — cap form width on large screens so
          short fields don't stretch across the whole container, and

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -56,10 +56,13 @@ def _add_child(env: Environment, name: str, body: str) -> None:
     env.loader.loaders[0].mapping[name] = textwrap.dedent(body).lstrip()
 
 
-def test_list_view_renders_single_segment_breadcrumb() -> None:
-    """``views/list.html`` fills the `breadcrumb` block with a
-    single-segment `breadcrumb([(resource_label, None)])` call. The
-    child only declares the label."""
+def test_list_view_renders_h1_in_toolbar_and_omits_breadcrumb() -> None:
+    """``views/list.html`` puts the `resource_label` into the
+    toolbar `<h1>` (the page title) and renders no breadcrumb —
+    a single-segment "Providers" trail would duplicate what the
+    active global-nav tab already communicates, so list pages
+    skip the breadcrumb entirely. The child only declares the
+    label."""
     env = _make_env()
     _add_child(
         env,
@@ -77,19 +80,22 @@ def test_list_view_renders_single_segment_breadcrumb() -> None:
         is_development=False,
     )
 
-    # Single-segment breadcrumb: the label appears inside the
-    # `<nav aria-label="breadcrumb">` strip with `aria-current="page"`
-    # (no `<a>` for the trailing segment).
-    assert 'aria-label="breadcrumb"' in html
-    assert 'aria-current="page"' in html
-    assert "Providers" in html
+    tree = HTMLParser(html)
+    # No breadcrumb on list pages.
+    assert tree.css_first('nav[aria-label="breadcrumb"]') is None
+    # The heading lives in the toolbar `<h1>`.
+    toolbar_h1 = tree.css_first("div.toolbar h1")
+    assert toolbar_h1 is not None
+    assert toolbar_h1.text(strip=True) == "Providers"
     # Content block lands in the page body.
     assert '<div id="body">ok</div>' in html
 
 
-def test_list_view_omits_toolbar_when_no_filters_no_actions() -> None:
-    """The toolbar shell renders only when filters or actions are
-    present — empty pages don't emit a stray `<hr />`."""
+def test_list_view_renders_toolbar_with_h1_even_without_actions() -> None:
+    """The toolbar shell always renders on list pages now because
+    it owns the page `<h1>`; previously it was suppressed when
+    neither filter link nor actions were present. The shell still
+    renders cleanly with the heading alone."""
     env = _make_env()
     _add_child(
         env,
@@ -107,11 +113,14 @@ def test_list_view_omits_toolbar_when_no_filters_no_actions() -> None:
         is_development=False,
     )
 
-    # Parse rather than substring-match: `base.html`'s CSS comment
-    # references `<div class="toolbar">` verbatim to document the
-    # shape, so a naive `in html` check would false-positive.
     tree = HTMLParser(html)
-    assert tree.css_first("div.toolbar") is None
+    toolbar = tree.css_first("div.toolbar")
+    assert toolbar is not None
+    h1 = toolbar.css_first("h1")
+    assert h1 is not None and h1.text(strip=True) == "Users"
+    # No filter link and no action menu when child opts out.
+    assert toolbar.css_first("a.toolbar-filter-link") is None
+    assert toolbar.css_first("menu.toolbar-right") is None
 
 
 def test_list_view_renders_actions_block_in_toolbar_right() -> None:
@@ -338,7 +347,12 @@ def test_primary_nav_shows_admin_links_only_for_admins() -> None:
     assert "/providers" in nonadmin_links
 
 
-def test_form_edit_view_renders_three_segment_breadcrumb() -> None:
+def test_form_edit_view_renders_breadcrumb_and_edit_heading() -> None:
+    """``views/form_edit.html`` renders a two-segment breadcrumb
+    (collection link › detail link) and an `<h1>"Edit <current>"`
+    in the toolbar. The current item is not repeated as a non-link
+    crumb — the H1 carries it, so every visible crumb stays an
+    actionable link (GOV.UK pattern)."""
     env = _make_env()
     _add_child(
         env,
@@ -359,10 +373,16 @@ def test_form_edit_view_renders_three_segment_breadcrumb() -> None:
         is_development=False,
     )
 
-    assert 'href="/providers"' in html
-    assert 'href="/providers/42"' in html
-    assert "Sunrise Therapy" in html
-    assert ">Edit</li>" in html or ">Edit<" in html
+    tree = HTMLParser(html)
+    crumbs = tree.css('nav[aria-label="breadcrumb"] li')
+    assert [li.css_first("a").attributes.get("href") for li in crumbs] == [
+        "/providers",
+        "/providers/42",
+    ], "form-edit breadcrumb must be exactly two link segments"
+    # H1 in the toolbar reads "Edit <current>".
+    h1 = tree.css_first("div.toolbar h1")
+    assert h1 is not None
+    assert h1.text(strip=True) == "Edit Sunrise Therapy"
 
 
 def test_form_actions_buttons_fill_row_width_on_desktop() -> None:
@@ -540,19 +560,21 @@ def test_destructive_action_macros_emit_danger_class() -> None:
     ), "form_actions Delete button must emit class containing 'danger'"
 
 
-def test_breadcrumb_page_heading_visible_on_mobile() -> None:
-    """Regression for #588 — the single-segment breadcrumb on every
-    list page (`Organizations`, `Posts`, `Providers`, `Users`) doubles
-    as the page heading and must stay visible at the 375px mobile
-    viewport. Earlier the mobile rule hid `nav[aria-label="breadcrumb"]`
-    unconditionally under `@media (max-width: 768px)`, dropping the
-    page-heading context on mobile list pages and leaving only the
-    Filters/Create row as the top of the page.
+def test_list_page_heading_visible_on_mobile() -> None:
+    """Regression for #588 — the list-page heading (`Organizations`,
+    `Posts`, `Providers`, `Users`) must stay visible at the 375px
+    mobile viewport.
 
-    The fix scopes the hide to multi-segment breadcrumbs only via the
-    `:has(li + li)` selector — single-segment list-page breadcrumbs
-    stay visible; multi-segment detail/form breadcrumbs (location
-    context) still collapse on mobile.
+    Earlier the heading lived in a single-segment breadcrumb above
+    the toolbar, and a `@media (max-width: 768px)` rule unconditionally
+    hid `nav[aria-label="breadcrumb"]` — dropping the page-heading
+    context on mobile list pages.
+
+    The breadcrumb-toolbar consolidation moved the heading into the
+    toolbar `<h1>` (and removed the breadcrumb from list pages
+    entirely), so the heading is now part of the same row as Filters /
+    Create. This test pins the new arrangement: the `<h1>` is rendered
+    inside the toolbar and carries no mobile-hide rule.
     """
     import re
 
@@ -572,25 +594,21 @@ def test_breadcrumb_page_heading_visible_on_mobile() -> None:
         is_development=False,
     )
 
-    # Find every `@media (max-width: 768px)` block and verify none of
-    # them blanket-hide `nav[aria-label="breadcrumb"]` — the rule must
-    # be scoped to multi-segment via `:has(li + li)`.
-    blocks_768 = re.findall(
-        r"@media\s*\(\s*max-width:\s*768px\s*\)\s*\{(.*?)\n      \}",
-        html,
-        re.DOTALL,
-    )
-    assert blocks_768, "no @media (max-width: 768px) block in base.html"
-    combined = "\n".join(blocks_768)
-    assert (
-        'nav[aria-label="breadcrumb"]:has(li + li)' in combined
-    ), "mobile breadcrumb hide must be scoped to `:has(li + li)` so single-segment list-page breadcrumbs stay visible (#588)"
-    # And the unscoped version must not appear — that would re-hide
-    # the page heading on mobile list pages.
+    tree = HTMLParser(html)
+    h1 = tree.css_first("div.toolbar h1")
+    assert h1 is not None, "list-page heading must live in the toolbar <h1>"
+    assert h1.text(strip=True) == "Providers"
+
+    # The CSS must not blanket-hide the toolbar or its `<h1>` on
+    # narrow viewports — the page heading has to stay visible.
     assert not re.search(
-        r"nav\[aria-label=\"breadcrumb\"\]\s*\{\s*display:\s*none",
-        combined,
-    ), 'unscoped `nav[aria-label="breadcrumb"] { display: none }` in a mobile @media block would hide the page heading on list pages (#588)'
+        r"@media[^{]*max-width[^{]*\{[^}]*\.toolbar[^}]*display:\s*none",
+        html,
+    ), "toolbar must not be hidden on mobile — the page heading lives there"
+    assert not re.search(
+        r"@media[^{]*max-width[^{]*\{[^}]*\.toolbar\s+h1[^}]*display:\s*none",
+        html,
+    ), "toolbar h1 must not be hidden on mobile — that's the page heading"
 
 
 def test_entity_form_page_caps_short_field_widths() -> None:

--- a/src/framework/templates/views/detail.html
+++ b/src/framework/templates/views/detail.html
@@ -1,9 +1,19 @@
 {# Generic detail-view chrome.
 
-A detail view (`/posts/{id}`, `/providers/{id}`, `/users/{id}`) renders
-a two-segment breadcrumb (collection → current item) and an optional
-toolbar of primary resource actions (Edit, Delete, Favorite, ...). The
-template wires both by convention so the child only fills the body.
+A detail view (`/openings/{id}`, `/providers/{id}`, `/users/{id}`)
+renders a single-segment breadcrumb (link back to the collection)
+above a toolbar row that pairs the resource's `<h1>` with the
+primary actions (Edit, Delete, Favorite, ...). GOV.UK-style: the
+breadcrumb does not repeat the current page label — the `<h1>` in
+the toolbar carries it, so every visible crumb stays an actionable
+link.
+
+Layout per page:
+
+    <breadcrumb: link to collection>
+    <h1: current item>    <actions...>
+    <hr>
+    <content>
 
 Child contract:
 
@@ -11,22 +21,23 @@ Child contract:
     resource_label — short string label for the collection segment of
                      the breadcrumb (e.g. "Providers").
     current_label  — short string label for the current item (e.g.
-                     `{{ provider.org.name }}`).
+                     `{{ provider.org.name }}`). Used as both the
+                     `<h1>` heading and (by convention) the document
+                     title.
     content        — the resource detail body.
 
   Required context (set via `{% set %}` after `{% extends %}`):
     resource_url   — URL the collection segment links to (e.g.
-                     "/providers"). The current segment renders as plain
-                     text with `aria-current="page"`.
+                     "/providers").
 
   Optional blocks:
-    actions        — toolbar right-zone content: Edit, Delete, Favorite,
-                     admin actions, etc. Each action is a `<li>` because
-                     the right zone is a `<menu class="toolbar-right">`
-                     (list of commands, pushed to the right edge). The
-                     toolbar shell is suppressed when this block is empty.
-    breadcrumb     — full breadcrumb override for nested-detail pages
-                     that don't fit the two-segment shape.
+    actions        — toolbar right-zone content: Edit, Delete,
+                     Favorite, admin actions, etc. Each action is a
+                     `<li>` because the right zone is a
+                     `<menu class="toolbar-right">` (list of
+                     commands, pushed to the right edge).
+    breadcrumb     — full breadcrumb override for nested-detail
+                     pages that need a multi-segment chain.
 #}
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
@@ -34,19 +45,13 @@ Child contract:
 
 {% block breadcrumb %}
 {%- set collection_label %}{% block resource_label %}{% endblock %}{% endset -%}
-{%- set current %}{% block current_label %}{% endblock %}{% endset -%}
-{{ breadcrumb([(collection_label, resource_url), (current, none)]) }}
+{{ breadcrumb([(collection_label | trim, resource_url)]) }}
 {% endblock %}
 
 {% block toolbar %}
+{%- set current %}{% block current_label %}{% endblock %}{% endset -%}
 {%- set actions_body %}{% block actions %}{% endblock %}{% endset -%}
-{%- if actions_body | trim %}
-{# Detail-page toolbar reuses the shared two-zone primitive with
-   no search/filter args, so the left zone is empty and the action
-   `<menu class="toolbar-right">` lands at the same right edge as
-   list-page actions (Create, Export...). #}
-{% call page_toolbar() %}{{ actions_body }}{% endcall %}
-{%- endif %}
+{% call page_toolbar(heading=current | trim) %}{{ actions_body }}{% endcall %}
 {% endblock %}
 
 {% block content %}{% endblock %}

--- a/src/framework/templates/views/form_edit.html
+++ b/src/framework/templates/views/form_edit.html
@@ -1,8 +1,17 @@
 {# Generic edit-form view chrome.
 
-An edit-form view (`/posts/{id}/form`, `/providers/{id}/form`) renders
-a three-segment breadcrumb (collection → current item → "Edit") and no
-toolbar — the form's Save and Cancel buttons own the actions.
+An edit-form view (`/openings/{id}/form`, `/providers/{id}/form`)
+renders a two-segment breadcrumb (collection → detail page, both
+links) above a toolbar row carrying the page `<h1>`. The form's
+own Save and Cancel buttons own the primary actions, so the
+toolbar row itself usually has no right-side actions.
+
+Layout per page:
+
+    <breadcrumb: link to collection › link back to detail>
+    <h1: "Edit <current_label>">
+    <hr>
+    <form>
 
 Child contract:
 
@@ -10,7 +19,9 @@ Child contract:
     resource_label — short string label for the collection segment of
                      the breadcrumb (e.g. "Providers").
     current_label  — short string label for the resource being edited
-                     (e.g. `{{ provider.org.name }}`).
+                     (e.g. `{{ provider.org.name }}`). Used in the
+                     toolbar `<h1>` as "Edit <current_label>" and as
+                     the link text for the second breadcrumb segment.
     content        — the `<form>` body. By convention forms keep a
                      `<a class="secondary outline">Cancel</a>` linking
                      to `resource_detail_url` so abandoning an edit is
@@ -19,23 +30,28 @@ Child contract:
 
   Required context:
     resource_url        — URL the collection segment links to.
-    resource_detail_url — URL the current-item segment links to (e.g.
-                          `"/providers/" ~ provider.id`).
+    resource_detail_url — URL the current-item breadcrumb segment
+                          links to (e.g. `"/providers/" ~ provider.id`).
 
   Optional blocks:
     breadcrumb          — full breadcrumb override for nested-edit pages.
 #}
 {% extends "base.html" %}
 {%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+{%- from "_shared/_toolbar.html" import page_toolbar -%}
 
 {% block breadcrumb %}
 {%- set collection_label %}{% block resource_label %}{% endblock %}{% endset -%}
 {%- set current %}{% block current_label %}{% endblock %}{% endset -%}
 {{ breadcrumb([
-  (collection_label, resource_url),
-  (current, resource_detail_url),
-  ("Edit", none),
+  (collection_label | trim, resource_url),
+  (current | trim, resource_detail_url),
 ]) }}
+{% endblock %}
+
+{% block toolbar %}
+{%- set current = self.current_label() | trim -%}
+{% call page_toolbar(heading="Edit " ~ current) %}{% endcall %}
 {% endblock %}
 
 {# `entity-form-page` — see `views/form_new.html`. #}

--- a/src/framework/templates/views/form_new.html
+++ b/src/framework/templates/views/form_new.html
@@ -1,31 +1,53 @@
 {# Generic create-form view chrome.
 
-A create-form view (`/posts/form`, `/providers/form`) renders a two-segment
-breadcrumb (collection → "New") and no toolbar — the submit button at
-the bottom of the form is the primary action. The child fills the form.
+A create-form view (`/openings/form`, `/providers/form`) renders a
+single-segment breadcrumb (link back to the collection) above a
+toolbar row that carries the page `<h1>`. The form's own submit
+button at the bottom is the primary action, so the toolbar row
+itself usually has no right-side actions.
+
+Layout per page:
+
+    <breadcrumb: link to collection>
+    <h1: "New" — or override with child's `current_label`>
+    <hr>
+    <form>
 
 Child contract:
 
   Required blocks:
-    resource_label — short string label for the collection segment of
-                     the breadcrumb (e.g. "Providers").
+    resource_label — short string label for the collection segment
+                     of the breadcrumb (e.g. "Providers").
     content        — the `<form>` body.
 
   Required context:
-    resource_url   — URL the collection segment links to (e.g. "/providers").
+    resource_url   — URL the collection segment links to (e.g.
+                     "/providers").
 
   Optional blocks:
-    breadcrumb     — full breadcrumb override for nested-create pages.
+    current_label  — override the toolbar `<h1>` text (default
+                     "New"). Children typically set this to
+                     something more specific like "New provider"
+                     or "New opening" when the singular reads
+                     better than the bare verb.
+    breadcrumb     — full breadcrumb override for nested-create
+                     pages.
 
-Edit-form chrome is in `form_edit.html` (three segments, with a link
-back to the resource's detail page on the middle one).
+Edit-form chrome is in `form_edit.html` (adds the detail-page link
+as a second crumb between collection and the H1).
 #}
 {% extends "base.html" %}
 {%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+{%- from "_shared/_toolbar.html" import page_toolbar -%}
 
 {% block breadcrumb %}
 {%- set collection_label %}{% block resource_label %}{% endblock %}{% endset -%}
-{{ breadcrumb([(collection_label, resource_url), ("New", none)]) }}
+{{ breadcrumb([(collection_label | trim, resource_url)]) }}
+{% endblock %}
+
+{% block toolbar %}
+{%- set current %}{% block current_label %}New{% endblock %}{% endset -%}
+{% call page_toolbar(heading=current | trim) %}{% endcall %}
 {% endblock %}
 
 {# `entity-form-page` carries the shared visual contract for entity

--- a/src/framework/templates/views/list.html
+++ b/src/framework/templates/views/list.html
@@ -1,54 +1,58 @@
 {# Generic list-view chrome.
 
-A list view (`/posts`, `/providers`, `/users`, `/users/me/favorites`,
-`/users/{id}/providers`) renders the same chrome: primary nav (from
-`base.html`), single-segment breadcrumb naming the resource, then a
-single toolbar strip. All toolbar content right-aligns: the filter
-link (when the spec opts into `routes.search`) and the action menu.
-The filter link reads `Filters` when none are applied and switches
-to an inline summary when any are; the search page's own form owns
-clearing.
+A list view (`/openings`, `/providers`, `/users`,
+`/users/me/favorites`, `/users/{id}/providers`) renders the page
+heading + actions in a single toolbar row above the list body. No
+breadcrumb: a single-segment "Openings" trail duplicates what the
+active global-nav tab already communicates (the breadcrumb guide
+flags this case explicitly), so list pages skip the breadcrumb
+block and let the `<h1>` in the toolbar carry the section name.
+Detail/form pages keep the breadcrumb for real ancestry.
+
+Toolbar row contents (left-to-right):
+  - `<h1>` heading (resource_label)
+  - filter link (when `routes.search` is opted in)
+  - action `<menu>` (Create, Export, ...)
 
 Child contract:
 
   Required blocks:
-    resource_label — short string label for the breadcrumb segment
-                     (e.g. "Providers"). Plain text, no markup.
+    resource_label — short string label for the toolbar `<h1>`
+                     and the page title (e.g. "Providers").
+                     Plain text, no markup.
     content        — the table or list body (typically an
                      `index_table(...)` call or a hand-rolled `<ul>`).
 
   Optional blocks:
-    actions        — toolbar action `<menu>` content (Create button,
-                     Export link). Each action is a `<li>` because
-                     the menu is `<menu class="toolbar-right">` (a
-                     commands list). Empty by default.
+    actions        — toolbar action `<menu>` content (Create
+                     button, Export link). Each action is a
+                     `<li>` because the menu is
+                     `<menu class="toolbar-right">` (a commands
+                     list). Empty by default.
     breadcrumb     — full breadcrumb override for subresource lists
-                     with multi-segment chains.
+                     with multi-segment chains (e.g.
+                     `/users/{id}/providers`). The default list
+                     view renders no breadcrumb; this override lets
+                     subresource list pages opt back in when there's
+                     real ancestry worth showing.
 
   Context the framework's `handle_list` injects (children don't set
   these by hand):
     active_filters, search_url, page_meta, paginator_base_query.
 #}
 {% extends "base.html" %}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
 {%- from "_shared/pagination.html" import pagination -%}
 
-{% block breadcrumb %}
-{%- set label %}{% block resource_label %}{% endblock %}{% endset -%}
-{{ breadcrumb([(label, none)]) }}
-{% endblock %}
-
 {% block toolbar %}
+{%- set label %}{% block resource_label %}{% endblock %}{% endset -%}
 {%- set actions_body %}{% block actions %}{% endblock %}{% endset -%}
 {%- set has_search = search_url is defined and search_url -%}
-{%- set has_actions = actions_body | trim -%}
-{%- if has_search or has_actions %}
 {% call page_toolbar(
+  heading=label | trim,
   active_filters=active_filters|default([]),
   search_url=search_url if has_search else none
 ) %}{{ actions_body }}{% endcall %}
-{%- endif %}
 {% endblock %}
 
 {% block content %}{% endblock %}

--- a/src/framework/templates/views/search.html
+++ b/src/framework/templates/views/search.html
@@ -26,14 +26,18 @@ the spec.
 #}
 {% extends "base.html" %}
 {%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+{%- from "_shared/_toolbar.html" import page_toolbar -%}
 
 {% block breadcrumb %}
 {%- set label %}{% block resource_label %}{% endblock %}{% endset -%}
-{{ breadcrumb([(label, list_action), ("Search", none)]) }}
+{{ breadcrumb([(label | trim, list_action)]) }}
+{% endblock %}
+
+{% block toolbar %}
+{% call page_toolbar(heading=self.resource_label() | trim ~ " search") %}{% endcall %}
 {% endblock %}
 
 {% block content %}
-<h1>{{ self.resource_label() }} search</h1>
 
 <form method="get" action="{{ list_action }}" class="search-form">
 


### PR DESCRIPTION
## Summary
The breadcrumb band and the toolbar were eating roughly equal vertical real estate above content. This consolidates them: one chrome band between the global nav and the content instead of two.

## New pattern

| Page type    | Pattern                                                      |
|--------------|--------------------------------------------------------------|
| List         | `<h1>` + actions in toolbar (no breadcrumb)                  |
| Detail       | `<breadcrumb: collection link>` then `<h1=current>` + actions |
| Form-new     | `<breadcrumb: collection link>` then `<h1=New>` row           |
| Form-edit    | `<breadcrumb: collection › detail link>` then `<h1=Edit X>`   |
| Search       | `<breadcrumb: collection link>` then `<h1=X search>`          |

GOV.UK-style throughout: the breadcrumb never repeats the current page label (the `<h1>` carries it), so every visible breadcrumb segment is an actionable link. List pages drop the breadcrumb entirely — a single-segment ``Providers`` trail was duplicating the active global-nav tab.

## Touch points

**Toolbar primitive** — `page_toolbar(heading, ...)` is now required to carry the page `<h1>` on the left of its row.

**View-type templates** — `list.html`, `detail.html`, `form_new.html`, `form_edit.html`, `search.html` all updated to the same shape.

**CSS in `base.html`**:
- Stripped breadcrumb band chrome (background, border, padding, margin).
- Removed `@media (max-width: 768px) { nav[aria-label="breadcrumb"]:has(li + li) { display: none; } }` — once the breadcrumb is inline text, it's cheap on mobile.
- Added `.toolbar h1 { margin: 0; }` — minimal margin reset so Pico's heading margins don't blow out the flex row.

## Test plan
- [x] `dev test` — 1518 passed, 106 skipped.
- [x] `dev test contract` — 34 passed.
- [x] `dev lint` — clean.
- [ ] Visual: confirm `/openings`, `/providers/{id}`, `/providers/{id}/form`, `/providers/form`, `/openings/search` all render the new chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)