### PR TITLE
fix(clinician-card): headline names the person, not the org

### DIFF
--- a/src/framework/templates/_shared/_clinician_card.html
+++ b/src/framework/templates/_shared/_clinician_card.html
@@ -15,8 +15,12 @@
    ../README.md "Layering rule"), so the shared shape goes here.
 
    Headline: the clinician's "{first_name} {last_name}" when both are
-   set; falls back to whichever is set, or to the first affiliation's
-   org name, or to a literal "Clinician" when nothing else is known.
+   set; falls back to whichever is set, or to "Unnamed clinician"
+   when neither is. The card represents a *person*, so the headline
+   must be a person identifier — never the org name (the Practice row
+   below already carries that, and using the org name as the headline
+   collapses the User → Clinician → Org hierarchy into one
+   indistinguishable string).
    The headline anchors to the clinician detail page so a click
    navigates into the directory entry — practice / location chips in
    the body link out to Orgs separately.
@@ -60,8 +64,7 @@
   {%- if first and last %}{{ first }} {{ last }}
   {%- elif first %}{{ first }}
   {%- elif last %}{{ last }}
-  {%- elif affiliations %}{{ affiliations[0].org.name }}
-  {%- else %}Clinician
+  {%- else %}Unnamed clinician
   {%- endif %}
 {%- endset -%}
 {% call card(


### PR DESCRIPTION
## Summary

On the user profile (\`/users/me\`) cards for the user's own clinicians were showing the headline AND the Practice row as the *same string* — "Will's Organization" appeared twice, with no visual cue that they pointed at different entities. The User → Clinician → Org hierarchy collapsed into one indistinguishable label.

Cause: the clinician_card headline fallback chain ended with \`affiliations[0].org.name\` when the Provider had no \`first_name\` / \`last_name\` set. A card representing a *person* was borrowing the org name as its identifier.

Fix: drop the org-name fallback. The chain is now:

| first + last | "Alice Wong" |
| first only   | "Alice"      |
| last only    | "Wong"       |
| neither      | "Unnamed clinician" |

The Practice row below the headline keeps the org link (a person can practice at multiple orgs; that's what the row is for).

## Test plan

- [x] \`dev test\` — 1522 passed, 96 skipped.
- [x] \`dev lint\` — clean.
- [ ] Visual on aimagain.art \`/users/me\`: card headline no longer duplicates the Practice value when the clinician has no name set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)