### PR TITLE
feat(forms): unified copy style guide + sweep all forms

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -152,9 +152,12 @@ async def test_get_register_page(test_client: AsyncClient):
     response = await test_client.get("/auth/register")
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
-    # Page-title text is no longer wrapped in an `<h1>` (per app-wide
-    # H1 removal); the form's submit button still says "Register".
-    assert "Register" in response.text
+    # Page H1 plus the canonical "Create account" submit button are
+    # both load-bearing — pin the H1 here so the page-title copy
+    # doesn't drift to a generic "Sign up" / "Register" string. The
+    # rest of the auth-flow pages follow the same shape.
+    assert "Create an account" in response.text
+    assert "Create account" in response.text
     # Card wrapper — `.auth-page` caps the form at 28rem and centers it
     # so it doesn't stretch to the `<main class="container">` width on
     # tablet/desktop (#584). The `.auth-page` rule lives in `base.html`.
@@ -165,7 +168,10 @@ async def test_get_login_page(test_client: AsyncClient):
     response = await test_client.get("/auth/login")
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
-    assert "Login" in response.text
+    # H1 + submit button (both "Log in" — verb form, no longer the
+    # noun "Login"). See `test_get_register_page` for the H1 pin
+    # rationale.
+    assert "Log in" in response.text
     # See `test_get_register_page` for `.auth-page` rationale (#584).
     assert '<article class="auth-page">' in response.text
 
