### PR TITLE
fix(breadcrumb): clean up the mobile back-link affordance

### DIFF
--- a/src/framework/templates/_shared/_breadcrumb.html
+++ b/src/framework/templates/_shared/_breadcrumb.html
@@ -47,7 +47,7 @@ breadcrumbs are ordered) loses Pico's auto-styling.
 {%- set _back = _linkable[-1] if _linkable else items[0] -%}
 <nav aria-label="breadcrumb">
   <a class="breadcrumb-back"{% if _back[1] %} href="{{ _back[1] }}"{% endif %}>
-    <i class="icon-arrow-left" aria-hidden="true"></i>{{ _back[0] }}
+    <i class="icon-arrow-left" aria-hidden="true"></i><span class="breadcrumb-back-label">{{ _back[0] }}</span>
   </a>
   <ul>
     {%- for label, href in items %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -347,13 +347,30 @@
          macro's full `<ul>` chain is hidden and the inline
          `<a class="breadcrumb-back">` is shown: a Lucide arrow-left
          glyph plus the deepest clickable parent's label. On desktop
-         the `<a>` is hidden and the chain renders normally. Two
-         rules, no JS — the macro emits both elements unconditionally
-         and CSS does the swapping. */
-      .breadcrumb-back { display: none; }
+         the `<a>` is hidden and the chain renders normally. The
+         macro emits both elements unconditionally; CSS does the
+         swapping (no JS).
+
+         Pico's default `<a>` underline ran across both the icon and
+         the label, and the icon's `vertical-align: -0.15em` made it
+         sit below the underline so the chevron read as visually
+         detached from the label. Strip the underline on the link as
+         a whole, scope the underline to the label `<span>` on hover/
+         focus, and use a flex `gap` for the chevron-to-label spacing
+         (overriding the icon's universal `margin-inline-end`). */
+      .breadcrumb-back { display: none; text-decoration: none; }
       @media (max-width: 540px) {
         nav[aria-label="breadcrumb"] > ul { display: none; }
-        .breadcrumb-back { display: inline-flex; align-items: center; }
+        .breadcrumb-back {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.25rem;
+        }
+        .breadcrumb-back > i { margin-inline-end: 0; }
+        .breadcrumb-back:hover .breadcrumb-back-label,
+        .breadcrumb-back:focus .breadcrumb-back-label {
+          text-decoration: underline;
+        }
       }
       /* Brand collapse on mobile. The two-word "Bedlam Connect" wraps
          to two lines on narrow viewports once the primary nav fills the


### PR DESCRIPTION
## Summary

Pico's default \`<a>\` underline ran across both the chevron icon and the label in the mobile breadcrumb back-link, and the icon font's \`vertical-align: -0.15em\` shift made the chevron sit *below* the underline. The arrow read as visually detached from the label (screenshot evidence: that boxed-arrow + underlined-label look).

- Wrap the label in \`<span class=\"breadcrumb-back-label\">\` so the underline can scope to just the text.
- Strip text-decoration on the \`<a>\`; restore underline on the label span on hover/focus.
- Use a flex \`gap: 0.25rem\` for the chevron-to-label spacing and override the icon's universal \`margin-inline-end\` to zero.

## Test plan

- [x] \`dev test\` — 1522 passed, 96 skipped.
- [x] \`dev lint\` — clean.
- [ ] Visual on aimagain.art at mobile width: the back link reads as a unified affordance — chevron + label sitting on the same baseline, no stray underline running across the icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)