### PR TITLE
refactor(toolbar): atomic grid reflow — actions cluster wraps as one unit

### DIFF
--- a/src/framework/templates/_shared/_toolbar.html
+++ b/src/framework/templates/_shared/_toolbar.html
@@ -20,8 +20,14 @@ left-to-right:
     commands (Create, Edit, Delete, Favorite, ...). `<menu>` is
     HTML's native "list of commands" element. Detail-page and
     list-page actions land in the same place because the whole
-    cluster is right-aligned via `margin-left: auto` in
-    `base.html`.
+    cluster is right-aligned by being the second grid cell of
+    `.toolbar` (see `base.html`).
+
+The filter link and action menu are wrapped together in a
+`.toolbar-actions` cell so the toolbar grid reflows as a single
+unit: at ≥641px the heading and actions share one row; at ≤640px
+the whole actions cell drops below the heading atomically. The
+cluster never splits mid-toolbar.
 
 Cap on how many filter chips appear inline before collapsing to
 `+N more filters`. Keeps the link readable on narrow viewports.
@@ -83,23 +89,30 @@ Args:
 
   <h1>{{ heading }}</h1>
 
-  {%- if search_url %}
-  <a href="{{ search_url }}" class="toolbar-filter-link">
-    {%- if not active_filters -%}
-    Filters
-    {%- else -%}
-      {%- set shown = active_filters[:_ACTIVE_FILTER_INLINE_LIMIT] -%}
-      {%- set hidden = active_filters | length - shown | length -%}
-      {%- for tag in shown -%}{{ tag.label }}{%- if not loop.last %}, {% endif -%}{%- endfor -%}
-      {%- if hidden > 0 %}, +{{ hidden }} more filter{% if hidden != 1 %}s{% endif %}{%- endif -%}
-    {%- endif -%}
-  </a>
-  {%- endif %}
+  {%- if search_url or has_actions %}
+  {# Filter + menu live in one grid cell so the actions cluster
+     reflows as a single unit (atomic wrap). See `.toolbar`'s grid
+     in `base.html`. #}
+  <div class="toolbar-actions">
+    {%- if search_url %}
+    <a href="{{ search_url }}" class="toolbar-filter-link">
+      {%- if not active_filters -%}
+      Filters
+      {%- else -%}
+        {%- set shown = active_filters[:_ACTIVE_FILTER_INLINE_LIMIT] -%}
+        {%- set hidden = active_filters | length - shown | length -%}
+        {%- for tag in shown -%}{{ tag.label }}{%- if not loop.last %}, {% endif -%}{%- endfor -%}
+        {%- if hidden > 0 %}, +{{ hidden }} more filter{% if hidden != 1 %}s{% endif %}{%- endif -%}
+      {%- endif -%}
+    </a>
+    {%- endif %}
 
-  {%- if has_actions %}
-  <menu class="toolbar-right">
-    {{ actions_html }}
-  </menu>
+    {%- if has_actions %}
+    <menu class="toolbar-right">
+      {{ actions_html }}
+    </menu>
+    {%- endif %}
+  </div>
   {%- endif %}
 
 </div>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -193,37 +193,45 @@
          appears. Works on any tag (`<span>`, `<a>`, etc.) — the
          selector is purely structural. */
       .meta > * + *::before { content: " · "; }
-      /* Page-scoped zone bar. Every page that needs page-scoped
-         controls renders a single `<div class="toolbar">` strip
-         whose children all right-align:
-           `.toolbar-filter-link` — `<a>` opening the dedicated
-             `/<collection>/search` page; only present when the spec
-             opts into `routes.search`. Doubles as the active-filter
-             summary when filters are applied. Detail pages omit it.
-             Clearing happens on the search page's form, not here.
-           `.toolbar-right` — page action `<menu>` (Create, Edit,
-             Favorite, Export...).
-         The first right-aligned item carries `margin-left: auto`,
-         so the whole cluster lands at the right edge whether one
-         or both pieces are present. */
-      .toolbar { display: flex; align-items: center; flex-wrap: wrap; gap: 0.75rem; }
-      /* Toolbar carries the page `<h1>` on the left. Reset Pico's
-         block-level heading margins so the heading sits cleanly in
-         the flex row (Pico defaults add ~1rem above/below); the
-         size stays at Pico's default `h1` so the heading reads as
-         the page title. */
+      /* Page-scoped zone bar. Every page renders one
+         `<div class="toolbar">` carrying:
+           `<h1>` — the page heading (left cell).
+           `.toolbar-actions` — a single cell wrapping the filter link
+             (`.toolbar-filter-link`) and the action menu
+             (`.toolbar-right`). Wrapping both in one cell is what
+             gives the toolbar atomic reflow: at ≥641px the heading
+             and actions share one row; at ≤640px the actions cell
+             drops below the heading as a single unit. The cluster
+             never splits mid-toolbar.
+         Pages without actions or filter link render only the H1; the
+         macro omits `.toolbar-actions` entirely so the grid's second
+         column collapses. */
+      .toolbar {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: center;
+        gap: 0.75rem;
+      }
       .toolbar h1 { margin: 0; }
       /* Pico's default `<button>` is `display: block; width: 100%`
          (form-shaped); the toolbar overrides to natural-width inline
          buttons. Reaches every nested `<button>` / `[role="button"]`
          regardless of whether it lives in a form, menu, or `<li>`. */
       .toolbar button, .toolbar [role="button"] { width: auto; margin: 0; }
-      .toolbar-filter-link { min-width: 0; margin-left: auto; }
-      .toolbar-right { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin-left: auto; }
-      /* When the filter link is present it already eats the slack,
-         so the action menu joins it directly instead of being pushed
-         to its own right edge. */
-      .toolbar-filter-link ~ .toolbar-right { margin-left: 0; }
+      .toolbar-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        justify-content: flex-end;
+      }
+      .toolbar-filter-link { min-width: 0; }
+      .toolbar-right { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+      /* Atomic stack on narrow viewports. The actions cell drops to
+         a second row in one move — the cluster doesn't split. */
+      @media (max-width: 640px) {
+        .toolbar { grid-template-columns: 1fr; }
+        .toolbar-actions { justify-content: flex-start; flex-wrap: wrap; }
+      }
       /* `<menu>` is HTML's native "list of commands" element — used
          by the page toolbar (`menu.toolbar`, `menu.toolbar-right`)
          and any in-row action cluster (e.g. the users-table Actions


### PR DESCRIPTION
## Summary

The page toolbar used \`display: flex; flex-wrap: wrap\`, which let individual children break to the next line independently — on narrow viewports the filter link could wrap while the action menu stayed up top, or one button in the menu could split off from the rest. The toolbar lost its \"single unit\" feel.

Switch to a grid layout with a new \`.toolbar-actions\` wrapper holding the filter link plus the action menu. The wrapper makes the cluster a single grid item, so when the viewport narrows the entire cluster drops below the heading atomically.

- \`_shared/_toolbar.html\` macro now emits \`.toolbar-actions\` around the filter \`<a>\` and the action \`<menu>\`, conditional on either being present (form pages with heading-only still render a bare \`<h1>\`).
- \`base.html\`: \`.toolbar\` becomes \`display: grid\` with \`grid-template-columns: minmax(0, 1fr) auto\`. New \`.toolbar-actions\` flex row right-aligns its contents. Legacy \`margin-left: auto\` overrides on \`.toolbar-filter-link\` and \`.toolbar-right\` are dropped — alignment flows from the wrapper now.
- \`@media (max-width: 640px)\` collapses the grid to one column and the actions wrapper flips to left-aligned. Threshold matches the existing index-table responsive cutoff.

Existing test selectors (\`menu.toolbar-right\`, \`a.toolbar-filter-link\`, \`div.toolbar h1\`) keep working because they're descendant selectors; the new wrapper sits between but doesn't break the match.

## Test plan

- [x] \`dev test\` — 1515 passed, 96 skipped.
- [x] \`dev lint\` — clean.
- [ ] Visual at three widths (≤640, between 640–1024, ≥1024) — desktop side-by-side, mobile atomic-stacked under H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)