### PR TITLE
feat(chrome): inline label-value rows for all dl/dt/dd globally

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -137,6 +137,40 @@
          `margin-inline-end` rule above already provides the icon → label
          gap, so this rule adds no per-item spacing. */
       .icon-list { list-style: none; padding-left: 0; }
+      /* Definition lists — the canonical "fact row" shape used by every
+         list-card facts block and resource detail view (`_facts_block`,
+         `providers/detail`, `programs/detail`, `users/detail`,
+         `organizations/detail`). Two rules to know:
+
+           1) **Markup contract.** Templates wrap each `<dt>/<dd>` pair
+              in a `<div>` so the row is one DOM unit (easier hooks,
+              easier responsive collapse). The wrapper `<div>` is
+              `display: contents` so the `<dt>` and `<dd>` are still
+              direct grid items of the parent `<dl>` — that's what
+              makes labels align in a column across rows. Don't drop
+              the wrapping `<div>` or the alignment breaks.
+
+           2) **Mobile collapse.** On ≤640px viewports the grid
+              collapses to a single column and each row's `<dt>` stacks
+              above its `<dd>` (keeps labels readable on narrow
+              screens; two columns would crush the value to ~half-
+              screen). The wrapper `<div>` exits `display: contents`
+              there so the row keeps its own block scope. */
+      dl {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        column-gap: 0.75rem;
+        row-gap: 0.25rem;
+        margin: 0;
+      }
+      dl > div { display: contents; }
+      dt { font-weight: 600; }
+      dd { margin: 0; }
+      @media (max-width: 640px) {
+        dl { grid-template-columns: 1fr; row-gap: 0.5rem; }
+        dl > div { display: block; }
+        dt { margin-bottom: 0.125rem; }
+      }
       /* Page-scoped zone bar. Every page that needs page-scoped
          controls renders a single `<div class="toolbar">` strip
          whose children all right-align:


### PR DESCRIPTION
## Summary
- Every facts block + resource detail view (`_facts_block`, `providers/detail`, `programs/detail`, `users/detail`, `organizations/detail`) used browser-default `dl` rendering: `dt` on its own line, `dd` indented 40px below. That meant a screen full of stacked "Label / 40px-indented value" pairs, with the location row's icon-only `dt` rendering as a lone icon above the address.
- Add one global rule in `base.html`: `dl` becomes a `max-content 1fr` grid; the `<div>` wrappers around each `dt/dd` pair are `display: contents` so labels align across rows without touching any template.
- ≤640px viewports collapse to a single column with the `dt` stacked above the `dd` — keeps long values readable on narrow screens.

## Before / after (Openings list, desktop)

Before
```
[icon]
        Brooklyn, NY
Ages
        Young adults (19–24), Adults (25–64)
Insurance
        In-network
```

After
```
[icon]      Brooklyn, NY
Ages        Young adults (19–24), Adults (25–64)
Insurance   In-network
```

## Test plan
- [x] `dev lint` clean, `dev test src/framework/templates/test_views.py` — 28 passed
- [x] Browser-verified at 1200px and 390px on `/openings`, `/organizations/<id>`, `/users/me`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)