### PR TITLE
refactor(forms): inject resource_url / resource_detail_url from handlers

### DIFF
--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -1,7 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions -%}
 
-{% set resource_url = entity_url('organization') %}
 
 {% block resource_label %}Organizations{% endblock %}
 {% block current_label %}{{ organization.name }}{% endblock %}

--- a/src/domain/templates/organizations/form_edit.html
+++ b/src/domain/templates/organizations/form_edit.html
@@ -2,8 +2,6 @@
 {%- from "_shared/form_fields.html" import entity_select_field, select_field, text_field -%}
 {%- from "_shared/actions.html" import actions -%}
 
-{% set resource_url = entity_url('organization') %}
-{% set resource_detail_url = entity_url('organization', id=organization.id) %}
 
 {% block resource_label %}Organizations{% endblock %}
 {% block current_label %}{{ organization.name }}{% endblock %}

--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -2,7 +2,6 @@
 {%- from "_shared/form_fields.html" import entity_select_field, select_field, text_field -%}
 {%- from "_shared/actions.html" import actions -%}
 
-{% set resource_url = entity_url('organization') %}
 
 {% block resource_label %}Organizations{% endblock %}
 

--- a/src/domain/templates/posts/openings/detail.html
+++ b/src/domain/templates/posts/openings/detail.html
@@ -3,7 +3,6 @@
 {%- from "posts/_shared/_facts_block.html" import facts_block -%}
 {%- from "posts/_shared/_how_to_refer.html" import how_to_refer -%}
 
-{% set resource_url = entity_url('opening') %}
 {%- set view = post_card_view(opening) -%}
 
 {% block resource_label %}Openings{% endblock %}

--- a/src/domain/templates/posts/openings/edit_clinician_opening.html
+++ b/src/domain/templates/posts/openings/edit_clinician_opening.html
@@ -1,8 +1,6 @@
 {% extends "views/form_edit.html" %}
 {% from "posts/openings/_form_clinician_opening.html" import opening_form %}
 
