### PR TITLE
chore(chrome): drop dev-spec form prelude + broken .danger CSS class

### DIFF
--- a/src/domain/templates/intakes/form_new.html
+++ b/src/domain/templates/intakes/form_new.html
@@ -9,7 +9,6 @@
 {% if not current_user.programs %}
 <p>You need a program before posting intake. <a href="{{ entity_form_url('program') }}">Create a program</a>, then return here.</p>
 {% else %}
-<p>Per <code>notes/forms_spec.md</code>. No PII.</p>
 {{ intake_form("post", entity_url('intake'), "Create intake", schema=intake_create_schema, current_user=current_user, cancel_url=entity_url('intake')) }}
 {% endif %}
 {% endblock %}

--- a/src/domain/templates/openings/form_new.html
+++ b/src/domain/templates/openings/form_new.html
@@ -9,7 +9,6 @@
 {% if not current_user.providers %}
 <p>You need a clinician profile before posting availability. <a href="{{ entity_form_url('clinician') }}">Create your clinician profile</a>, then return here.</p>
 {% else %}
-<p>Per <code>notes/forms_spec.md</code>. No PII.</p>
 {{ opening_form("post", entity_url('opening'), "Create opening", schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('opening')) }}
 {% endif %}
 {% endblock %}

--- a/src/domain/templates/providers/_credential_row.html
+++ b/src/domain/templates/providers/_credential_row.html
@@ -45,11 +45,6 @@
     {%- endif %}
   </div>
   {%- if delete_url and delete_confirm %}
