### PR TITLE
fix(toolbar): drop .toolbar h1 margin-zero, trust Pico's defaults

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -295,7 +295,6 @@
         align-items: center;
         gap: 0.75rem;
       }
-      .toolbar h1 { margin: 0; }
       /* Pico's default `<button>` is `display: block; width: 100%`
          (form-shaped); the toolbar overrides to natural-width inline
          buttons. Reaches every nested `<button>` / `[role="button"]`


### PR DESCRIPTION
## Summary
The custom `.toolbar h1 { margin: 0 }` rule (added in #663 when the breadcrumb + toolbar were consolidated, with the rationale "keep Pico's heading margins from blowing out the toolbar row's flex layout") was the actual source of the missing breathing room between the breadcrumb and the H1 on detail / form pages.

The `<nav aria-label="breadcrumb">` itself has no margin override — its computed `margin-bottom` is `0px` because that's Pico's default for `nav`. Stripping the H1's default top margin via `.toolbar h1 { margin: 0 }` then collapsed the only remaining gap.

Drop the rule. Toolbar now uses CSS grid (not the original flex from #663) with `align-items: center`, so Pico's vertical H1 margins are absorbed into the toolbar row's cell height without misaligning the right-zone actions.

## Before / after (referral detail page)

Before: "Referrals" breadcrumb sat tight against "Adolescent female (14-18)" H1.
After: clear breathing room between the breadcrumb and the H1, with the actions cluster still centered against the (now slightly taller) H1 cell.

## Test plan
- [x] `dev test src/framework/templates/test_views.py` — 20 passed
- [x] Browser-verified at desktop on list (`/openings`), detail (`/referrals/{id}`), and form (`/clinicians/form`) pages — H1 stays centered against the right-zone actions; breadcrumb gains visible breathing room
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)