### PR TITLE
feat(nav): bias home to /referrals (Journey 1: find new clients)

### DIFF
--- a/src/auth_config.py
+++ b/src/auth_config.py
@@ -39,7 +39,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         response: Optional[Response] = None,
     ):
         print(f"User {user.id} has logged in.")
-        redirect_url = "/openings"
+        # Post-login lands on the "find new clients" home — kept in
+        # lockstep with `src/main.py:read_root`'s redirect target.
+        redirect_url = "/referrals"
         next_url = request.query_params.get("next")
         if next_url:
             # Security check: only allow relative URLs that start with "/"

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -600,9 +600,10 @@
        flow. The right-side slot (`#primary-nav`) adapts: authed users
        see the profile icon (with `aria-current="page"` while on
        `/users/me`); anonymous visitors see a Login link. The brand
-       link goes to `/`, which redirects authed users to `/openings`
-       (the highest-trafficked URL family) and unauthed users to the
-       login page — safe on either side of the auth gate.
+       link goes to `/`, which redirects authed users to `/referrals`
+       (the "find new clients" journey home — see
+       `src/main.py:read_root` for the bias rationale) and unauthed
+       users to the login page — safe on either side of the auth gate.
 
        Self-reference suppression: when an anonymous visitor is already
        on an auth-flow page (`/auth/login`, `/auth/register`,

--- a/src/main.py
+++ b/src/main.py
@@ -88,10 +88,13 @@ async def unauthorized_exception_handler(request: Request, exc: HTTPException):
 
 @app.get("/")
 def read_root():
-    # `/openings` is the highest-trafficked URL family — see #628's
-    # split rationale. Anonymous visitors landing on `/` redirect here;
-    # auth gating happens at the route, not at root.
-    return RedirectResponse(url="/openings", status_code=302)
+    # Home biases to the "find new clients" journey: `/referrals` is the
+    # list of clients other clinicians are looking to place — the surface
+    # a working clinician scans to fill their caseload. The mirror
+    # journey ("refer out") still has a top-level nav tab to `/openings`.
+    # Anonymous visitors landing on `/` redirect here; auth gating
+    # happens at the route, not at root.
+    return RedirectResponse(url="/referrals", status_code=302)
 
 
 app.include_router(


### PR DESCRIPTION
## Summary

PR A of the journey-led nav bias. Both root (`/`) and post-login redirects now land on `/referrals` instead of `/openings`.

The product is two journeys — *find new clients* and *refer out a client* — and the more common case for a working clinician is the first. Landing them on the list of clients seeking placement (rather than on other clinicians' availability) puts the journey's primary scan surface in front of them by default. \`/openings\` keeps its nav tab; this is purely a default-landing flip. Existing bookmarks are unchanged.

- \`src/main.py:read_root\` → \`/referrals\`
- \`src/auth_config.py:on_after_login\` → \`/referrals\` (kept in lockstep with \`read_root\`)
- \`base.html\` inline doc comment updated to match

## Test plan

- [x] \`dev test\` — 1518 passed, 106 skipped.
- [x] \`dev lint\` — clean.
- [ ] Visual: log in → land on \`/referrals\`. Click brand → \`/referrals\`.

## What's next

PR B will reorder the nav (Referrals first) and add an adaptive chrome CTA that flips between *Set up your profile* (for first-time users without a clinician profile) and *Post availability* (for returning users). PR B does not depend on this merging first — they commute — but landing PR A keeps the visible bias consistent throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)