### PR TITLE
refactor(cards): replace icon-only Location dt with text label

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -386,9 +386,9 @@ def test_view_pa_referral_none_when_both_empty():
 
 def test_view_pa_location_chunk_pulled_from_provider():
     """PA's `location_chunk` reads city/state/zip from the linked
-    Provider so the listing card renders the same icon-only
-    `entity-location` row referral cards do. Detail page still gets
-    the full address via `full_address` for the expanded rows."""
+    Provider so the listing card renders the same "Location" row
+    referral cards do. Detail page still gets the full address via
+    `full_address` for the expanded rows."""
     v = post_card_view(_make_pa_post())
     assert v["location_chunk"] == {"city": "Brooklyn", "state": "NY", "zip": "11201"}
     assert v["full_address"] == "Brooklyn, NY 11201"

--- a/src/domain/templates/_shared/posts/_facts_block.html
+++ b/src/domain/templates/_shared/posts/_facts_block.html
@@ -1,13 +1,12 @@
 {# Demographics fact `<dl>` — the post card's body.
 
-Each fact is wrapped in a `<div>` so CSS can style chunks
-individually (e.g. the location chunk gets an icon-only `<dt>` via
-`div.entity-location`, suppressing the trailing colon the generic
-`dt::after` rule applies to other rows). Both referral and opening
-posts surface their location via this row — referral reads it from
-the post's own detail row, opening reads it from the linked
-clinician (the underlying model class is still `Provider`); the
-rendering treatment is identical.
+Each fact is wrapped in a `<div>` so the `<dl>` grid can treat each
+`dt/dd` pair as one logical row (the wrapper is `display: contents`
+in `base.html`, so the dt/dd still align in the parent's columns).
+Both referral and opening posts surface their location via the
+"Location" row — referral reads it from the post's own detail row,
+opening reads it from the linked clinician (the underlying model
+class is still `Provider`); the rendering treatment is identical.
 
 The list leads with the services row (`view.kind_verb` — `Seeking`
 for CR, `Providing` for PA/program/intake) when the post has any
@@ -73,13 +72,11 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
     <div class="entity-services"><dt>{{ view.kind_verb }}</dt><dd>{{ icon_list(_items) }}</dd></div>
     {%- endif %}
     {%- if view.location_chunk and not expanded %}
-    {#- Compact mode: icon-only "City, ST". Both referral and opening
-        kinds populate `location_chunk` so the row renders with the
-        same icon/treatment on both cards. The icon-only treatment is
-        a list-density choice; expanded mode uses the labeled
-        "Address" row below instead so the row reads consistently
-        with its siblings. -#}
-    <div class="entity-location"><dt aria-label="Location"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>
+    {#- Compact mode: "City, ST". Both referral and opening kinds
+        populate `location_chunk` so the row renders identically on
+        both cards. Expanded mode replaces this with the labeled
+        "Address" row below (full street address). -#}
+    <div><dt>Location</dt><dd>
       {%- if view.location_chunk.city -%}{{ view.location_chunk.city }}, {% endif -%}{{ view.location_chunk.state }}
     </dd></div>
     {%- endif %}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -100,7 +100,7 @@
   <section class="entity-facts">
     <dl>
       {%- if aff.full_address %}
-      <div class="entity-location"><dt aria-label="Address"><i class="icon-map-pinned" aria-hidden="true"></i></dt><dd>{{ aff.full_address }}</dd></div>
+      <div><dt>Address</dt><dd>{{ aff.full_address }}</dd></div>
       {%- endif %}
       <div><dt>In-person sessions</dt><dd>{{ aff.in_person_label }}</dd></div>
       <div><dt>Virtual sessions</dt><dd>{{ aff.virtual_label }}</dd></div>


### PR DESCRIPTION
## Summary
Now that every other `<dl>` row uses a text label aligned in the left column (#661, #663), the icon-only 📍 treatment on the location row breaks the visual rhythm — every other `dt` reads as a word, this one as a glyph. Use plain `Location` (post list cards via `_facts_block`) and `Address` (clinician detail via `providers/detail`) so the column reads consistently top-to-bottom.

Drops the `entity-location` class hook and the `icon-map-pinned` glyph from both call sites; no CSS rule referenced the class.

## Before / after (Openings list card)

Before
```
Providing   Psychotherapy, Medication mgmt, …
📍          Brooklyn, NY
Ages        Young adults …
```

After
```
Providing   Psychotherapy, Medication mgmt, …
Location    Brooklyn, NY
Ages        Young adults …
```

## Test plan
- [x] `dev lint` clean; `dev test src/framework/templates/test_views.py src/domain/logic/posts/test_view.py` — 75 passed
- [x] Browser-verified on `/openings` — "Location" row now aligns under the other label-column rows
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)