### PR TITLE
feat(nav): strip non-journey links from primary nav

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -24,13 +24,14 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """Authenticated pages render the primary nav with section
-    shortcuts (Referrals / Openings / Intakes / Directory) on the left
-    and on the right an adaptive primary CTA (Create-clinician for
-    first-time users without a provider profile, Create-opening for
-    returning users) plus the `/users/me` profile icon. Other section
-    links (Users / Favorites) are reachable from within their pages
-    rather than from the top-level chrome."""
+    """Authenticated pages render the primary nav with the two Journey
+    surfaces on the left (Referrals = "find new clients", Openings =
+    "refer out a client") and on the right an adaptive primary CTA
+    (Create-clinician for first-time users without a provider profile,
+    Create-opening for returning users) plus the `/users/me` profile
+    icon. Other URL families — `/intakes`, `/clinicians`,
+    `/organizations`, `/programs`, `/users` — stay live and reachable
+    by URL/bookmark, but are no longer chrome-promoted."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
@@ -44,12 +45,9 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     section_hrefs = [a.attributes.get("href") for a in section_items]
     # Brand link is `<li><strong><a>` so the `> li > a` direct-child
     # selector picks up only the section shortcuts in render order.
-    # Each post-kind family is its own top-level URL (#628).
     assert section_hrefs == [
         "/referrals",
         "/openings",
-        "/intakes",
-        "/clinicians",
     ]
 
 
@@ -57,10 +55,8 @@ async def test_primary_nav_highlights_active_section(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """Each post kind has its own URL family; the matching tab lights
-    on the family's list page (and any subpath) — same path-prefix
-    rule Directory uses. The old `?kind=` query-param disambiguation
-    is gone along with the shared `/posts` route (#628)."""
+    """The two journey tabs (Referrals / Openings) light on their own
+    list page and subpaths; the other tab does not."""
     referrals = await authenticated_client.get("/referrals")
     tree = HTMLParser(referrals.text)
     assert (
@@ -74,15 +70,6 @@ async def test_primary_nav_highlights_active_section(
             "aria-current"
         )
         is None
-    )
-
-    directory = await authenticated_client.get("/clinicians")
-    tree = HTMLParser(directory.text)
-    assert (
-        tree.css_first(
-            'nav[aria-label="Primary"] a[href="/clinicians"]'
-        ).attributes.get("aria-current")
-        == "page"
     )
 
 

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -615,40 +615,21 @@
     {%- set _profile_path = entity_url('user', id='me') -%}
     {%- set _on_profile = is_authenticated and (request.url.path == _profile_path or request.url.path.startswith(_profile_path + '/')) -%}
     {%- set _on_auth_flow = request.url.path == '/auth/login' or request.url.path == '/auth/register' or request.url.path == '/auth/forgot-password' or request.url.path.startswith('/auth/reset-password') -%}
-    {# Section shortcuts. Each kind has its own URL family — `/referrals`,
-       `/openings`, `/intakes` — so the active-state rule is the same
-       path-prefix shape used everywhere else in the nav (#628):
-       the tab lights on the family's list page and any subpath
-       (`/referrals/42`, `/referrals/42/form`). The old `?kind=` query
-       param disappeared along with `/posts` — there's no longer a
-       shared list page that needs disambiguation. Directory is its
-       own route under `/clinicians` (renamed from `/providers` in
-       #642 PR 4 — the Python model class stays `Provider`, only the
-       URL family and user-facing entity name flipped). #}
+    {# Section shortcuts. After the journey-led nav refactor the
+       primary nav promotes only the two surfaces a clinician scans:
+       `/referrals` (clients others are placing — "find new clients")
+       and `/openings` (clinicians with availability — "refer out a
+       client"). The other URL families — `/intakes`, `/clinicians`
+       (Directory), `/organizations`, `/programs`, `/users` — stay live
+       and reachable by URL/bookmark; they're just no longer
+       chrome-promoted. Admin tools are reachable by typing the URL.
+       Active-state rule is the same path-prefix shape used everywhere
+       else: the tab lights on the family's list page and any subpath
+       (`/referrals/42`, `/referrals/42/form`). #}
     {%- set _referrals_path = entity_url('referral') -%}
     {%- set _on_referrals = is_authenticated and (request.url.path == _referrals_path or request.url.path.startswith(_referrals_path + '/')) -%}
     {%- set _openings_path = entity_url('opening') -%}
     {%- set _on_openings = is_authenticated and (request.url.path == _openings_path or request.url.path.startswith(_openings_path + '/')) -%}
-    {%- set _intakes_path = entity_url('intake') -%}
-    {%- set _on_intakes = is_authenticated and (request.url.path == _intakes_path or request.url.path.startswith(_intakes_path + '/')) -%}
-    {%- set _directory_path = entity_url('clinician') -%}
-    {%- set _on_directory = is_authenticated and (request.url.path == _directory_path or request.url.path.startswith(_directory_path + '/')) -%}
-    {# Admin section shortcuts — `/organizations`, `/programs`, `/users`
-       were unreachable from the nav (#590). They're not product
-       surfaces for ordinary viewers, so render the links only for
-       admins (`is_admin` is a chrome scalar from
-       `framework.http.responses.html_response`). Each highlights when
-       on its collection list or any sub-path. #}
-    {%- set _orgs_path = entity_url('organization') -%}
-    {%- set _on_orgs = is_admin and (request.url.path == _orgs_path or request.url.path.startswith(_orgs_path + '/')) -%}
-    {%- set _programs_path = entity_url('program') -%}
-    {%- set _on_programs = is_admin and (request.url.path == _programs_path or request.url.path.startswith(_programs_path + '/')) -%}
-    {# Users nav lights on the collection list and on per-user detail/
-       edit pages, but NOT on `/users/me` — the profile icon already
-       owns that path. The admin-only guard avoids double-lighting when
-       a regular user lands on their own profile. #}
-    {%- set _users_path = entity_url('user') -%}
-    {%- set _on_users = is_admin and (request.url.path == _users_path or (request.url.path.startswith(_users_path + '/') and not _on_profile)) -%}
     <header class="container">
       <nav aria-label="Primary">
         <ul>
@@ -664,13 +645,6 @@
           {% if is_authenticated %}
           <li><a href="{{ entity_url('referral') }}"{% if _on_referrals %} aria-current="page"{% endif %}>Referrals</a></li>
           <li><a href="{{ entity_url('opening') }}"{% if _on_openings %} aria-current="page"{% endif %}>Openings</a></li>
-          <li><a href="{{ entity_url('intake') }}"{% if _on_intakes %} aria-current="page"{% endif %}>Intakes</a></li>
-          <li><a href="{{ entity_url('clinician') }}"{% if _on_directory %} aria-current="page"{% endif %}>Directory</a></li>
-          {% if is_admin %}
-          <li><a href="{{ entity_url('organization') }}"{% if _on_orgs %} aria-current="page"{% endif %}>Organizations</a></li>
-          <li><a href="{{ entity_url('program') }}"{% if _on_programs %} aria-current="page"{% endif %}>Programs</a></li>
-          <li><a href="{{ entity_url('user') }}"{% if _on_users %} aria-current="page"{% endif %}>Users</a></li>
-          {% endif %}
           {% endif %}
         </ul>
         <ul id="primary-nav">

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -293,12 +293,14 @@ def test_in_cell_action_menu_lays_out_inline() -> None:
     ), "`td > menu` must use flex layout so `<li>` commands sit inline (#580)"
 
 
-def test_primary_nav_shows_admin_links_only_for_admins() -> None:
-    """Regression for #590 — `/organizations`, `/programs`, `/users` are
-    admin tools, not surfaces for ordinary viewers. Render the chrome
-    twice: once as an admin (the three links appear), once as a
-    non-admin authenticated user (the links don't render).
-    Referrals/Openings/Directory render for any authed user."""
+def test_primary_nav_excludes_non_journey_links_for_all_viewers() -> None:
+    """The primary nav promotes only the two journey surfaces
+    (`/referrals`, `/openings`). Non-journey URL families —
+    `/intakes`, `/clinicians` (Directory), and the admin trio
+    `/organizations` / `/programs` / `/users` — stay live and
+    reachable by URL/bookmark but are intentionally absent from the
+    chrome. Render twice (admin and non-admin) to pin that the
+    `is_admin` branch doesn't reintroduce them either."""
     env = _make_env()
     _add_child(
         env,
@@ -310,41 +312,32 @@ def test_primary_nav_shows_admin_links_only_for_admins() -> None:
         """,
     )
 
-    admin_html = env.get_template("stub.html").render(
-        request=_request_stub(),
-        is_authenticated=True,
-        is_admin=True,
-        is_development=False,
-    )
-    nonadmin_html = env.get_template("stub.html").render(
-        request=_request_stub(),
-        is_authenticated=True,
-        is_admin=False,
-        is_development=False,
-    )
-
-    admin_tree = HTMLParser(admin_html)
-    admin_links = {
-        a.attributes.get("href") for a in admin_tree.css('nav[aria-label="Primary"] a')
-    }
-    assert "/organizations" in admin_links, "admin nav must include Organizations link"
-    assert "/programs" in admin_links, "admin nav must include Programs link"
-    assert "/users" in admin_links, "admin nav must include Users link"
-
-    nonadmin_tree = HTMLParser(nonadmin_html)
-    nonadmin_links = {
-        a.attributes.get("href")
-        for a in nonadmin_tree.css('nav[aria-label="Primary"] a')
-    }
-    assert (
-        "/organizations" not in nonadmin_links
-    ), "non-admin viewer must not see Organizations link"
-    assert (
-        "/programs" not in nonadmin_links
-    ), "non-admin viewer must not see Programs link"
-    assert "/users" not in nonadmin_links, "non-admin viewer must not see Users link"
-    # Referrals/Openings/Directory still present for the authed non-admin.
-    assert "/clinicians" in nonadmin_links
+    for is_admin_flag in (True, False):
+        html = env.get_template("stub.html").render(
+            request=_request_stub(),
+            is_authenticated=True,
+            is_admin=is_admin_flag,
+            is_development=False,
+        )
+        tree = HTMLParser(html)
+        nav_links = {
+            a.attributes.get("href") for a in tree.css('nav[aria-label="Primary"] a')
+        }
+        # Both journey tabs are present.
+        assert "/referrals" in nav_links
+        assert "/openings" in nav_links
+        # Non-journey families are NOT in the primary nav (regardless of
+        # admin flag).
+        for absent in (
+            "/intakes",
+            "/clinicians",
+            "/organizations",
+            "/programs",
+            "/users",
+        ):
+            assert (
+                absent not in nav_links
+            ), f"{absent} must not appear in primary nav (is_admin={is_admin_flag})"
 
 
 def test_form_edit_view_renders_breadcrumb_and_edit_heading() -> None:
@@ -835,18 +828,6 @@ def test_login_link_color_is_consistent_across_auth_pages() -> None:
 # --- Primary nav: section active-state + Login shortcut --------------
 
 
-def test_primary_nav_directory_active_on_clinicians_list() -> None:
-    """`/clinicians` is the canonical Directory URL — its tab is active."""
-    assert _active_tab_labels(_render_chrome("/clinicians")) == ["Directory"]
-
-
-def test_primary_nav_directory_active_on_clinician_detail() -> None:
-    """Subpaths under `/clinicians` (detail, edit) keep Directory lit so
-    the chrome stays consistent through the full clinician drill-down."""
-    assert _active_tab_labels(_render_chrome("/clinicians/42")) == ["Directory"]
-    assert _active_tab_labels(_render_chrome("/clinicians/42/form")) == ["Directory"]
-
-
 def test_primary_nav_referrals_active_on_referrals_list() -> None:
     """`/referrals` is the canonical Referrals URL — its tab is active."""
     assert _active_tab_labels(_render_chrome("/referrals")) == ["Referrals"]
@@ -870,24 +851,14 @@ def test_primary_nav_openings_active_on_openings_subpath() -> None:
     assert _active_tab_labels(_render_chrome("/openings/42/form")) == ["Openings"]
 
 
-def test_primary_nav_intakes_active_on_intakes_list() -> None:
-    """`/intakes` is the canonical Intakes URL."""
-    assert _active_tab_labels(_render_chrome("/intakes")) == ["Intakes"]
-
-
-def test_primary_nav_intakes_active_on_intakes_subpath() -> None:
-    assert _active_tab_labels(_render_chrome("/intakes/42")) == ["Intakes"]
-
-
-def test_primary_nav_no_post_tab_when_outside_post_families() -> None:
-    """The three post URL families are mutually exclusive — when none
-    of them owns the request path, none of `Referrals`/`Openings`/
-    `Intakes` is active. (`/clinicians` lights Directory, which is
-    asserted separately above.)"""
-    labels = _active_tab_labels(_render_chrome("/clinicians"))
-    assert "Referrals" not in labels
-    assert "Openings" not in labels
-    assert "Intakes" not in labels
+def test_primary_nav_no_tab_active_on_non_journey_paths() -> None:
+    """Neither Referrals nor Openings is active on URL families that
+    aren't chrome-promoted (`/clinicians`, `/intakes`, `/organizations`,
+    `/programs`, `/users`). The journey-1 bias intentionally leaves the
+    primary nav inert on these still-reachable-by-URL surfaces."""
+    for path in ("/clinicians", "/intakes", "/organizations", "/users"):
+        labels = _active_tab_labels(_render_chrome(path))
+        assert labels == [], f"{path} should not light any nav tab, got {labels}"
 
 
 def test_primary_nav_renders_login_link_off_auth_flow() -> None:


### PR DESCRIPTION
## Summary

The primary nav now shows only the two journey surfaces — **Referrals** and **Openings** — that match the product's two intents (find new clients, refer out a client). Five other URL families (\`/intakes\`, \`/clinicians\` Directory, plus admin trio \`/organizations\`, \`/programs\`, \`/users\`) stay live and reachable by URL/bookmark, but no longer take chrome space.

\`is_admin\` still exists as a chrome scalar for any future per-page admin affordance; we just stopped using it to gate top-level nav items.

### Files

- \`src/framework/templates/base.html\` — drop 5 \`<li>\`s + the \`{% if is_admin %}\` admin block + 5 unused path vars. Doc comment updated.
- \`src/domain/routes/test_users.py\` — 2 nav-shape tests trimmed for the 2-tab world.
- \`src/framework/templates/test_views.py\` — rewrote the admin-links test as a "non-journey URLs absent from primary nav" assertion (covers both admin and non-admin); rewrote the no-post-tab assertion for the 2-tab world; deleted 4 obsolete active-state tests for Intakes and Directory tabs.

## Test plan

- [x] \`dev test\` — 1516 passed, 106 skipped.
- [x] \`dev lint\` — clean.
- [ ] Visual at aimagain.art: nav row shows brand · Referrals · Openings · CTA · profile. Type \`/users\` in the URL bar → still loads (admin URL still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)