### PR TITLE
feat(openings): single Create CTA + kind filter on /openings

### DIFF
--- a/src/domain/routes/test_post_families.py
+++ b/src/domain/routes/test_post_families.py
@@ -30,10 +30,12 @@ from httpx import AsyncClient
 from selectolax.parser import HTMLParser
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import Post, Provider
+from src.domain.models import Organization, Post, Program, Provider
 from tests.helpers import (
     create_test_user,
+    make_intake_detail,
     make_opening_detail,
+    make_program,
     make_provider_with_org,
     make_referral_detail,
     promote_to_admin,
@@ -64,6 +66,21 @@ def _opening_post(
     detail = make_opening_detail(provider_id=provider.id)
     detail.provider = provider
     post.opening_detail = detail
+    return post
+
+
+def _intake_post(*, owner_id, org_id, program: Program | None = None) -> Post:
+    """Build a `kind='program_intake'` Post row with a fresh Program +
+    IntakeDetail attached. `org_id` is required because Program FKs to
+    Organization and the test session needs the parent row present."""
+    if program is None:
+        program = make_program(owner_id=owner_id, org_id=org_id)
+    if program.id is None:
+        program.id = uuid.uuid4()
+    post = Post(kind="program_intake", owner_id=owner_id)
+    detail = make_intake_detail(program_id=program.id)
+    detail.program = program
+    post.intake_detail = detail
     return post
 
 
@@ -180,26 +197,39 @@ async def test_edit_form_404s_when_id_belongs_to_other_kind(
 # --- Search form: kind filter is gone ------------------------------------
 
 
-@pytest.mark.parametrize("kind,collection,_builder", _FAMILIES)
-async def test_search_form_omits_kind_filter(
-    kind: str,
-    collection: str,
-    _builder,
+async def test_search_form_omits_kind_filter_on_kind_locked_face(
     authenticated_client: AsyncClient,
     logged_in_user,
 ):
-    """The kind picker has nothing to pick on a single-kind family,
-    so the search form on `/<family>/search` must not render a
-    `name="kind"` input (radio, select, or otherwise). The other six
-    filters stay."""
-    response = await authenticated_client.get(f"/{collection}/search")
+    """The kind picker has nothing to pick on a kind-locked family
+    (`/referrals` is bound to `kind='referral'`), so its search form
+    must not render a `name="kind"` input."""
+    response = await authenticated_client.get("/referrals/search")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     kind_inputs = tree.css('form [name="kind"]')
     assert kind_inputs == [], (
-        f"/{collection}/search rendered a `kind` input; the family is "
+        "/referrals/search rendered a `kind` input; the family is "
         "bound to one kind by spec, so the picker has no role"
     )
+
+
+async def test_search_form_renders_kind_filter_on_subset_supertype_face(
+    authenticated_client: AsyncClient,
+    logged_in_user,
+):
+    """The subset-supertype face (`/openings`) lists two subkinds.
+    Its search form must render a `name="kind"` input (multi-select
+    checkbox group) so the viewer can narrow to one subkind without
+    leaving the URL family."""
+    response = await authenticated_client.get("/openings/search")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    kind_inputs = tree.css('form [name="kind"]')
+    assert kind_inputs, "/openings/search did not render a `kind` input"
+    # Both subkinds appear as checkbox values.
+    values = {inp.attributes.get("value") for inp in kind_inputs}
+    assert {"clinician_opening", "program_intake"} <= values
 
 
 # --- List filter: row of another kind doesn't leak in --------------------
@@ -249,7 +279,10 @@ async def test_list_kind_query_param_does_not_override_lock(
     logged_in_user,
 ):
     """An attacker-supplied `?kind=other` on the URL is silently
-    overridden by the spec's `discriminator_value`."""
+    dropped — kind-locked faces stomp it with `discriminator_value`,
+    subset-supertype faces intersect it with `discriminator_values`
+    and fall back to the full subset when the intersection is empty.
+    Either way, no rows of the wrong kind leak in."""
     author = create_test_user(username=f"a-{uuid.uuid4()}")
     own = _builder(owner_id=author.id)
     async with db_test_session_manager() as session:
@@ -257,16 +290,65 @@ async def test_list_kind_query_param_does_not_override_lock(
             session.add(author)
             session.add(own)
 
+    # Pick a kind that's NOT in this face's served set:
+    # - /referrals serves {referral} → "clinician_opening" is foreign.
+    # - /openings serves {clinician_opening, program_intake} → "referral" is foreign.
     other_kind = "clinician_opening" if kind == "referral" else "referral"
     response = await authenticated_client.get(f"/{collection}?kind={other_kind}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     cards = tree.css(f"#{collection}-list > article")
-    kinds = {c.attributes.get("data-kind") for c in cards}
-    # Own kind still showing despite the malicious query param.
-    assert kinds <= {
-        kind
-    }, f"/{collection}?kind={other_kind} returned non-{kind} rows: {kinds!r}"
+    kinds_in_page = {c.attributes.get("data-kind") for c in cards}
+    # Foreign-kind row never leaks in; for the subset face this means
+    # the wrong-kind value was clamped out of the intersection. The
+    # served set is the face's invariant — `/openings` may render
+    # either subkind, `/referrals` may render only `referral`.
+    if kind == "referral":
+        assert kinds_in_page <= {"referral"}
+    else:
+        assert kinds_in_page <= {"clinician_opening", "program_intake"}
+
+
+async def test_openings_kind_filter_narrows_to_one_subkind(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The subset-supertype face honors a `?kind=<one of subset>`
+    filter: with both subkinds in the DB, `/openings?kind=clinician_opening`
+    returns only clinician_opening rows."""
+    author = create_test_user(username=f"a-{uuid.uuid4()}")
+    org = Organization(owner_id=author.id, name=f"Org {uuid.uuid4()}", type="clinic")
+    org.id = uuid.uuid4()
+    org.root_org_id = org.id
+    clinician_opening = _opening_post(owner_id=author.id)
+    program_intake = _intake_post(owner_id=author.id, org_id=org.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(author)
+            session.add(org)
+            session.add(clinician_opening)
+            session.add(program_intake)
+
+    # No filter → both subkinds visible.
+    response = await authenticated_client.get("/openings")
+    assert response.status_code == 200
+    kinds_unfiltered = {
+        c.attributes.get("data-kind")
+        for c in HTMLParser(response.text).css("#openings-list > article")
+    }
+    assert {"clinician_opening", "program_intake"} <= kinds_unfiltered
+
+    # Filtered to one subkind → only that subkind.
+    response = await authenticated_client.get("/openings?kind=clinician_opening")
+    assert response.status_code == 200
+    kinds_filtered = {
+        c.attributes.get("data-kind")
+        for c in HTMLParser(response.text).css("#openings-list > article")
+    }
+    assert kinds_filtered == {
+        "clinician_opening"
+    }, f"/openings?kind=clinician_opening returned: {kinds_filtered!r}"
 
 
 # --- Owner authz invariants ----------------------------------------------

--- a/src/domain/specs/posts/_base.py
+++ b/src/domain/specs/posts/_base.py
@@ -141,6 +141,26 @@ def _post_face(
             "or `kinds=` (subset-supertype); got "
             f"kind={kind!r}, kinds={kinds!r}"
         )
+    # Subset-supertype faces expose a `kind` filter on their list /
+    # search page so a viewer can narrow to one subkind without leaving
+    # the umbrella URL. Kind-locked leaves can't filter further by
+    # definition — they're already bound to one kind — so the kind
+    # filter is added only when `kinds=` is set. Choices read the
+    # human label from `POST_KINDS[k].list_label`. The annotation
+    # stays permissive (default `list[str] | None`) so out-of-subset
+    # values silently drop in `handle_list` instead of 422-ing — same
+    # convention kind-locked faces follow for an attacker-supplied
+    # `?kind=other`.
+    if kinds is not None:
+        kind_filter = ChoiceFilter(
+            name="kind",
+            label="Type",
+            choices=tuple((k, POST_KINDS[k].list_label) for k in kinds),
+            multi=True,
+        )
+        face_filters: tuple = (kind_filter,) + _POST_FILTERS
+    else:
+        face_filters = _POST_FILTERS
     return EntitySpec(
         name=name,
         url_collection=url_collection,
@@ -164,7 +184,7 @@ def _post_face(
             form_edit=True,
             search=True,
         ),
-        filters=_POST_FILTERS,
+        filters=face_filters,
         # Post-face templates live under `templates/posts/<face>/` (the
         # post cluster's own sub-directory) rather than the framework's
         # default `templates/<url_collection>/`. The nesting reflects

--- a/src/domain/specs/posts/test_post_faces.py
+++ b/src/domain/specs/posts/test_post_faces.py
@@ -69,24 +69,44 @@ def test_both_faces_share_the_post_kinds_registry():
         assert face.discriminator is POST_KINDS
 
 
-def test_faces_drop_kind_filter_on_search_form():
-    """The six surviving filters (q, posted_by, state, city, age_group,
-    language) appear on every face's search form. The seventh filter
-    (`kind`) lived on the old supertype only — `/referrals` is locked to
-    one kind, and `/openings` is bound to its subset by the framework's
-    `discriminator_values` lock, so a user-facing kind picker would be
-    redundant on both."""
-    for face in _FACES:
-        filter_names = [f.name for f in face.filters]
-        assert "kind" not in filter_names
-        assert set(filter_names) == {
-            "q",
-            "posted_by",
-            "state",
-            "city",
-            "age_group",
-            "language",
-        }
+def test_kind_locked_face_drops_kind_filter():
+    """`/referrals` is bound to one kind — a kind picker on the search
+    form would be a no-op. The shared `_POST_FILTERS` tuple already
+    omits `kind`."""
+    filter_names = [f.name for f in REFERRAL_ENTITY.filters]
+    assert "kind" not in filter_names
+    assert set(filter_names) == {
+        "q",
+        "posted_by",
+        "state",
+        "city",
+        "age_group",
+        "language",
+    }
+
+
+def test_subset_supertype_face_exposes_kind_filter_over_its_subkinds():
+    """`/openings` lists two subkinds (`clinician_opening`,
+    `program_intake`). The search page exposes a `kind` filter so
+    viewers can narrow to one subkind; the choices are exactly the
+    face's `discriminator_values`."""
+    filter_names = [f.name for f in OPENING_ENTITY.filters]
+    assert "kind" in filter_names
+    kind_filter = next(f for f in OPENING_ENTITY.filters if f.name == "kind")
+    assert kind_filter.choices == (
+        ("clinician_opening", "clinician opening"),
+        ("program_intake", "program intake"),
+    )
+    # The six non-kind post filters are still present.
+    assert set(filter_names) == {
+        "kind",
+        "q",
+        "posted_by",
+        "state",
+        "city",
+        "age_group",
+        "language",
+    }
 
 
 def test_referral_face_uses_per_kind_adapter():

--- a/src/domain/templates/posts/openings/list.html
+++ b/src/domain/templates/posts/openings/list.html
@@ -4,8 +4,7 @@
 {% block resource_label %}Openings{% endblock %}
 
 {% block actions %}
-<li><a href="{{ entity_form_url('opening') }}?kind=clinician_opening" role="button">Create clinician opening</a></li>
-<li><a href="{{ entity_form_url('opening') }}?kind=program_intake" role="button">Create program intake</a></li>
+<li><a href="{{ entity_form_url('opening') }}" role="button">Create opening</a></li>
 {% endblock %}
 
 {% block content %}

--- a/src/framework/dispatch/handlers.py
+++ b/src/framework/dispatch/handlers.py
@@ -909,17 +909,35 @@ async def handle_list(
     page_number = parse_page(request)
     per_page = spec.page_size or DEFAULT_PAGE_SIZE
     list_kwargs: dict[str, Any] = dict(filter_values)
-    # Kind-locked / subset-supertype face — force `kind` to the bound
-    # value(s) so the URL family only ever lists its own kind(s). The
-    # user-facing filter form drops the `kind` choice (the spec strips
-    # it from `filters`), so `filter_values` won't carry it from query
-    # params; an attacker-supplied `?kind=other` is silently ignored.
-    # Subset faces pass a list — the repository's `kind` predicate
-    # widens to `kind IN (...)`.
+    # Kind-locked / subset-supertype face — bind `kind` to the face's
+    # discriminator. Kind-locked leaves stomp any user value (the URL
+    # family is bound to one kind regardless of `?kind=`). Subset faces
+    # respect a user-supplied `kind` filter when the spec declares one
+    # (intersecting the user's pick with the face's subset); when no
+    # user filter is set, fall back to the full subset.
     if spec.discriminator_value is not None:
         list_kwargs[spec.discriminator.column] = spec.discriminator_value
     elif spec.discriminator_values is not None:
-        list_kwargs[spec.discriminator.column] = list(spec.discriminator_values)
+        column = spec.discriminator.column
+        user_value = list_kwargs.get(column)
+        # Normalize user input to a set of kinds. The kind filter on a
+        # subset face is conventionally `multi=True` (a `ChoiceFilter`
+        # whose choices are the subset). Empty / unset → full subset.
+        if user_value:
+            if isinstance(user_value, list):
+                user_kinds = [k for k in user_value if k in spec.discriminator_values]
+            elif user_value in spec.discriminator_values:
+                user_kinds = [user_value]
+            else:
+                user_kinds = []
+        else:
+            user_kinds = []
+        # Empty intersection (user picked only kinds outside the subset,
+        # or didn't pick any) → use the full subset. The alternative
+        # (return zero rows when user's pick is invalid) is surprising;
+        # silently clamping matches kind-locked faces' behavior of
+        # ignoring ?kind=other.
+        list_kwargs[column] = user_kinds or list(spec.discriminator_values)
     if spec.list_exclude_self and requesting_user is not None:
         list_kwargs["exclude_self"] = requesting_user
     list_kwargs["offset"] = offset_for(page_number, per_page)

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -613,19 +613,16 @@
         </ul>
         <ul id="primary-nav">
           {% if is_authenticated %}
-          {# Primary chrome CTA — adapts to onboarding state. First-time
-             users (no provider profile yet) see "Create clinician",
-             which takes them to `/clinicians/form` so they can unblock
-             posting. Returning users see "Create opening", the primary
-             Journey-1 action ("find new clients" → broadcast your
-             availability so referrers find you). The flag
+          {# Onboarding-only chrome CTA — first-time users (no provider
+             profile yet) see "Create clinician", which takes them to
+             `/clinicians/form` so they can unblock posting. Returning
+             users with a profile see no CTA in the nav: the page-level
+             "Create opening" / "Create referral" buttons on the
+             respective list views are the right surface for those
+             actions (one CTA per page, not duplicated in chrome).
              `has_provider_profile` is a chrome scalar in
-             `src.framework.http.responses.base_context`. Labels mirror
-             the per-list-page toolbar verb ("Create <entity>") so the
-             vocabulary stays consistent across surfaces. #}
-          {% if has_provider_profile %}
-          <li><a role="button" href="{{ entity_form_url('opening') }}">Create opening</a></li>
-          {% else %}
+             `src.framework.http.responses.base_context`. #}
+          {% if not has_provider_profile %}
           <li><a role="button" href="{{ entity_form_url('clinician') }}">Create clinician</a></li>
           {% endif %}
           <li>


### PR DESCRIPTION
## Summary

Three small `/openings` UX changes driven off the existing subset-supertype face (#671):

1. **One "Create opening" CTA on `/openings`** (was two: "Create clinician opening" + "Create program intake"). The single CTA points at `/openings/form` and the framework's kind picker — already rendered when `?kind=` is missing — handles the per-subkind disambiguation.
2. **No "Create opening" CTA in the primary nav.** Page-level buttons are the canonical surface for create actions; the chrome was duplicating. First-time users without a provider profile still see "Create clinician" in the nav (onboarding nudge unchanged).
3. **Kind filter on `/openings/search`.** Subset-supertype faces now expose a `ChoiceFilter(name="kind", multi=True)` over their `discriminator_values`. Viewers can narrow `/openings` to clinician openings or program intakes via a "Type" checkbox group.

## How

- `_post_face` builder prepends a `kind` `ChoiceFilter` when `kinds=` is supplied. Annotation stays permissive — out-of-subset values silently drop in the handler, matching kind-locked faces' convention.
- `handle_list` for subset faces intersects the user-supplied `kind` with the face's `discriminator_values`: in-subset values narrow the query; empty / unset / all-out-of-subset falls back to the full subset.
- `base.html` drops the chrome-level "Create opening" branch (keeps "Create clinician" for first-time onboarding).
- `posts/openings/list.html` collapses the two CTAs into one.

## Test plan

- [x] `dev test` — 1515 passed, 96 skipped, 0 failed
- [x] `dev test contract` — 36 passed
- [x] `dev lint` — clean
- [x] New positive test: `test_openings_kind_filter_narrows_to_one_subkind` — both subkinds in DB, `?kind=clinician_opening` returns only clinician_opening cards.
- [x] Existing pin: `test_subset_supertype_face_exposes_kind_filter_over_its_subkinds` — the filter declares the two subkind choices with their `list_label` text.
- [x] Kind-locked invariant survives: `test_kind_locked_face_drops_kind_filter` — `/referrals` has no `kind` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)