### PR TITLE
feat(clinicians): add first_name / last_name

### DIFF
--- a/alembic/versions/3a9d52f17b04_add_clinician_first_last_name.py
+++ b/alembic/versions/3a9d52f17b04_add_clinician_first_last_name.py
@@ -1,0 +1,38 @@
+"""add clinician first_name / last_name columns
+
+Revision ID: 3a9d52f17b04
+Revises: 7c3c296c9429
+Create Date: 2026-05-20 16:50:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3a9d52f17b04"
+down_revision: Union[str, None] = "7c3c296c9429"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Both nullable — existing rows predate the columns, backfill is
+    # operator-driven, same posture as `clinicians.npi`. The
+    # verification pipeline reads the name to score NPPES / OIG
+    # matches; nullable here matches the wire schema where both fields
+    # are optional.
+    with op.batch_alter_table("clinicians") as batch_op:
+        batch_op.add_column(sa.Column("first_name", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("last_name", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("clinicians") as batch_op:
+        batch_op.drop_column("last_name")
+        batch_op.drop_column("first_name")

--- a/scripts/dev/seed.py
+++ b/scripts/dev/seed.py
@@ -99,6 +99,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 2,
         "provider": {
             "practice_name": "Katie Reeves, PhD",
+            "first_name": "Katie",
+            "last_name": "Reeves",
             "org_type": "solo_practice",
             # Telehealth-only practice — sessions happen over video, but
             # the practice is legally registered at a real Bay Area
@@ -145,6 +147,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 14,
         "provider": {
             "practice_name": "Camp BooHoo",
+            "first_name": "Maya",
+            "last_name": "Patel",
             "org_type": "other",
             "location_city": "Santa Clara",
             "location_state": "CA",
@@ -187,6 +191,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 30,
         "provider": {
             "practice_name": "RISE IOP at CHC",
+            "first_name": "James",
+            "last_name": "Chen",
             "org_type": "clinic",
             "parent_org_name": "Children's Health Council",
             "location_city": "Palo Alto",
@@ -234,6 +240,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 5,
         "provider": {
             "practice_name": "Lakeside Therapy Collective",
+            "first_name": "Sarah",
+            "last_name": "Goldberg",
             "org_type": "group_practice",
             "location_city": "Seattle",
             "location_state": "WA",
@@ -270,6 +278,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 1,
         "provider": {
             "practice_name": "Greenfield Psychiatry",
+            "first_name": "David",
+            "last_name": "Greenfield",
             "org_type": "solo_practice",
             "location_city": "Brooklyn",
             "location_state": "NY",
@@ -311,6 +321,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 9,
         "provider": {
             "practice_name": "Rivera Family Psychology",
+            "first_name": "Elena",
+            "last_name": "Rivera",
             "org_type": "solo_practice",
             "location_city": "Austin",
             "location_state": "TX",
@@ -357,6 +369,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 21,
         "provider": {
             "practice_name": "Beacon Hill Family Therapy",
+            "first_name": "Patrick",
+            "last_name": "O'Brien",
             "org_type": "group_practice",
             "location_city": "Boston",
             "location_state": "MA",
@@ -405,6 +419,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 60,
         "provider": {
             "practice_name": "Mountainview Residential",
+            "first_name": "Michael",
+            "last_name": "Lee",
             "org_type": "clinic",
             "location_city": "Boulder",
             "location_state": "CO",
@@ -452,6 +468,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 45,
         "provider": {
             "practice_name": "Cascade PHP",
+            "first_name": "Aisha",
+            "last_name": "Williams",
             "org_type": "clinic",
             "parent_org_name": "Cascade Health Network",
             "location_city": "Tacoma",
@@ -500,6 +518,8 @@ FIXTURE_OPENING: list[FixtureOpening] = [
         "days_ago": 110,
         "provider": {
             "practice_name": "North Loop Counseling",
+            "first_name": "Rachel",
+            "last_name": "Friedman",
             "org_type": "group_practice",
             "location_city": "Minneapolis",
             "location_state": "MN",

--- a/src/domain/logic/providers/schema.py
+++ b/src/domain/logic/providers/schema.py
@@ -216,6 +216,12 @@ class ProviderRead(ReadProjection):
     # verification pipeline to look up the provider in NPPES. No UNIQUE
     # constraint at the DB layer yet.
     npi: str | None = None
+    # Legal first / last name — surfaced via `from_attributes` through
+    # `Provider.first_name` / `last_name`, which proxy to the linked
+    # `Clinician` (the actual column owner). Optional on read because
+    # backfill is operator-driven.
+    first_name: str | None = None
+    last_name: str | None = None
     # `(city, state, zip)` arrive flat — from ORM attributes via
     # ``from_attributes`` or from a flat dict — and dump flat (JSON
     # responses still expose ``location_city`` / ``location_state`` /
@@ -268,6 +274,12 @@ class ProviderCreate(WirePayload):
     # Optional on create; backfill is operator-driven. Empty input
     # normalizes to `None` so an unfilled form field doesn't 422.
     npi: NpiText = None
+    # Legal first / last name — both optional, both normalize empty
+    # string to `None` via `StrippedOptionalText` so an unfilled form
+    # field doesn't persist `""`. Forwarded to the linked Clinician
+    # via `Provider.__init__`'s kwarg peeling.
+    first_name: StrippedOptionalText = None
+    last_name: StrippedOptionalText = None
     location: Location
     in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
     virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
@@ -313,6 +325,12 @@ class ProviderUpdate(PartialUpdate):
     # Patch the NPI by writing a 10-digit string or empty (→ `None`,
     # clearing the field). Same validator as :class:`ProviderCreate`.
     npi: NpiText = None
+    # Patch the linked Clinician's first / last name. Empty input
+    # normalizes to `None` so submitting a blank field clears the
+    # column; absent fields pass through `exclude_unset=True` and
+    # don't touch the persisted value.
+    first_name: StrippedOptionalText = None
+    last_name: StrippedOptionalText = None
     location: LocationPartial | None = None
     in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
     virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None

--- a/src/domain/logic/verifications/handlers.py
+++ b/src/domain/logic/verifications/handlers.py
@@ -54,17 +54,26 @@ _NPPES_SKIPPED_FLAG = "nppes_skipped"
 _SKIPPED_NPPES = NppesResult(found=False, first_name=None, last_name=None, raw=None)
 
 
-def _user_names(owner: User | None) -> tuple[str, str]:
-    """Best-available (first, last) name for a provider's owning user.
+def _clinician_names(provider: Provider, owner: User | None) -> tuple[str, str]:
+    """Best-available (first, last) name for a provider's clinician.
 
-    The `User` model carries no first/last name fields today — see
-    `src/domain/models/users/user.py`. We fall back to `user.username`
-    in the first-name slot and leave last-name empty so the scoring
-    layer's similarity check lands far below threshold (`needs_review`)
-    until proper name fields are added. This is the safe default: every
-    verification routes to a human reviewer rather than silently
-    "verifying" against a name we never actually had.
+    Reads `provider.first_name` / `last_name` (proxies to the linked
+    `Clinician` row — the actual column owner). When BOTH are set,
+    those become the names the NPPES + OIG scorers compare against;
+    that's the path that lets a verification actually pass.
+
+    When either is missing — legacy rows that predate the columns, or a
+    half-filled edit form — falls back to `(user.username, "")`. The
+    username fallback scores far below threshold (`needs_review`), so
+    the verification routes to a human reviewer rather than silently
+    "verifying" against a name we never actually had. Same posture as
+    the original `_user_names`; this just reads from the right place
+    once the columns are available.
     """
