### PR TITLE
fix(openings): picker uses hgroup links, drop nav-styled kind picker

### DIFF
--- a/src/domain/templates/posts/openings/form_new.html
+++ b/src/domain/templates/posts/openings/form_new.html
@@ -3,12 +3,13 @@
 Reached when a user visits `/openings/form` without `?kind=` — the
 framework's `handle_get_new_form` falls through to
 `spec.templates.form_new` (this file) when no kind is specified. The
-canonical entry points are the two CTAs on `/openings/list.html` that
-always include `?kind=`; this page exists for direct-URL access.
+canonical entry point is the "Create opening" CTA on
+`posts/openings/list.html`; this picker is where that CTA lands.
 
-`POST_KINDS` is merged into context by the framework's `static_context`
-pattern; the loop uses `OPENING_ENTITY.discriminator_values` to surface
-only the two availability subkinds (not `referral`).
+Each option is an `<a>` wrapping an `<hgroup>` — the heading + tagline
+read as content the user picks from, not as a navigation menu (the
+previous `<nav><ul>` layout encouraged Pico to apply horizontal-nav
+styles that didn't fit the "pick a kind to post" intent).
 #}
 {% extends "views/form_new.html" %}
 
@@ -16,19 +17,24 @@ only the two availability subkinds (not `referral`).
 {% block current_label %}New{% endblock %}
 
 {% block content %}
-<p>Pick what you're posting:</p>
-<nav>
-  <ul>
-    <li>
-      <a class="kind-picker-option" data-kind="clinician_opening"
-         href="{{ entity_form_url('opening') }}?kind=clinician_opening">Clinician opening</a>
-      <small>an individual clinician with availability on their caseload.</small>
-    </li>
-    <li>
-      <a class="kind-picker-option" data-kind="program_intake"
-         href="{{ entity_form_url('opening') }}?kind=program_intake">Program intake</a>
-      <small>an organization's program announcing open intake slots.</small>
-    </li>
-  </ul>
-</nav>
+{# Each `<h2>` line carries a `title-case-ignore` marker — the
+   linter's concatenated-text heuristic flags the heading+tagline as
+   mid-text-capital ("Heading An individual…") even though each
+   element is correct sentence case in isolation, and resolves the
+   violation against the first leaf text-node (the `<h2>`). The
+   marker scope is the same line as the violation, so it sits on the
+   `<h2>`, not the parent `<a>`. #}
+<a href="{{ entity_form_url('opening') }}?kind=clinician_opening">
+  <hgroup>
+    <h2>Post a clinician opening</h2> <!-- title-case-ignore -->
+    <p>An individual clinician with availability on their caseload.</p>
+  </hgroup>
+</a>
+
+<a href="{{ entity_form_url('opening') }}?kind=program_intake">
+  <hgroup>
+    <h2>Post a program intake</h2> <!-- title-case-ignore -->
+    <p>An organization's program announcing open intake slots.</p>
+  </hgroup>
+</a>
 {% endblock %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -343,69 +343,6 @@
         .form-actions { flex-direction: column; align-items: stretch; }
         .form-actions > .form-actions-destructive { margin-left: 0; }
       }
-      /* Kind-picker chooser — used by `posts/form_new.html` (the
-         `/posts/form` page when the request omits `?kind=`). Each
-         `<a class="kind-picker-option">` is a full-bleed card the user
-         clicks to enter the kind-specific create form: Lucide icon on
-         the left, two-line text stack (title + 1-line description) on
-         the right. The `data-kind` attribute mirrors the convention
-         used on the entity-card markup so the kind reads the same
-         across post surfaces. Pico styles `<a>` as inline text; the
-         rules here promote each option to a block-level card with
-         border, padding, and a hover/focus accent. The cap reuses
-         `--form-max-width` so the chooser shares the page-width
-         envelope with the per-kind create forms it routes to. */
-      .kind-picker {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-        max-width: var(--form-max-width);
-      }
-      .kind-picker-option {
-        display: grid;
-        grid-template-columns: auto 1fr;
-        grid-template-rows: auto auto;
-        column-gap: 1rem;
-        align-items: center;
-        padding: 1rem;
-        border: var(--pico-border-width) solid var(--pico-muted-border-color);
-        border-left: 4px solid var(--pico-muted-border-color);
-        border-radius: var(--pico-border-radius);
-        background: var(--pico-card-background-color);
-        color: inherit;
-        text-decoration: none;
-      }
-      .kind-picker-option[data-kind="referral"] { border-left-color: darkorange; }
-      .kind-picker-option[data-kind="clinician_opening"] { border-left-color: darkcyan; }
-      .kind-picker-option[data-kind="program_intake"] { border-left-color: darkcyan; }
-      .kind-picker-option:is(:hover, :focus-visible) {
-        border-color: var(--pico-primary);
-        background: var(--pico-card-sectioning-background-color);
-        text-decoration: none;
-      }
-      .kind-picker-icon {
-        grid-row: 1 / span 2;
-        grid-column: 1;
-        font-size: 1.75rem;
-        margin-inline-end: 0;
-        color: var(--pico-primary);
-      }
-      .kind-picker-title {
-        grid-row: 1;
-        grid-column: 2;
-        font-weight: 600;
-        font-size: 1.05rem;
-      }
-      .kind-picker-description {
-        grid-row: 2;
-        grid-column: 2;
-        color: var(--pico-muted-color);
-        font-size: 0.9rem;
-        line-height: 1.35;
-      }
       /* Pico's `<fieldset>` carries a top margin that visually competes
          with the cap above — flatten the rhythm so siblings sit at a
          consistent gap inside the capped form. */


### PR DESCRIPTION
## Summary

The `/openings/form` picker (reached when no `?kind=` is supplied) was rendering as a `<nav><ul>` styled with the `.kind-picker*` CSS in `base.html`. PR #673 shipped the picker template without the `.kind-picker` class on the `<ul>`, so Pico's default horizontal-nav styles applied and the page read as a nav bar rather than a content picker.

This replaces the nav structure with two `<a>`-wrapped `<hgroup>`s — matching the markup you sketched. Each option is a heading + tagline ("Post a clinician opening" / "Post a program intake" with one-sentence descriptions). Pico's default `<hgroup>` styles (heading + muted tagline) carry the visual weight without bespoke CSS.

## Markup

```html
<a href="/openings/form?kind=clinician_opening">
  <hgroup>
    <h2>Post a clinician opening</h2>
    <p>An individual clinician with availability on their caseload.</p>
  </hgroup>
</a>

<a href="/openings/form?kind=program_intake">
  <hgroup>
    <h2>Post a program intake</h2>
    <p>An organization's program announcing open intake slots.</p>
  </hgroup>
</a>
```

## Also dropped

The 40-line `.kind-picker*` CSS block in `base.html`. Authored for the retired whole-supertype `/posts/form` picker; no remaining consumer after this template rewrite.

## Title-case lint

Each `<h2>` line gets a `<!-- title-case-ignore -->` marker. The linter concatenates the heading with the tagline ("Post a clinician opening An individual…") and flags the mid-text capital as a title-case violation, even though each element is correct sentence case in isolation. Marker scope is the same line as the violation (per `should_ignore_line` in `scripts/dev/title_case_check.py`), which resolves against the first leaf text-node (the `<h2>`).

## Test plan

- [x] `dev test` — 1515 passed, 96 skipped, 0 failed
- [x] `dev test contract` — 36 passed
- [x] `dev lint` — clean
- [x] Route smoke (existing): `GET /openings/form` 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)