### PR TITLE
refactor(forms): label-left grid layout, matching the dl pattern

### DIFF
--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -77,8 +77,8 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
 {# ---- text-like inputs --------------------------------------------- #}
 
 {% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None, help=None, invalid=None, type="text", autocomplete=None) -%}
-<label for="{{ name }}">
-  {{ label }}
+<label class="form-field" for="{{ name }}">
+  <span class="form-field-label">{{ label }}</span>
   <input type="{{ type }}" id="{{ name }}" name="{{ name }}"
     {%- if current is not none %} value="{{ current }}"{% endif %}
     {%- if pattern %} pattern="{{ pattern }}"{% endif %}
@@ -92,8 +92,8 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
 {%- endmacro %}
 
 {% macro textarea_field(name, label, current=None, required=True, help=None, invalid=None) -%}
-<label for="{{ name }}">
-  {{ label }}
+<label class="form-field" for="{{ name }}">
+  <span class="form-field-label">{{ label }}</span>
   <textarea id="{{ name }}" name="{{ name }}"
     {%- if required %} required{% endif %}
     {%- if help %} aria-describedby="{{ name }}-helper"{% endif %}
@@ -112,8 +112,8 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
 {# ---- selects ------------------------------------------------------- #}
 
 {% macro select_field(name, label, options, labels=None, current=None, required=True, placeholder=False, help=None, invalid=None) -%}
-<label for="{{ name }}">
-  {{ label }}
+<label class="form-field" for="{{ name }}">
+  <span class="form-field-label">{{ label }}</span>
   <select id="{{ name }}" name="{{ name }}"
     {%- if required %} required{% endif %}
     {%- if help %} aria-describedby="{{ name }}-helper"{% endif %}
@@ -140,8 +140,8 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    value), not this macro. #}
 {% macro multi_select_field(name, label, options, labels=None, current=None, help=None, invalid=None) -%}
 {%- set selected = current or [] -%}
-<label for="{{ name }}">
-  {{ label }}
+<label class="form-field" for="{{ name }}">
+  <span class="form-field-label">{{ label }}</span>
   <select id="{{ name }}" name="{{ name }}" multiple size="{{ [options|length, 8]|min }}"
     {%- if help %} aria-describedby="{{ name }}-helper"{% endif %}
     {%- if invalid is not none %} aria-invalid="{{ 'true' if invalid else 'false' }}"{% endif %}>
@@ -174,8 +174,8 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    anyway, so callers don't need to coerce. #}
 {% macro entity_select_field(name, label, entities, current=None, required=True, blank_label=None, help=None, invalid=None, value_attr="id", label_attr="name") -%}
 {%- set current_s = current|string if current is not none else "" -%}
-<label for="{{ name }}">
-  {{ label }}
+<label class="form-field" for="{{ name }}">
+  <span class="form-field-label">{{ label }}</span>
   <select id="{{ name }}" name="{{ name }}"
     {%- if required %} required{% endif %}
     {%- if help %} aria-describedby="{{ name }}-helper"{% endif %}
@@ -202,17 +202,19 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    inputs. Each radio carries `aria-describedby` so screen readers
    announce the helper text on either selection. #}
 {% macro radio_bool_field(name, label, current=None, required=True, help=None) -%}
-<fieldset>
-  <legend>{{ label }}</legend>
-  <label><input type="radio" name="{{ name }}" value="true"
-    {%- if current is sameas true %} checked{% endif %}
-    {%- if required %} required{% endif %}
-    {%- if help %} aria-describedby="{{ name }}-helper"{% endif %} />Yes</label>
-  <label><input type="radio" name="{{ name }}" value="false"
-    {%- if current is sameas false %} checked{% endif %}
-    {%- if required %} required{% endif %}
-    {%- if help %} aria-describedby="{{ name }}-helper"{% endif %} />No</label>
-  {{- _help_small(name, help) }}
+<fieldset class="form-field">
+  <legend class="form-field-label">{{ label }}</legend>
+  <div class="form-field-control">
+    <label class="form-field-inline"><input type="radio" name="{{ name }}" value="true"
+      {%- if current is sameas true %} checked{% endif %}
+      {%- if required %} required{% endif %}
+      {%- if help %} aria-describedby="{{ name }}-helper"{% endif %} />Yes</label>
+    <label class="form-field-inline"><input type="radio" name="{{ name }}" value="false"
+      {%- if current is sameas false %} checked{% endif %}
+      {%- if required %} required{% endif %}
+      {%- if help %} aria-describedby="{{ name }}-helper"{% endif %} />No</label>
+    {{- _help_small(name, help) }}
+  </div>
 </fieldset>
 {%- endmacro %}
 
@@ -249,8 +251,8 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    empty array. #}
 {% macro time_grid_field(name, label, current=None, help=None) -%}
 {%- set selected = current or [] -%}
