### PR TITLE
fix(breadcrumb): collapse to back chevron on mobile

### DIFF
--- a/src/framework/templates/_shared/_breadcrumb.html
+++ b/src/framework/templates/_shared/_breadcrumb.html
@@ -5,12 +5,24 @@ Renders the page's location chain as Pico's native breadcrumb nav
 above the page toolbar — see the `breadcrumb` block slot wired in
 [`../base.html`](../base.html). Pico styles the markup automatically
 (horizontal inline list, `›` separator via CSS on `li + li::before`)
-so no classes are added to the nav or list; the divider character
-is set globally in `base.html` via `--pico-nav-breadcrumb-divider`.
+so no classes are added to the `<ul>`; the divider character is set
+globally in `base.html` via `--pico-nav-breadcrumb-divider`.
 
 Each item is a `(label, href)` tuple. The last item's `href` is
 typically `None` — it renders as plain text (the current page) and
 carries `aria-current="page"` for screen readers.
+
+On narrow viewports (≤540px) the full chain collapses to a single
+back affordance: a Lucide arrow-left chevron plus the deepest
+clickable parent's label (the last item with a non-None href). The
+`<ul>` chain is hidden and the `<a class="breadcrumb-back">` is
+shown — see the `@media` block in `base.html`. Both elements are
+emitted unconditionally; CSS does the swapping so no JS branches on
+viewport.
+
+When every item has `href=None` (theoretical edge case — a page
+with no parent), the back affordance falls back to the first
+item's label as plain text so the markup stays valid.
 
     {{ breadcrumb([
         ("Posts", "/posts"),
@@ -27,7 +39,16 @@ breadcrumbs are ordered) loses Pico's auto-styling.
 {# title-case-ignore: literal aria-label value `breadcrumb` is the Pico hook #}
 {% macro breadcrumb(items) -%}
 {%- if items %}
+{# Deepest clickable parent — the back target on mobile. Walk from the
+   end backward; the current page (last item) typically has `href=None`
+   so its parent is at index -2. For single-item crumbs (detail pages)
+   the only item carries the href. #}
+{%- set _linkable = items | selectattr(1) | list -%}
+{%- set _back = _linkable[-1] if _linkable else items[0] -%}
 <nav aria-label="breadcrumb">
+  <a class="breadcrumb-back"{% if _back[1] %} href="{{ _back[1] }}"{% endif %}>
+    <i class="icon-arrow-left" aria-hidden="true"></i>{{ _back[0] }}
+  </a>
   <ul>
     {%- for label, href in items %}
     <li{% if loop.last %} aria-current="page"{% endif %}>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -212,6 +212,18 @@
       nav[aria-label="breadcrumb"] {
         --pico-nav-breadcrumb-divider: '›';
       }
+      /* Mobile back affordance. On narrow viewports the breadcrumb
+         macro's full `<ul>` chain is hidden and the inline
+         `<a class="breadcrumb-back">` is shown: a Lucide arrow-left
+         glyph plus the deepest clickable parent's label. On desktop
+         the `<a>` is hidden and the chain renders normally. Two
+         rules, no JS — the macro emits both elements unconditionally
+         and CSS does the swapping. */
+      .breadcrumb-back { display: none; }
+      @media (max-width: 540px) {
+        nav[aria-label="breadcrumb"] > ul { display: none; }
+        .breadcrumb-back { display: inline-flex; align-items: center; }
+      }
       /* Entity create/edit forms — cap form width on large screens so
          short fields don't stretch across the whole container, and
          standardize the Save/Cancel/Delete action cluster. The wrapper


### PR DESCRIPTION
## Summary

PR 4 of the 5-PR detail-layout sequence. The single-segment crumb on every detail page (`Openings ›`) carried no back affordance on mobile — users had to tap the small text link or rely on the browser back button. Now the breadcrumb macro emits two elements:

- `<a class=\"breadcrumb-back\">` — Lucide arrow-left glyph + the deepest clickable parent's label.
- `<ul>` — the full chain (existing behavior).

Two CSS rules in `base.html` swap visibility based on viewport:

```css
.breadcrumb-back { display: none; }
@media (max-width: 540px) {
  nav[aria-label=\"breadcrumb\"] > ul { display: none; }
  .breadcrumb-back { display: inline-flex; align-items: center; }
}
```

No JavaScript, no second macro. Multi-segment breadcrumbs (e.g. `/users/{id}/clinicians`) pick the immediate clickable parent automatically by selecting the last item with a non-None href.

## Test plan

- [x] `dev test` — 1518 passed, 106 skipped.
- [x] `dev lint` — clean.
- [ ] Visual check: detail page at ≤540px shows `← Openings`; ≥541px shows the existing crumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)