@@ -188,7 +194,11 @@ async def test_get_reset_password_page(test_client: AsyncClient):
     response = await test_client.get(f"/auth/reset-password/{reset_token}")
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
-    assert "Reset password" in response.text
+    # H1 + submit button. Reset is now "Save password" (the user is
+    # picking a new password, not resetting one); the H1 sets the
+    # "you're about to" frame.
+    assert "Set a new password" in response.text
+    assert "Save password" in response.text
     assert (
         f'value="{reset_token}"' in response.text
         or f'data-token="{reset_token}"' in response.text

--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -262,8 +262,8 @@ async def test_form_new_renders_parent_org_select_with_root_option(
     logged_in_user: User,
 ):
     """Pins the new picker structure from issue #581: a ``<select
-    name="parent_org_id">`` with a "(root — no parent)" default option
-    plus one ``<option>`` per Org visible to the requesting user.
+    name="parent_org_id">`` with a "(no parent)" default option plus
+    one ``<option>`` per Org visible to the requesting user.
     """
     mine_a = await _seed_org(
         db_test_session_manager, owner_id=logged_in_user.id, name="Mine A"
@@ -278,15 +278,15 @@ async def test_form_new_renders_parent_org_select_with_root_option(
     select = tree.css_first('select[name="parent_org_id"]')
     assert select is not None, "parent-org picker should be a <select>"
     options = select.css("option")
-    # Root option + one option per visible Org. selectolax surfaces
-    # `value=""` as ``None`` in the attribute dict, so we test the root
-    # option by position + the absence of a value.
+    # Blank-option + one option per visible Org. selectolax surfaces
+    # `value=""` as ``None`` in the attribute dict, so we test the
+    # blank option by position + the absence of a value.
     assert len(options) == 3
     assert options[0].attributes.get("value") is None
     assert "selected" in options[0].attributes
-    assert "root" in options[0].text().lower()
+    assert "no parent" in options[0].text().lower()
     values = {opt.attributes.get("value") for opt in options}
-    # `None` is the root option's value (empty-string attribute).
+    # `None` is the blank option's value (empty-string attribute).
     assert values == {None, str(mine_a), str(mine_b)}
     # Free-text input from the prior UI is gone.
     assert tree.css_first('input[name="parent_org_id"]') is None
@@ -382,7 +382,7 @@ async def test_form_edit_preselects_root_for_top_level_org(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """A root org (no parent) edits with the "(root — no parent)" option
+    """A root org (no parent) edits with the "(no parent)" option
     pre-selected."""
     create_resp = await authenticated_client.post(
         "/organizations", data=_org_payload(name="Top-Level")
@@ -394,10 +394,10 @@ async def test_form_edit_preselects_root_for_top_level_org(
     tree = HTMLParser(response.text)
     selected = tree.css_first('select[name="parent_org_id"] option[selected]')
     assert selected is not None
-    # `value=""` is rendered as the root option; selectolax surfaces an
+    # `value=""` is rendered as the blank option; selectolax surfaces an
     # empty-string attribute as ``None``.
     assert selected.attributes.get("value") is None
-    assert "root" in selected.text().lower()
+    assert "no parent" in selected.text().lower()
 
 
 async def test_delete_removes_org(

--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -42,6 +42,68 @@ The services list is the first row of `_facts_block`'s `<dl>` rather than its ow
 
 The auth-flow pages (`auth/login.html`, `auth/register.html`, `auth/forgot_password.html`, `auth/reset_password.html`) each render a single `<article class="auth-page">` card. The `.auth-page` rule in [`../../framework/templates/base.html`](../../framework/templates/base.html) caps the card at 28rem and centers it horizontally — without the class the card stretches to the full `<main class="container">` width on tablet/desktop.
 
+## Copy style guide
+
+Every label, legend, help string, button, and intro paragraph in `src/domain/templates/` follows the rules below. The audience is mental-health clinicians — copy reads as concise plain English, not clinical jargon. Pinned by [`test_copy_conventions.py`](test_copy_conventions.py); a violation surfaces as a test failure, not a code review note.
+
+### Labels and legends
+
+- **Sentence case.** `First name`, `In-network carriers`, `Treatment settings` — not `First Name` or `Treatment Settings`. Acronyms keep their canonical case (`NPI`, `ZIP`, `DBT`).
+- **No trailing punctuation** unless the label is genuinely a question. `Sliding scale?` yes; `Last name.` no.
+- **No app-internal abbreviations.** `Organization`, never `Org`. Domain acronyms every clinician already says aloud (`NPI`, `ZIP`) stay.
+
+### Help text (`help=`)
+
+- **Full sentence, period at the end.** `10-digit National Provider Identifier.` not `10-digit National Provider Identifier`.
+- **Specific.** Explain *what the value is for*, not that the field exists. `For example: DBT, EMDR, IFS.` beats `Free text.`.
+- **Never write `help="Optional."`.** The `(optional)` indicator on the label is the single canonical signal — see below.
+- If the same help string appears in two or more forms, move it to [`../../framework/templates/_shared/form_copy.html`](../../framework/templates/_shared/form_copy.html) and import it.
+
+### Optional fields
+
+Pass `required=False` to any form-field macro. The macro renders a muted `(optional)` after the label automatically (see `_field_label` in [`../../framework/templates/_shared/form_fields.html`](../../framework/templates/_shared/form_fields.html)).
+
+```jinja
+{# OK — `(optional)` is rendered automatically #}
+{{ text_field("npi", "NPI", required=False, help="10-digit National Provider Identifier.") }}
+
+{# Bad — duplicates the (optional) indicator with prose #}
+{{ text_field("npi", "NPI", required=False, help="Optional. 10-digit NPI.") }}
+```
+
+Fieldset-level "everything below is optional" lines (the previous `<small>Both lists optional.</small>` pattern) are gone — every field carries its own indicator now.
+
+### Buttons
+
+- **Verb-noun, sentence case.** `Create program`, `Post referral`, `Save changes`, `Send reset link`.
+- **Create / edit submit pattern.** Create forms use `entity_create_label(spec.name, kind=...)` so the submit button text matches the H1 (`Create clinician opening` everywhere). Edit forms use `Save changes` — every edit form, no exceptions. The structural pin lives in `entity_create_label` (see [`../../framework/templates/README.md` § "Create / filter labels"](../../framework/templates/README.md)).
+
+### Vocabulary
+
+One word per concept, no synonyms. Replace any of the variants below in any new copy:
+
+| Concept                    | Word                | Don't use                                |
+| -------------------------- | ------------------- | ---------------------------------------- |
+| Person who treats          | clinician           | provider, practitioner, therapist        |
+| Person treated             | client              | patient                                  |
+| Practice / employer entity | organization        | practice, clinic, group, agency          |
+| Delivery format            | in-person / virtual | telehealth, remote, online               |
+| The post type announcing availability for individual clinicians | opening | listing, slot, position |
+| The post type announcing program-level intake | intake | enrollment, admission window |
+| The post type seeking placement for a client | referral | seeker post, lead |
+
+The model class `Provider` and the audit string `provider` are historical and kept on the Python side; user-facing copy says `clinician`. See `src/domain/specs/provider.py` for the rename rationale.
+
+### Shared microcopy
+
+Strings repeated across forms live in [`../../framework/templates/_shared/form_copy.html`](../../framework/templates/_shared/form_copy.html). Today:
+
+- `org_picker_help()` — the "Can't find your organization?" hint for every Org-FK picker.
+- `modality_help()` — the `e.g. DBT, EMDR, IFS` example for the treatment-modality free-text field.
+- `select_all_help()` — the `Select all that apply.` hint for multi-choice demographics.
+
+If a new string would otherwise live in two forms, add it here.
+
 ## Tests
 
-Exercised indirectly via route tests under [`../routes/`](../routes/). Selector and fixture conventions live in [`../../../tests/README.md`](../../../tests/README.md).
+Exercised indirectly via route tests under [`../routes/`](../routes/), plus [`test_copy_conventions.py`](test_copy_conventions.py) (this directory) which scans every template for forbidden patterns (literal `Optional.` help strings, `Org` abbreviation, etc.). Selector and fixture conventions live in [`../../../tests/README.md`](../../../tests/README.md).

--- a/src/domain/templates/auth/forgot_password.html
+++ b/src/domain/templates/auth/forgot_password.html
@@ -2,11 +2,9 @@
 {% block content %}
 <article class="auth-page">
   <header>
+    <h1>Reset your password</h1>
+    <p>Enter your email and we'll send you a reset link.</p>
   </header>
-  <p>
-    Enter your email address below and we'll send you a link to reset your
-    password.
-  </p>
   <!-- POSTs to the FastAPI Users forgot-password endpoint. -->
   <form method="post" action="/auth/forgot-password">
     <label for="email">
@@ -17,8 +15,8 @@
   </form>
   <footer>
     <p>
-      Remembered your password?
-      <a href="/auth/login">Login here</a>
+      Remembered it?
+      <a href="/auth/login">Log in.</a>
     </p>
   </footer>
 </article>

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -2,6 +2,8 @@
 {% block content %}
 <article class="auth-page">
   <header>
+    <h1>Log in</h1>
+    <p>Welcome back. Log in to post or browse referrals.</p>
   </header>
   <!-- FastAPI Users JWT login endpoint expects 'username' (which is email) and 'password' as form data. -->
   <form
@@ -9,22 +11,22 @@
     action="/auth/jwt/login{% if next_url %}?next={{ next_url }}{% endif %}">
     <label for="username">
       Email
-      <input type="email" id="username" name="username" />
+      <input type="email" id="username" name="username" required />
     </label>
     <label for="password">
       Password
-      <input type="password" id="password" name="password" />
+      <input type="password" id="password" name="password" required />
     </label>
-    <button type="submit">Login</button>
+    <button type="submit">Log in</button>
   </form>
   <footer>
     <p>
       Forgot your password?
-      <a href="/auth/forgot-password">Reset here</a>
+      <a href="/auth/forgot-password">Reset it.</a>
     </p>
     <p>
-      Need an account?
-      <a href="/auth/register">Register here</a>
+      New here?
+      <a href="/auth/register">Create an account.</a>
     </p>
   </footer>
 </article>

--- a/src/domain/templates/auth/register.html
+++ b/src/domain/templates/auth/register.html
@@ -2,6 +2,8 @@
 {% block content %}
 <article class="auth-page">
   <header>
+    <h1>Create an account</h1>
+    <p>Set up your account to post openings, referrals, and intakes.</p>
   </header>
   <form hx-post="/auth/register" hx-ext="json-enc">
     <label for="email">
@@ -16,12 +18,12 @@
       Password
       <input type="password" id="password" name="password" required />
     </label>
-    <button type="submit">Register</button>
+    <button type="submit">Create account</button>
   </form>
   <footer>
     <p>
       Already have an account?
-      <a href="/auth/login">Login here</a>
+      <a href="/auth/login">Log in.</a>
     </p>
   </footer>
 </article>

--- a/src/domain/templates/auth/reset_password.html
+++ b/src/domain/templates/auth/reset_password.html
@@ -2,6 +2,8 @@
 {% block content %}
 <article class="auth-page">
   <header>
+    <h1>Set a new password</h1>
+    <p>Pick something memorable. You'll use it next time you log in.</p>
   </header>
   <!-- POSTs to the FastAPI Users reset-password endpoint.
        The endpoint expects JSON {"token": "...", "password": "..."}; a real
@@ -9,10 +11,10 @@
   <form method="post" action="/auth/reset-password">
     <input type="hidden" name="token" value="{{ token }}" />
     <label for="password">
-      Enter new password
+      New password
       <input type="password" id="password" name="password" required />
     </label>
-    <button type="submit">Reset password</button>
+    <button type="submit">Save password</button>
   </form>
 </article>
 {% endblock %}

--- a/src/domain/templates/organizations/form_edit.html
+++ b/src/domain/templates/organizations/form_edit.html
@@ -35,13 +35,13 @@
          "Parent organization",
          parent_org_options,
          current=organization.parent_org_id,
-         blank_label="(root — no parent)",
+         blank_label="(no parent)",
          required=false,
-         help='Leave as "(root — no parent)" for a top-level organization.',
+         help="Set one only if this is part of a larger network.",
     ) }}
   </fieldset>
   {{ actions(
-      "Save organization",
+      "Save changes",
       cancel_url=entity_url('organization', id=organization.id),
       delete_url=entity_url('organization', id=organization.id),
       delete_confirm="Delete this organization?",

--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -23,9 +23,9 @@
          "parent_org_id",
          "Parent organization",
          parent_org_options,
-         blank_label="(root — no parent)",
+         blank_label="(no parent)",
          required=false,
-         help='Leave as "(root — no parent)" for a top-level organization. Most users do.',
+         help="Most organizations have no parent. Set one only if this is part of a larger network.",
     ) }}
   </fieldset>
 

--- a/src/domain/templates/posts/openings/_form_clinician_opening.html
+++ b/src/domain/templates/posts/openings/_form_clinician_opening.html
@@ -19,6 +19,7 @@ when `current_user.providers` is empty, so this macro always renders
 with at least one provider available.
 #}
 {%- from "_shared/form_fields.html" import entity_select_field, text_field, textarea_field, select_field, time_grid_field, multi_select_field, field_for -%}
+{%- from "_shared/form_copy.html" import modality_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro opening_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
 {%- set d = post.opening_detail if post else None -%}
@@ -39,7 +40,7 @@ with at least one provider available.
      the (provider, affiliation) pair is unambiguous (file an issue
      once a clinician actually adds a second affiliation). #}
   <label for="provider_id">
-    At which of your practices?
+    Which practice?
     <select id="provider_id" name="provider_id" required>
       {%- if not d %}
       <option value="" disabled selected>--</option>
@@ -62,8 +63,8 @@ with at least one provider available.
 
   <fieldset>
     <legend>Availability</legend>
-    {{ time_grid_field("desired_times", "Desired times", current=d.desired_times if d else None, help="Optional.") }}
-    {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help="e.g. start date, cohort dates, fixed program hours.") }}
+    {{ time_grid_field("desired_times", "Desired times", current=d.desired_times if d else None) }}
+    {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help="For example: start date, cohort dates, fixed program hours.") }}
   </fieldset>
 
   <fieldset>
@@ -72,9 +73,8 @@ with at least one provider available.
       {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
       {{ multi_select_field("settings", "Treatment settings", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
     </div>
-    <small>Both lists optional.</small>
-    {{ text_field("treatment_modality", "Treatment modality", current=d.treatment_modality if d else None, required=false, help="Optional. e.g. DBT, EMDR.") }}
-    {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help="Select all that apply.") }}
+    {{ text_field("treatment_modality", "Treatment modality", current=d.treatment_modality if d else None, required=false, help=modality_help()) }}
+    {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help()) }}
     <div class="grid">
       {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
       {{ multi_select_field("genders", "Genders served", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None) }}

--- a/src/domain/templates/posts/openings/_form_program_intake.html
+++ b/src/domain/templates/posts/openings/_form_program_intake.html
@@ -19,6 +19,7 @@ when `current_user.programs` is empty, so this macro always renders
 with at least one Program available.
 #}
 {%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, time_grid_field, multi_select_field, field_for -%}
+{%- from "_shared/form_copy.html" import modality_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro intake_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
 {%- set d = post.intake_detail if post else None -%}
@@ -26,7 +27,7 @@ with at least one Program available.
   <input type="hidden" name="kind" value="program_intake" />
 
   <label for="program_id">
-    Which program is this availability for?
+    Which program?
     <select id="program_id" name="program_id" required>
       {%- if not d %}
       <option value="" disabled selected>--</option>
@@ -47,8 +48,8 @@ with at least one Program available.
 
   <fieldset>
     <legend>Availability</legend>
-    {{ time_grid_field("desired_times", "Desired times", current=d.desired_times if d else None, help="Optional.") }}
-    {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help="e.g. start date, cohort dates, fixed program hours.") }}
+    {{ time_grid_field("desired_times", "Desired times", current=d.desired_times if d else None) }}
+    {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help="For example: start date, cohort dates, fixed program hours.") }}
   </fieldset>
 
   <fieldset>
@@ -57,9 +58,8 @@ with at least one Program available.
       {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
       {{ multi_select_field("settings", "Treatment settings", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
     </div>
-    <small>Both lists optional.</small>
-    {{ text_field("treatment_modality", "Treatment modality", current=d.treatment_modality if d else None, required=false, help="Optional. e.g. DBT, EMDR.") }}
-    {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help="Select all that apply.") }}
+    {{ text_field("treatment_modality", "Treatment modality", current=d.treatment_modality if d else None, required=false, help=modality_help()) }}
+    {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help()) }}
     <div class="grid">
       {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
       {{ multi_select_field("genders", "Genders served", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None) }}

--- a/src/domain/templates/posts/openings/new_clinician_opening.html
+++ b/src/domain/templates/posts/openings/new_clinician_opening.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 {% if not current_user.providers %}
-<p>You need a clinician profile before posting availability. <a href="{{ entity_form_url('clinician') }}">Create your clinician profile</a>, then return here.</p>
+<p>Set up your clinician profile first — every opening is tied to one. <a href="{{ entity_form_url('clinician') }}">Create your clinician profile.</a></p>
 {% else %}
 {{ opening_form("post", entity_url('opening'), entity_create_label('opening', kind='clinician_opening'), schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('opening')) }}
 {% endif %}

--- a/src/domain/templates/posts/openings/new_program_intake.html
+++ b/src/domain/templates/posts/openings/new_program_intake.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 {% if not current_user.programs %}
-<p>You need a program before posting an intake. <a href="{{ entity_form_url('program') }}">Create a program</a>, then return here.</p>
+<p>Create a program first — every intake is tied to one. <a href="{{ entity_form_url('program') }}">Create a program.</a></p>
 {% else %}
 {{ intake_form("post", entity_url('opening'), entity_create_label('opening', kind='program_intake'), schema=intake_create_schema, current_user=current_user, cancel_url=entity_url('opening')) }}
 {% endif %}

--- a/src/domain/templates/posts/referrals/_form.html
+++ b/src/domain/templates/posts/referrals/_form.html
@@ -18,6 +18,7 @@ checkboxes as `desired_times=monday_am&desired_times=friday_pm`,
 which FastAPI/Pydantic parses as a list.
 #}
 {%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, time_grid_field, multi_select_field, field_for -%}
+{%- from "_shared/form_copy.html" import modality_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro referral_form(hx_method, action, submit_label, post=None, schema=None, cancel_url=None) -%}
 {%- set d = post.referral_detail if post else None -%}
@@ -35,26 +36,26 @@ which FastAPI/Pydantic parses as a list.
       {{ select_field("location_in_person", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.location_in_person if d else None, placeholder=true) }}
       {{ select_field("location_virtual", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.location_virtual if d else None, placeholder=true) }}
     </div>
-    {{ time_grid_field("desired_times", "Desired times", current=d.desired_times if d else None, help="Optional.") }}
+    {{ time_grid_field("desired_times", "Desired times", current=d.desired_times if d else None) }}
   </fieldset>
 
   <fieldset>
-    <legend>Demographics</legend>
-    {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help="Select all that apply.") }}
+    <legend>Client demographics</legend>
+    {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help()) }}
     {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
-    {{ select_field("gender", "Gender identity", GENDERS, labels=GENDER_LABELS, current=d.gender if d else None) }}
+    {{ select_field("gender", "Gender", GENDERS, labels=GENDER_LABELS, current=d.gender if d else None) }}
   </fieldset>
 
-  {{ textarea_field("description", "Description", current=d.description if d else None, help="No PII.") }}
+  {{ textarea_field("description", "About the client", current=d.description if d else None, help="Anything else a clinician needs to know. Please don't include identifying details.") }}
 
   <fieldset>
     <legend>Services</legend>
-    {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None, help="Optional.") }}
-    {{ text_field("treatment_modality", "Psychotherapy modality", current=d.treatment_modality if d else None, required=false, help="Optional. e.g. DBT, EMDR.") }}
+    {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
+    {{ text_field("treatment_modality", "Treatment modality", current=d.treatment_modality if d else None, required=false, help=modality_help()) }}
   </fieldset>
 
   {# Insurance: two controls. `network_preference` is the referrer's
-     posture (always set); `insurance_carrier` is the patient's carrier
+     posture (always set); `insurance_carrier` is the client's carrier
      (optional — null when network_preference='no_preference'). The
      carrier <div> is hidden whenever no_preference is selected; a tiny
      inline script (below) toggles on change. Server-side, the

--- a/src/domain/templates/programs/form_edit.html
+++ b/src/domain/templates/programs/form_edit.html
@@ -1,5 +1,6 @@
 {% extends "views/form_edit.html" %}
 {%- from "_shared/form_fields.html" import entity_select_field, radio_bool_field, select_field, text_field -%}
+{%- from "_shared/form_copy.html" import org_picker_help -%}
 {%- from "_shared/actions.html" import actions -%}
 
 {% set resource_url = entity_url('program') %}
@@ -17,31 +18,24 @@
 <form hx-patch="{{ entity_url('program', id=program.id) }}">
   <fieldset>
     <legend>Identity</legend>
-    {{ entity_select_field(
-         "org_id",
-         "Organization",
-         organizations,
-         current=program.org_id,
-         help='Don\'t see your organization? <a href="' ~ entity_form_url('organization') ~ '">Create one first</a>.',
-    ) }}
+    {{ entity_select_field("org_id", "Organization", organizations, current=program.org_id, help=org_picker_help()) }}
     {{ text_field("name", "Name", current=program.name) }}
-    {{ text_field("description", "Description", current=program.description, required=false, help="Optional.") }}
+    {{ text_field("description", "Description", current=program.description, required=false) }}
   </fieldset>
   <fieldset>
-    <legend>State &amp; dates</legend>
+    <legend>Where and when</legend>
     {{ select_field("state_preference", "State served", US_STATES, current=program.state_preference, required=false, placeholder=true) }}
     <div class="grid">
       {{ text_field("start_date", "Start date", current=program.start_date, required=false, type="date") }}
       {{ text_field("end_date", "End date", current=program.end_date, required=false, type="date") }}
     </div>
-    <small>All three above are optional.</small>
   </fieldset>
   <fieldset>
     <legend>Intake</legend>
     {{ radio_bool_field("accepting_referrals", "Accepting referrals?", current=program.accepting_referrals, required=false) }}
   </fieldset>
   {{ actions(
-      "Save program",
+      "Save changes",
       cancel_url=entity_url('program', id=program.id),
       delete_url=entity_url('program', id=program.id),
       delete_confirm="Delete this program?",

--- a/src/domain/templates/programs/form_new.html
+++ b/src/domain/templates/programs/form_new.html
@@ -1,5 +1,6 @@
 {% extends "views/form_new.html" %}
 {%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field -%}
+{%- from "_shared/form_copy.html" import org_picker_help -%}
 {%- from "_shared/actions.html" import actions -%}
 
 {% set resource_url = entity_url('program') %}
@@ -7,34 +8,29 @@
 {% block resource_label %}Programs{% endblock %}
 
 {% block content %}
-<p>A program is a treatment offering — a cohort, intensive outpatient, or day program — owned by an organization.</p>
+<p>A program is a treatment offering owned by an organization — for example a cohort, IOP, or day program.</p> <!-- title-case-ignore -->
+
 
 {# `org_id` is the FK to the owning Organization. The dropdown is
    scoped per-viewer by `program_form_extras` (the spec's
    `form_extras_path`) — it lists only the Orgs the requesting user
-   owns. Superusers see every Org. To attach to a new Organization,
-   create it via `entity_form_url('organization')` first. #}
+   owns. Superusers see every Org. The "create one first" hint lives
+   in `_shared/form_copy.html::org_picker_help`. #}
 <form hx-post="{{ entity_url('program') }}">
   <fieldset>
     <legend>Program</legend>
-    {{ entity_select_field(
-         "org_id",
-         "Organization",
-         organizations,
-         help='Don\'t see your organization? <a href="' ~ entity_form_url('organization') ~ '">Create one first</a>.',
-    ) }}
+    {{ entity_select_field("org_id", "Organization", organizations, help=org_picker_help()) }}
     {{ field_for(schema, "name", "Name") }}
-    {{ field_for(schema, "description", "Description", required=false, help="Optional.") }}
+    {{ field_for(schema, "description", "Description", required=false) }}
   </fieldset>
 
   <fieldset>
-    <legend>State &amp; dates</legend>
+    <legend>Where and when</legend>
     {{ field_for(schema, "state_preference", "State served", required=false) }}
     <div class="grid">
       {{ text_field("start_date", "Start date", required=false, type="date") }}
       {{ text_field("end_date", "End date", required=false, type="date") }}
     </div>
-    <small>All three above are optional.</small>
   </fieldset>
 
   <fieldset>

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -1,5 +1,6 @@
 {% extends "views/form_edit.html" %}
 {%- from "_shared/form_fields.html" import entity_select_field, text_field, select_field, radio_bool_field, multi_select_field -%}
+{%- from "_shared/form_copy.html" import org_picker_help -%}
 {%- from "_shared/forms.html" import inline_add_form -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- from "providers/_credential_row.html" import credential_row -%}
@@ -36,17 +37,11 @@
         {{ text_field("first_name", "First name", current=provider.first_name, required=false, maxlength=120) }}
         {{ text_field("last_name", "Last name", current=provider.last_name, required=false, maxlength=120) }}
       </div>
-      {{ text_field("npi", "NPI", current=provider.npi, required=false, pattern="\\d{10}", maxlength=10, help="10-digit National Provider Identifier. Optional.") }}
+      {{ text_field("npi", "NPI", current=provider.npi, required=false, pattern="\\d{10}", maxlength=10, help="10-digit National Provider Identifier.") }}
     </fieldset>
     <fieldset>
       <legend>Practice location</legend>
-      {{ entity_select_field(
-           "org_id",
-           "Organization",
-           orgs,
-           current=provider.org_id,
-           help='Don\'t see your organization? <a href="' ~ entity_form_url('organization') ~ '">Create one first</a>.',
-      ) }}
+      {{ entity_select_field("org_id", "Organization", orgs, current=provider.org_id, help=org_picker_help()) }}
       <div class="grid">
         {{ text_field("location_city", "City", current=provider.location_city, maxlength=120) }}
         {{ select_field("location_state", "State", US_STATES, current=provider.location_state) }}
@@ -63,18 +58,18 @@
     {# Insurance & payment. Empty carrier list = no in-network. #}
     <fieldset>
       <legend>Insurance &amp; payment</legend>
-      {{ multi_select_field("in_network_carriers", "In-network carriers", INSURANCE_CARRIERS, labels=INSURANCE_CARRIER_LABELS, current=provider.in_network_carriers, help="Leave empty for none.") }}
+      {{ multi_select_field("in_network_carriers", "In-network carriers", INSURANCE_CARRIERS, labels=INSURANCE_CARRIER_LABELS, current=provider.in_network_carriers) }}
       <div class="grid">
         {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", current=provider.accepts_out_of_network, required=false) }}
         {{ radio_bool_field("sliding_scale", "Sliding scale?", current=provider.sliding_scale, required=false) }}
       </div>
-      {{ text_field("cost", "Cost", current=provider.cost, required=false, help="Free text. Optional.") }}
+      {{ text_field("cost", "Cost", current=provider.cost, required=false, help="Free text — for example, &quot;$200/session&quot; or &quot;sliding 80–200&quot;.") }}
     </fieldset>
     {# Practice-details form keeps its own action cluster; credentials
        are managed via the inline add/remove forms below. Delete for
        the Provider itself lives on the detail page's toolbar (see
        `providers/detail.html`). #}
-    {{ actions("Save practice details", cancel_url=entity_url('clinician', id=provider.id)) }}
+    {{ actions("Save changes", cancel_url=entity_url('clinician', id=provider.id)) }}
   </form>
 </section>
 
@@ -164,7 +159,7 @@
     {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
     {{ text_field("license_number", "License number", maxlength=120) }}
     {{ select_field("issuing_state", "Issuing state", US_STATES, placeholder=true) }}
-    {{ text_field("expiration_date", "Expiration date (YYYY-MM-DD)", required=false, pattern="\\d{4}-\\d{2}-\\d{2}", maxlength=10) }}
+    {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
   {% endcall %}
 </section>
 
@@ -188,7 +183,7 @@
   {% call inline_add_form(entity_url('clinician', id=provider.id) ~ "/educations", "Add education", "Add education") %}
     {{ select_field("education_type", "Education type", EDUCATION_TYPES, labels=EDUCATION_TYPES_LABELS, placeholder=true) }}
     {{ text_field("institution", "Institution", maxlength=200) }}
-    {{ text_field("month_completed", "Month completed (YYYY-MM)", required=false, pattern="\\d{4}-\\d{2}", maxlength=7) }}
+    {{ text_field("month_completed", "Month completed", required=false, type="month") }}
   {% endcall %}
 </section>
 
@@ -212,7 +207,7 @@
   {% call inline_add_form(entity_url('clinician', id=provider.id) ~ "/certifications", "Add certification", "Add certification") %}
     {{ select_field("certification_type", "Certification type", CERTIFICATION_TYPES, labels=CERTIFICATION_TYPES_LABELS, placeholder=true) }}
     {{ text_field("certifying_body", "Certifying body", maxlength=200) }}
-    {{ text_field("expiration_date", "Expiration date (YYYY-MM-DD)", required=false, pattern="\\d{4}-\\d{2}-\\d{2}", maxlength=10) }}
+    {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
   {% endcall %}
 </section>
 

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -1,5 +1,6 @@
 {% extends "views/form_new.html" %}
 {%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field -%}
+{%- from "_shared/form_copy.html" import org_picker_help -%}
 {%- from "_shared/actions.html" import actions -%}
 
 {% set resource_url = entity_url('clinician') %}
@@ -7,16 +8,16 @@
 {% block resource_label %}Clinicians{% endblock %}
 
 {% block content %}
-<p>Practice details only. Add licensures, education, and certifications after creating the clinician entry.</p>
+<p>Start with the basics. You can add licensures, education, and certifications after the clinician is created.</p>
 
 {# `org_id` is the FK to the directory entry's Organization (the
    practice's display name lives on `org.name`). The dropdown lists
    every Org in the directory; any user may attach their clinician
-   entry to any Org. To create a new Organization, visit the create form
-   (use `entity_form_url('organization')`) first; this form doesn't
-   bundle inline-create into the clinician create page. The underlying
-   model class is still `Provider` — only the user-facing surface
-   flipped in #642 PR 4. #}
+   entry to any Org. To create a new Organization, visit the create
+   form first; the org-picker help (`org_picker_help` in
+   `_shared/form_copy.html`) links there. The underlying model class
+   is still `Provider` — only the user-facing surface flipped in #642
+   PR 4. #}
 <form hx-post="{{ entity_url('clinician') }}">
   {# Person-level fields (name, NPI) — these live on the linked
      `Clinician` row and follow the person across affiliations. Kept in
@@ -28,17 +29,12 @@
       {{ field_for(schema, "first_name", "First name") }}
       {{ field_for(schema, "last_name", "Last name") }}
     </div>
-    {{ field_for(schema, "npi", "NPI", help="10-digit National Provider Identifier. Optional.") }}
+    {{ field_for(schema, "npi", "NPI", required=false, help="10-digit National Provider Identifier.") }}
   </fieldset>
 
   <fieldset>
     <legend>Practice</legend>
-    {{ entity_select_field(
-         "org_id",
-         "Organization",
-         orgs,
-         help='Don\'t see your organization? <a href="' ~ entity_form_url('organization') ~ '">Create one first</a>.',
-    ) }}
+    {{ entity_select_field("org_id", "Organization", orgs, help=org_picker_help()) }}
     <div class="grid">
       {{ field_for(schema, "location_city", "City") }}
       {{ field_for(schema, "location_state", "State") }}
@@ -59,12 +55,12 @@
      independent. No cross-field invariant. #}
   <fieldset>
     <legend>Insurance &amp; payment</legend>
-    {{ field_for(schema, "in_network_carriers", "In-network carriers", help="Leave empty for none.") }}
+    {{ field_for(schema, "in_network_carriers", "In-network carriers") }}
     <div class="grid">
       {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", required=false) }}
       {{ radio_bool_field("sliding_scale", "Sliding scale?", required=false) }}
     </div>
-    {{ text_field("cost", "Cost", required=false, help="Free text. Optional.") }}
+    {{ text_field("cost", "Cost", required=false, help="Free text — for example, &quot;$200/session&quot; or &quot;sliding 80–200&quot;.") }}
   </fieldset>
 
   {{ actions(entity_create_label('clinician'), cancel_url=entity_url('clinician')) }}

--- a/src/domain/templates/test_copy_conventions.py
+++ b/src/domain/templates/test_copy_conventions.py
@@ -1,0 +1,114 @@
+"""Copy-style-guide conformance tests.
+
+Every template under `src/domain/templates/` is scanned for forbidden
+patterns the audit found in production. Adding a violation surfaces as
+a test failure here rather than as a code-review note.
+
+The rules pinned (see [`./README.md` § "Copy style guide"](README.md)
+for the full statement of each):
+
+  1. `help="Optional."` is forbidden — the `(optional)` indicator
+     rendered by `_field_label` is the single canonical signal.
+  2. `help="Optional. ..."` (period-as-prose-prefix) is forbidden for
+     the same reason.
+  3. The app-internal abbreviation `Org` is forbidden in user-facing
+     copy — `Organization` is the canonical noun.
+  4. The deprecated `(root — no parent)` phrasing is gone — the
+     standard blank-option label is `(no parent)`.
+  5. The "Save X" submit-button vocabulary is unified to "Save changes"
+     across every edit form.
+
+The scan looks at literal text in `.html` files; conditional Jinja
+that builds the string at runtime is out of scope (we don't try to
+parse Jinja). That's fine — every forbidden pattern below appeared as
+a literal in the pre-PR audit.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+TEMPLATES_ROOT = Path(__file__).resolve().parent
+
+
+def _all_template_files() -> list[Path]:
+    """Every `.html` template under `src/domain/templates/`."""
+    return sorted(TEMPLATES_ROOT.rglob("*.html"))
+
+
+@pytest.mark.parametrize(
+    "pattern,explanation",
+    [
+        (
+            r'help=["\']Optional\.?["\']',
+            'help="Optional." duplicates the (optional) indicator',
+        ),
+        (
+            r'help=["\']Optional\.\s',
+            'help="Optional. ..." duplicates the (optional) indicator — '
+            "use `required=False` and put the explanation in help= without "
+            'the "Optional." prefix',
+        ),
+        (
+            r"\(root — no parent\)",
+            "use `(no parent)` — the `root` jargon is internal",
+        ),
+        (
+            # Match the action-cluster submit label only when the
+            # convention diverges. "Save practice details" / "Save
+            # program" / etc. are all unified to "Save changes".
+            r'actions\(\s*["\']Save (?:practice details|program|organization|clinician|opening|referral|intake)["\']',
+            'edit forms use "Save changes" — see the copy style guide',
+        ),
+    ],
+)
+def test_no_forbidden_copy_patterns(pattern: str, explanation: str) -> None:
+    """Scan every template for forbidden patterns. The parametrize
+    expansion lets pytest report each violation against the rule that
+    flagged it instead of a single bulk failure."""
+    rx = re.compile(pattern)
+    violations: list[str] = []
+    for path in _all_template_files():
+        text = path.read_text()
+        for match in rx.finditer(text):
+            # Compute 1-based line number for the violation report.
+            line_no = text[: match.start()].count("\n") + 1
+            rel = path.relative_to(TEMPLATES_ROOT.parents[2])
+            violations.append(f"{rel}:{line_no}: {match.group(0)!r}")
+    assert (
+        not violations
+    ), f"Forbidden copy pattern found ({explanation}):\n  " + "\n  ".join(violations)
+
+
+def test_org_abbreviation_only_in_comments_or_code() -> None:
+    """`Org` (capitalized abbreviation) shouldn't appear in user-facing
+    text — `Organization` is the canonical noun. The scan ignores Jinja
+    comments (`{# ... #}`) and HTML comments (`<!-- ... -->`); those
+    are developer-facing and use the abbreviation freely. Also ignores
+    `org_id`, `org.name`, etc. — the *attribute* name stays `org` for
+    historical reasons.
+    """
+    # Strip Jinja comments + HTML comments so the scan is on rendered
+    # text only. Anything left that matches "\bOrg\b" not followed by
+    # `_` / `.` / `s` (forming "Org_id", "Org.name", "Orgs") is a
+    # user-facing leak.
+    jinja_comment = re.compile(r"\{#.*?#\}", re.DOTALL)
+    html_comment = re.compile(r"<!--.*?-->", re.DOTALL)
+    org_word = re.compile(r"\bOrg(?![_\.s])\b")
+    violations: list[str] = []
+    for path in _all_template_files():
+        text = path.read_text()
+        text = jinja_comment.sub("", text)
+        text = html_comment.sub("", text)
+        for match in org_word.finditer(text):
+            line_no = text[: match.start()].count("\n") + 1
+            rel = path.relative_to(TEMPLATES_ROOT.parents[2])
+            violations.append(f"{rel}:{line_no}: {match.group(0)!r}")
+    assert (
+        not violations
+    ), "Use `Organization` (not `Org`) in user-facing copy:\n  " + "\n  ".join(
+        violations
+    )

--- a/src/framework/templates/_shared/form_copy.html
+++ b/src/framework/templates/_shared/form_copy.html
@@ -1,0 +1,46 @@
+{# Shared form microcopy — single source of truth for any help string
+   the app would otherwise re-type in two or more forms.
+
+   The audit at the top of this PR found three duplications:
+
+     - "Don't see your organization? <a>Create one first</a>." — used by
+       the clinician, program, and organization create/edit forms.
+     - "e.g. DBT, EMDR." — used by the referral, clinician-opening,
+       and program-intake forms for the treatment-modality field.
+     - "Select all that apply." — used by every multi-choice
+       demographics field.
+
+   Each lives here as a single macro so a copy change is a one-place
+   edit. Importing pattern:
+
+     {%- from "_shared/form_copy.html" import org_picker_help, modality_help -%}
+     {{ entity_select_field("org_id", "Organization", orgs, help=org_picker_help()) }}
+
+   The macro is invoked (not just referenced) so Jinja renders it to a
+   string before the host macro reads `help=`. `|safe` plumbing inside
+   `_help_small` keeps any inline `<a>` from being escaped.
+#}
+
+{# The Org-picker help — every create/edit form that takes a parent-Org
+   or owning-Org FK renders this so the "I can't find my Org" path is
+   one click away. The link target is the Organization create form. #}
+{%- macro org_picker_help() -%}
+Don't see your organization? <a href="{{ entity_form_url('organization') }}">Create one first.</a>
+{%- endmacro %}
+
+{# Treatment-modality help — referrals, clinician openings, and program
+   intakes all expose a single free-text "treatment modality" field
+   alongside the structured services/settings multi-selects. The
+   abbreviation expansion lives here once so a future style change
+   (full-name examples, link to a glossary, etc.) is one edit. #}
+{%- macro modality_help() -%}
+For example: DBT, EMDR, IFS.
+{%- endmacro %}
+
+{# Multi-choice demographics fields (Age groups, Languages, Genders
+   served) — each opens with the same explanatory line. Centralized so
+   adding a new multi-choice field on a future form picks up the
+   convention. #}
+{%- macro select_all_help() -%}
+Select all that apply.
+{%- endmacro %}

--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -74,11 +74,21 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
     {%- endif %}
 {%- endmacro %}
 
+{# Field label + optional indicator. Every macro funnels its label through
+   here so the "(optional)" marker is the *only* way an optional field is
+   communicated visually — there is no `help="Optional."` pattern anymore
+   (the per-field marker beats a help line both visually and in terms of
+   discoverability). Pinned by ``src/domain/templates/test_copy_conventions.py``.
+#}
+{% macro _field_label(label, required) -%}
+{{ label }}{% if not required %} <small class="form-field-optional">(optional)</small>{% endif %}
+{%- endmacro %}
+
 {# ---- text-like inputs --------------------------------------------- #}
 
 {% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None, help=None, invalid=None, type="text", autocomplete=None) -%}
 <label class="form-field" for="{{ name }}">
-  <span class="form-field-label">{{ label }}</span>
+  <span class="form-field-label">{{ _field_label(label, required) }}</span>
   <input type="{{ type }}" id="{{ name }}" name="{{ name }}"
     {%- if current is not none %} value="{{ current }}"{% endif %}
     {%- if pattern %} pattern="{{ pattern }}"{% endif %}
@@ -93,7 +103,7 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
 
 {% macro textarea_field(name, label, current=None, required=True, help=None, invalid=None) -%}
 <label class="form-field" for="{{ name }}">
-  <span class="form-field-label">{{ label }}</span>
+  <span class="form-field-label">{{ _field_label(label, required) }}</span>
   <textarea id="{{ name }}" name="{{ name }}"
     {%- if required %} required{% endif %}
     {%- if help %} aria-describedby="{{ name }}-helper"{% endif %}
@@ -113,7 +123,7 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
 
 {% macro select_field(name, label, options, labels=None, current=None, required=True, placeholder=False, help=None, invalid=None) -%}
 <label class="form-field" for="{{ name }}">
-  <span class="form-field-label">{{ label }}</span>
+  <span class="form-field-label">{{ _field_label(label, required) }}</span>
   <select id="{{ name }}" name="{{ name }}"
     {%- if required %} required{% endif %}
     {%- if help %} aria-describedby="{{ name }}-helper"{% endif %}
@@ -138,10 +148,14 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    scalar back into a list. Used today for create/edit forms; the
    search-form variant is `.search-checkbox-fieldset` (one checkbox per
    value), not this macro. #}
-{% macro multi_select_field(name, label, options, labels=None, current=None, help=None, invalid=None) -%}
+{# Multi-select: `required=False` by default because the canonical
+   semantic is "any subset, including the empty set" (no in-network
+   carriers, no featured services). Callers can pass `required=True`
+   to force at least one selection. #}
+{% macro multi_select_field(name, label, options, labels=None, current=None, required=False, help=None, invalid=None) -%}
 {%- set selected = current or [] -%}
 <label class="form-field" for="{{ name }}">
-  <span class="form-field-label">{{ label }}</span>
+  <span class="form-field-label">{{ _field_label(label, required) }}</span>
   <select id="{{ name }}" name="{{ name }}" multiple size="{{ [options|length, 8]|min }}"
     {%- if help %} aria-describedby="{{ name }}-helper"{% endif %}
     {%- if invalid is not none %} aria-invalid="{{ 'true' if invalid else 'false' }}"{% endif %}>
@@ -175,7 +189,7 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
 {% macro entity_select_field(name, label, entities, current=None, required=True, blank_label=None, help=None, invalid=None, value_attr="id", label_attr="name") -%}
 {%- set current_s = current|string if current is not none else "" -%}
 <label class="form-field" for="{{ name }}">
-  <span class="form-field-label">{{ label }}</span>
+  <span class="form-field-label">{{ _field_label(label, required) }}</span>
   <select id="{{ name }}" name="{{ name }}"
     {%- if required %} required{% endif %}
     {%- if help %} aria-describedby="{{ name }}-helper"{% endif %}
@@ -203,7 +217,7 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    announce the helper text on either selection. #}
 {% macro radio_bool_field(name, label, current=None, required=True, help=None) -%}
 <fieldset class="form-field">
-  <legend class="form-field-label">{{ label }}</legend>
+  <legend class="form-field-label">{{ _field_label(label, required) }}</legend>
   <div class="form-field-control">
     <label class="form-field-inline"><input type="radio" name="{{ name }}" value="true"
       {%- if current is sameas true %} checked{% endif %}
@@ -249,10 +263,14 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    list on edit). The form using this macro must also declare
    `data-array-fields="<name> ..."` so a 0-checked grid still posts an
    empty array. #}
-{% macro time_grid_field(name, label, current=None, help=None) -%}
+{# `time_grid_field` is `required=False` by default — every existing
+   usage treats "no checkboxes selected" as a legitimate state. Callers
+   that need a non-empty selection can pass `required=True` (no caller
+   today). #}
+{% macro time_grid_field(name, label, current=None, required=False, help=None) -%}
 {%- set selected = current or [] -%}
 <fieldset class="form-field">
-  <legend class="form-field-label">{{ label }}</legend>
+  <legend class="form-field-label">{{ _field_label(label, required) }}</legend>
   <table>
     <thead>
       <tr>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -222,6 +222,17 @@
         border: 0;
       }
       .form-field-label { font-weight: 600; }
+      /* "(optional)" indicator rendered by every form-field macro when
+         `required=False`. Reads as muted secondary text next to the
+         label so it's visually clear the field can be left blank
+         without competing with the label itself. Replaces the previous
+         per-form `help="Optional."` pattern (single source of truth in
+         `_field_label` — see `_shared/form_fields.html`). */
+      .form-field-optional {
+        font-weight: 400;
+        color: var(--pico-muted-color);
+        margin-inline-start: 0.25em;
+      }
       .entity-form-page form .form-field > input,
       .entity-form-page form .form-field > select,
       .entity-form-page form .form-field > textarea,


### PR DESCRIPTION
## Summary

Audit found a sprawl of inconsistent form copy across the app — `help="Optional."` lines, three different "Don't see your organization?" strings, `Org` abbreviations creeping in, generic submit buttons like "Save program" vs "Save practice details", and clinical jargon like "Psychotherapy modality". This PR puts the rules in one place and rewrites every form to match them.

### What changes

**Style guide** in `src/domain/templates/README.md` — sentence case for labels/legends, period-terminated help sentences, vocabulary table (clinician/client/organization/in-person), and the new optional-field pattern.

**`(optional)` indicator** rendered by `_field_label` in `_shared/form_fields.html` whenever a macro is called with `required=False`. Drops ~10 redundant `help="Optional."` lines.

**Shared microcopy** in `_shared/form_copy.html`: `org_picker_help()`, `modality_help()`, `select_all_help()` — three strings that were duplicated across three forms each.

**Sweep**: every auth form gets an H1 + intro paragraph, every "Save X" edit-form button becomes "Save changes", date-format hints like "(YYYY-MM-DD)" move into `type="date"` inputs, "Description" on referrals becomes "About the client", "No PII." becomes "Anything else a clinician needs to know. Please don't include identifying details.", and the parent-Org picker's blank option drops the internal-jargon "(root — no parent)" for "(no parent)".

**`test_copy_conventions.py`** scans every template for forbidden patterns (`help="Optional."`, `Org` abbreviation, "Save X" verbs, the old root-org phrasing) so style violations land as test failures.

## Test plan

- [x] `pytest` — 1527 passed / 96 skipped
- [x] `pytest tests/test_contract` — 36 passed
- [x] `dev lint` clean
- [x] 5 conformance assertions in `test_copy_conventions.py`
- [x] Updated 4 existing route/auth tests that pinned old copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)