-<fieldset>
-  <legend>{{ label }}</legend>
+<fieldset class="form-field">
+  <legend class="form-field-label">{{ label }}</legend>
   <table>
     <thead>
       <tr>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -182,6 +182,74 @@
         dl > div { display: block; }
         dt { margin-bottom: 0.125rem; }
       }
+      /* Form-field layout — the form-side mirror of the `<dl>` grid
+         above. Label sits in column 1 (`max-content`); input/select/
+         textarea fills column 2 (`1fr`). Helper `<small>` and grouped
+         `<fieldset>` controls also land in column 2 so the labels stay
+         in a clean vertical column down the page.
+         Markup contract (emitted by `_shared/form_fields.html` macros):
+
+           <label class="form-field" for="x">
+             <span class="form-field-label">Label</span>
+             <input id="x" ... />
+             <small id="x-helper">helper</small>     {# optional #}
+           </label>
+
+         Fieldset-shaped fields (radio_bool_field, time_grid_field)
+         use the same `.form-field` class on `<fieldset>` with the
+         label in `<legend class="form-field-label">` and the controls
+         wrapped in `<div class="form-field-control">` so the right
+         column holds the radio cluster atomically.
+
+         Mobile (≤640px): collapse to a single column with the label
+         stacked above the control. Matches the `<dl>` collapse
+         threshold so the form and the facts panel agree on when the
+         label-on-left layout becomes too cramped. */
+      .form-field {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        column-gap: 0.75rem;
+        row-gap: 0.25rem;
+        align-items: center;
+        margin-block: 0;
+        padding: 0;
+        border: 0;
+      }
+      .form-field + .form-field { margin-block-start: var(--pico-spacing); }
+      .form-field-label { font-weight: 600; }
+      .form-field > input,
+      .form-field > select,
+      .form-field > textarea,
+      .form-field > .form-field-control { margin: 0; }
+      .form-field > small {
+        grid-column: 2;
+        margin: 0;
+        color: var(--pico-muted-color);
+      }
+      /* Multi-row controls (textarea, multi-select, time grid) align
+         their label to the first line of the control rather than the
+         vertical center, so a long textarea doesn't push the label
+         halfway down. */
+      .form-field:has(> textarea),
+      .form-field:has(> select[multiple]),
+      .form-field:has(> table) { align-items: start; }
+      /* Radio cluster: yes/no labels inline inside the right column. */
+      .form-field-control {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+      }
+      .form-field-control > .form-field-inline {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
+      @media (max-width: 640px) {
+        .form-field { grid-template-columns: 1fr; row-gap: 0.25rem; }
+        .form-field > small { grid-column: 1; }
+        .form-field-label { margin-bottom: 0.125rem; }
+      }
       /* Inline meta list — the small print under a card heading or
          page H1 that joins several short facts with " · ". Templates
          wrap each fact in its own element (`<span>{{ date }}</span>


### PR DESCRIPTION
## Summary

Forms used Pico's default vertical stack — label on its own line above the input. Detail-page facts already use a \`<dl>\` grid that puts \`<dt>\` on the left and \`<dd>\` on the right with a column-collapse at ≤640px. This PR generalizes that grid to forms, so a clinician filling out a referral or opening sees the same label-left visual rhythm they see when reading a detail page.

### Markup contract (all `_shared/form_fields.html` macros)

```html
<label class="form-field" for="x">
  <span class="form-field-label">Label</span>
  <input id="x" ... />
  <small id="x-helper">helper</small>   <!-- optional -->
</label>
```

Fieldset-shaped fields (`radio_bool_field`, `time_grid_field`) use the same class on `<fieldset>` with the label in `<legend class="form-field-label">` and the right-column controls in `<div class="form-field-control">` so the radio cluster lands as a single unit.

### CSS

- `.form-field { display: grid; grid-template-columns: max-content 1fr; }` — same shape as the existing `<dl>` rule.
- Multi-row controls (textarea, multi-select, time grid) align label to the first line via `align-items: start` (matched through `:has()`).
- Helper `<small>` sits in column 2 under the input.
- `@media (max-width: 640px)`: collapse to single column, label stacked above. Same threshold the `<dl>` rule uses, so forms and detail facts agree on when label-left is too cramped.

Pico's default `<fieldset>` border/padding/margin are reset on `.form-field` so the radio/time-grid fields don't render a stray visual frame.

### Tests

No test changes needed — existing assertions use descendant selectors (\`label > input\`, \`label > small#x-helper\`, etc.) which still match through the new \`<span>\` wrapping the label text. 1515 passed, 96 skipped.

## Test plan

- [x] \`dev test\` — 1515 passed.
- [x] \`dev lint\` — clean.
- [ ] Visual check at desktop + ≤640px on representative forms: \`/openings/form\`, \`/referrals/form\`, \`/clinicians/form\`, \`/clinicians/{id}/form\`. Confirm label-left rhythm matches detail-page facts, and forms collapse to single column on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)