### PR TITLE
refactor(framework): mount_entity defaults owned_subentities to spec.children

### DIFF
--- a/src/domain/routes/providers.py
+++ b/src/domain/routes/providers.py
@@ -1,26 +1,21 @@
-from src.domain.specs.affiliation import AFFILIATION_ENTITY
+from src.domain.specs.affiliation import AFFILIATION_ENTITY  # noqa: F401
 from src.domain.specs.provider import PROVIDER_ENTITY
-from src.domain.specs.provider_certification import CERTIFICATION_ENTITY
-from src.domain.specs.provider_education import EDUCATION_ENTITY
-from src.domain.specs.provider_licensure import LICENSURE_ENTITY
+from src.domain.specs.provider_certification import CERTIFICATION_ENTITY  # noqa: F401
+from src.domain.specs.provider_education import EDUCATION_ENTITY  # noqa: F401
+from src.domain.specs.provider_licensure import LICENSURE_ENTITY  # noqa: F401
 from src.framework import register_entity
 from src.framework.dispatch.resource_routes import mount_entity
 
 router = register_entity(PROVIDER_ENTITY)
 
 
-# Owned subentities: affiliations (clinician × org practice-role rows,
+# Owned subentities — affiliations (clinician × org practice-role rows,
 # inline list on the edit page, #642 PR 1) and the three credential
-# sub-tables (person-level, FK to `clinicians.id` after #635 PR A).
-# Each self-registers on `PROVIDER_ENTITY.children` and picks up the
-# framework's create / update / delete factories at mount time.
-mount_entity(
-    router,
-    PROVIDER_ENTITY,
-    owned_subentities=(
-        AFFILIATION_ENTITY,
-        LICENSURE_ENTITY,
-        EDUCATION_ENTITY,
-        CERTIFICATION_ENTITY,
-    ),
-)
+# sub-tables (person-level, FK to `clinicians.id` after #635 PR A) —
+# self-register on `PROVIDER_ENTITY.children` at spec-construction time
+# (each child spec declares `parent=PROVIDER_ENTITY`). `mount_entity`
+# defaults `owned_subentities=entity.children`, so the `noqa: F401`
+# imports above are the only thing needed: they trigger each child
+# spec's module-load side effect (registration), and the parent
+# mount picks them up automatically.
+mount_entity(router, PROVIDER_ENTITY)

--- a/src/framework/dispatch/resource_routes.py
+++ b/src/framework/dispatch/resource_routes.py
@@ -1160,7 +1160,7 @@ def mount_entity(
     entity: Any,  # `EntitySpec` — imported lazily to avoid a cycle
     *,
     handlers: dict[str, Callable[..., Awaitable[Any]]] | None = None,
-    owned_subentities: tuple[Any, ...] = (),
+    owned_subentities: tuple[Any, ...] | None = None,
 ) -> None:
     """Spec-driven dispatcher for an entity's full route surface.
 
@@ -1225,6 +1225,14 @@ def mount_entity(
     spec = entity.to_resource_spec()
     if handlers is None:
         handlers = {}
+    # Default to the spec's `children` tuple — every subentity that
+    # declared `parent=<this>` at construction time is already in
+    # `entity.children` (see `EntitySpec.__post_init__`), so route
+    # files don't need to list them twice. Callers can still pass
+    # an explicit tuple (e.g. `()` to mount only the parent, or a
+    # subset for staged rollouts).
+    if owned_subentities is None:
+        owned_subentities = entity.children
 
     # The path/handler pairing is the only check that can't live in
     # `EntitySpec.__post_init__` — `handlers` arrive at the mount call,


### PR DESCRIPTION
## Summary

Owned subentities self-register on \`parent._children\` in \`EntitySpec.__post_init__\` (each child spec declares \`parent=<this>\`). Route files were still listing the same tuple explicitly as \`owned_subentities=(...)\` on \`mount_entity\` — two sources of truth for the same fact, costing two-file edits when a new credential subentity got added.

Default \`owned_subentities\` to \`entity.children\` when the caller omits the kwarg. Callers can still pass an explicit tuple (\`()\` to skip, or a subset for staged rollouts).

\`src/domain/routes/providers.py\` collapses from a 4-line \`owned_subentities=(...)\` to a one-line \`mount_entity(...)\` call. The child-spec imports remain (with \`# noqa: F401\`) so module-load side effects still populate \`PROVIDER_ENTITY.children\`.

## Test plan

- [x] \`dev test\` — 1531 passed, 96 skipped.
- [x] \`dev lint\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)