-{% set resource_url = entity_url('opening') %}
-{% set resource_detail_url = entity_url('opening', id=opening.id) %}
 {# `view.headline` is the same identity string the detail page's H1
    renders ("Will's Org, NY" for an opening). Reusing it here pins the
    edit-page breadcrumb / H1 to the *specific* post being edited

--- a/src/domain/templates/posts/openings/edit_program_intake.html
+++ b/src/domain/templates/posts/openings/edit_program_intake.html
@@ -1,8 +1,6 @@
 {% extends "views/form_edit.html" %}
 {% from "posts/openings/_form_program_intake.html" import intake_form %}
 
-{% set resource_url = entity_url('opening') %}
-{% set resource_detail_url = entity_url('opening', id=opening.id) %}
 {# `view.headline` for an intake is the program name — same identity
    the detail page renders. See `edit_clinician_opening.html` for the
    `post_card_view` rationale. #}

--- a/src/domain/templates/posts/openings/new_clinician_opening.html
+++ b/src/domain/templates/posts/openings/new_clinician_opening.html
@@ -1,7 +1,6 @@
 {% extends "views/form_new.html" %}
 {% from "posts/openings/_form_clinician_opening.html" import opening_form %}
 
-{% set resource_url = entity_url('opening') %}
 
 {% block resource_label %}Openings{% endblock %}
 

--- a/src/domain/templates/posts/openings/new_program_intake.html
+++ b/src/domain/templates/posts/openings/new_program_intake.html
@@ -1,7 +1,6 @@
 {% extends "views/form_new.html" %}
 {% from "posts/openings/_form_program_intake.html" import intake_form %}
 
-{% set resource_url = entity_url('opening') %}
 
 {% block resource_label %}Openings{% endblock %}
 

--- a/src/domain/templates/posts/referrals/detail.html
+++ b/src/domain/templates/posts/referrals/detail.html
@@ -3,7 +3,6 @@
 {%- from "posts/_shared/_facts_block.html" import facts_block -%}
 {%- from "posts/_shared/_how_to_refer.html" import how_to_refer -%}
 
-{% set resource_url = entity_url('referral') %}
 {%- set view = post_card_view(referral) -%}
 
 {% block resource_label %}Referrals{% endblock %}

--- a/src/domain/templates/posts/referrals/form_edit.html
+++ b/src/domain/templates/posts/referrals/form_edit.html
@@ -1,8 +1,6 @@
 {% extends "views/form_edit.html" %}
 {% from "posts/referrals/_form.html" import referral_form %}
 
-{% set resource_url = entity_url('referral') %}
-{% set resource_detail_url = entity_url('referral', id=referral.id) %}
 {# `view.headline` is the referral's identity line (age + gender combo).
    Reusing it here pins the breadcrumb / H1 to the specific referral
    the user is editing. #}

--- a/src/domain/templates/posts/referrals/form_new.html
+++ b/src/domain/templates/posts/referrals/form_new.html
@@ -1,7 +1,6 @@
 {% extends "views/form_new.html" %}
 {% from "posts/referrals/_form.html" import referral_form %}
 
-{% set resource_url = entity_url('referral') %}
 
 {% block resource_label %}Referrals{% endblock %}
 

--- a/src/domain/templates/programs/detail.html
+++ b/src/domain/templates/programs/detail.html
@@ -1,7 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions -%}
 
-{% set resource_url = entity_url('program') %}
 
 {% block resource_label %}Programs{% endblock %}
 {% block current_label %}{{ program.name }}{% endblock %}

--- a/src/domain/templates/programs/form_edit.html
+++ b/src/domain/templates/programs/form_edit.html
@@ -3,8 +3,6 @@
 {%- from "_shared/form_copy.html" import org_picker_help -%}
 {%- from "_shared/actions.html" import actions -%}
 
-{% set resource_url = entity_url('program') %}
-{% set resource_detail_url = entity_url('program', id=program.id) %}
 
 {% block resource_label %}Programs{% endblock %}
 {% block current_label %}{{ program.name }}{% endblock %}

--- a/src/domain/templates/programs/form_new.html
+++ b/src/domain/templates/programs/form_new.html
@@ -3,7 +3,6 @@
 {%- from "_shared/form_copy.html" import org_picker_help -%}
 {%- from "_shared/actions.html" import actions -%}
 
-{% set resource_url = entity_url('program') %}
 
 {% block resource_label %}Programs{% endblock %}
 

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -9,7 +9,6 @@
    vocabulary — the underlying model class is still `Provider`. #}
 {% set provider = clinician %}
 
-{% set resource_url = entity_url('clinician') %}
 
 {%- set view = provider_card_view(provider) -%}
 

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -12,8 +12,6 @@
    vocabulary — the underlying model class is still `Provider`. #}
 {% set provider = clinician %}
 
-{% set resource_url = entity_url('clinician') %}
-{% set resource_detail_url = entity_url('clinician', id=provider.id) %}
 
 {% block resource_label %}Clinicians{% endblock %}
 {# Same H1-fallback shape as the detail page — name when set, primary

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -3,7 +3,6 @@
 {%- from "_shared/form_copy.html" import org_picker_help -%}
 {%- from "_shared/actions.html" import actions -%}
 
-{% set resource_url = entity_url('clinician') %}
 
 {% block resource_label %}Clinicians{% endblock %}
 

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -1,7 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/_clinician_card.html" import clinician_card -%}
 
-{% set resource_url = entity_url('user') %}
 
 {% block resource_label %}Users{% endblock %}
 {% block current_label %}{{ target_user.username }}{% endblock %}

--- a/src/framework/dispatch/handlers.py
+++ b/src/framework/dispatch/handlers.py
@@ -632,17 +632,25 @@ async def handle_get_edit_form(
     # kind-locked faces is the same value `_assert_kind_lock` just
     # checked; subset-supertype faces use the row's stored kind).
     from src.framework.rendering.labels import edit_label_for
+    from src.framework.rendering.route_urls import url_for_spec
 
     edit_kind: str | None = None
     if spec.discriminator is not None:
         edit_kind = getattr(target, spec.discriminator.column)
 
+    # `resource_url` / `resource_detail_url` are derivable from the
+    # spec + the loaded target — every form-edit template used to set
+    # them via two `{% set %}` lines. Inject from the handler so child
+    # templates skip the boilerplate; same funnel `edit_heading` uses
+    # for the H1.
     context: dict[str, Any] = {
         "request": request,
         spec.name: target,
         "entity_name": spec.name,
         "current_user": requesting_user,
         "edit_heading": edit_label_for(spec, kind=edit_kind),
+        "resource_url": url_for_spec(spec),
+        "resource_detail_url": url_for_spec(spec, id=target.id),
     }
     # Spec-declared constants (enum labels, schema classes the form
     # references, etc.) — same merge precedence as detail/list.
@@ -718,12 +726,18 @@ async def handle_get_new_form(
     # the structural pin (the other half is the Jinja global on the
     # CTAs); pinned by `tests/test_form_chrome_labels.py`.
     from src.framework.rendering.labels import create_label_for
+    from src.framework.rendering.route_urls import url_for_spec
 
+    # `resource_url` is derivable from `spec.name` — every form-new
+    # template used to set it via a `{% set %}` line. Inject from the
+    # handler so child templates skip the boilerplate; same funnel
+    # `create_heading` uses for the H1.
     context: dict[str, Any] = {
         "request": request,
         "entity_name": spec.name,
         "current_user": requesting_user,
         "create_heading": create_label_for(spec, kind=kind),
+        "resource_url": url_for_spec(spec),
     }
     if spec.static_context:
         context.update(spec.static_context)
@@ -806,6 +820,8 @@ async def handle_detail(
         raise NotFoundError(detail=f"{spec.name.capitalize()} not found")
     _assert_kind_lock(spec, target)
 
+    from src.framework.rendering.route_urls import url_for_spec
+
     context: dict[str, Any] = {
         "request": request,
         spec.name: target,
@@ -816,6 +832,10 @@ async def handle_detail(
         # context.
         "entity_name": spec.name,
         "current_user": requesting_user,
+        # Detail templates' breadcrumb back-link to the collection
+        # used to set `resource_url` via a `{% set %}` line; inject
+        # here so child templates skip the boilerplate.
+        "resource_url": url_for_spec(spec),
     }
     if spec.can_write is not None:
         context["can_edit"] = spec.can_write(target, requesting_user)

--- a/src/framework/rendering/route_urls.py
+++ b/src/framework/rendering/route_urls.py
@@ -62,6 +62,22 @@ def _prefix(spec: "EntitySpec") -> str:
     )
 
 
+def url_for_spec(spec: "EntitySpec", *, id: Any = None) -> str:
+    """Spec-direct form of `entity_url` — same path resolution, no
+    registry lookup.
+
+    Used by `handle_detail` / `handle_get_new_form` / `handle_get_edit_form`
+    to inject `resource_url` / `resource_detail_url` into template
+    context. Routing through the spec directly lets handler tests with
+    synthetic (unregistered) specs round-trip without registering them
+    with `entity_registry` first.
+    """
+    prefix = _prefix(spec)
+    if id is None:
+        return prefix
+    return f"{prefix}/{id}"
+
+
 def entity_url(name: str, *, id: Any = None, subresource: str | None = None) -> str:
     """Parent-resource URL for the entity ``name``.
 


### PR DESCRIPTION
## Summary

Every form-edit, form-new, and detail template opened with one or two boilerplate lines:

\`\`\`jinja
{% set resource_url = entity_url('organization') %}
{% set resource_detail_url = entity_url('organization', id=organization.id) %}
\`\`\`

Both are derivable from \`spec.name\` + the loaded target. Inject from \`handle_detail\`, \`handle_get_new_form\`, and \`handle_get_edit_form\` so child templates skip the boilerplate. Same funnel pattern \`edit_heading\` / \`create_heading\` use for the H1.

## How

- **\`rendering/route_urls.py\`** — new \`url_for_spec(spec, id=None)\`. Spec-direct twin of \`entity_url(name, id=...)\` — same path resolution, no registry lookup. The handler uses this so unit tests with synthetic (unregistered) specs round-trip without registering them first.
- **\`handle_detail\`** — sets \`resource_url\` in context.
- **\`handle_get_new_form\`** — sets \`resource_url\`.
- **\`handle_get_edit_form\`** — sets \`resource_url\` and \`resource_detail_url\`.
- **18 templates** lose 23 \`{% set %}\` lines.

## Test plan

- [x] \`dev test\` — 1531 passed, 96 skipped, 0 failed (no test changes needed — handler tests pass because \`url_for_spec\` works on the synthetic specs they use)
- [x] \`dev test contract\` — 36 passed
- [x] \`dev lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)