-  {# Every Delete in the app uses `class="danger"` (filled red) — see
-     the action-vocabulary table in `_shared/actions.html`. The
-     outlined-danger treatment that used to live here softened the
-     visual weight and made misfire risk indistinguishable from a
-     no-op Edit, which is the whole reason `.danger` (filled) exists. #}
   {{ confirm_delete_button(delete_url, delete_confirm) }}
   {%- endif %}
 </div>

--- a/src/domain/templates/referrals/form_new.html
+++ b/src/domain/templates/referrals/form_new.html
@@ -6,6 +6,5 @@
 {% block resource_label %}Referrals{% endblock %}
 
 {% block content %}
-<p>Per <code>notes/forms_spec.md</code>. No PII.</p>
 {{ referral_form("post", entity_url('referral'), "Create referral", schema=referral_create_schema, cancel_url=entity_url('referral')) }}
 {% endblock %}

--- a/src/framework/templates/_shared/actions.html
+++ b/src/framework/templates/_shared/actions.html
@@ -2,7 +2,7 @@
 
 ## Action-style vocabulary
 
-Every clickable affordance in the app picks one of these four visual
+Every clickable affordance in the app picks one of these three visual
 treatments. Pages stay readable when an Edit button always looks like
 an Edit button regardless of where it lives.
 
@@ -10,8 +10,7 @@ an Edit button regardless of where it lives.
 |-----------------|----------------------------|-----------------------------------------------------|
 | Primary CTA     | (none — Pico default)      | Create org, Save, Submit, Apply, "Add licensure"    |
 | Secondary       | `class="outline"`          | Edit, Favorite (toggle on), Favorites (nav link)    |
-| Neutral         | `class="secondary outline"`| Cancel, Clear, Email, Unfavorite, Deactivate        |
-| Destructive     | `class="danger"`           | Delete (every form / row / toolbar)                 |
+| Neutral         | `class="secondary outline"`| Cancel, Clear, Email, Unfavorite, Deactivate, Delete|
 
 Rules:
   - **Primary** is filled blue. One per page conceptually — Create on a
@@ -22,11 +21,10 @@ Rules:
   - **Neutral** is outlined muted. Used for non-destructive escapes
     (Cancel, Clear) and contextual "do this thing" affordances that
     aren't the page's primary (Email, Unfavorite, admin Deactivate).
-  - **Destructive** is filled red. Reserved for irreversible mutations
-    — always `class="danger"`, never the outlined-danger variant (the
-    softer outlined treatment hid the visual weight that keeps misfire
-    risk low — #579). Pinned by
-    `test_views.py::test_no_template_uses_outlined_danger_for_delete`.
+    Delete also renders as neutral while we work out a destructive
+    color treatment that survives Pico's button cascade — every
+    Delete still pairs the click with an `hx-confirm` dialog so a
+    misfire requires explicit confirmation.
 
 When an action fits one of these axes, **use the matching class
 combination directly** (or the macro below for Delete) — don't
@@ -59,14 +57,12 @@ Slot semantics:
   - `cancel_url` — neutral outline Cancel link. Form layout only.
   - `edit_url` + `edit_label` — secondary outline Edit link. Mainly
     toolbar, but valid in form layout too.
-  - `delete_url` + `delete_confirm` + `delete_label` — destructive
-    `class="danger"` button with `hx-confirm`. Form layout adds
-    `.form-actions-destructive` for right-alignment.
-
-The Delete button's `class="danger"` (filled red, defined in base.html
-— #579) keeps every Delete at the same visual weight; the outlined
-variant would let a destructive misfire look like a no-op Edit. Pinned
-by `test_no_template_uses_outlined_danger_for_delete`.
+  - `delete_url` + `delete_confirm` + `delete_label` — Delete button
+    with an `hx-confirm` dialog. Renders as neutral outline (same
+    treatment as Cancel) for now; the destructive color treatment
+    was removed when the custom `.danger` class wasn't taking effect.
+    The `hx-confirm` requirement is what keeps misfires unlikely.
+    Form layout adds `.form-actions-destructive` for right-alignment.
 
 Examples:
 
@@ -112,7 +108,7 @@ Examples:
 {%- endif %}
 {%- if delete_url and delete_confirm %}
 {%- if is_toolbar %}<li>{% endif -%}
-<button type="button" class="danger{% if not is_toolbar %} form-actions-destructive{% endif %}" hx-delete="{{ delete_url }}" hx-confirm="{{ delete_confirm }}">{{ delete_label }}</button>
+<button type="button" class="secondary outline{% if not is_toolbar %} form-actions-destructive{% endif %}" hx-delete="{{ delete_url }}" hx-confirm="{{ delete_confirm }}">{{ delete_label }}</button>
 {%- if is_toolbar %}</li>{% endif %}
 {%- endif %}
 {%- if not is_toolbar %}</div>{% endif -%}
@@ -122,7 +118,11 @@ Examples:
 `hx-confirm` dialog. Used by inline sub-resource list rows (e.g.
 providers/form_edit.html licensure delete) where a single Delete sits
 outside any action cluster. For Save/Cancel/Edit/Delete clusters, use
-the `actions` macro above. #}
+the `actions` macro above.
+
+Renders as neutral outline (matches Cancel) until a destructive color
+treatment that survives Pico's cascade is added back. The `hx-confirm`
+dialog is what keeps misfires unlikely. #}
 {% macro confirm_delete_button(url, confirm_message, label="Delete") -%}
-<button type="button" class="danger" hx-delete="{{ url }}" hx-confirm="{{ confirm_message }}">{{ label }}</button>
+<button type="button" class="secondary outline" hx-delete="{{ url }}" hx-confirm="{{ confirm_message }}">{{ label }}</button>
 {%- endmacro %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -406,42 +406,6 @@
         font-size: 0.9rem;
         line-height: 1.35;
       }
-      /* Destructive button style. Pico v2 ships primary (filled blue),
-         `.secondary`, `.contrast`, and the `.outline` modifier, but no
-         destructive-action color — every Delete in the app picked a
-         different style (primary blue, contrast black, secondary
-         outline) and read as the page's main CTA at the same visual
-         weight as Save/Create (#579). `.danger` is the single canonical
-         destructive class: filled red by default, red-outlined under
-         `.outline` for inline subentity deletes (credential rows) so
-         the row's main affordance doesn't shout. Reuses Pico's red
-         tokens so the color tracks the theme. */
-      button.danger,
-      [role="button"].danger,
-      input[type="button"].danger,
-      input[type="reset"].danger,
-      input[type="submit"].danger {
-        --pico-background-color: var(--pico-color-red-550);
-        --pico-border-color: var(--pico-color-red-550);
-        --pico-color: var(--pico-color-azure-50);
-      }
-      button.danger:is(:hover, :active, :focus),
-      [role="button"].danger:is(:hover, :active, :focus) {
-        --pico-background-color: var(--pico-color-red-600);
-        --pico-border-color: var(--pico-color-red-600);
-      }
-      button.danger.outline,
-      [role="button"].danger.outline {
-        --pico-background-color: transparent;
-        --pico-color: var(--pico-color-red-550);
-        --pico-border-color: var(--pico-color-red-550);
-      }
-      button.danger.outline:is(:hover, :active, :focus),
-      [role="button"].danger.outline:is(:hover, :active, :focus) {
-        --pico-background-color: var(--pico-color-red-50);
-        --pico-color: var(--pico-color-red-650);
-        --pico-border-color: var(--pico-color-red-650);
-      }
       /* Pico's `<fieldset>` carries a top margin that visually competes
          with the cap above — flatten the rhythm so siblings sit at a
          consistent gap inside the capped form. */

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -474,15 +474,12 @@ def test_actions_macro_supports_cancel_only_for_page_level_clusters() -> None:
     assert cancel.attributes.get("href") == "/widgets/1"
 
 
-def test_no_template_uses_outlined_danger_for_delete() -> None:
-    """Every Delete affordance uses `class="danger"` (filled red) —
-    the outlined-danger treatment (`class="danger outline"`) softens
-    the visual weight and lets a destructive misfire look like a
-    no-op Edit, which is the whole reason `.danger` (filled) exists
-    (#579). The action-vocabulary table in `_shared/actions.html`
-    documents this; this test scans the template tree so a future
-    drift fails here loudly rather than waiting for a UI review.
-    """
+def test_no_template_uses_danger_class() -> None:
+    """The custom `.danger` button class was removed when its Pico-token
+    overrides weren't taking effect. Guard against re-introducing
+    `class="danger"` anywhere in the template tree — if a destructive
+    color treatment is added back later, it should land via a new
+    selector + CSS in one place, not via per-template class strings."""
     import re
     from pathlib import Path
 
@@ -490,76 +487,19 @@ def test_no_template_uses_outlined_danger_for_delete() -> None:
         Path("src/framework/templates"),
         Path("src/domain/templates"),
     ]
-    # Match any class attribute that includes BOTH `danger` and
-    # `outline` (in any order, possibly with other classes). The
-    # whitespace boundary lets `class="danger outline"` and
-    # `class="outline danger"` both fail; a class containing the
-    # substring `danger` in a longer token (`.danger-icon`) wouldn't
-    # match because `\b` anchors on word boundary.
     violations: list[str] = []
     for root in templates_roots:
         for path in root.rglob("*.html"):
             text = path.read_text(encoding="utf-8")
             for match in re.finditer(r'class="([^"]*)"', text):
                 classes = match.group(1).split()
-                if "danger" in classes and "outline" in classes:
+                if "danger" in classes:
                     violations.append(f"{path}: {match.group(0)}")
 
     assert not violations, (
-        "outlined-danger violates the action-style vocabulary "
-        '(see `_shared/actions.html`) — Delete must be `class="danger"` '
-        '(filled), not `class="danger outline"`. Found:\n  ' + "\n  ".join(violations)
+        "the `.danger` class was removed; do not reintroduce it on "
+        "template markup. Found:\n  " + "\n  ".join(violations)
     )
-
-
-def test_destructive_action_macros_emit_danger_class() -> None:
-    """Regression for #579 — every Delete affordance must carry
-    `class="danger"` (defined in base.html). Pins the two macros that
-    own the destructive-button vocabulary:
-
-    1. `_shared/actions.html::confirm_delete_button` — used by toolbar
-       owner/admin actions and inline subentity rows.
-    2. `_shared/actions.html::actions` — the standard
-       Save/Cancel/Delete cluster at the bottom of every entity form
-       and the Edit/Delete cluster in every detail-page toolbar.
-    """
-    env = _make_env()
-    _add_child(
-        env,
-        "stub.html",
-        """
-        {% from "_shared/actions.html" import confirm_delete_button, actions %}
-        <div id="bare-delete">
-          {{ confirm_delete_button("/posts/1", "Sure?") }}
-        </div>
-        <div id="form-delete">
-          {{ actions("Save", cancel_url="/posts/1", delete_url="/posts/1", delete_confirm="Sure?") }}
-        </div>
-        <menu id="toolbar-delete">
-          {{ actions(wrapper="toolbar", delete_url="/posts/1", delete_confirm="Sure?") }}
-        </menu>
-        """,
-    )
-    html = env.get_template("stub.html").render()
-
-    tree = HTMLParser(html)
-    bare = tree.css_first("#bare-delete button")
-    assert bare is not None
-    assert "danger" in (
-        bare.attributes.get("class") or ""
-    ), "confirm_delete_button must emit class containing 'danger'"
-
-    form_delete = tree.css_first("#form-delete .form-actions-destructive")
-    assert form_delete is not None
-    assert "danger" in (
-        form_delete.attributes.get("class") or ""
-    ), "actions form-mode Delete must emit `danger` + `form-actions-destructive`"
-
-    toolbar_delete = tree.css_first("#toolbar-delete li button")
-    assert toolbar_delete is not None, "toolbar-mode Delete must be wrapped in <li>"
-    assert "danger" in (
-        toolbar_delete.attributes.get("class") or ""
-    ), "actions toolbar-mode Delete must emit class containing 'danger'"
 
 
 def test_list_page_heading_visible_on_mobile() -> None:
@@ -685,38 +625,6 @@ def test_entity_form_page_caps_short_field_widths() -> None:
         'base.html must cap `<input type="date">` width inside '
         "`.entity-form-page` so program start/end dates don't stretch (#585)"
     )
