### PR TITLE
test(contract): restore provider-edit-form pact (closes #647)

### DIFF
--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -244,6 +244,10 @@ def _setup_provider_edit_form_stub(app: FastAPI) -> None:
             # `orgs` context var to render options.
             org_id=org_id,
             org=org,
+            # `npi` is an empty optional text input on the stub (#525);
+            # it serializes as `npi=` in the encoded body right after
+            # `location_zip`.
+            npi=None,
             location_city="Brooklyn",
             location_state="NY",
             location_zip="11201",
@@ -255,6 +259,11 @@ def _setup_provider_edit_form_stub(app: FastAPI) -> None:
             in_network_carriers=[],
             sliding_scale=False,
             cost=None,
+            # `affiliations` is the inline list (#642 PR 1) the template
+            # renders below the practice-fields form. Empty here so the
+            # "No affiliations yet." branch renders without adding extra
+            # forms that would compete for the practice form's selectors.
+            affiliations=[],
             licensures=[],
             educations=[],
             certifications=[],
@@ -266,8 +275,11 @@ def _setup_provider_edit_form_stub(app: FastAPI) -> None:
         )
         return APIResponse.html_response(
             template_name="providers/form_edit.html",
+            # The framework binds `context[spec.name] = target`; after
+            # #642 PR 4 the entity name is "clinician" (the template
+            # aliases it back to `provider` internally).
             context={
-                "provider": provider,
+                "clinician": provider,
                 "current_user": current_user,
                 "orgs": [org],
             },

--- a/tests/test_contract/manifest.py
+++ b/tests/test_contract/manifest.py
@@ -11,6 +11,7 @@ from .infrastructure.servers.consumer import (
     _setup_post_owner_actions_stub,
     _setup_program_create_form_stub,
     _setup_provider_create_form_stub,
+    _setup_provider_edit_form_stub,
     _setup_users_admin_actions_stub,
 )
 from .tests.shared.mock_data_factory import MockDataFactory
@@ -80,24 +81,25 @@ CONTRACT_PAIRS: list[ContractPair] = [
         provider_state="User can create a provider",
         pytest_marks=(pytest.mark.provider, pytest.mark.providers),
     ),
-    # `provider-edit-form` pair temporarily dropped from the manifest in
-    # #642 PR 1 — the contract was "PATCH /providers/{id} accepts
-    # location_*, sessions, insurance, sliding_scale, cost as a single
-    # form-encoded body" but those fields moved into inline affiliation
-    # rows. The wire endpoint shifted from `PATCH /providers/{id}` to
-    # `PATCH /providers/{id}/affiliations/{affiliation_id}` and the body
-    # shape changed. Re-add a replacement pair (or decide affiliation
-    # editing doesn't need a separate contract) when working #647.
-    #
-    # ContractPair(
-    #     consumer_name="provider-edit-form",
-    #     provider_name="providers-api",
-    #     pact_port=1240,
-    #     handler_mocks_factory=MockDataFactory.create_provider_update_dependency_config,
-    #     consumer_setup_fn=_setup_provider_edit_form_stub,
-    #     provider_state="Provider 44444444-4444-4444-4444-444444444444 exists and is owned by the requester",
-    #     pytest_marks=(pytest.mark.provider, pytest.mark.providers),
-    # ),
+    # `provider-edit-form` covers the top-level `PATCH /clinicians/{id}`
+    # form. After #642 PR 1 a Provider may hold multiple Affiliations and
+    # this form's per-role fields (`location_*`, sessions, insurance,
+    # `sliding_scale`, `cost`) write through Provider per-role property
+    # proxies to the primary (oldest) affiliation row — the wire shape
+    # is unchanged (#642 PR 4 renamed the URL family `/providers` →
+    # `/clinicians`; the participant names keep the Pact "provider"
+    # vocabulary for continuity). The sub-resource PATCH endpoint
+    # `PATCH /clinicians/{id}/affiliations/{aff_id}` exists but has no
+    # consumer UI today, so it is intentionally not contract-tested.
+    ContractPair(
+        consumer_name="provider-edit-form",
+        provider_name="providers-api",
+        pact_port=1240,
+        handler_mocks_factory=MockDataFactory.create_provider_update_dependency_config,
+        consumer_setup_fn=_setup_provider_edit_form_stub,
+        provider_state="Provider 44444444-4444-4444-4444-444444444444 exists and is owned by the requester",
+        pytest_marks=(pytest.mark.provider, pytest.mark.providers),
+    ),
     ContractPair(
         consumer_name="organization-create-form",
         provider_name="organizations-api",

--- a/tests/test_contract/tests/consumer/test_provider_edit_form.py
+++ b/tests/test_contract/tests/consumer/test_provider_edit_form.py
@@ -1,4 +1,4 @@
-"""Consumer contract: editing the practice fields on the provider edit form.
+"""Consumer contract: editing the practice fields on the clinician edit form.
 
 Verifies that the practice-fields HTMX form rendered by
 `templates/providers/form_edit.html` (mounted via the
@@ -9,9 +9,19 @@ the route expects. After #524 the practice's display name lives on
 ``org_id`` `<select>`; the form still PATCHes ``location_*`` and
 session/insurance fields directly on the Provider.
 
-Sub-resource pacts (licensures, educations, certifications) are not
-covered here — each would warrant its own pair if it diverges from this
-shape.
+After #642 PR 1 a Provider may hold multiple Affiliations and the
+edit page surfaces them as an inline list. The top-level
+`PATCH /clinicians/{id}` form is unchanged on the wire — the per-role
+fields it posts (`location_*`, sessions, insurance, `sliding_scale`,
+`cost`) are routed by Provider per-role property proxies to the primary
+(oldest) affiliation row. The affiliation sub-resource PATCH endpoint
+(`PATCH /clinicians/{id}/affiliations/{aff_id}`) exists in the framework
+but has no consumer UI today, so it is intentionally not contract-tested
+here — see #647.
+
+Sub-resource pacts (licensures, educations, certifications, plus the
+inline "Add affiliation" POST) are not covered here — each would warrant
+its own pair if it diverges from this shape.
 """
 
 import pytest
@@ -33,18 +43,6 @@ from tests.test_contract.tests.shared.helpers import (
 )
 
 
-@pytest.mark.skip(
-    reason=(
-        "Pact stale after #642 PR 1: per-role fields (`location_*`, sessions, "
-        "insurance, sliding_scale, cost) moved out of the top-level provider "
-        "PATCH form into inline affiliation rows. The wire endpoint shifted "
-        "from `PATCH /clinicians/{id}` to `PATCH /clinicians/{id}/affiliations/"
-        "{affiliation_id}` and the encoded body shape changed. Tracked in "
-        "#647 — rewrite the pact pair for the affiliation PATCH surface, or "
-        "drop it if affiliation editing doesn't need a separate consumer "
-        "contract."
-    )
-)
 @pytest.mark.parametrize(
     "origin_with_routes",
     [{"provider_edit_form": True, "auth_pages": False}],
@@ -113,14 +111,17 @@ async def test_consumer_provider_edit_form_submits(origin_with_routes: str, page
         http_method="PATCH",
     )
 
+    # The inline "Add affiliation" form below the practice section reuses
+    # the same input names (`location_city`, etc.), so every locator on
+    # this page must be scoped to the practice-fields form to avoid
+    # strict-mode multi-match.
+    practice_form = page.locator(f'form[hx-patch="{PROVIDER_PATCH_API_PATH}"]')
+
     with pact:
         await page.goto(edit_page_url)
         await page.wait_for_selector('select[name="org_id"]')
-        await page.locator('input[name="location_city"]').fill("Bayside")
-        # Submit the practice-fields form (the first one on the page).
-        await page.locator(
-            f'form[hx-patch="{PROVIDER_PATCH_API_PATH}"] button[type="submit"]'
-        ).click()
+        await practice_form.locator('input[name="location_city"]').fill("Bayside")
+        await practice_form.locator('button[type="submit"]').click()
         await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
 
     # Pact verification happens automatically on context exit.


### PR DESCRIPTION
## Summary

- Restores the `provider-edit-form` ContractPair that was commented out and skipped during #642 PR 1.
- The issue's premise was off: PR 1 only *added* the inline affiliations section to the edit page — it didn't move the per-role fields off the top-level PATCH form. `PATCH /clinicians/{id}` is still the live wire, and the Provider's per-role property proxies write through to the primary (oldest) affiliation row.
- Two ripples handled while restoring:
  - The consumer stub now passes the context key as `clinician` (#642 PR 4 renamed the entity) and populates `npi` + `affiliations` so the new inline-list branch renders cleanly.
  - Practice-form locators are scoped via `form[hx-patch=...]` to avoid Playwright strict-mode collisions with the inline "Add affiliation" form, which reuses the same input names.
- The sub-resource `PATCH /clinicians/{id}/affiliations/{aff_id}` endpoint exists in the framework but has no consumer UI yet, so it is intentionally not contract-tested — documented in the manifest entry and the test docstring (the "documented decision" branch of #647's acceptance criteria).

## Test plan

- [x] `dev test tests/test_contract` — 36 passed (including the restored pair, both consumer + provider sides).
- [x] `dev test` — 1518 passed, 106 skipped.
- [x] `dev lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)