### PR TITLE
fix(dev-auth): redirect to / after seed login

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ After `dev seed` populates the seed admin user, bookmark:
 http://localhost:8000/dev/login-as-seed-user
 ```
 
-Hitting it issues the same session cookie a real login would (for the user named by `DEV_LOGIN_EMAIL`, defaulting to `admin@example.com`) and redirects to `/posts`. Saves a form submission every time you reopen the browser to the dev server. The route is only mounted when `ENVIRONMENT=development` — production never registers it. See [`src/domain/routes/dev_auth.py`](src/domain/routes/dev_auth.py) for the security guards.
+Hitting it issues the same session cookie a real login would (for the user named by `DEV_LOGIN_EMAIL`, defaulting to `admin@example.com`) and redirects to `/`, which forwards to the current default landing page (today: `/openings`). Saves a form submission every time you reopen the browser to the dev server. The route is only mounted when `ENVIRONMENT=development` — production never registers it. See [`src/domain/routes/dev_auth.py`](src/domain/routes/dev_auth.py) for the security guards.
 
 ### Playwright MCP for design review <!-- title-case-ignore: "MCP" is the Anthropic acronym (Model Context Protocol) -->
 
-Claude Code can drive a real browser against the dev server to navigate, click, resize, and screenshot — useful for "load `/posts` at iPhone width and check the location row" tasks. The MCP entry is pre-configured in [`.claude/settings.json`](.claude/settings.json); the one-time browser install is:
+Claude Code can drive a real browser against the dev server to navigate, click, resize, and screenshot — useful for "load `/openings` at iPhone width and check the location row" tasks. The MCP entry is pre-configured in [`.claude/settings.json`](.claude/settings.json); the one-time browser install is:
 
 ```bash
 dev playwright-setup      # installs Chromium (~150MB)

--- a/src/domain/routes/dev_auth.py
+++ b/src/domain/routes/dev_auth.py
@@ -47,7 +47,9 @@ async def login_as_seed_user(
     user_manager: BaseUserManager[User, object] = Depends(get_user_manager),
 ) -> Response:
     """Issue a session cookie for the configured seed user and 302 to
-    ``/posts``."""
+    ``/`` — root then decides where to land (see ``read_root`` in
+    ``src/main.py``), so this handler doesn't bake in a specific
+    resource path."""
     if settings.ENVIRONMENT != "development":
         raise HTTPException(status_code=404)
 
@@ -65,10 +67,13 @@ async def login_as_seed_user(
     # `auth_backend.login(strategy, user)` builds a Response with the
     # cookie set by the transport (CookieTransport in our config). We
     # then swap the status + Location header so the agent / browser
-    # lands on `/posts` carrying the freshly-set cookie.
+    # lands on `/` (which redirects onward) carrying the freshly-set
+    # cookie. Routing the landing through `/` keeps the
+    # "where does an authenticated session land?" decision in one
+    # place — `src/main.py:read_root` — instead of duplicating it here.
     response = await auth_backend.login(get_strategy(), user)
     response.status_code = 302
-    response.headers["Location"] = "/posts"
+    response.headers["Location"] = "/"
     return response
 
 

--- a/src/domain/routes/test_dev_auth.py
+++ b/src/domain/routes/test_dev_auth.py
@@ -13,8 +13,10 @@ Two layers of guarding:
 The happy-path test goes through the test client's already-mounted
 ``app`` (which runs with ``ENVIRONMENT="development"`` via
 ``.env.test``) and pins the contract a Playwright agent or a manual
-bookmark relies on: 302 + ``Location: /posts`` + ``Set-Cookie:
-fastapiusersauth=...``.
+bookmark relies on: 302 + ``Location: /`` + ``Set-Cookie:
+fastapiusersauth=...``. The handler redirects to ``/`` so the root
+handler (``src/main.py:read_root``) owns the choice of landing page;
+this route only proves the cookie was issued.
 """
 
 import pytest
@@ -73,8 +75,8 @@ async def test_dev_login_issues_session_cookie_and_redirects(
 ):
     """Hitting the route with a seed user in the DB issues the same
     `fastapiusersauth` cookie a production login would, and 302s to
-    `/posts`. This is the contract a Playwright MCP agent's
-    first-tool-call relies on."""
+    `/` (root then forwards to the actual landing page). This is the
+    contract a Playwright MCP agent's first-tool-call relies on."""
     # Seed the DEV_LOGIN_EMAIL user. Use the standard fastapi-users
     # user-manager dependency so the password is hashed correctly.
     seed_email = "dev-login-seed@example.com"
@@ -84,7 +86,7 @@ async def test_dev_login_issues_session_cookie_and_redirects(
 
     response = await test_client.get("/dev/login-as-seed-user", follow_redirects=False)
     assert response.status_code == 302
-    assert response.headers["Location"] == "/posts"
+    assert response.headers["Location"] == "/"
     set_cookie = response.headers.get("Set-Cookie", "")
     assert "fastapiusersauth=" in set_cookie, (
         "expected the session cookie to be set on the response — "


### PR DESCRIPTION
## Summary
- `/dev/login-as-seed-user` was 302'ing to `/posts`, which no longer exists (the post resource was split into `/openings`, `/referrals`, `/intakes`), so seed-login landed on a 404 JSON page.
- Redirect to `/` instead, and let `read_root` in `src/main.py` own the landing-page decision — next rename only touches one file.

## Test plan
- [x] `dev test src/domain/routes/test_dev_auth.py` — 6 passed
- [x] `dev lint` clean
- [x] Manually verified in the browser: `/dev/login-as-seed-user` → 302 → `/` → 302 → `/openings`, cookie set

🤖 Generated with [Claude Code](https://claude.com/claude-code)