### PR TITLE
fix(detail): drop entity-card header that duplicates toolbar H1

### DIFF
--- a/src/domain/templates/intakes/detail.html
+++ b/src/domain/templates/intakes/detail.html
@@ -6,12 +6,15 @@
 
 {% set resource_url = entity_url('intake') %}
 {%- set view = post_card_view(intake) -%}
+{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 
 {% block resource_label %}Intakes{% endblock %}
 {# The toolbar H1 carries the full identity string (`headline` plus
-   the optional `header_state` — e.g. "Will's Org, NY") so the
-   entity-card below doesn't need to repeat it. #}
+   the optional `header_state` — e.g. "Will's Org, NY"); the
+   `subtitle` block below carries date · modality meta. The
+   entity-card body therefore needs no `<header>`. #}
 {% block current_label %}{{ view.headline or 'Intakes'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
+{% block subtitle %}{{ intake.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}{% endblock %}
 
 {% block actions %}
 {% with post=intake %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}
@@ -23,12 +26,7 @@
    in `post_card_view` (one place); every visual element in the card
    reads from `view`. #}
 {% block content %}
-{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-kind="{{ intake.kind }}">
-  <header>
-    <small>{{ intake.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
-  </header>
-
   {%- if view.description %}
   <p>{{ view.description }}</p>
   {%- endif %}

--- a/src/domain/templates/intakes/detail.html
+++ b/src/domain/templates/intakes/detail.html
@@ -5,13 +5,13 @@
 {%- from "_shared/posts/_how_to_refer.html" import how_to_refer -%}
 
 {% set resource_url = entity_url('intake') %}
-{# `view.headline` is the same identity string the entity-card's header
-   renders. Computing it once at module scope keeps the breadcrumb leaf
-   and the in-card headline in lock-step — see #593. #}
 {%- set view = post_card_view(intake) -%}
 
 {% block resource_label %}Intakes{% endblock %}
-{% block current_label %}{{ view.headline or 'Intakes'|truncate(40) }}{% endblock %}
+{# The toolbar H1 carries the full identity string (`headline` plus
+   the optional `header_state` — e.g. "Will's Org, NY") so the
+   entity-card below doesn't need to repeat it. #}
+{% block current_label %}{{ view.headline or 'Intakes'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
 
 {% block actions %}
 {% with post=intake %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}
@@ -26,10 +26,7 @@
 {%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-kind="{{ intake.kind }}">
   <header>
-    <hgroup>
-      <h3>{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</h3>
-      <small>{{ intake.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
-    </hgroup>
+    <small>{{ intake.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
   </header>
 
   {%- if view.description %}

--- a/src/domain/templates/openings/detail.html
+++ b/src/domain/templates/openings/detail.html
@@ -5,13 +5,13 @@
 {%- from "_shared/posts/_how_to_refer.html" import how_to_refer -%}
 
 {% set resource_url = entity_url('opening') %}
-{# `view.headline` is the same identity string the entity-card's header
-   renders. Computing it once at module scope keeps the breadcrumb leaf
-   and the in-card headline in lock-step — see #593. #}
 {%- set view = post_card_view(opening) -%}
 
 {% block resource_label %}Openings{% endblock %}
-{% block current_label %}{{ view.headline or 'Openings'|truncate(40) }}{% endblock %}
+{# The toolbar H1 carries the full identity string (`headline` plus
+   the optional `header_state` — e.g. "Will's Org, NY") so the
+   entity-card below doesn't need to repeat it. #}
+{% block current_label %}{{ view.headline or 'Openings'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
 
 {% block actions %}
 {% with post=opening %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}
@@ -26,10 +26,7 @@
 {%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-kind="{{ opening.kind }}">
   <header>
-    <hgroup>
-      <h3>{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</h3>
-      <small>{{ opening.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
-    </hgroup>
+    <small>{{ opening.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
   </header>
 
   {%- if view.description %}

--- a/src/domain/templates/openings/detail.html
+++ b/src/domain/templates/openings/detail.html
@@ -6,12 +6,15 @@
 
 {% set resource_url = entity_url('opening') %}
 {%- set view = post_card_view(opening) -%}
+{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 
 {% block resource_label %}Openings{% endblock %}
 {# The toolbar H1 carries the full identity string (`headline` plus
-   the optional `header_state` — e.g. "Will's Org, NY") so the
-   entity-card below doesn't need to repeat it. #}
+   the optional `header_state` — e.g. "Will's Org, NY"); the
+   `subtitle` block below carries date · modality meta. The
+   entity-card body therefore needs no `<header>`. #}
 {% block current_label %}{{ view.headline or 'Openings'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
+{% block subtitle %}{{ opening.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}{% endblock %}
 
 {% block actions %}
 {% with post=opening %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}
@@ -23,12 +26,7 @@
    in `post_card_view` (one place); every visual element in the card
    reads from `view`. #}
 {% block content %}
-{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-kind="{{ opening.kind }}">
-  <header>
-    <small>{{ opening.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
-  </header>
-
   {%- if view.description %}
   <p>{{ view.description }}</p>
   {%- endif %}

--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -17,9 +17,10 @@
    the previous template emitted the raw UUID as the link text, which
    read as a bare hex number in the UI.
 
-   The name does NOT appear as a `<dt>Name</dt>` row in the facts list
-   because the header `<strong>` already carries it — duplicating the
-   primary identifier inside the body was filed as #594.
+   The card has no `<header>` block — the toolbar H1 above already
+   carries `organization.name`, and the type label is already a
+   `<dt>Type</dt>` row in the facts list, so an in-card header would
+   only restate both.
 
    Root organizations (no `parent_org_id`) omit the parent row entirely
    rather than rendering placeholder text — matching the optional-field
@@ -29,11 +30,6 @@
    empty-state conventions (em-dash + parenthetical). #}
 {% block content %}
 <article class="entity-card">
-  <header class="entity-header">
-    <strong>{{ organization.name }}</strong>
-    <small>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</small>
-  </header>
-
   <section class="entity-facts">
     <dl>
       <div><dt>Type</dt><dd>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</dd></div>

--- a/src/domain/templates/programs/detail.html
+++ b/src/domain/templates/programs/detail.html
@@ -14,16 +14,13 @@
 {# Program detail uses the `.entity-card` chrome shared with
    posts/detail.html and providers/detail.html. Description renders as
    `.entity-description` lead prose above the facts dl when present
-   (matches posts/detail.html's optional description block). #}
+   (matches posts/detail.html's optional description block).
+
+   The card has no `<header>` block — the toolbar H1 above already
+   carries `program.name`, and `state_preference` is already a
+   `<dt>State served</dt>` row in the facts list. #}
 {% block content %}
 <article class="entity-card">
-  <header class="entity-header">
-    <strong>{{ program.name }}</strong>
-    {%- if program.state_preference %}
-    <small>{{ program.state_preference }}</small>
-    {%- endif %}
-  </header>
-
   {%- if program.description %}
   <p class="entity-description">{{ program.description }}</p>
   {%- endif %}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -11,8 +11,12 @@
 
 {% set resource_url = entity_url('clinician') %}
 
+{%- set view = provider_card_view(provider) -%}
+
 {% block resource_label %}Clinicians{% endblock %}
 {% block current_label %}{{ provider.org.name }}{% endblock %}
+{# title-case-ignore: NPI is an industry abbreviation (National Provider Identifier) #}
+{% block subtitle %}{% if view.npi %}NPI {{ view.npi }}{% endif %}{% endblock %}
 
 {% block actions %}
 {# Primary resource actions (Favorite toggle, Edit, Delete) live in
@@ -68,17 +72,11 @@
    availability display labels. Templates never reach for
    `affiliation.org.name` directly — they read `aff.org_name`. #}
 {% block content %}
-{%- set view = provider_card_view(provider) -%}
-{# Identity card (practice_name + NPI) collapses to a single `<p>` —
-   the toolbar H1 above already carries `view.practice_name`, so an
-   in-card header would just restate it. NPI is the only non-duplicate
-   piece, so it survives as a one-line subtitle when present. #}
-{%- if view.npi %}
-{# title-case-ignore: NPI is an industry abbreviation (National Provider Identifier) #}
-<p><small>NPI {{ view.npi }}</small></p>
-{%- endif %}
+{# Identity card collapsed: the toolbar H1 carries `view.practice_name`
+   and the `subtitle` block above carries NPI. The page starts straight
+   into the affiliation cards.
 
-{# Stacked affiliation cards — one per row in `provider.affiliations`.
+   Stacked affiliation cards — one per row in `provider.affiliations`.
    Reads as "At <Org A>: ... · At <Org B>: ...". Each card links its
    heading to the owning Organization so the cross-resource navigation
    the old (single-card) layout exposed via the "Organization" facts

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -69,15 +69,14 @@
    `affiliation.org.name` directly — they read `aff.org_name`. #}
 {% block content %}
 {%- set view = provider_card_view(provider) -%}
-<article class="entity-card">
-  <header class="entity-header">
-    <strong>{{ view.practice_name }}</strong>
-    {%- if view.npi %}
-    {# title-case-ignore: NPI is an industry abbreviation (National Provider Identifier) #}
-    <small>NPI {{ view.npi }}</small>
-    {%- endif %}
-  </header>
-</article>
+{# Identity card (practice_name + NPI) collapses to a single `<p>` —
+   the toolbar H1 above already carries `view.practice_name`, so an
+   in-card header would just restate it. NPI is the only non-duplicate
+   piece, so it survives as a one-line subtitle when present. #}
+{%- if view.npi %}
+{# title-case-ignore: NPI is an industry abbreviation (National Provider Identifier) #}
+<p><small>NPI {{ view.npi }}</small></p>
+{%- endif %}
 
 {# Stacked affiliation cards — one per row in `provider.affiliations`.
    Reads as "At <Org A>: ... · At <Org B>: ...". Each card links its

--- a/src/domain/templates/referrals/detail.html
+++ b/src/domain/templates/referrals/detail.html
@@ -6,12 +6,15 @@
 
 {% set resource_url = entity_url('referral') %}
 {%- set view = post_card_view(referral) -%}
+{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 
 {% block resource_label %}Referrals{% endblock %}
 {# The toolbar H1 carries the full identity string (`headline` plus
-   the optional `header_state` — e.g. "Will's Org, NY") so the
-   entity-card below doesn't need to repeat it. #}
+   the optional `header_state` — e.g. "Will's Org, NY"); the
+   `subtitle` block below carries date · modality meta. The
+   entity-card body therefore needs no `<header>`. #}
 {% block current_label %}{{ view.headline or 'Referrals'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
+{% block subtitle %}{{ referral.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}{% endblock %}
 
 {% block actions %}
 {% with post=referral %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}
@@ -23,12 +26,7 @@
    in `post_card_view` (one place); every visual element in the card
    reads from `view`. #}
 {% block content %}
-{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-kind="{{ referral.kind }}">
-  <header>
-    <small>{{ referral.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
-  </header>
-
   {%- if view.description %}
   <p>{{ view.description }}</p>
   {%- endif %}

--- a/src/domain/templates/referrals/detail.html
+++ b/src/domain/templates/referrals/detail.html
@@ -5,13 +5,13 @@
 {%- from "_shared/posts/_how_to_refer.html" import how_to_refer -%}
 
 {% set resource_url = entity_url('referral') %}
-{# `view.headline` is the same identity string the entity-card's header
-   renders. Computing it once at module scope keeps the breadcrumb leaf
-   and the in-card headline in lock-step — see #593. #}
 {%- set view = post_card_view(referral) -%}
 
 {% block resource_label %}Referrals{% endblock %}
-{% block current_label %}{{ view.headline or 'Referrals'|truncate(40) }}{% endblock %}
+{# The toolbar H1 carries the full identity string (`headline` plus
+   the optional `header_state` — e.g. "Will's Org, NY") so the
+   entity-card below doesn't need to repeat it. #}
+{% block current_label %}{{ view.headline or 'Referrals'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
 
 {% block actions %}
 {% with post=referral %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}
@@ -26,10 +26,7 @@
 {%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-kind="{{ referral.kind }}">
   <header>
-    <hgroup>
-      <h3>{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</h3>
-      <small>{{ referral.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
-    </hgroup>
+    <small>{{ referral.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
   </header>
 
   {%- if view.description %}

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -23,13 +23,15 @@
    detail pages. The Clinicians section is a separate card below the
    main user card — embedded card-in-card would read as visual noise,
    so the page is two stacked cards: identity + private-fields on top,
-   the clinician-entries index table on bottom. #}
+   the clinician-entries index table on bottom.
+
+   The identity card has no `<header>` — the toolbar H1 above already
+   carries `target_user.username`, so an in-card header would just
+   restate it. The Clinicians card keeps its header because the
+   `<strong>Clinicians</strong>` is a section label, not a duplicate
+   of any heading above. #}
 {% block content %}
 <article class="entity-card">
-  <header class="entity-header">
-    <strong>{{ target_user.username }}</strong>
-  </header>
-
   {# Private rows (email, active, verified) are gated by
      `can_view_private`, computed in handle_get_user_detail as
      `is_self OR is_admin(viewer)`. The handler also omits these

--- a/src/framework/templates/views/detail.html
+++ b/src/framework/templates/views/detail.html
@@ -13,6 +13,7 @@ Layout per page:
     <breadcrumb: link to collection>
     <h1: current item>    <actions...>
     <hr>
+    <subtitle: optional one-line meta>
     <content>
 
 Child contract:
@@ -32,6 +33,14 @@ Child contract:
                      text with `aria-current="page"`.
 
   Optional blocks:
+    subtitle       — plain-text one-liner rendered as muted small text
+                     directly below the toolbar H1 (above content). Use
+                     for identity-adjacent meta that doesn't belong in
+                     the H1 itself — e.g. NPI on clinicians, date ·
+                     modality on posts. The chrome wraps the block's
+                     output in `<p><small>...</small></p>` so children
+                     only emit text; nothing renders when the block is
+                     empty.
     actions        — toolbar right-zone content: Edit, Delete,
                      Favorite, admin actions, etc. Each action is a
                      `<li>` because the right zone is a
@@ -53,6 +62,8 @@ Child contract:
 {%- set current %}{% block current_label %}{% endblock %}{% endset -%}
 {%- set actions_body %}{% block actions %}{% endblock %}{% endset -%}
 {% call page_toolbar(heading=current | trim) %}{{ actions_body }}{% endcall %}
+{%- set sub %}{% block subtitle %}{% endblock %}{% endset -%}
+{%- if sub | trim %}<p><small>{{ sub | trim | safe }}</small></p>{% endif %}
 {% endblock %}
 
 {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary

Every entity detail page rendered its title twice — once as the toolbar H1 (via `current_label`) and again inside the entity-card. On mobile the duplicate eats a third of the viewport before any content shows. PR 1 of a 5-PR sequence aimed at tightening the detail-view layout.

- **Posts (referrals/intakes/openings):** drop the inner `<h3>` + `<hgroup>`. The `<small>` meta line (date · modality) survives — it's not duplicated. `header_state` is appended to `current_label` so identity info stays intact in the toolbar.
- **Organizations / programs:** drop the whole `<header class=\"entity-header\">` block. The label inside it was already a `<dt>/<dd>` row in the facts list.
- **Users:** drop the identity card's header. The Clinicians section header stays (section label, not a duplicate).
- **Providers:** drop the identity card entirely; NPI survives as a one-line `<p><small>NPI ...</small></p>` subtitle. Affiliation cards' headers are unchanged — they identify per-row org links.

No CSS changes. No `.entity-header` selector exists in any stylesheet (grep'd `base.html` and `static/`). The contract test that scopes `header.entity-header a[href^='/organizations/']` runs against affiliation cards, which keep their header.

## Test plan

- [x] `dev test` — 1518 passed, 106 skipped.
- [x] `dev lint` — clean.
- [ ] Visual spot-check in browser of each entity detail page (left to reviewer / follow-up PRs in this sequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)