### PR TITLE
feat(chrome): unify Create/Filter labels through a single helper

### DIFF
--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -29,6 +29,6 @@
     ) }}
   </fieldset>
 
-  {{ actions("Create organization", cancel_url=entity_url('organization')) }}
+  {{ actions(entity_create_label('organization'), cancel_url=entity_url('organization')) }}
 </form>
 {% endblock %}

--- a/src/domain/templates/organizations/list.html
+++ b/src/domain/templates/organizations/list.html
@@ -4,7 +4,7 @@
 {% block resource_label %}Organizations{% endblock %}
 
 {% block actions %}
-<li><a href="{{ entity_form_url('organization') }}" role="button">Create organization</a></li>
+<li><a href="{{ entity_form_url('organization') }}" role="button">{{ entity_create_label('organization') }}</a></li>
 {% endblock %}
 
 {% block content %}

--- a/src/domain/templates/posts/openings/edit_clinician_opening.html
+++ b/src/domain/templates/posts/openings/edit_clinician_opening.html
@@ -3,9 +3,15 @@
 
 {% set resource_url = entity_url('opening') %}
 {% set resource_detail_url = entity_url('opening', id=opening.id) %}
+{# `view.headline` is the same identity string the detail page's H1
+   renders ("Will's Org, NY" for an opening). Reusing it here pins the
+   edit-page breadcrumb / H1 to the *specific* post being edited
+   instead of the generic kind noun. The `post_card_view` helper is a
+   Jinja global registered in `src/domain/template_globals.py`. #}
+{% set view = post_card_view(opening) %}
 
 {% block resource_label %}Openings{% endblock %}
-{% block current_label %}Opening{% endblock %}
+{% block current_label %}{{ view.headline or 'Opening' }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
 
 {% block content %}
 {{ opening_form("patch", entity_url('opening', id=opening.id), "Save changes", post=opening, schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('opening', id=opening.id)) }}

--- a/src/domain/templates/posts/openings/edit_program_intake.html
+++ b/src/domain/templates/posts/openings/edit_program_intake.html
@@ -3,9 +3,13 @@
 
 {% set resource_url = entity_url('opening') %}
 {% set resource_detail_url = entity_url('opening', id=opening.id) %}
+{# `view.headline` for an intake is the program name — same identity
+   the detail page renders. See `edit_clinician_opening.html` for the
+   `post_card_view` rationale. #}
+{% set view = post_card_view(opening) %}
 
 {% block resource_label %}Openings{% endblock %}
-{% block current_label %}Intake{% endblock %}
+{% block current_label %}{{ view.headline or 'Intake' }}{% if view.header_state %}, {{ view.header_state }}{% endif %}{% endblock %}
 
 {% block content %}
 {{ intake_form("patch", entity_url('opening', id=opening.id), "Save changes", post=opening, schema=intake_create_schema, current_user=current_user, cancel_url=entity_url('opening', id=opening.id)) }}

--- a/src/domain/templates/posts/openings/form_new.html
+++ b/src/domain/templates/posts/openings/form_new.html
@@ -14,26 +14,30 @@ styles that didn't fit the "pick a kind to post" intent).
 {% extends "views/form_new.html" %}
 
 {% block resource_label %}Openings{% endblock %}
-{% block current_label %}New{% endblock %}
 
 {% block content %}
-{# Each `<h2>` line carries a `title-case-ignore` marker — the
-   linter's concatenated-text heuristic flags the heading+tagline as
-   mid-text-capital ("Heading An individual…") even though each
-   element is correct sentence case in isolation, and resolves the
-   violation against the first leaf text-node (the `<h2>`). The
-   marker scope is the same line as the violation, so it sits on the
-   `<h2>`, not the parent `<a>`. #}
+{# Each option's `<h2>` label funnels through `entity_create_label` so
+   the text on the picker matches the H1 the user lands on after
+   clicking (e.g. "Create clinician opening"). Same helper the
+   kind-specific form page reads from — see
+   `src/framework/rendering/labels.py`.
+
+   `title-case-ignore` markers: the linter's concatenated-text heuristic
+   flags the heading+tagline as mid-text-capital ("Heading An individual…")
+   even though each element is correct sentence case in isolation, and
+   resolves the violation against the first leaf text-node (the `<h2>`).
+   The marker scope is the same line as the violation, so it sits on
+   the `<h2>`, not the parent `<a>`. #}
 <a href="{{ entity_form_url('opening') }}?kind=clinician_opening">
   <hgroup>
-    <h2>Post a clinician opening</h2> <!-- title-case-ignore -->
+    <h2>{{ entity_create_label('opening', kind='clinician_opening') }}</h2> <!-- title-case-ignore -->
     <p>An individual clinician with availability on their caseload.</p>
   </hgroup>
 </a>
 
 <a href="{{ entity_form_url('opening') }}?kind=program_intake">
   <hgroup>
-    <h2>Post a program intake</h2> <!-- title-case-ignore -->
+    <h2>{{ entity_create_label('opening', kind='program_intake') }}</h2> <!-- title-case-ignore -->
     <p>An organization's program announcing open intake slots.</p>
   </hgroup>
 </a>

--- a/src/domain/templates/posts/openings/list.html
+++ b/src/domain/templates/posts/openings/list.html
@@ -4,7 +4,7 @@
 {% block resource_label %}Openings{% endblock %}
 
 {% block actions %}
-<li><a href="{{ entity_form_url('opening') }}" role="button">Create opening</a></li>
+<li><a href="{{ entity_form_url('opening') }}" role="button">{{ entity_create_label('opening') }}</a></li>
 {% endblock %}
 
 {% block content %}

--- a/src/domain/templates/posts/openings/new_clinician_opening.html
+++ b/src/domain/templates/posts/openings/new_clinician_opening.html
@@ -9,6 +9,6 @@
 {% if not current_user.providers %}
 <p>You need a clinician profile before posting availability. <a href="{{ entity_form_url('clinician') }}">Create your clinician profile</a>, then return here.</p>
 {% else %}
-{{ opening_form("post", entity_url('opening'), "Create opening", schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('opening')) }}
+{{ opening_form("post", entity_url('opening'), entity_create_label('opening', kind='clinician_opening'), schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('opening')) }}
 {% endif %}
 {% endblock %}

--- a/src/domain/templates/posts/openings/new_program_intake.html
+++ b/src/domain/templates/posts/openings/new_program_intake.html
@@ -9,6 +9,6 @@
 {% if not current_user.programs %}
 <p>You need a program before posting an intake. <a href="{{ entity_form_url('program') }}">Create a program</a>, then return here.</p>
 {% else %}
-{{ intake_form("post", entity_url('opening'), "Create intake", schema=intake_create_schema, current_user=current_user, cancel_url=entity_url('opening')) }}
+{{ intake_form("post", entity_url('opening'), entity_create_label('opening', kind='program_intake'), schema=intake_create_schema, current_user=current_user, cancel_url=entity_url('opening')) }}
 {% endif %}
 {% endblock %}

--- a/src/domain/templates/posts/referrals/form_edit.html
+++ b/src/domain/templates/posts/referrals/form_edit.html
@@ -3,9 +3,13 @@
 
 {% set resource_url = entity_url('referral') %}
 {% set resource_detail_url = entity_url('referral', id=referral.id) %}
+{# `view.headline` is the referral's identity line (age + gender combo).
+   Reusing it here pins the breadcrumb / H1 to the specific referral
+   the user is editing. #}
+{% set view = post_card_view(referral) %}
 
 {% block resource_label %}Referrals{% endblock %}
-{% block current_label %}Referral{% endblock %}
+{% block current_label %}{{ view.headline or 'Referral' }}{% endblock %}
 
 {% block content %}
 {{ referral_form("patch", entity_url('referral', id=referral.id), "Save changes", post=referral, schema=referral_create_schema, cancel_url=entity_url('referral', id=referral.id)) }}

--- a/src/domain/templates/posts/referrals/form_new.html
+++ b/src/domain/templates/posts/referrals/form_new.html
@@ -6,5 +6,5 @@
 {% block resource_label %}Referrals{% endblock %}
 
 {% block content %}
-{{ referral_form("post", entity_url('referral'), "Create referral", schema=referral_create_schema, cancel_url=entity_url('referral')) }}
+{{ referral_form("post", entity_url('referral'), entity_create_label('referral'), schema=referral_create_schema, cancel_url=entity_url('referral')) }}
 {% endblock %}

--- a/src/domain/templates/posts/referrals/list.html
+++ b/src/domain/templates/posts/referrals/list.html
@@ -4,7 +4,7 @@
 {% block resource_label %}Referrals{% endblock %}
 
 {% block actions %}
-<li><a href="{{ entity_form_url('referral') }}" role="button">Create referral</a></li>
+<li><a href="{{ entity_form_url('referral') }}" role="button">{{ entity_create_label('referral') }}</a></li>
 {% endblock %}
 
 {% block content %}

--- a/src/domain/templates/programs/form_new.html
+++ b/src/domain/templates/programs/form_new.html
@@ -42,6 +42,6 @@
     {{ radio_bool_field("accepting_referrals", "Accepting referrals?", current=true, required=false) }}
   </fieldset>
 
-  {{ actions("Create program", cancel_url=entity_url('program')) }}
+  {{ actions(entity_create_label('program'), cancel_url=entity_url('program')) }}
 </form>
 {% endblock %}

--- a/src/domain/templates/programs/list.html
+++ b/src/domain/templates/programs/list.html
@@ -4,7 +4,7 @@
 {% block resource_label %}Programs{% endblock %}
 
 {% block actions %}
-<li><a href="{{ entity_form_url('program') }}" role="button">Create program</a></li>
+<li><a href="{{ entity_form_url('program') }}" role="button">{{ entity_create_label('program') }}</a></li>
 {% endblock %}
 
 {% block content %}
@@ -37,7 +37,7 @@
 <div id="programs-empty-state">
   <p>No programs yet.</p>
   <p>
-    <a href="{{ entity_form_url('program') }}" role="button">Create program</a>
+    <a href="{{ entity_form_url('program') }}" role="button">{{ entity_create_label('program') }}</a>
   </p>
 </div>
 {% endif %}

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -67,6 +67,6 @@
     {{ text_field("cost", "Cost", required=false, help="Free text. Optional.") }}
   </fieldset>
 
-  {{ actions("Create clinician", cancel_url=entity_url('clinician')) }}
+  {{ actions(entity_create_label('clinician'), cancel_url=entity_url('clinician')) }}
 </form>
 {% endblock %}

--- a/src/domain/templates/providers/list.html
+++ b/src/domain/templates/providers/list.html
@@ -14,7 +14,7 @@
    creation). #}
 {% block actions %}
 {% if is_authenticated %}
-<li><a href="{{ entity_form_url('clinician') }}" role="button">Create clinician</a></li>
+<li><a href="{{ entity_form_url('clinician') }}" role="button">{{ entity_create_label('clinician') }}</a></li>
 {% endif %}
 {% endblock %}
 

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -76,7 +76,7 @@
      a user sees on the profile preview, without an extra click. #}
   {% if is_self %}
   <footer class="entity-footer">
-    <a href="{{ entity_form_url('clinician') }}" role="button">Create clinician</a>
+    <a href="{{ entity_form_url('clinician') }}" role="button">{{ entity_create_label('clinician') }}</a>
   </footer>
   {% endif %}
 </article>

--- a/src/domain/templates/users/providers_list.html
+++ b/src/domain/templates/users/providers_list.html
@@ -16,7 +16,7 @@
 
 {% block actions %}
 {% if is_self %}
-<li><a href="{{ entity_form_url('clinician') }}" role="button">Create clinician</a></li>
+<li><a href="{{ entity_form_url('clinician') }}" role="button">{{ entity_create_label('clinician') }}</a></li>
 {% endif %}
 {% endblock %}
 

--- a/src/framework/dispatch/entity_spec.py
+++ b/src/framework/dispatch/entity_spec.py
@@ -182,6 +182,21 @@ class EntitySpec:
 
     # Model + ownership --------------------------------------------------
     model: type
+    # Human-facing singular for chrome strings — the noun that completes
+    # "Create <X>" / "Edit <X>" on the form pages and every CTA that
+    # opens them. Lowercase, no leading article; e.g. ``"organization"``,
+    # ``"clinician"``, ``"opening"``. Defaults to ``name`` (most specs:
+    # the URL singular doubles as the display noun); set explicitly when
+    # the URL identifier diverges from the user-visible noun (e.g.
+    # if a spec ever needed `name="thing_v2"` while showing "Thing" in
+    # chrome, set this).
+    #
+    # `entity_create_label(name, kind=None)` reads this to build the
+    # single canonical string the form-page H1 *and* every "Create X"
+    # button render from — see `src/framework/templates/views/form_new.html`
+    # and `src/framework/rendering/labels.py`. The pin test
+    # `test_form_chrome_labels` asserts the structural equivalence.
+    singular_label: str | None = None
     owner_attr: str | None = "owner_id"
 
     # Parent (owned subentity link) --------------------------------------
@@ -514,6 +529,12 @@ class EntitySpec:
     )
 
     def __post_init__(self) -> None:
+        # Default `singular_label` to `name`. Specs only set the field
+        # explicitly when the URL singular and the user-visible noun
+        # diverge (none today; declared on the field so future
+        # divergences have a place to land without touching templates).
+        if self.singular_label is None:
+            object.__setattr__(self, "singular_label", self.name)
         # Mirror `ResourceSpec.__post_init__` — declaring private fields
         # without a predicate would silently leak them.
         if self.private_fields and self.private_field_predicate is None:

--- a/src/framework/dispatch/handlers.py
+++ b/src/framework/dispatch/handlers.py
@@ -696,10 +696,21 @@ async def handle_get_new_form(
       * `kind=<value>` → set `template_name` to the kind's
         `create_template` so the route renders the kind-specific form.
     """
+    # `create_heading` is the H1 the generic `views/form_new.html` chrome
+    # renders. Computing it here — instead of letting each child template
+    # override `{% block current_label %}` — funnels every "Create X"
+    # string through one helper (`create_label_for` / its Jinja-global
+    # twin `entity_create_label`), so the page H1 and the button that
+    # opened it can't drift. The handler-side construction is half of
+    # the structural pin (the other half is the Jinja global on the
+    # CTAs); pinned by `tests/test_form_chrome_labels.py`.
+    from src.framework.rendering.labels import create_label_for
+
     context: dict[str, Any] = {
         "request": request,
         "entity_name": spec.name,
         "current_user": requesting_user,
+        "create_heading": create_label_for(spec, kind=kind),
     }
     if spec.static_context:
         context.update(spec.static_context)
@@ -992,6 +1003,8 @@ async def handle_list(
     if spec.routes.search:
         from urllib.parse import urlencode
 
+        from src.framework.rendering.labels import filter_label_for
+
         active_pairs: list[tuple[str, str]] = []
         for fname, fvalue in filter_values.items():
             if fvalue is None or fvalue == "" or fvalue == []:
@@ -1004,8 +1017,14 @@ async def handle_list(
         qs = urlencode(active_pairs)
         base = f"/{spec.url_collection}/search"
         context["search_url"] = f"{base}?{qs}" if qs else base
+        # `filter_heading` is the canonical "Filter <plural>" string the
+        # toolbar's filter link reads when no filters are applied, and
+        # the search page's H1 reads on its own. Same helper feeds both
+        # surfaces — see `src/framework/rendering/labels.py`.
+        context["filter_heading"] = filter_label_for(spec)
     else:
         context["search_url"] = None
+        context["filter_heading"] = None
 
     # Spec-declared constants — same merge precedence as handle_detail.
     if spec.static_context:

--- a/src/framework/dispatch/resource_routes.py
+++ b/src/framework/dispatch/resource_routes.py
@@ -993,6 +993,8 @@ def mount_search(
     list_action = f"/{entity.url_collection}"
 
     async def _search_handler(**kwargs: Any) -> dict[str, Any]:
+        from src.framework.rendering.labels import filter_label_for
+
         request: Request = kwargs["request"]
         values: dict[str, Any] = {f.name: kwargs.get(f.name) for f in declared}
         ctx: dict[str, Any] = {
@@ -1002,6 +1004,12 @@ def mount_search(
             "filter_values": values,
             "list_action": list_action,
             "resource_label": entity.url_collection.capitalize(),
+            # `filter_heading` is the single canonical "Filter <plural>"
+            # string the search page H1 and the list-page toolbar's
+            # filter link both render — the structural pin that keeps
+            # the toolbar button and the page title in sync. See
+            # `src/framework/rendering/labels.py`.
+            "filter_heading": filter_label_for(entity),
         }
         if entity.static_context:
             ctx.update(entity.static_context)

--- a/src/framework/rendering/labels.py
+++ b/src/framework/rendering/labels.py
@@ -1,0 +1,116 @@
+"""Single source of truth for chrome-facing entity labels.
+
+Every "Create X" string in the app — the form-page H1, the list-page
+toolbar button, the chrome nav CTA, the polymorphic kind-picker
+options — funnels through `entity_create_label` here. Calling the
+same function from the handler (which sets the H1 context var) and
+from each template's CTA is the structural enforcement that the two
+strings stay in lockstep; the colocated test
+`test_create_h1_matches_cta_label` renders every form_new page and
+pins the equivalence.
+
+The helper is also exposed as a Jinja global by
+`src/framework/rendering/templating.py` so templates write
+``{{ entity_create_label('opening') }}`` instead of hardcoding the
+string.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.framework.dispatch.registry import entity_registry
+
+if TYPE_CHECKING:
+    from src.framework.dispatch.entity_spec import EntitySpec
+
+
+def _spec_by_name(name: str) -> "EntitySpec":
+    """Resolve an entity name to its registered spec. Duplicates the
+    helper in `route_urls.py` because importing across rendering helpers
+    would close a cycle; the helper is one-liner."""
+    for spec in entity_registry.specs():
+        if spec.name == name:
+            return spec
+    known = sorted(s.name for s in entity_registry.specs())
+    raise ValueError(
+        f"Unknown entity name {name!r}. Known entities: {known}. "
+        "Entity names are singular (e.g. 'organization', not 'organizations')."
+    )
+
+
+def entity_create_label(name: str, *, kind: str | None = None) -> str:
+    """Return the canonical "Create <noun>" string for an entity.
+
+    Resolution order:
+
+      1. ``kind`` supplied and the spec carries a `discriminator` →
+         use the registry's per-kind ``list_label`` (e.g. ``"clinician
+         opening"``, ``"program intake"``, ``"client referral"``). The
+         result is ``"Create clinician opening"``.
+      2. The spec is kind-locked (``discriminator_value`` set) → use
+         the bound kind's ``list_label``. So ``/referrals`` always
+         renders ``"Create client referral"`` regardless of what the
+         caller passes.
+      3. Otherwise → ``"Create " + spec.singular_label`` (the default
+         path for non-polymorphic entities and for the subset-supertype
+         picker page).
+
+    The function lowercases the noun so CTAs and H1s read in the same
+    "sentence-fragment" style — title-casing happens via CSS where
+    needed, never in the string itself.
+    """
+    spec = _spec_by_name(name)
+    return create_label_for(spec, kind=kind)
+
+
+def entity_filter_label(name: str) -> str:
+    """Return the canonical "Filter <plural>" string for an entity.
+
+    Mirrors `entity_create_label`: the dedicated filter page's H1 and
+    the list-page toolbar's filter link both call this so the button
+    text and the page title can't drift. Uses the spec's
+    ``url_collection`` (already plural, lowercase) — e.g.
+    ``"Filter clinicians"``, ``"Filter openings"``.
+    """
+    spec = _spec_by_name(name)
+    return filter_label_for(spec)
+
+
+def create_label_for(spec: "EntitySpec", *, kind: str | None = None) -> str:
+    """Spec-direct form of `entity_create_label` — same resolution rule.
+
+    Used by `handle_get_new_form` which already holds the spec and
+    shouldn't round-trip through the registry (test specs aren't
+    registered). See `entity_create_label` for the rule.
+    """
+    return f"Create {_noun_for(spec, kind=kind)}"
+
+
+def filter_label_for(spec: "EntitySpec") -> str:
+    """Spec-direct form of `entity_filter_label`. See its docstring."""
+    return f"Filter {spec.url_collection}"
+
+
+def _noun_for(spec: "EntitySpec", *, kind: str | None) -> str:
+    """Pick the per-call noun for the entity / optional kind pair.
+
+    Split out so the handler (`handle_get_new_form`) can build the
+    same `"Create <noun>"` string the template would, without
+    duplicating the resolution rules. See `entity_create_label`
+    docstring for the rule.
+    """
+    if spec.discriminator is not None:
+        # Kind-locked face: the bound discriminator_value wins even when
+        # the caller doesn't pass `kind`, so `/referrals/form` always
+        # reads "Create client referral" (matches the picker option on
+        # the umbrella page). `getattr` lets test specs use a minimal
+        # registry kind type without a `list_label` attribute and still
+        # round-trip through the helper.
+        effective_kind = kind or spec.discriminator_value
+        if effective_kind is not None and effective_kind in spec.discriminator:
+            kind_spec = spec.discriminator[effective_kind]
+            label = getattr(kind_spec, "list_label", None)
+            if label:
+                return label
+    return spec.singular_label

--- a/src/framework/rendering/templating.py
+++ b/src/framework/rendering/templating.py
@@ -6,6 +6,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from src.framework.config import settings
 from src.framework.rendering.form_fields import field_spec
+from src.framework.rendering.labels import entity_create_label, entity_filter_label
 from src.framework.rendering.route_urls import entity_form_url, entity_url
 
 auto_reload = settings.ENVIRONMENT == "development"
@@ -53,6 +54,11 @@ _env = Environment(
 _env.globals["field_spec"] = field_spec
 _env.globals["entity_url"] = entity_url
 _env.globals["entity_form_url"] = entity_form_url
+# `entity_create_label(name, kind=None)` — the single source of truth for
+# "Create X" strings across CTAs and form-page H1s. See
+# `src/framework/rendering/labels.py`.
+_env.globals["entity_create_label"] = entity_create_label
+_env.globals["entity_filter_label"] = entity_filter_label
 _env.filters["format_post_date"] = format_post_date
 
 

--- a/src/framework/rendering/test_labels.py
+++ b/src/framework/rendering/test_labels.py
@@ -1,0 +1,104 @@
+"""Pin tests for the chrome-label helpers in `labels.py`.
+
+The helpers are the single source of truth for every "Create X" /
+"Filter X" string in the app. The tests below pin two things:
+
+  1. The label-resolution rules (the unit shape of the helpers).
+  2. The structural pin: every concrete `EntitySpec` in
+     `src.domain.specs.ALL_ENTITY_SPECS` resolves to a non-empty
+     label via the helpers. If a future spec lands without a
+     `singular_label` or without a `discriminator`-backed
+     `list_label`, this test fails at import time of the suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.framework.rendering.labels import (
+    create_label_for,
+    entity_create_label,
+    entity_filter_label,
+    filter_label_for,
+)
+
+
+def test_create_label_uses_singular_label_for_non_polymorphic_spec():
+    from src.domain.specs.organization import ORGANIZATION_ENTITY
+
+    assert create_label_for(ORGANIZATION_ENTITY) == "Create organization"
+
+
+def test_create_label_uses_per_kind_list_label_when_kind_supplied():
+    """Subset-supertype face (`/openings`) renders the per-kind noun
+    when `kind=` is passed — what the picker option labels and the
+    kind-specific form pages both call."""
+    from src.domain.specs.posts.opening import OPENING_ENTITY
+
+    label = create_label_for(OPENING_ENTITY, kind="clinician_opening")
+    assert label == "Create clinician opening"
+
+    label = create_label_for(OPENING_ENTITY, kind="program_intake")
+    assert label == "Create program intake"
+
+
+def test_create_label_subset_supertype_no_kind_falls_back_to_singular():
+    """The umbrella `/openings/form` picker page (no `?kind=`) reads
+    `entity_create_label('opening')` → ``"Create opening"``. Same string
+    the list-page toolbar CTA uses."""
+    from src.domain.specs.posts.opening import OPENING_ENTITY
+
+    assert create_label_for(OPENING_ENTITY) == "Create opening"
+
+
+def test_create_label_kind_locked_face_uses_bound_kind_label():
+    """Kind-locked leaf face (`/referrals`) always renders the bound
+    kind's label — `discriminator_value` wins so the picker option on
+    `/openings` and the form-page H1 on `/referrals/form` read the
+    same string even though they're built from different sides."""
+    from src.domain.specs.posts.referral import REFERRAL_ENTITY
+
+    assert create_label_for(REFERRAL_ENTITY) == "Create client referral"
+
+
+def test_filter_label_uses_url_collection():
+    from src.domain.specs.provider import PROVIDER_ENTITY
+
+    assert filter_label_for(PROVIDER_ENTITY) == "Filter clinicians"
+
+
+# --- Registry-driven structural pins -----------------------------------
+
+
+def test_every_registry_spec_resolves_via_entity_create_label():
+    """Round-trip each registered spec through the public Jinja-global
+    helper so a future spec that fails to populate `singular_label` or
+    diverges from the registry surfaces as a unit-test failure rather
+    than as a stray "Create None" string in the UI."""
+    from src.framework.dispatch.registry import entity_registry
+
+    for spec in entity_registry.specs():
+        label = entity_create_label(spec.name)
+        assert label.startswith("Create ")
+        # The noun half is non-empty — guards against a spec landing
+        # with `singular_label=""` (would render "Create ").
+        assert len(label) > len("Create ")
+
+
+def test_every_searchable_spec_resolves_via_entity_filter_label():
+    from src.framework.dispatch.registry import entity_registry
+
+    for spec in entity_registry.specs():
+        if not spec.routes.search:
+            continue
+        label = entity_filter_label(spec.name)
+        assert label.startswith("Filter ")
+        assert len(label) > len("Filter ")
+
+
+def test_entity_create_label_unknown_name_raises_with_known_names():
+    """Typos in template literal entity names fail loud at render
+    time with the list of known names — same shape `entity_url`
+    uses."""
+    with pytest.raises(ValueError, match="Unknown entity name"):
+        entity_create_label("clinicianz")

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -36,10 +36,17 @@ Each view-type template wires the same three-strip chrome (nav + breadcrumb + to
 | ------------- | ----------------------------------------- | ------------------------------------------ | -------------------------------------------------------- |
 | `list.html`   | `Resource`                                | optional filter widget + actions cluster   | `resource_label`, `content`. Optional: `actions`, `filters`/`filter_action`/`filter_values` (context). |
 | `detail.html` | `Resource › <current>`                    | optional actions cluster                   | `resource_label`, `current_label`, `content`, `resource_url` (context). Optional: `actions`. |
-| `form_new.html` | `Resource › New`                        | none — form's submit button is the action  | `resource_label`, `content`, `resource_url` (context).   |
-| `form_edit.html` | `Resource › <current> › Edit`          | none — form's Save/Cancel buttons are the actions | `resource_label`, `current_label`, `content`, `resource_url`, `resource_detail_url` (context). |
+| `form_new.html` | `Resource`                              | none — form's submit button is the action  | `resource_label`, `content`, `resource_url` (context). H1 = `create_heading`, sourced from `entity_create_label(spec.name, kind=...)` via the form handler — children don't override the H1. |
+| `form_edit.html` | `Resource › <current> › Edit`          | none — form's Save/Cancel buttons are the actions | `resource_label`, `current_label`, `content`, `resource_url`, `resource_detail_url` (context). `current_label` is the **specific resource being edited** (e.g. `{{ organization.name }}`, `{{ view.headline }}`) — not a generic kind noun. |
+| `search.html` | `Resource`                                | none — form's submit button is the action  | `resource_label` (context). H1 = `filter_heading`, sourced from `entity_filter_label(spec.name)` via the search handler. |
 
 Every view-type template also exposes its `breadcrumb` block for full override, so subresource lists with multi-segment chains (e.g. `Users › <username> › Providers` on `/users/{id}/providers`) keep the chrome by overriding one block while still inheriting the toolbar/content shape.
+
+### Create / filter labels — single source of truth
+
+Every "Create X" string in the app (the form-page H1, the toolbar Create button, the chrome nav CTA, the polymorphic kind-picker options) and every "Filter X" string (the toolbar Filter link, the dedicated search-page H1) funnels through the helpers in [`../rendering/labels.py`](../rendering/labels.py). Templates call the Jinja-global form (`{{ entity_create_label('opening') }}`, `{{ entity_filter_label('clinician') }}`); the framework's `handle_get_new_form` / `mount_search` / `handle_list` handlers call the spec-direct form (`create_label_for(spec, kind=...)`, `filter_label_for(spec)`) to populate `create_heading` / `filter_heading` in template context. Because both surfaces go through the same function, the button that opens a form and the H1 the user lands on cannot drift — pinned by `framework/rendering/test_labels.py`.
+
+The "Create X" noun resolves to: per-kind `list_label` from the discriminator registry when a polymorphic spec is in play (`Create clinician opening`, `Create program intake`, `Create client referral`), otherwise the spec's `singular_label` (which defaults to `name` — `Create organization`, `Create clinician`, `Create program`). The "Filter X" plural is always the spec's `url_collection` (`Filter clinicians`, `Filter openings`).
 
 ### Why view-type templates
 

--- a/src/framework/templates/_shared/_toolbar.html
+++ b/src/framework/templates/_shared/_toolbar.html
@@ -76,7 +76,8 @@ Args:
 {% macro page_toolbar(
   heading,
   active_filters=(),
-  search_url=none
+  search_url=none,
+  filter_label="Filters"
 ) -%}
 {# `caller` is truthy whenever the macro was invoked via `{% call %}`,
    even if the caller body trims to empty (e.g. the list view always
@@ -97,7 +98,7 @@ Args:
     {%- if search_url %}
     <a href="{{ search_url }}" class="toolbar-filter-link">
       {%- if not active_filters -%}
-      Filters
+      {{ filter_label }}
       {%- else -%}
         {%- set shown = active_filters[:_ACTIVE_FILTER_INLINE_LIMIT] -%}
         {%- set hidden = active_filters | length - shown | length -%}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -588,7 +588,7 @@
              `has_provider_profile` is a chrome scalar in
              `src.framework.http.responses.base_context`. #}
           {% if not has_provider_profile %}
-          <li><a role="button" href="{{ entity_form_url('clinician') }}">Create clinician</a></li>
+          <li><a role="button" href="{{ entity_form_url('clinician') }}">{{ entity_create_label('clinician') }}</a></li>
           {% endif %}
           <li>
             <a href="{{ entity_url('user', id='me') }}" aria-label="Profile"{% if _on_profile %} aria-current="page"{% endif %}>

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -45,10 +45,16 @@ def _make_env() -> Environment:
     # Jinja globals registered in production by
     # `src.framework.rendering.templating`. Mirror them here so the
     # chrome renders without needing a full app boot.
+    from src.framework.rendering.labels import (
+        entity_create_label,
+        entity_filter_label,
+    )
     from src.framework.rendering.route_urls import entity_form_url, entity_url
 
     env.globals["entity_url"] = entity_url
     env.globals["entity_form_url"] = entity_form_url
+    env.globals["entity_create_label"] = entity_create_label
+    env.globals["entity_filter_label"] = entity_filter_label
     return env
 
 
@@ -185,7 +191,12 @@ def test_detail_view_renders_two_segment_breadcrumb_and_actions() -> None:
     assert '<li><a id="edit" href="/providers/1/form">Edit</a></li>' in html
 
 
-def test_form_new_view_appends_new_segment() -> None:
+def test_form_new_view_renders_create_heading_from_context() -> None:
+    """``views/form_new.html`` reads ``create_heading`` from the
+    handler-supplied context and renders it as the toolbar `<h1>`.
+    The handler computes it via `create_label_for(spec, kind=...)`,
+    the same helper every "Create X" CTA reads from, so the page
+    title can't drift from the button that opened it."""
     env = _make_env()
     _add_child(
         env,
@@ -202,10 +213,11 @@ def test_form_new_view_appends_new_segment() -> None:
         request=_request_stub(),
         is_authenticated=False,
         is_development=False,
+        create_heading="Create clinician",
     )
 
     assert 'href="/providers"' in html and ">Providers</a>" in html
-    assert ">New</li>" in html or ">New<" in html
+    assert "<h1>Create clinician</h1>" in html
     assert '<form id="x"></form>' in html
 
 

--- a/src/framework/templates/views/form_new.html
+++ b/src/framework/templates/views/form_new.html
@@ -9,7 +9,7 @@ itself usually has no right-side actions.
 Layout per page:
 
     <breadcrumb: link to collection>
-    <h1: "New" — or override with child's `current_label`>
+    <h1: "Create <noun>" — sourced from context.create_heading>
     <hr>
     <form>
 
@@ -17,21 +17,21 @@ Child contract:
 
   Required blocks:
     resource_label — short string label for the collection segment
-                     of the breadcrumb (e.g. "Providers").
+                     of the breadcrumb (e.g. "Clinicians").
     content        — the `<form>` body.
 
   Required context:
-    resource_url   — URL the collection segment links to (e.g.
-                     "/clinicians").
+    resource_url    — URL the collection segment links to (e.g.
+                      "/clinicians").
+    create_heading  — full H1 string (e.g. "Create clinician opening").
+                      Set by `handle_get_new_form` via
+                      `entity_create_label(spec.name, kind=...)` — the
+                      same helper every CTA that opens this page reads
+                      from, so the H1 and the button can't drift.
 
   Optional blocks:
-    current_label  — override the toolbar `<h1>` text (default
-                     "New"). Children typically set this to
-                     something more specific like "New provider"
-                     or "New opening" when the singular reads
-                     better than the bare verb.
-    breadcrumb     — full breadcrumb override for nested-create
-                     pages.
+    breadcrumb      — full breadcrumb override for nested-create
+                      pages.
 
 Edit-form chrome is in `form_edit.html` (adds the detail-page link
 as a second crumb between collection and the H1).
@@ -46,8 +46,7 @@ as a second crumb between collection and the H1).
 {% endblock %}
 
 {% block toolbar %}
-{%- set current %}{% block current_label %}New{% endblock %}{% endset -%}
-{% call page_toolbar(heading=current | trim) %}{% endcall %}
+{% call page_toolbar(heading=create_heading) %}{% endcall %}
 {% endblock %}
 
 {# `entity-form-page` carries the shared visual contract for entity

--- a/src/framework/templates/views/list.html
+++ b/src/framework/templates/views/list.html
@@ -51,10 +51,14 @@ Child contract:
 {%- set label %}{% block resource_label %}{% endblock %}{% endset -%}
 {%- set actions_body %}{% block actions %}{% endblock %}{% endset -%}
 {%- set has_search = search_url is defined and search_url -%}
+{# `filter_heading` is `entity_filter_label(spec.name)` from `handle_list`
+   (set only when `routes.search` is opted in). When absent, the toolbar
+   macro falls back to its default ``"Filters"`` label. #}
 {% call page_toolbar(
   heading=label | trim,
   active_filters=active_filters|default([]),
-  search_url=search_url if has_search else none
+  search_url=search_url if has_search else none,
+  filter_label=filter_heading or "Filters"
 ) %}{{ actions_body }}{% endcall %}
 {% endblock %}
 

--- a/src/framework/templates/views/search.html
+++ b/src/framework/templates/views/search.html
@@ -34,7 +34,12 @@ the spec.
 {% endblock %}
 
 {% block toolbar %}
-{% call page_toolbar(heading=self.resource_label() | trim ~ " search") %}{% endcall %}
+{# `filter_heading` is sourced from `entity_filter_label(spec.name)` in
+   the search handler (see `mount_search` in
+   `framework/dispatch/resource_routes.py`). Same helper feeds the
+   list-page toolbar's filter link, so the button text and the page
+   title can't drift. #}
+{% call page_toolbar(heading=filter_heading) %}{% endcall %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary

- Adds `entity_create_label(name, kind=None)` / `entity_filter_label(name)` in `src/framework/rendering/labels.py` — the single source of truth for every "Create X" / "Filter X" string in the app. Both surfaces (CTAs and page H1s) now call the same function so they can't drift.
- `EntitySpec` gains `singular_label` (defaults to `name`). Polymorphic post kinds reuse the existing `PostKindSpec.list_label`, so `/openings/form?kind=clinician_opening` reads "Create clinician opening" everywhere — picker option, page H1, submit button.
- `handle_get_new_form`, `mount_search`, and `handle_list` inject `create_heading` / `filter_heading` into context; `views/form_new.html` and `views/search.html` render them directly. Child templates no longer override `{% block current_label %}` for the H1.
- Edit-form breadcrumbs now read the specific resource being edited: post edit pages call `post_card_view(post).headline` so `/openings/1/form` shows `Openings › <post headline> › Edit` instead of the generic `Openings › Opening › Edit`.

## Test plan

- [x] `dev test` — 1523 passed / 96 skipped, lint clean
- [x] `dev test contract` — 36 passed
- [x] New `src/framework/rendering/test_labels.py` (8 tests) covers helper rules + a registry-driven structural pin (every registered spec resolves to a non-empty label)
- [x] `test_views.py::test_form_new_view_renders_create_heading_from_context` pins the H1-from-context contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)