### PR TITLE
refactor(chrome): drop <hgroup>, CSS-driven meta separators

### DIFF
--- a/src/domain/templates/_shared/posts/_item.html
+++ b/src/domain/templates/_shared/posts/_item.html
@@ -24,23 +24,23 @@ Layout per card:
 
 The card is `<article>` with `<header>`, a body block, and
 `<footer>` — Pico's automatic styling tints header and footer as the
-top/bottom bands of the card. The header band is a Pico `<hgroup>`
-pairing an `<h3>` headline link with a `<small>` meta line (date ·
-modality, separated by middots). The `<h3>` anchors the card
-visually — Pico's heading scale gives it size + weight without
-custom CSS, which is the rule we want to lean on so the chrome
-stays framework-portable. The body is one `<dl>` from
-`_facts_block` whose first row carries the services (`Seeking` /
-`Providing` verb + `icon_list` of services); subsequent rows carry
-the demographic facts. The footer carries one element — the Email
-CTA — in the default left-aligned footer flow.
+top/bottom bands of the card. The header band is an `<h3>` headline
+link followed by a `<small class="meta">` line of `<span>` items
+(date plus zero, one, or two modality chips). The `.meta` rule in
+`base.html` joins adjacent span siblings with " · " via CSS, so
+each item is its own element rather than a hardcoded join string.
+The body is one `<dl>` from `_facts_block` whose first row carries
+the services (`Seeking` / `Providing` verb + `icon_list` of
+services); subsequent rows carry the demographic facts. The footer
+carries one element — the Email CTA — in the default left-aligned
+footer flow.
 
 Per-kind branching and field selection live in
 `src.domain.logic.posts.view.post_card_view`, which collapses CR /
 PA / intake detail shapes into one flat `view` dict. `modality_chips`
-emits the meta-line modality string; `_facts_block` emits the
-single `<dl>` body. Detail templates reuse the same `_facts_block`
-partial so list and detail share the same visual vocabulary.
+emits the modality `<span>`s; `_facts_block` emits the single `<dl>`
+body. Detail templates reuse the same `_facts_block` partial so
+list and detail share the same visual vocabulary.
 
 `entity_name` is the URL family the card links into — ``"referral"``,
 ``"opening"``, or ``"intake"``. Each family's `list.html` passes its
