### PR TITLE
fix(header): collapse brand to short form on mobile

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -224,6 +224,18 @@
         nav[aria-label="breadcrumb"] > ul { display: none; }
         .breadcrumb-back { display: inline-flex; align-items: center; }
       }
+      /* Brand collapse on mobile. The two-word "Bedlam Connect" wraps
+         to two lines on narrow viewports once the primary nav fills the
+         row (see screenshot in #647-followup). The header markup emits
+         two spans — `.brand-full` (default) and `.brand-mark` (the
+         short form) — and the media query swaps them. No JS, two
+         rules. Threshold matches the breadcrumb back affordance above
+         so both kick in at the same width. */
+      .brand-mark { display: none; }
+      @media (max-width: 540px) {
+        .brand-full { display: none; }
+        .brand-mark { display: inline; }
+      }
       /* Entity create/edit forms — cap form width on large screens so
          short fields don't stretch across the whole container, and
          standardize the Save/Cancel/Delete action cluster. The wrapper
@@ -584,7 +596,14 @@
       <nav aria-label="Primary">
         <ul>
           {# title-case-ignore: "Bedlam Connect" is a brand name #}
-          <li><strong><a href="/">Bedlam Connect</a></strong></li>
+          {# Brand wraps the full label and a short "mark" form; only
+             one is visible at a time. CSS in the `<style>` block
+             above swaps them at ≤540px so the brand stays on one
+             line as the primary nav fills the row. #}
+          <li><strong><a href="/">
+            <span class="brand-full">Bedlam Connect</span>
+            <span class="brand-mark">Bedlam</span>
+          </a></strong></li>
           {% if is_authenticated %}
           <li><a href="{{ entity_url('referral') }}"{% if _on_referrals %} aria-current="page"{% endif %}>Referrals</a></li>
           <li><a href="{{ entity_url('opening') }}"{% if _on_openings %} aria-current="page"{% endif %}>Openings</a></li>


### PR DESCRIPTION
## Summary

PR 5 (final) of the 5-PR detail-layout sequence. The two-word "Bedlam Connect" wraps to two lines on narrow viewports once the primary nav fills the row (visible in the screenshot that kicked off the sequence) — eating ~32px of vertical space before any content appears.

- Brand markup emits two spans: `<span class="brand-full">Bedlam Connect</span>` + `<span class="brand-mark">Bedlam</span>`. Only one is visible at a time.
- Two CSS rules in `base.html` swap them at the same 540px threshold the breadcrumb back affordance uses (PR 4):
  ```css
  .brand-mark { display: none; }
  @media (max-width: 540px) {
    .brand-full { display: none; }
    .brand-mark { display: inline; }
  }
  ```

No JS, no extra image asset, no new utility class. Single word "Bedlam" picked as the short form so the brand still reads as itself on a quick glance — easy to swap to an SVG mark or initials later by changing one string + the `.brand-mark` selector.

## Test plan

- [x] `dev test` — 1518 passed, 106 skipped.
- [x] `dev lint` — clean.
- [ ] Visual check: header at ≤540px shows single-line "Bedlam"; ≥541px shows full "Bedlam Connect".

🤖 Generated with [Claude Code](https://claude.com/claude-code)