### PR TITLE
feat(posts): link Organization (+ surface org link on openings)

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -167,7 +167,7 @@ def _make_pa_post(*, provider_attrs=None, **detail_overrides):
     """Realistic PA stub. Defaults populate provider + detail fields."""
     p = dict(
         id="prov-1",
-        org=SimpleNamespace(name="Acme Counseling"),
+        org=SimpleNamespace(id="org-1", name="Acme Counseling"),
         location_city="Brooklyn",
         location_state="NY",
         location_zip="11201",
@@ -208,7 +208,7 @@ def _make_program_post(*, program_attrs=None, **detail_overrides):
         id="prog-1",
         name="RISE IOP",
         state_preference="CT",
-        organization=SimpleNamespace(name="Acme Health"),
+        organization=SimpleNamespace(id="org-h", name="Acme Health"),
     )
     if program_attrs:
         p.update(program_attrs)
@@ -303,6 +303,7 @@ def test_view_cr_cr_only_fields_set_pa_only_fields_none():
     assert v["accepts_out_of_network"] is None
     assert v["practice_link"] is None
     assert v["program_link"] is None
+    assert v["organization_link"] is None
 
 
 def test_view_cr_no_referral_section():
@@ -350,6 +351,13 @@ def test_view_pa_in_person_virtual_come_from_provider():
 def test_view_pa_practice_link_carries_id_and_org_name():
     v = post_card_view(_make_pa_post())
     assert v["practice_link"] == {"id": "prov-1", "name": "Acme Counseling"}
+
+
+def test_view_pa_organization_link_carries_org_id_and_name():
+    """Opening's org link reads through `provider.org` so the detail
+    page's `Organization` row is a one-click jump to the owning org."""
+    v = post_card_view(_make_pa_post())
+    assert v["organization_link"] == {"id": "org-1", "name": "Acme Counseling"}
 
 
 def test_view_pa_full_address_from_provider():
@@ -440,12 +448,13 @@ def test_view_program_link_carries_id_and_name():
     assert v["program_link"] == {"id": "prog-1", "name": "RISE IOP"}
 
 
-def test_view_program_organization_name_exposed_separately():
-    """Detail page surfaces the owning Org's name as a separate row
-    below the Program link. The view-model exposes it as a flat
-    field so the template doesn't reach for `prog.organization.name`."""
+def test_view_program_organization_link_carries_org_id_and_name():
+    """Detail page surfaces the owning Org as a clickable link below
+    the Program link — the view-model exposes `{id, name}` so the
+    template renders an `<a>` (mirrors `practice_link` /
+    `program_link`); a one-click jump to `/organizations/{id}`."""
     v = post_card_view(_make_program_post())
-    assert v["organization_name"] == "Acme Health"
+    assert v["organization_link"] == {"id": "org-h", "name": "Acme Health"}
 
 
 def test_view_program_no_in_person_virtual_no_insurance_no_address():
@@ -512,6 +521,7 @@ def test_view_pa_missing_provider_returns_partial_view():
     assert v["header_state"] is None
     assert v["full_address"] is None
     assert v["practice_link"] is None
+    assert v["organization_link"] is None
     assert v["sliding_scale"] is None
     # Detail-row fields independent of the provider relationship still
     # populate so the card can render whatever it can.

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -202,8 +202,12 @@ def post_card_view(post) -> dict[str, Any]:
             ``None`` for other kinds.
         program_link: ``{id, name}`` of program's linked Program;
             ``None`` for other kinds.
-        organization_name: program's owning organization name;
-            ``None`` for other kinds.
+        organization_link: ``{id, name}`` of the post's owning
+            Organization (PA reads through ``provider.org``; program
+            intake reads through ``program.organization``). ``None``
+            for referral (CR has no org linkage in the model). The
+            facts block renders this as a clickable link so any post
+            is one click from its org's detail page.
         full_address: ``"City, ST ZIP"`` string for the detail page's
             expanded location row. CR reads from its own location;
             PA reads from the linked Provider; program returns