-
-
-def test_base_html_defines_danger_button_style() -> None:
-    """Regression for #579 — `.danger` button style must be defined in
-    base.html with a red token. Without it, `class="danger"` falls back
-    to Pico's primary blue and the destructive button looks like the
-    page's main CTA."""
-    import re
-
-    env = _make_env()
-    _add_child(
-        env,
-        "stub.html",
-        """
-        {% extends "views/list.html" %}
-        {% block resource_label %}Posts{% endblock %}
-        {% block content %}body{% endblock %}
-        """,
-    )
-    html = env.get_template("stub.html").render(
-        request=_request_stub(),
-        is_authenticated=False,
-        is_development=False,
-    )
-    match = re.search(
-        r"button\.danger,[^{]*\{[^}]*--pico-color-red-[^}]*\}",
-        html,
-        re.DOTALL,
-    )
-    assert (
-        match is not None
-    ), "base.html must define `button.danger` with a Pico red token"
 
 
 class _RequestStub:


### PR DESCRIPTION
## Summary

Two small UI cleanups bundled because both are *remove user-facing cruft*:

### 1. Drop the dev-spec form prelude

Removed \`<p>Per <code>notes/forms_spec.md</code>. No PII.</p>\` from \`intakes/form_new.html\`, \`openings/form_new.html\`, and \`referrals/form_new.html\`. It leaked an internal spec filename into the UI and restated guidance the per-field \`help=\"No PII.\"\` already carries.

### 2. Remove the broken \`.danger\` button-color class

The four \`.danger\` CSS rules in \`base.html\` attempted to override Pico's button cascade via custom-properties (\`--pico-background-color\`, \`--pico-color-red-550\`) but the overrides weren't taking effect. Every Delete in the app rendered as Pico's default primary blue instead of red.

Rather than patch the cascade, the class is removed. Every Delete now renders as neutral outline (\`class=\"secondary outline\"\` — matches Cancel) until a destructive treatment that survives Pico's cascade is added back. The \`hx-confirm\` dialog on every Delete is what keeps misfires unlikely; the color was a nice-to-have, not a safety gate.

**Changes**

- \`base.html\` — delete the 4 \`.danger\` rule blocks (~25 lines).
- \`_shared/actions.html\` — \`actions\` macro and \`confirm_delete_button\` now emit \`class=\"secondary outline\"\` (or \`... form-actions-destructive\` in form layout) instead of \`class=\"danger\"\`. Action-vocabulary doc table updated.
- \`providers/_credential_row.html\` — drop the now-stale comment.
- \`test_views.py\` — replace the \`outlined-danger\` ban with a \`no-template-uses-danger-class\` absence guard; delete the two now-obsolete tests.

\`.form-actions-destructive\` (layout-only — pushes Delete right) is kept; it's independent of the color treatment.

## Test plan

- [x] \`dev test\` — 1514 passed, 106 skipped.
- [x] \`dev lint\` — clean.
- [ ] Visual on aimagain.art: forms no longer show "Per notes/forms_spec.md. No PII." Delete buttons render as muted outlined (same treatment as Cancel) — still confirmable via the existing \`hx-confirm\` dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)