### PR TITLE
feat(nav): adaptive primary CTA — first-time vs returning users

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -26,17 +26,20 @@ async def test_base_template_renders_primary_nav_when_authenticated(
 ):
     """Authenticated pages render the primary nav with section
     shortcuts (Referrals / Openings / Intakes / Directory) on the left
-    and a single `/users/me` profile shortcut on the right. Other
-    section links (Users / Favorites) and the create-post CTA are
-    reachable from within their pages rather than from the top-level
-    chrome."""
+    and on the right an adaptive primary CTA (Create-clinician for
+    first-time users without a provider profile, Create-opening for
+    returning users) plus the `/users/me` profile icon. Other section
+    links (Users / Favorites) are reachable from within their pages
+    rather than from the top-level chrome."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     profile_items = tree.css("#primary-nav > li > a")
     profile_hrefs = {a.attributes.get("href") for a in profile_items}
-    assert profile_hrefs == {"/users/me"}
+    # First-time user (no `Provider` row yet) — the CTA points at
+    # `/clinicians/form` so they can unblock posting.
+    assert profile_hrefs == {"/clinicians/form", "/users/me"}
     section_items = tree.css('nav[aria-label="Primary"] > ul:first-of-type > li > a')
     section_hrefs = [a.attributes.get("href") for a in section_items]
     # Brand link is `<li><strong><a>` so the `> li > a` direct-child

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -22,12 +22,21 @@ def base_context(user: Actor | None) -> dict:
 
     `is_admin` is computed via `src.framework.authz.is_admin` so the rule
     has a single home; templates never re-derive it.
+
+    `has_provider_profile` is duck-typed off the user's `providers`
+    relationship (eagerly loaded on `User` via `lazy="selectin"`, see
+    `src/domain/models/users/user.py`). It defaults to `False` when the
+    attribute is missing — Actor is a structural Protocol that doesn't
+    declare `providers`, so test stubs without the attribute read as
+    "first-time user" (no provider profile yet) and the chrome shows
+    the profile-setup CTA accordingly.
     """
     return {
         "is_authenticated": user is not None,
         "is_admin": is_admin(user),
         "current_username": user.username if user is not None else None,
         "current_user_id": user.id if user is not None else None,
+        "has_provider_profile": bool(getattr(user, "providers", None)),
     }
 
 

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -24,6 +24,7 @@ def test_base_context_anonymous():
         "is_admin": False,
         "current_username": None,
         "current_user_id": None,
+        "has_provider_profile": False,
     }
 
 
@@ -35,6 +36,7 @@ def test_base_context_regular_user():
         "is_admin": False,
         "current_username": "alice",
         "current_user_id": user_id,
+        "has_provider_profile": False,
     }
 
 
@@ -43,6 +45,28 @@ def test_base_context_admin():
     ctx = base_context(user)
     assert ctx["is_admin"] is True
     assert ctx["is_authenticated"] is True
+
+
+def test_base_context_user_with_provider_profile():
+    """A user whose `providers` relationship is non-empty reads as
+    `has_provider_profile=True` — the chrome uses this to swap the
+    primary CTA from "Set up your profile" to "+ Post availability"."""
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        username="alice",
+        is_superuser=False,
+        providers=[SimpleNamespace(id=uuid.uuid4())],
+    )
+    ctx = base_context(user)
+    assert ctx["has_provider_profile"] is True
+
+
+def test_base_context_user_without_providers_attr_defaults_false():
+    """Missing `providers` attribute (Actor protocol doesn't declare it)
+    defaults to `False` — same shape as a brand-new user who hasn't
+    created a clinician profile yet."""
+    user = SimpleNamespace(id=uuid.uuid4(), username="alice", is_superuser=False)
+    assert base_context(user)["has_provider_profile"] is False
 
 
 # --- existing helpers ----------------------------------------------------

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -675,6 +675,21 @@
         </ul>
         <ul id="primary-nav">
           {% if is_authenticated %}
+          {# Primary chrome CTA — adapts to onboarding state. First-time
+             users (no provider profile yet) see "Create clinician",
+             which takes them to `/clinicians/form` so they can unblock
+             posting. Returning users see "Create opening", the primary
+             Journey-1 action ("find new clients" → broadcast your
+             availability so referrers find you). The flag
+             `has_provider_profile` is a chrome scalar in
+             `src.framework.http.responses.base_context`. Labels mirror
+             the per-list-page toolbar verb ("Create <entity>") so the
+             vocabulary stays consistent across surfaces. #}
+          {% if has_provider_profile %}
+          <li><a role="button" href="{{ entity_form_url('opening') }}">Create opening</a></li>
+          {% else %}
+          <li><a role="button" href="{{ entity_form_url('clinician') }}">Create clinician</a></li>
+          {% endif %}
           <li>
             <a href="{{ entity_url('user', id='me') }}" aria-label="Profile"{% if _on_profile %} aria-current="page"{% endif %}>
               {# Lucide `user` icon, inlined. `currentColor` makes it


### PR DESCRIPTION
## Summary

PR B of the journey-led nav bias. Adds a chrome-level primary CTA whose label depends on the viewer's onboarding state, so a brand-new user lands on the home and immediately sees the right next step.

- **First-time user (no `Provider` row yet)** → button reads **Create clinician** and points at `/clinicians/form`. They can't post anything until they fill this out; the chrome tells them so.
- **Returning user (has a clinician profile)** → button reads **Create opening** and points at `/openings/form`. This is the primary Journey-1 action ("find new clients" → broadcast availability so referrers find you).

Both labels match the existing per-list-page toolbar verb (\`Create <entity>\`) so the vocabulary stays consistent across surfaces. The CTA reuses Pico's default \`role=\"button\"\` primary styling — no new CSS.

### The flag

\`src/framework/http/responses.py::base_context\` gains \`has_provider_profile\`, duck-typed off \`user.providers\` (eagerly loaded on \`User\` via \`lazy=\"selectin\"\`). The \`Actor\` Protocol stays untouched; test stubs that omit \`providers\` read as first-time users via a \`getattr(..., None)\` fallback. Two unit tests in \`test_responses.py\` pin both branches.

### Section nav order

Referrals-first ordering already shipped in #642 PR 4 — no reorder needed for this PR.

## Test plan

- [x] \`dev test\` — 1520 passed (2 new \`base_context\` tests), 106 skipped.
- [x] \`dev lint\` — clean (title-case check passes once \"Create\" replaced the \"+ Post\" verb that triggered the HTTP-method false-positive).
- [ ] Visual: log in as a fresh user → home shows **Create clinician** on the right. Complete the profile → reload → button now reads **Create opening**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)