@@ -242,7 +246,7 @@ def post_card_view(post) -> dict[str, Any]:
         "desired_times": [],
         "practice_link": None,
         "program_link": None,
-        "organization_name": None,
+        "organization_link": None,
         "full_address": None,
         "sliding_scale": None,
         "cost": None,
@@ -321,6 +325,14 @@ def post_card_view(post) -> dict[str, Any]:
                 if p and getattr(p, "org", None) and getattr(p, "id", None)
                 else None
             ),
+            organization_link=(
+                {"id": p.org.id, "name": p.org.name}
+                if p
+                and getattr(p, "org", None)
+                and getattr(p.org, "id", None)
+                and getattr(p.org, "name", None)
+                else None
+            ),
             full_address=(
                 _full_address(
                     getattr(p, "location_city", None),
@@ -367,9 +379,15 @@ def post_card_view(post) -> dict[str, Any]:
                 if prog and getattr(prog, "id", None) and getattr(prog, "name", None)
                 else None
             ),
-            organization_name=(
-                getattr(prog.organization, "name", None)
-                if prog and getattr(prog, "organization", None)
+            organization_link=(
+                {
+                    "id": prog.organization.id,
+                    "name": prog.organization.name,
+                }
+                if prog
+                and getattr(prog, "organization", None)
+                and getattr(prog.organization, "id", None)
+                and getattr(prog.organization, "name", None)
                 else None
             ),
             referral=_referral_or_none(

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -23,8 +23,9 @@ Two modes:
     insurance_posture, treatment_modality.
 
   expanded=True (detail page) — every chunk the compact mode shows
-    PLUS the detail-only rows: practice link (PA) / program +
-    organization (program), full address line, desired times,
+    PLUS the detail-only rows: practice link (PA) / program link
+    (program), organization link (PA + program — clickable jump to
+    `/organizations/{id}`), full address line, desired times,
     schedule notes (PA/program), network preference + insurance
     carrier (CR), sliding scale + cost (PA). Languages always render
     in expanded mode (the English-only suppression is a list-density
@@ -136,8 +137,8 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
       {%- if view.program_link %}
       <div><dt>Program</dt><dd><a href="{{ entity_url('program', id=view.program_link.id) }}">{{ view.program_link.name }}</a></dd></div>
       {%- endif %}
-      {%- if view.organization_name %}
-      <div><dt>Organization</dt><dd>{{ view.organization_name }}</dd></div>
+      {%- if view.organization_link %}
+      <div><dt>Organization</dt><dd><a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a></dd></div>
       {%- endif %}
       {%- if view.full_address %}
       <div><dt>Address</dt><dd>{{ view.full_address }}</dd></div>


### PR DESCRIPTION
## Summary
Posts that have a linked organization now expose it as a clickable `<a href="/organizations/{id}">` in the facts block — one click from any post detail to its owning organization.

**Before**
- **Intake (program)** — showed `organization_name` as plain text.
- **Opening (PA)** — had `practice_link` to the clinician but no `organization_link` at all. Reaching the owning org required chaining through the clinician detail page.
- **Referral (CR)** — has no org/clinician linkage in the model. Unchanged.

**After** — every facts block with an associated org renders an `Organization` row as a navigable link, alongside the existing `Practice` (PA) or `Program` (intake) links.

## Change
- `view.py` — renamed `organization_name` → `organization_link` (`{id, name}`, mirrors `practice_link`/`program_link`). Populated for opening (`provider.org`) and intake (`program.organization`).
- `_facts_block.html` — single conditional row turns the org name into an `<a>` when `organization_link` is set.

## Test plan
- [x] `dev test` — 1516 passed, 96 skipped
- [x] `dev test tests/test_contract` — 36 passed
- [x] Browser-verified on opening detail (`/openings/{id}` for a PA): "Practice" + "Organization" both render as links; same name on solo-practice fixtures but distinct hrefs (`/clinicians/{prov_id}` vs `/organizations/{org_id}`)
- [x] Browser-verified on intake detail: "Program" + "Organization" both linked
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)