### PR TITLE
fix(templates): load htmx-2 json-enc extension, clear v1 warning

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -490,7 +490,10 @@
       src="https://unpkg.com/htmx.org@2.0.4"
       integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"
       crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/htmx.org@2.0.4/dist/ext/json-enc.js"></script>
+    {# htmx 2 ships extensions as separate npm packages — the in-tree
+       `dist/ext/json-enc.js` is the htmx-1 build and logs a "v1 extension
+       with htmx 2" console warning. Use the htmx-2 package instead. #}
+    <script src="https://unpkg.com/htmx-ext-json-enc@2.0.2/json-enc.js"></script>
     {% block head %}{% endblock %} {% if is_development %}
     <!-- LiveReload script for development hot reloading -->
     <script>


### PR DESCRIPTION
## Summary
- Every page rendered a "WARNING: You are using an htmx 1 extension with htmx 2.0.4" console warning because `base.html` loaded `unpkg.com/htmx.org@2.0.4/dist/ext/json-enc.js` (the v1 build shipped inside htmx 2 for back-compat).
- Switched to `unpkg.com/htmx-ext-json-enc@2.0.2/json-enc.js`, the separately-packaged htmx-2 build.
- Behavior unchanged — both versions set `Content-Type: application/json` and JSON-encode the form params.

## Test plan
- [x] `dev lint` clean, `dev test src/framework/templates/test_views.py` — 28 passed
- [x] Verified in browser: `/openings` and `/auth/register` both load with 0 console warnings (was 1)
- [ ] CI green (tests + contract-tests + docker-health)

🤖 Generated with [Claude Code](https://claude.com/claude-code)