+    first = (provider.first_name or "").strip()
+    last = (provider.last_name or "").strip()
+    if first and last:
+        return (first, last)
     if owner is None:
         return ("", "")
     return (owner.username or "", "")
@@ -101,7 +110,7 @@ async def run_provider_verification(
     # with the repos keeps everything inside the orchestrator's
     # transaction.
     owner = await verification_repo.session.get(User, provider.owner_id)
-    first_name, last_name = _user_names(owner)
+    first_name, last_name = _clinician_names(provider, owner)
 
     extra_flags: list[str] = []
     if provider.npi:

--- a/src/domain/logic/verifications/test_handlers.py
+++ b/src/domain/logic/verifications/test_handlers.py
@@ -81,17 +81,60 @@ async def _seed_provider(
     *,
     npi: str | None = None,
     username: str = "owner",
+    first_name: str | None = None,
+    last_name: str | None = None,
 ) -> tuple[Provider, User]:
     owner = create_test_user(username=f"{username}-{uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(owner)
-            provider = make_provider_with_org(owner_id=owner.id, npi=npi)
+            provider = make_provider_with_org(
+                owner_id=owner.id,
+                npi=npi,
+                first_name=first_name,
+                last_name=last_name,
+            )
             session.add(provider)
     return provider, owner
 
 
 # --- Status outcomes ----------------------------------------------------
+
+
+async def test_run_returns_verified_when_clinician_name_matches_nppes(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """When the clinician's first/last_name match NPPES' return, the
+    similarity scorer clears threshold → `verified`. Pins the
+    `_clinician_names` path that reads through to the linked Clinician
+    instead of the historical username fallback (which scored too low
+    to ever verify)."""
+    provider, _ = await _seed_provider(
+        db_test_session_manager,
+        npi="1234567890",
+        first_name="Eva",
+        last_name="Stone",
+    )
+    http = _mock_http({"1234567890": _nppes_basic_payload(first="Eva", last="Stone")})
+
+    async with db_test_session_manager() as session:
+        async with http:
+            verification = await run_provider_verification(
+                provider_id=provider.id,
+                verification_repo=VerificationRepository(session),
+                provider_repo=ProviderRepository(session),
+                audit_repo=AuditRepository(session),
+                http=http,
+                actor_id=None,
+            )
+
+    assert verification.status == "verified"
+    assert verification.oig_match is False
+    assert verification.name_match_score is not None
+    assert verification.name_match_score >= 0.9, (
+        f"expected high similarity on exact-name match, got "
+        f"{verification.name_match_score}"
+    )
 
 
 async def test_run_returns_needs_review_when_nppes_name_differs(

--- a/src/domain/models/clinicians/clinician.py
+++ b/src/domain/models/clinicians/clinician.py
@@ -58,6 +58,15 @@ class Clinician(BaseModel):
     # before the field is curated; tighten once the data is clean.
     npi = Column(Text, nullable=True)
 
+    # Legal first / last name. Both nullable because existing rows
+    # predate the columns (backfill is operator-driven, same posture as
+    # `npi`). The verification pipeline reads through here for the
+    # NPPES + OIG name match — without these, every check routes to
+    # human review because the username fallback in `_clinician_names`
+    # scores far below threshold (see `handlers.py:_clinician_names`).
+    first_name = Column(Text, nullable=True)
+    last_name = Column(Text, nullable=True)
+
     # Back-populates `Provider.clinician`. 1:many in the schema so PR 2
     # can attach more `Provider` rows (which become `Affiliation`s) to
     # one clinician without a relationship-cardinality migration. In

--- a/src/domain/models/clinicians/test_clinician.py
+++ b/src/domain/models/clinicians/test_clinician.py
@@ -149,3 +149,69 @@ async def test_clinician_npi_check_constraint_rejects_non_ten_digits(session):
     session.add(clinician)
     with pytest.raises(IntegrityError):
         await session.flush()
+
+
+# --- first_name / last_name -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_construct_auto_creates_clinician_with_names():
+    """`Provider(first_name=..., last_name=...)` should land on the
+    auto-created Clinician — same kwarg-peeling pattern as `npi`. The
+    verification pipeline's `_clinician_names` reads through these."""
+    user = _make_user("eve")
+    org = _make_org("Acme", user.id)
+    provider = _make_provider(owner=user, org=org)
+    provider.first_name = "Eva"
+    provider.last_name = "Stone"
+    assert provider.clinician is not None
+    assert provider.clinician.first_name == "Eva"
+    assert provider.clinician.last_name == "Stone"
+    # Read proxies dereference through the clinician.
+    assert provider.first_name == "Eva"
+    assert provider.last_name == "Stone"
+
+
+@pytest.mark.asyncio
+async def test_provider_construct_passes_names_to_clinician():
+    """When `first_name` / `last_name` arrive as construct kwargs (the
+    framework's `spec.model(**payload.model_dump())` path), the
+    Provider constructor peels them off and forwards into the
+    auto-created Clinician — the same flow `npi` uses."""
+    user = _make_user("frank")
+    org = _make_org("Acme", user.id)
+    provider = Provider(
+        owner_id=user.id,
+        org_id=org.id,
+        first_name="Frank",
+        last_name="Tucker",
+        in_person_sessions="yes",
+        virtual_sessions="no",
+        accepts_out_of_network=True,
+        in_network_carriers=[],
+        sliding_scale=False,
+        location_city="Brooklyn",
+        location_state="NY",
+        location_zip="11201",
+    )
+    assert provider.clinician.first_name == "Frank"
+    assert provider.clinician.last_name == "Tucker"
+
+
+@pytest.mark.asyncio
+async def test_setting_provider_first_name_writes_to_linked_clinician(session):
+    """`setattr(provider, 'first_name', value)` — the path
+    `repo.patch(provider, first_name="X")` takes — must route to the
+    linked Clinician's column so updates persist."""
+    user = _make_user("gina")
+    org = _make_org("Acme", user.id)
+    provider = _make_provider(owner=user, org=org)
+    session.add_all([user, org, provider])
+    await session.flush()
+
+    provider.first_name = "Gina"
+    provider.last_name = "Hart"
+    await session.flush()
+    await session.refresh(provider)
+    assert provider.clinician.first_name == "Gina"
+    assert provider.clinician.last_name == "Hart"

--- a/src/domain/models/providers/provider.py
+++ b/src/domain/models/providers/provider.py
@@ -130,9 +130,10 @@ class Provider(BaseModel):
         ``spec.model(**payload.model_dump())`` create path keeps
         working unchanged through the multi-PR split (#629 / #635).
 
-        - Any wire-side ``npi=`` kwarg becomes a fresh ``Clinician``
-          attached as ``self.clinician`` (the column moved off
-          ``providers`` in #629 PR 1).
+        - Any wire-side ``npi=`` / ``first_name=`` / ``last_name=``
+          kwarg becomes a fresh ``Clinician`` attached as
+          ``self.clinician`` (`npi` moved off ``providers`` in
+          #629 PR 1; the name columns landed alongside it).
         - The per-role kwargs (``org_id``, ``location_*``,
           ``in_person_sessions``, ``virtual_sessions``,
           ``accepts_out_of_network``, ``in_network_carriers``,
@@ -156,6 +157,8 @@ class Provider(BaseModel):
         from src.domain.models import Affiliation, Clinician
 
         npi = kwargs.pop("npi", None)
+        first_name = kwargs.pop("first_name", None)
+        last_name = kwargs.pop("last_name", None)
         # Peel per-role kwargs off before the SQLAlchemy column
         # constructor sees them — they target Affiliation now.
         per_role = {k: kwargs.pop(k) for k in list(_PER_ROLE_ATTRS) if k in kwargs}
@@ -166,7 +169,9 @@ class Provider(BaseModel):
             and "clinician" not in kwargs
             and "clinician_id" not in kwargs
         ):
-            self.clinician = Clinician(npi=npi)
+            self.clinician = Clinician(
+                npi=npi, first_name=first_name, last_name=last_name
+            )
         if not self.affiliations and "affiliations" not in kwargs:
             # Mirror the affiliation column defaults explicitly (column
             # `server_default`s only fire at flush) so the transient
@@ -216,6 +221,37 @@ class Provider(BaseModel):
             self.clinician = Clinician(npi=value)
         else:
             self.clinician.npi = value
+
+    # `first_name` / `last_name` — same proxy shape as `npi`. The
+    # columns live on `Clinician` (one person, many affiliations); the
+    # proxy here keeps `ProviderRead.model_validate(provider)` working
+    # via `from_attributes` and `repo.patch(provider, first_name="X")`
+    # landing on the linked clinician.
+    @property
+    def first_name(self) -> str | None:
+        return self.clinician.first_name if self.clinician is not None else None
+
+    @first_name.setter
+    def first_name(self, value: str | None) -> None:
+        from src.domain.models import Clinician
+
+        if self.clinician is None:
+            self.clinician = Clinician(first_name=value)
+        else:
+            self.clinician.first_name = value
+
+    @property
+    def last_name(self) -> str | None:
+        return self.clinician.last_name if self.clinician is not None else None
+
+    @last_name.setter
+    def last_name(self, value: str | None) -> None:
+        from src.domain.models import Clinician
+
+        if self.clinician is None:
+            self.clinician = Clinician(last_name=value)
+        else:
+            self.clinician.last_name = value
 
     # --- Per-role property proxies ----------------------------------
     # These delegate reads and writes to `provider.primary_affiliation.X`.

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -14,9 +14,14 @@
 {%- set view = provider_card_view(provider) -%}
 
 {% block resource_label %}Clinicians{% endblock %}
-{% block current_label %}{{ provider.org.name }}{% endblock %}
+{# H1 is the clinician's name when set; falls back to the primary
+   affiliation's organization name for legacy rows without name data.
+   The stacked affiliation cards below already list every org the
+   clinician practices at, so the org-as-H1 fallback only matters
+   while the name backfill is in progress. #}
+{% block current_label %}{% if provider.first_name and provider.last_name %}{{ provider.first_name }} {{ provider.last_name }}{% else %}{{ provider.org.name }}{% endif %}{% endblock %}
 {# title-case-ignore: NPI is an industry abbreviation (National Provider Identifier) #}
-{% block subtitle %}{% if view.npi %}NPI {{ view.npi }}{% endif %}{% endblock %}
+{% block subtitle %}{% if view.npi %}<span>NPI {{ view.npi }}</span>{% endif %}{% endblock %}
 
 {% block actions %}
 {# Primary resource actions (Favorite toggle, Edit, Delete) live in

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -15,7 +15,9 @@
 {% set resource_detail_url = entity_url('clinician', id=provider.id) %}
 
 {% block resource_label %}Clinicians{% endblock %}
-{% block current_label %}{{ provider.org.name }}{% endblock %}
+{# Same H1-fallback shape as the detail page — name when set, primary
+   affiliation's org name otherwise. #}
+{% block current_label %}{% if provider.first_name and provider.last_name %}{{ provider.first_name }} {{ provider.last_name }}{% else %}{{ provider.org.name }}{% endif %}{% endblock %}
 
 {% block content %}
 <section>
@@ -25,6 +27,17 @@
      form). To use a new Organization, create one via
      `entity_form_url('organization')` first. #}
   <form hx-patch="{{ entity_url('clinician', id=provider.id) }}">
+    {# Person-level fields (name, NPI) — these live on the linked
+       `Clinician` row, so they follow the person across affiliations.
+       Practice/location lives below. #}
+    <fieldset>
+      <legend>Clinician</legend>
+      <div class="grid">
+        {{ text_field("first_name", "First name", current=provider.first_name, required=false, maxlength=120) }}
+        {{ text_field("last_name", "Last name", current=provider.last_name, required=false, maxlength=120) }}
+      </div>
+      {{ text_field("npi", "NPI", current=provider.npi, required=false, pattern="\\d{10}", maxlength=10, help="10-digit National Provider Identifier. Optional.") }}
+    </fieldset>
     <fieldset>
       <legend>Practice location</legend>
       {{ entity_select_field(
@@ -39,7 +52,6 @@
         {{ select_field("location_state", "State", US_STATES, current=provider.location_state) }}
         {{ text_field("location_zip", "ZIP", current=provider.location_zip, pattern="\\d{5}", maxlength=5) }}
       </div>
-      {{ text_field("npi", "NPI", current=provider.npi, required=false, pattern="\\d{10}", maxlength=10, help="10-digit National Provider Identifier. Optional.") }}
     </fieldset>
     <fieldset>
       <legend>Session availability</legend>

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -18,6 +18,19 @@
    model class is still `Provider` — only the user-facing surface
    flipped in #642 PR 4. #}
 <form hx-post="{{ entity_url('clinician') }}">
+  {# Person-level fields (name, NPI) — these live on the linked
+     `Clinician` row and follow the person across affiliations. Kept in
+     their own fieldset so the form reads "who is this clinician" →
+     "where do they practice" top-to-bottom. #}
+  <fieldset>
+    <legend>Clinician</legend>
+    <div class="grid">
+      {{ field_for(schema, "first_name", "First name") }}
+      {{ field_for(schema, "last_name", "Last name") }}
+    </div>
+    {{ field_for(schema, "npi", "NPI", help="10-digit National Provider Identifier. Optional.") }}
+  </fieldset>
+
   <fieldset>
     <legend>Practice</legend>
     {{ entity_select_field(
@@ -31,7 +44,6 @@
       {{ field_for(schema, "location_state", "State") }}
       {{ field_for(schema, "location_zip", "ZIP") }}
     </div>
-    {{ field_for(schema, "npi", "NPI", help="10-digit National Provider Identifier. Optional.") }}
   </fieldset>
 
   <fieldset>

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -244,9 +244,12 @@ def _setup_provider_edit_form_stub(app: FastAPI) -> None:
             # `orgs` context var to render options.
             org_id=org_id,
             org=org,
-            # `npi` is an empty optional text input on the stub (#525);
-            # it serializes as `npi=` in the encoded body right after
-            # `location_zip`.
+            # `first_name`, `last_name`, and `npi` are empty optional
+            # text inputs on the stub. They live in the "Clinician"
+            # fieldset which renders first, so the form serializes them
+            # ahead of `org_id` in the encoded body.
+            first_name=None,
+            last_name=None,
             npi=None,
             location_city="Brooklyn",
             location_state="NY",

--- a/tests/test_contract/tests/consumer/test_provider_create_form.py
+++ b/tests/test_contract/tests/consumer/test_provider_create_form.py
@@ -55,20 +55,23 @@ async def test_consumer_provider_create_form_submits(
     expected_request_headers = {
         "Content-Type": Like("application/x-www-form-urlencoded")
     }
-    # `cost` and `npi` are empty text inputs — the browser includes
-    # empty-valued text inputs in the form body. The bool radios for
-    # `accepts_out_of_network` / `sliding_scale` are not pre-checked on
-    # the create form, so they're absent. The carrier multi-select is
-    # similarly empty. `org_id` carries the Organization picked from the
-    # dropdown (#524); the stub server seeds one Org. `npi` lives in the
-    # Practice fieldset (right after `location_zip`) so its empty value
-    # serializes between `location_zip` and `in_person_sessions` (#525).
+    # `first_name`, `last_name`, `npi`, and `cost` are empty text
+    # inputs — the browser includes empty-valued text inputs in the
+    # form body. The bool radios for `accepts_out_of_network` /
+    # `sliding_scale` are not pre-checked on the create form, so
+    # they're absent. The carrier multi-select is similarly empty.
+    # `org_id` carries the Organization picked from the dropdown
+    # (#524); the stub server seeds one Org. The "Clinician" fieldset
+    # holds the person-level fields and renders first, so
+    # `first_name`, `last_name`, `npi` serialize ahead of `org_id`.
     expected_request_body = (
-        "org_id=66666666-6666-6666-6666-666666666666"
+        "first_name="
+        "&last_name="
+        "&npi="
+        "&org_id=66666666-6666-6666-6666-666666666666"
         "&location_city=Brooklyn"
         "&location_state=NY"
         "&location_zip=11201"
-        "&npi="
         "&in_person_sessions=yes"
         "&virtual_sessions=please_contact"
         "&cost="

--- a/tests/test_contract/tests/consumer/test_provider_edit_form.py
+++ b/tests/test_contract/tests/consumer/test_provider_edit_form.py
@@ -72,15 +72,19 @@ async def test_consumer_provider_edit_form_submits(origin_with_routes: str, page
     # OON off, no sliding scale). The form pre-checks the "No" radio for
     # each Boolean (since `current=False`) and renders `cost` as an empty
     # text input. `in_network_carriers` is a multi-select with no current
-    # selection so it doesn't appear in the encoded form body. `npi` is
-    # an empty optional text input on the stub (#525), so it serializes
-    # as `npi=` right after `location_zip`.
+    # selection so it doesn't appear in the encoded form body. The
+    # "Clinician" fieldset holds the person-level fields (first/last
+    # name and npi) and renders first, so they serialize ahead of
+    # `org_id`. `first_name`, `last_name`, and `npi` are empty optional
+    # text inputs on the stub.
     expected_request_body = (
-        "org_id=55555555-5555-5555-5555-555555555555"
+        "first_name="
+        "&last_name="
+        "&npi="
+        "&org_id=55555555-5555-5555-5555-555555555555"
         "&location_city=Bayside"
         "&location_state=NY"
         "&location_zip=11201"
-        "&npi="
         "&in_person_sessions=yes"
         "&virtual_sessions=please_contact"
         "&accepts_out_of_network=false"


### PR DESCRIPTION
## Summary
The `Clinician` model carried `npi` but no person name — every NPPES / OIG verification fell back to `(user.username, "")` for the name match, deliberately scoring below threshold so every run routed to manual review. Add `first_name` and `last_name` columns to `clinicians`, surface them everywhere the existing `npi` flow already goes, and let verifications actually pass.

## Changes
- **Migration `3a9d52f17b04`** — two nullable Text columns on `clinicians`. Backfill is operator-driven (same posture as `npi`), so nullable; the `_clinician_names` fallback keeps verifications routing to review for rows without name data.
- **Models** — `Clinician` gains the columns. `Provider` peels `first_name` / `last_name` kwargs in `__init__` and proxies reads/writes through `provider.clinician.X` — exact same shape as the existing NPI proxy.
- **Schemas** — `ProviderRead` / `ProviderCreate` / `ProviderUpdate` carry the fields. Empty form input normalizes to `None` via `StrippedOptionalText`.
- **Forms** — clinician edit / new forms gain a "Clinician" fieldset at the top for name + NPI.
- **Detail page** — H1 uses "First Last" when both are set; falls back to the primary affiliation's org name for legacy rows.
- **Verification** — `_user_names` → `_clinician_names(provider, owner)` reads the clinician's name when both fields are populated; otherwise keeps the safe `(username, "")` fallback that scores below threshold.
- **Seed** — each of the 10 clinician fixtures now carries realistic first / last names so the new fields show out of the box.

## Test plan
- [x] `dev test` — **1518 passed, 106 skipped**
- [x] `dev lint` clean
- [x] New tests:
  - `test_clinician.py` × 3 (auto-create with names, kwarg forwarding, setter routing) — mirrors the existing NPI test trio
  - `test_handlers.py` × 1 — `test_run_returns_verified_when_clinician_name_matches_nppes` pins the path that lets a verification actually pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)