### PR TITLE
refactor(lists): extract icon_list macro; drop default bullet marker

### DIFF
--- a/src/domain/templates/_shared/posts/_services_block.html
+++ b/src/domain/templates/_shared/posts/_services_block.html
@@ -1,12 +1,16 @@
 {# Services-with-icons block — the post card's left column.
 
 `<h4>` carries the kind-aware verb (`Seeking` for CR, `Providing` for
-PA/program); the `<ul>` items combine a Lucide icon with the service's
-display label. Priority sort puts `psychotherapy` and
-`medication_management` first since those are the two services
-scanners most often look for; the rest follow in
-`REFERRAL_SERVICES` declaration order. PA+program `settings`
-render under the same `<ul>` after the services.
+PA/program); the list items combine a Lucide icon with the service's
+display label and are rendered through the shared
+`_shared/icon_list.html::icon_list` macro so the Lucide glyph serves
+as the only marker (no default disc bullet — `.icon-list` in
+`base.html` strips it).
+
+Priority sort puts `psychotherapy` and `medication_management` first
+since those are the two services scanners most often look for; the
+rest follow in `REFERRAL_SERVICES` declaration order. PA+program
+`settings` render under the same `<ul>` after the services.
 
 Reads from `view` (the `post_card_view` dict):
   - view.kind_verb — H4 heading text
@@ -17,26 +21,24 @@ Renders nothing when both lists are empty so the H4 doesn't stand
 alone. The display-label and icon-name dicts come in via Jinja
 globals (`REFERRAL_SERVICE_LABELS` / `_ICONS`, same for
 `TREATMENT_SETTINGS_*`) registered in `src/domain/template_globals.py`. #}
-{% macro _service_item(value, label_dict, icon_dict) -%}
-<li><i class="icon-{{ icon_dict[value] }}" aria-hidden="true"></i>{{ label_dict[value] }}</li>
-{%- endmacro %}
+{%- from "_shared/icon_list.html" import icon_list -%}
 
 {% macro services_block(view) -%}
-<section class="entity-icon-list">
-  {%- if view.services or view.settings %}
+{%- if view.services or view.settings %}
+{%- set _priority = ["psychotherapy", "medication_management"] -%}
+{%- set _items = [] -%}
+{%- for s in _priority if s in view.services -%}
+  {%- set _ = _items.append({"icon": REFERRAL_SERVICE_ICONS[s], "label": REFERRAL_SERVICE_LABELS[s]}) -%}
+{%- endfor -%}
+{%- for s in view.services if s not in _priority -%}
+  {%- set _ = _items.append({"icon": REFERRAL_SERVICE_ICONS[s], "label": REFERRAL_SERVICE_LABELS[s]}) -%}
+{%- endfor -%}
+{%- for s in view.settings -%}
+  {%- set _ = _items.append({"icon": TREATMENT_SETTINGS_ICONS[s], "label": TREATMENT_SETTINGS_LABELS[s]}) -%}
+{%- endfor -%}
+<section>
   <h4>{{ view.kind_verb }}</h4>
-  {%- set _priority = ["psychotherapy", "medication_management"] %}
-  <ul>
-    {%- for s in _priority if s in view.services %}
-    {{ _service_item(s, REFERRAL_SERVICE_LABELS, REFERRAL_SERVICE_ICONS) }}
-    {%- endfor %}
-    {%- for s in view.services if s not in _priority %}
-    {{ _service_item(s, REFERRAL_SERVICE_LABELS, REFERRAL_SERVICE_ICONS) }}
-    {%- endfor %}
-    {%- for s in view.settings %}
-    {{ _service_item(s, TREATMENT_SETTINGS_LABELS, TREATMENT_SETTINGS_ICONS) }}
-    {%- endfor %}
-  </ul>
-  {%- endif %}
+  {{ icon_list(_items) }}
 </section>
+{%- endif %}
 {%- endmacro %}

--- a/src/framework/templates/_shared/icon_list.html
+++ b/src/framework/templates/_shared/icon_list.html
@@ -1,0 +1,36 @@
+{# Bulleted-with-Lucide-glyphs list.
+
+The default `<ul>` disc bullet plus a leading Lucide icon double-marks
+every item (the screenshot in #647-followup showed this). This macro
+emits a `<ul class="icon-list">` whose list-style is stripped via
+`base.html`, letting the Lucide glyph serve as the only marker.
+
+Items are plain `{"icon": "pill", "label": "Medication management"}`
+dicts — pass whatever sequence of mappings the caller has, in display
+order. Lucide icon class names live in
+[`src/framework/static/icons/`](../../static/icons); the
+`[class^="icon-"]` rule in `base.html` gives every glyph its trailing
+`margin-inline-end: 0.25em` gap, so this macro adds no per-item
+spacing CSS.
+
+When a per-item label needs richer content than plain text (a link,
+strong emphasis), inline the `<li>` directly instead of passing through
+the macro — three lines of HTML stays cheaper than overloading the
+contract.
+
+Example:
+
+    {% from "_shared/icon_list.html" import icon_list %}
+    {{ icon_list([
+        {"icon": "pill",         "label": "Medication management"},
+        {"icon": "clipboard",    "label": "Evaluation"},
+        {"icon": "heart-handshake","label": "Couples therapy"},
+    ]) }}
+#}
+{% macro icon_list(items) -%}
+<ul class="icon-list">
+  {%- for item in items %}
+  <li><i class="icon-{{ item.icon }}" aria-hidden="true"></i>{{ item.label }}</li>
+  {%- endfor %}
+</ul>
+{%- endmacro %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -130,6 +130,13 @@
         color: inherit;
         margin-inline-end: 0.25em;
       }
+      /* `<ul class="icon-list">` (rendered by the shared `icon_list`
+         macro in `_shared/icon_list.html`). The Lucide glyph in each
+         `<li>` is the only marker; strip the default disc bullet and
+         the left padding the bullet was indented from. The icon's
+         `margin-inline-end` rule above already provides the icon → label
+         gap, so this rule adds no per-item spacing. */
+      .icon-list { list-style: none; padding-left: 0; }
       /* Page-scoped zone bar. Every page that needs page-scoped
          controls renders a single `<div class="toolbar">` strip
          whose children all right-align:


### PR DESCRIPTION
## Summary

PR 3 of the 5-PR detail-layout sequence. The Providing / Seeking list on every post detail page rendered each item with both a default `<ul>` disc bullet **and** a leading Lucide glyph — double-marking, visible in the screenshot that kicked off this sequence. The in-card section had `class=\"entity-icon-list\"` but no stylesheet targeted it.

- New \`_shared/icon_list.html::icon_list(items)\` macro: emits \`<ul class=\"icon-list\">\` with one \`<li>\` per \`{\"icon\", \"label\"}\` dict. The Lucide glyph is the only marker.
- One CSS rule added to \`base.html\`: \`.icon-list { list-style: none; padding-left: 0; }\`. Existing \`[class^=\"icon-\"]\` rule already provides the icon → label gap, so no other spacing CSS is needed.
- \`_shared/posts/_services_block.html\` refactored to build a flat items list and pass through the macro. Local \`_service_item\` helper and obsolete \`entity-icon-list\` class dropped.

No new Lucide icons added — every item reuses glyphs already registered in \`src/framework/static/icons/\`. Future icon-labelled lists (insurance carriers, treatment settings, specialties, etc.) become a one-line import + call.

## Test plan

- [x] \`dev test\` — 1518 passed, 106 skipped.
- [x] \`dev lint\` — clean.
- [ ] Visual check that the Providing/Seeking list now shows only icon markers (no double bullet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)