### PR TITLE
fix(forms): edit-page H1 reads "Edit <noun>", not "Edit <row identity>"

### DIFF
--- a/src/framework/dispatch/handlers.py
+++ b/src/framework/dispatch/handlers.py
@@ -625,11 +625,24 @@ async def handle_get_edit_form(
     if spec.write_authz is not None:
         spec.write_authz(target, requesting_user, action=f"edit this {spec.name}")
 
+    # `edit_heading` mirrors `create_heading` in `handle_get_new_form`:
+    # one funnel for the H1 string so the page H1 can't drift from the
+    # CTA that opened it. For polymorphic specs the kind is derived
+    # from the loaded target row (the spec's `discriminator_value` for
+    # kind-locked faces is the same value `_assert_kind_lock` just
+    # checked; subset-supertype faces use the row's stored kind).
+    from src.framework.rendering.labels import edit_label_for
+
+    edit_kind: str | None = None
+    if spec.discriminator is not None:
+        edit_kind = getattr(target, spec.discriminator.column)
+
     context: dict[str, Any] = {
         "request": request,
         spec.name: target,
         "entity_name": spec.name,
         "current_user": requesting_user,
+        "edit_heading": edit_label_for(spec, kind=edit_kind),
     }
     # Spec-declared constants (enum labels, schema classes the form
     # references, etc.) — same merge precedence as detail/list.

--- a/src/framework/rendering/labels.py
+++ b/src/framework/rendering/labels.py
@@ -64,6 +64,21 @@ def entity_create_label(name: str, *, kind: str | None = None) -> str:
     return create_label_for(spec, kind=kind)
 
 
+def entity_edit_label(name: str, *, kind: str | None = None) -> str:
+    """Return the canonical "Edit <noun>" string for an entity.
+
+    Mirrors `entity_create_label`'s resolution rule — same per-kind
+    `list_label` lookup so the edit page's H1 reads "Edit clinician
+    opening" / "Edit program intake" / "Edit client referral" / "Edit
+    organization" rather than the row's identity string ("Edit Adult
+    male (25-64)" was the friction this funnel fixes). The row
+    identity stays on the breadcrumb's middle segment via the
+    template's `current_label` block.
+    """
+    spec = _spec_by_name(name)
+    return edit_label_for(spec, kind=kind)
+
+
 def entity_filter_label(name: str) -> str:
     """Return the canonical "Filter <plural>" string for an entity.
 
@@ -85,6 +100,16 @@ def create_label_for(spec: "EntitySpec", *, kind: str | None = None) -> str:
     registered). See `entity_create_label` for the rule.
     """
     return f"Create {_noun_for(spec, kind=kind)}"
+
+
+def edit_label_for(spec: "EntitySpec", *, kind: str | None = None) -> str:
+    """Spec-direct form of `entity_edit_label` — same resolution rule.
+
+    Used by `handle_get_edit_form` which already holds the spec and
+    derives `kind` from the loaded target row when the spec is
+    polymorphic. See `entity_edit_label` for the rule.
+    """
+    return f"Edit {_noun_for(spec, kind=kind)}"
 
 
 def filter_label_for(spec: "EntitySpec") -> str:

--- a/src/framework/rendering/templating.py
+++ b/src/framework/rendering/templating.py
@@ -6,7 +6,11 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from src.framework.config import settings
 from src.framework.rendering.form_fields import field_spec
-from src.framework.rendering.labels import entity_create_label, entity_filter_label
+from src.framework.rendering.labels import (
+    entity_create_label,
+    entity_edit_label,
+    entity_filter_label,
+)
 from src.framework.rendering.route_urls import entity_form_url, entity_url
 
 auto_reload = settings.ENVIRONMENT == "development"
@@ -58,6 +62,9 @@ _env.globals["entity_form_url"] = entity_form_url
 # "Create X" strings across CTAs and form-page H1s. See
 # `src/framework/rendering/labels.py`.
 _env.globals["entity_create_label"] = entity_create_label
+# `entity_edit_label(name, kind=None)` — the create-label twin for the
+# edit-page H1 and any "Edit X" button text. See `labels.py`.
+_env.globals["entity_edit_label"] = entity_edit_label
 _env.globals["entity_filter_label"] = entity_filter_label
 _env.filters["format_post_date"] = format_post_date
 

--- a/src/framework/rendering/test_labels.py
+++ b/src/framework/rendering/test_labels.py
@@ -17,7 +17,9 @@ import pytest
 
 from src.framework.rendering.labels import (
     create_label_for,
+    edit_label_for,
     entity_create_label,
+    entity_edit_label,
     entity_filter_label,
     filter_label_for,
 )
@@ -61,6 +63,36 @@ def test_create_label_kind_locked_face_uses_bound_kind_label():
     assert create_label_for(REFERRAL_ENTITY) == "Create client referral"
 
 
+def test_edit_label_uses_singular_label_for_non_polymorphic_spec():
+    from src.domain.specs.organization import ORGANIZATION_ENTITY
+
+    assert edit_label_for(ORGANIZATION_ENTITY) == "Edit organization"
+
+
+def test_edit_label_uses_per_kind_list_label_when_kind_supplied():
+    """The edit page for a subset-supertype face's row reads the
+    row's stored kind off the loaded target — `handle_get_edit_form`
+    derives this and passes it as `kind=`. Same per-kind noun the
+    create page uses for the matching form."""
+    from src.domain.specs.posts.opening import OPENING_ENTITY
+
+    assert edit_label_for(OPENING_ENTITY, kind="clinician_opening") == (
+        "Edit clinician opening"
+    )
+    assert edit_label_for(OPENING_ENTITY, kind="program_intake") == (
+        "Edit program intake"
+    )
+
+
+def test_edit_label_kind_locked_face_uses_bound_kind_label():
+    """Kind-locked leaf face (`/referrals`): the bound discriminator
+    wins, so the edit-page H1 reads "Edit client referral" regardless
+    of the row's identity string."""
+    from src.domain.specs.posts.referral import REFERRAL_ENTITY
+
+    assert edit_label_for(REFERRAL_ENTITY) == "Edit client referral"
+
+
 def test_filter_label_uses_url_collection():
     from src.domain.specs.provider import PROVIDER_ENTITY
 
@@ -83,6 +115,17 @@ def test_every_registry_spec_resolves_via_entity_create_label():
         # The noun half is non-empty — guards against a spec landing
         # with `singular_label=""` (would render "Create ").
         assert len(label) > len("Create ")
+
+
+def test_every_registry_spec_resolves_via_entity_edit_label():
+    """Mirror of the create-label round-trip — every registered spec
+    produces a sensible "Edit <noun>" string."""
+    from src.framework.dispatch.registry import entity_registry
+
+    for spec in entity_registry.specs():
+        label = entity_edit_label(spec.name)
+        assert label.startswith("Edit ")
+        assert len(label) > len("Edit ")
 
 
 def test_every_searchable_spec_resolves_via_entity_filter_label():

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -270,10 +270,13 @@ def test_primary_nav_excludes_non_journey_links_for_all_viewers() -> None:
 
 def test_form_edit_view_renders_breadcrumb_and_edit_heading() -> None:
     """``views/form_edit.html`` renders a two-segment breadcrumb
-    (collection link › detail link) and an `<h1>"Edit <current>"`
-    in the toolbar. The current item is not repeated as a non-link
-    crumb — the H1 carries it, so every visible crumb stays an
-    actionable link (GOV.UK pattern)."""
+    (collection link › detail link, the latter carrying the row's
+    identity as `current_label`) above an `<h1>"Edit <noun>"` sourced
+    from `edit_heading`. The H1 reads the resource noun ("clinician",
+    "clinician opening", "client referral") rather than the row's
+    identity — that lives on the breadcrumb's middle segment, where
+    "back to <row>" is the natural verb. Mirrors the create-page
+    contract where `create_heading` sources the H1."""
     env = _make_env()
     _add_child(
         env,
@@ -292,6 +295,7 @@ def test_form_edit_view_renders_breadcrumb_and_edit_heading() -> None:
         request=_request_stub(),
         is_authenticated=False,
         is_development=False,
+        edit_heading="Edit clinician",
     )
 
     tree = HTMLParser(html)
@@ -300,10 +304,12 @@ def test_form_edit_view_renders_breadcrumb_and_edit_heading() -> None:
         "/providers",
         "/providers/42",
     ], "form-edit breadcrumb must be exactly two link segments"
-    # H1 in the toolbar reads "Edit <current>".
+    # Middle crumb's link text is the row's identity (current_label).
+    assert crumbs[1].css_first("a").text(strip=True) == "Sunrise Therapy"
+    # H1 in the toolbar reads `edit_heading`, NOT "Edit <current_label>".
     h1 = tree.css_first("div.toolbar h1")
     assert h1 is not None
-    assert h1.text(strip=True) == "Edit Sunrise Therapy"
+    assert h1.text(strip=True) == "Edit clinician"
 
 
 def test_actions_buttons_fill_row_width_on_desktop() -> None:

--- a/src/framework/templates/views/form_edit.html
+++ b/src/framework/templates/views/form_edit.html
@@ -9,7 +9,7 @@ toolbar row itself usually has no right-side actions.
 Layout per page:
 
     <breadcrumb: link to collection › link back to detail>
-    <h1: "Edit <current_label>">
+    <h1: "Edit <noun>" — sourced from context.edit_heading>
     <hr>
     <form>
 
@@ -19,9 +19,13 @@ Child contract:
     resource_label — short string label for the collection segment of
                      the breadcrumb (e.g. "Providers").
     current_label  — short string label for the resource being edited
-                     (e.g. `{{ provider.org.name }}`). Used in the
-                     toolbar `<h1>` as "Edit <current_label>" and as
-                     the link text for the second breadcrumb segment.
+                     (e.g. `{{ provider.org.name }}` or a referral's
+                     identity line). Used only as the link text for
+                     the second breadcrumb segment — NOT in the H1.
+                     The H1 reads `edit_heading` (sourced from
+                     `entity_edit_label(spec.name, kind=...)` via the
+                     form handler) so it reads "Edit clinician
+                     opening" instead of "Edit <row identity>".
     content        — the `<form>` body. By convention forms keep a
                      `<a class="secondary outline">Cancel</a>` linking
                      to `resource_detail_url` so abandoning an edit is
@@ -32,6 +36,12 @@ Child contract:
     resource_url        — URL the collection segment links to.
     resource_detail_url — URL the current-item breadcrumb segment
                           links to (e.g. `"/clinicians/" ~ provider.id`).
+    edit_heading        — full H1 string (e.g. "Edit clinician
+                          opening"). Set by `handle_get_edit_form` via
+                          `edit_label_for(spec, kind=...)` — same
+                          funnel `create_heading` uses on the create
+                          page so the H1 and any "Edit X" button text
+                          can't drift.
 
   Optional blocks:
     breadcrumb          — full breadcrumb override for nested-edit pages.
@@ -50,8 +60,7 @@ Child contract:
 {% endblock %}
 
 {% block toolbar %}
-{%- set current = self.current_label() | trim -%}
-{% call page_toolbar(heading="Edit " ~ current) %}{% endcall %}
+{% call page_toolbar(heading=edit_heading) %}{% endcall %}
 {% endblock %}
 
 {# `entity-form-page` — see `views/form_new.html`. #}


### PR DESCRIPTION
## Summary

The referral edit page rendered "Edit Adult male (25–64)" — the row's auto-generated identity (used as the breadcrumb's middle segment) was also bolted to the H1 via `"Edit " ~ current_label`. That reads like the page edits a 25–64yo male, not a referral about one.

Mirror the create-page funnel: every "Edit X" string now flows through `entity_edit_label(name, kind=None)` / `edit_label_for(spec, kind=None)`, the create-label twins. The H1 reads the resource noun ("Edit client referral", "Edit clinician opening", "Edit program intake", "Edit organization"). The row identity stays on the breadcrumb's middle segment as the back-link text.

## Before / after

| URL | Before | After |
|---|---|---|
| `/referrals/{id}/form` | `Edit Adult male (25–64)` | `Edit client referral` |
| `/openings/{id}/form` (clinician_opening) | `Edit Will's Org, NY` | `Edit clinician opening` |
| `/openings/{id}/form` (program_intake) | `Edit RISE IOP` | `Edit program intake` |
| `/organizations/{id}/form` | `Edit Open House` | `Edit organization` |
| `/clinicians/{id}/form` | `Edit Sunrise Therapy` | `Edit clinician` |
| `/programs/{id}/form` | `Edit RISE IOP` | `Edit program` |

In each case the breadcrumb's middle segment still reads the row identity (e.g. `Referrals › Adult male (25–64)`), so the "which row am I editing?" context isn't lost — it's just in the right place.

## How

- **`labels.py`** — new `entity_edit_label(name, kind=None)` and `edit_label_for(spec, kind=None)`. Resolution mirrors the create-label functions exactly: per-kind `list_label` when the spec is polymorphic; `singular_label` otherwise.
- **`handle_get_edit_form`** — sets `edit_heading` in template context. For polymorphic specs, the kind is derived from the loaded target row's discriminator column.
- **`views/form_edit.html`** — H1 reads `edit_heading` instead of `"Edit " ~ current_label`. The `current_label` block keeps its job as the middle breadcrumb segment's link text.
- **`templating.py`** — registers `entity_edit_label` as a Jinja global, mirroring `entity_create_label`.

## Test plan

- [x] `dev test` — 1526 passed, 96 skipped, 0 failed (4 new edit-label tests; the existing `test_form_edit_view_renders_breadcrumb_and_edit_heading` was updated to pin the new contract)
- [x] `dev test contract` — 36 passed
- [x] `dev lint` — clean
- [x] Registry round-trip: `test_every_registry_spec_resolves_via_entity_edit_label` exercises every registered spec through the public Jinja-global helper, same shape the create-label registry pin uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)