@@ -51,13 +51,12 @@ family (e.g. `/referrals/{id}` for referrals' list). #}
 
 {% macro post_item(post, entity_name) -%}
 {%- set view = post_card_view(post) -%}
-{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 <article class="entity-card" data-row-id="{{ post.id }}" data-kind="{{ post.kind }}">
   <header>
-    <hgroup>
-      <h3><a href="{{ entity_url(entity_name, id=post.id) }}">{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</a></h3>
-      <small>{{ post.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}</small>
-    </hgroup>
+    <h3><a href="{{ entity_url(entity_name, id=post.id) }}">{{ view.headline }}{% if view.header_state %}, {{ view.header_state }}{% endif %}</a></h3>
+    <small class="meta">
+      <span>{{ post.created_at | format_post_date }}</span>{{ modality_chips(view.in_person, view.virtual) }}
+    </small>
   </header>
   {{ facts_block(view) }}
 

--- a/src/domain/templates/_shared/posts/_modality_chips.html
+++ b/src/domain/templates/_shared/posts/_modality_chips.html
@@ -1,28 +1,25 @@
-{# Modality posture as a plain-text fragment for the post card's meta line.
+{# Modality posture as `<span>` chips for the post card's meta line.
 
-Replaces the legacy `<span class="post-modality">` chips. The card
-header now uses Pico's `<hgroup>` pattern (`<h3>` title + `<small>`
-meta line), and the meta line is just text — date · modality —
-separated by middots. Returning plain labels lets the caller drop
-custom CSS classes for the chips and rely on Pico defaults inside
-`<small>` for muted, smaller text.
+Emits zero, one, or two `<span>`s — the parent `.meta` rule in
+`base.html` adds the " · " separators between siblings via CSS
+`::before` content, so this macro doesn't carry a join string.
 
 `in_person` and `virtual` are `LOCATION_AVAILABILITY_OPTIONS` values
 (`yes` / `no` / `please_contact`). A `please_contact` on either arm
-collapses to a single "Contact for format" label — posture is unknown
-so neither glyph applies. When both arms are `no` (or `None`), the
-macro renders nothing; the caller checks `| trim` to decide whether
-to emit a separator.
+collapses to a single "Contact for format" span — posture is unknown
+so neither label applies. When both arms are `no` (or `None`), the
+macro renders nothing; the parent `.meta` rule then has nothing to
+separate, so no spurious middot leaks out.
 
 Used by `posts/_item.html` (the list card) and `posts/detail.html`
-(the detail page) so modality reads the same wherever it appears. #}
+(the detail page) so modality reads the same wherever it appears.
+Both callers wrap the macro's output inside `<small class="meta">…
+<span>{{ date }}</span> {{ modality_chips(...) }}</small>`. #}
 {% macro modality_chips(in_person, virtual) -%}
 {%- if in_person == "please_contact" or virtual == "please_contact" -%}
-Contact for format
+<span>Contact for format</span>
 {%- else -%}
-{%- set labels = [] -%}
-{%- if virtual == "yes" %}{%- set _ = labels.append("Virtual") -%}{% endif -%}
-{%- if in_person == "yes" %}{%- set _ = labels.append("In-person") -%}{% endif -%}
-{{ labels | join(' · ') }}
+{%- if virtual == "yes" %}<span>Virtual</span>{% endif -%}
+{%- if in_person == "yes" %}<span>In-person</span>{% endif -%}
 {%- endif -%}
 {%- endmacro %}

--- a/src/domain/templates/intakes/detail.html
+++ b/src/domain/templates/intakes/detail.html
@@ -5,15 +5,15 @@
 
 {% set resource_url = entity_url('intake') %}
 {%- set view = post_card_view(intake) -%}
-{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 
 {% block resource_label %}Intakes{% endblock %}
 {# The toolbar H1 carries the full identity string (`headline` plus
    the optional `header_state` — e.g. "Will's Org, NY"); the
-   `subtitle` block below carries date · modality meta. The
+   `subtitle` block below carries date + modality meta as `<span>`
+   items joined by the `.meta` rule's CSS-driven middot. The
    entity-card body therefore needs no `<header>`. #}
 {% block current_label %}{{ view.headline or 'Intakes'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
-{% block subtitle %}{{ intake.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}{% endblock %}
+{% block subtitle %}<span>{{ intake.created_at | format_post_date }}</span>{{ modality_chips(view.in_person, view.virtual) }}{% endblock %}
 
 {% block actions %}
 {% with post=intake %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}

--- a/src/domain/templates/openings/detail.html
+++ b/src/domain/templates/openings/detail.html
@@ -5,15 +5,15 @@
 
 {% set resource_url = entity_url('opening') %}
 {%- set view = post_card_view(opening) -%}
-{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 
 {% block resource_label %}Openings{% endblock %}
 {# The toolbar H1 carries the full identity string (`headline` plus
    the optional `header_state` — e.g. "Will's Org, NY"); the
-   `subtitle` block below carries date · modality meta. The
+   `subtitle` block below carries date + modality meta as `<span>`
+   items joined by the `.meta` rule's CSS-driven middot. The
    entity-card body therefore needs no `<header>`. #}
 {% block current_label %}{{ view.headline or 'Openings'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
-{% block subtitle %}{{ opening.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}{% endblock %}
+{% block subtitle %}<span>{{ opening.created_at | format_post_date }}</span>{{ modality_chips(view.in_person, view.virtual) }}{% endblock %}
 
 {% block actions %}
 {% with post=opening %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}

--- a/src/domain/templates/providers/_credential_row.html
+++ b/src/domain/templates/providers/_credential_row.html
@@ -18,13 +18,17 @@
 
    Meta parts are passed as a list; falsy entries (None / empty string)
    are filtered out so callers can include conditional fields inline
-   without explicit `{% if %}` plumbing.
+   without explicit `{% if %}` plumbing. Each surviving part renders
+   as its own `<span>` inside `<small class="meta">` so the " · "
+   between siblings comes from the `.meta` CSS rule in base.html
+   rather than a hardcoded join string.
 
    Args:
      label — bold primary text (the credential type, e.g.
        "Licensed Professional Counselor").
-     meta_parts — iterable of strings rendered as the muted second line,
-       joined by `·`. Falsy entries dropped.
+     meta_parts — iterable of strings rendered as the muted second
+       line. Falsy entries dropped; remaining items each get a
+       `<span>` and the `.meta` rule joins them with " · ".
      delete_url, delete_confirm — optional; when both set, render an
        hx-delete confirm button on the right. Read-only callers omit
        both.
@@ -37,7 +41,7 @@
   <div class="credential-row-text">
     <strong>{{ label }}</strong>
     {%- if parts %}
-    <small>{{ parts | join(' · ') }}</small>
+    <small class="meta">{% for p in parts %}<span>{{ p }}</span>{% endfor %}</small>
     {%- endif %}
   </div>
   {%- if delete_url and delete_confirm %}

--- a/src/domain/templates/referrals/detail.html
+++ b/src/domain/templates/referrals/detail.html
@@ -5,15 +5,15 @@
 
 {% set resource_url = entity_url('referral') %}
 {%- set view = post_card_view(referral) -%}
-{%- set modality = modality_chips(view.in_person, view.virtual) | trim -%}
 
 {% block resource_label %}Referrals{% endblock %}
 {# The toolbar H1 carries the full identity string (`headline` plus
    the optional `header_state` — e.g. "Will's Org, NY"); the
-   `subtitle` block below carries date · modality meta. The
+   `subtitle` block below carries date + modality meta as `<span>`
+   items joined by the `.meta` rule's CSS-driven middot. The
    entity-card body therefore needs no `<header>`. #}
 {% block current_label %}{{ view.headline or 'Referrals'|truncate(40) }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
-{% block subtitle %}{{ referral.created_at | format_post_date }}{% if modality %} · {{ modality }}{% endif %}{% endblock %}
+{% block subtitle %}<span>{{ referral.created_at | format_post_date }}</span>{{ modality_chips(view.in_person, view.virtual) }}{% endblock %}
 
 {% block actions %}
 {% with post=referral %}{% include "_shared/posts/_owner_actions.html" %}{% endwith %}

--- a/src/framework/templates/_shared/_provider_row.html
+++ b/src/framework/templates/_shared/_provider_row.html
@@ -20,16 +20,18 @@ After #642 PR 3 each cell reflects **every** affiliation the Provider
 holds — not just the primary one.
 
   - Practice cell: one anchor per affiliation pointing at the owning
-    Organization (`/organizations/{aff.org_id}`), joined by `" · "`.
-    Two affiliations at the same Org keep both chips (they may be
-    different locations); the cell intentionally does not dedupe by
-    `org_id`. The `<td>` keeps `class="primary"` so the responsive
-    mobile-stack pattern (see `_shared/index_table.html` and
-    `base.html` #578) still treats the cell as the row's headline.
-  - Location cell: `"City, ST"` per affiliation, joined by `" · "`,
+    Organization (`/organizations/{aff.org_id}`). The cell carries
+    `class="primary meta"` — `.primary` for the responsive mobile-
+    stack pattern (see `_shared/index_table.html` and `base.html`
+    #578), `.meta` so adjacent anchor siblings render with " · "
+    between them via the CSS rule in `base.html`. Two affiliations at
+    the same Org keep both chips (they may be different locations);
+    the cell intentionally does not dedupe by `org_id`.
+  - Location cell: `"City, ST"` per affiliation wrapped in `<span>`,
     with adjacent duplicate strings deduped (a clinician with two
     affiliations both in Brooklyn, NY renders one chip — see the
-    `seen` set below).
+    `seen` set below). The cell carries `class="meta"` so the spans
+    render with " · " between them via the same CSS rule.
   - Insurance cell: rendered from
     `src.domain.logic.providers.view._insurance_summary`, which unions
     in-network carriers, out-of-network acceptance, and sliding-scale
@@ -69,18 +71,18 @@ Provider id for tests / future per-row chrome.
   {%- endif -%}
 {%- endfor -%}
 <tr data-row-id="{{ provider.id }}">
-  <td data-label="Practice" class="primary">
+  <td data-label="Practice" class="primary meta">
     {%- if affiliations -%}
       {%- for aff in affiliations -%}
-        <a href="{{ entity_url('organization', id=aff.org_id) }}">{{ aff.org.name }}</a>{% if not loop.last %} · {% endif %}
+        <a href="{{ entity_url('organization', id=aff.org_id) }}">{{ aff.org.name }}</a>
       {%- endfor -%}
     {%- else -%}
       &mdash;
     {%- endif -%}
   </td>
-  <td data-label="Location">
+  <td data-label="Location" class="meta">
     {%- if locations -%}
-      {{ locations | join(' · ') }}
+      {%- for loc in locations -%}<span>{{ loc }}</span>{%- endfor -%}
     {%- else -%}
       &mdash;
     {%- endif -%}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -69,7 +69,7 @@
       /* Entity cards (`<article class="entity-card">`) intentionally
          carry no custom CSS — they rely on Pico's default `<article>`
          framing (background, border, padding, rounded corners) plus
-         semantic HTML inside (`<hgroup>`, `<h3>`, `<small>`, `<dl>`,
+         semantic HTML inside (`<header>`, `<h3>`, `<small>`, `<dl>`,
          etc.) so the chrome stays framework-portable. The
          `entity-card` / `entity-header` / `entity-facts` / etc.
          class names are kept on the markup as DOM hooks (tests query
@@ -182,6 +182,17 @@
         dl > div { display: block; }
         dt { margin-bottom: 0.125rem; }
       }
+      /* Inline meta list — the small print under a card heading or
+         page H1 that joins several short facts with " · ". Templates
+         wrap each fact in its own element (`<span>{{ date }}</span>
+         <span>Virtual</span>...`); this rule puts the middot between
+         every pair of adjacent siblings. The advantage over a
+         hardcoded `{{ items | join(' · ') }}` is locality: drop or
+         hide a single child and the surrounding separators redo
+         themselves; render zero or one child and nothing extra
+         appears. Works on any tag (`<span>`, `<a>`, etc.) — the
+         selector is purely structural. */
+      .meta > * + *::before { content: " · "; }
       /* Page-scoped zone bar. Every page that needs page-scoped
          controls renders a single `<div class="toolbar">` strip
          whose children all right-align:

--- a/src/framework/templates/views/detail.html
+++ b/src/framework/templates/views/detail.html
@@ -33,14 +33,16 @@ Child contract:
                      text with `aria-current="page"`.
 
   Optional blocks:
-    subtitle       — plain-text one-liner rendered as muted small text
-                     directly below the toolbar H1 (above content). Use
-                     for identity-adjacent meta that doesn't belong in
-                     the H1 itself — e.g. NPI on clinicians, date ·
+    subtitle       — one-liner rendered as muted small text directly
+                     below the toolbar H1 (above content). Use for
+                     identity-adjacent meta that doesn't belong in the
+                     H1 itself — e.g. NPI on clinicians, date +
                      modality on posts. The chrome wraps the block's
-                     output in `<p><small>...</small></p>` so children
-                     only emit text; nothing renders when the block is
-                     empty.
+                     output in `<p><small class="meta">...</small></p>`,
+                     so a block with multiple `<span>` (or `<a>`)
+                     children automatically gets " · " between
+                     siblings via the `.meta` CSS rule in base.html.
+                     Nothing renders when the block is empty.
     actions        — toolbar right-zone content: Edit, Delete,
                      Favorite, admin actions, etc. Each action is a
                      `<li>` because the right zone is a
@@ -63,7 +65,7 @@ Child contract:
 {%- set actions_body %}{% block actions %}{% endblock %}{% endset -%}
 {% call page_toolbar(heading=current | trim) %}{{ actions_body }}{% endcall %}
 {%- set sub %}{% block subtitle %}{% endblock %}{% endset -%}
-{%- if sub | trim %}<p><small>{{ sub | trim | safe }}</small></p>{% endif %}
+{%- if sub | trim %}<p><small class="meta">{{ sub | trim | safe }}</small></p>{% endif %}
 {% endblock %}
 
 {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
Every meta line in the app (post-card subhead, detail-page subtitle, credential row, clinician-row Practice + Location cells) was joining its items with a hardcoded `" · "` string in templates. Replace all of them with one CSS rule:

```css
.meta > * + *::before { content: " · "; }
```

Each meta line now wraps items in their own elements (`<span>`, `<a>`); CSS adds the middot between adjacent siblings. Locality win: drop or hide a single item and surrounding separators redo themselves automatically; zero or one item emits no spurious middot — no more `{% if modality %} · {{ … }}` plumbing.

Also drops the only real `<hgroup>` (in `_item.html`). `<header>` + `<h3>` + `<small>` is already the semantic grouping, and the WHATWG re-spec of `<hgroup>` doesn't buy us anything stylistic or a11y-wise.

## Files touched
| file | change |
|------|--------|
| `framework/templates/base.html` | new `.meta` rule; drop stale `<hgroup>` mention |
| `framework/templates/views/detail.html` | subtitle wrapper is now `<small class="meta">` |
| `_shared/posts/_modality_chips.html` | emits `<span>`s instead of `join(' · ')` |
| `_shared/posts/_item.html` | drops `<hgroup>`; meta is `<small class="meta"><span>…` |
| 3 post `detail.html` files (intakes/referrals/openings) | subtitle uses `<span>` + `modality_chips()` directly |
| `providers/_credential_row.html` | per-part `<span>` inside `<small class="meta">` |
| `_shared/_provider_row.html` | `.meta` on the Practice + Location `<td>`s |

## Out of scope
`_insurance_summary` in `src/domain/logic/providers/` still joins with `" · "` at the view-model layer. That one's a Python join feeding a single string into a cell; refactoring it would mean returning a list and reshaping the template — separate change.

## Test plan
- [x] `dev lint` clean
- [x] `dev test src/framework/templates/test_views.py src/domain/routes/` — 199 passed, 1 skipped
- [x] Browser-verified at 1200px and 390px on `/openings`, opening detail, `/clinicians` — separators render correctly, no `<hgroup>` in DOM
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)