### PR TITLE
refactor(templates): unify fact-row markup via fact() macro

### DIFF
--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -1,5 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions -%}
+{%- from "_shared/sections.html" import fact -%}
 
 
 {% block resource_label %}Organizations{% endblock %}
@@ -36,15 +37,11 @@
 <article class="entity-card">
   <section class="entity-facts">
     <dl>
-      <div><dt>Type</dt><dd>{{ ORGANIZATION_TYPES_LABELS[organization.type] }}</dd></div>
+      {{ fact('type', 'Type', ORGANIZATION_TYPES_LABELS[organization.type]) }}
       {%- if organization.parent_org_id %}
-      <div><dt>Parent organization</dt><dd>
-        {%- if organization.parent -%}
-        <a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent.name }}</a>
-        {%- else -%}
-        <a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent_org_id }}</a>
-        {%- endif -%}
-      </dd></div>
+      {%- call fact('parent', 'Parent organization') %}
+        <a href="{{ entity_url('organization', id=organization.parent_org_id) }}">{{ organization.parent.name if organization.parent else organization.parent_org_id }}</a>
+      {%- endcall %}
       {%- endif %}
     </dl>
   </section>

--- a/src/domain/templates/organizations/list.html
+++ b/src/domain/templates/organizations/list.html
@@ -1,5 +1,6 @@
 {% extends "views/list.html" %}
 {%- from "_shared/_card.html" import card -%}
+{%- from "_shared/sections.html" import fact -%}
 
 {% block resource_label %}Organizations{% endblock %}
 
@@ -17,9 +18,9 @@
        headline=org.name) -%}
   <section class="entity-facts">
     <dl>
-      <div><dt>Type</dt><dd>{{ ORGANIZATION_TYPES_LABELS[org.type] }}</dd></div>
+      {{ fact('type', 'Type', ORGANIZATION_TYPES_LABELS[org.type]) }}
       {%- if org.parent_org_id %}
-      <div><dt>Parent</dt><dd><a href="{{ entity_url('organization', id=org.parent_org_id) }}">View parent</a></dd></div>
+      {%- call fact('parent', 'Parent') %}<a href="{{ entity_url('organization', id=org.parent_org_id) }}">View parent</a>{% endcall %}
       {%- endif %}
     </dl>
   </section>

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -48,6 +48,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
 `REFERRAL_SERVICE_ICONS`, `TREATMENT_SETTINGS_LABELS`,
 `TREATMENT_SETTINGS_ICONS`) are Jinja globals. #}
 {%- from "_shared/icon_list.html" import icon_list -%}
+{%- from "_shared/sections.html" import fact -%}
 {% macro facts_block(view, expanded=False) -%}
 <section class="entity-facts">
   <dl>
@@ -70,49 +71,41 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
     {%- for s in view.settings -%}
       {%- set _ = _items.append({"icon": TREATMENT_SETTINGS_ICONS[s], "label": TREATMENT_SETTINGS_LABELS[s]}) -%}
     {%- endfor -%}
-    <div class="entity-services"><dt>{{ view.kind_verb }}</dt><dd>{{ icon_list(_items) }}</dd></div>
+    {%- call fact('services', view.kind_verb) %}{{ icon_list(_items) }}{% endcall %}
     {%- endif %}
     {%- if view.location_chunk and not expanded %}
     {#- Compact mode: "City, ST". Both referral and opening kinds
         populate `location_chunk` so the row renders identically on
         both cards. Expanded mode replaces this with the labeled
         "Address" row below (full street address). -#}
-    <div><dt>Location</dt><dd>
-      {%- if view.location_chunk.city -%}{{ view.location_chunk.city }}, {% endif -%}{{ view.location_chunk.state }}
-    </dd></div>
+    {%- call fact('location', 'Location') %}{% if view.location_chunk.city %}{{ view.location_chunk.city }}, {% endif %}{{ view.location_chunk.state }}{% endcall %}
     {%- endif %}
     {%- if view.ages and view.kind != "referral" %}
     {#- `opening` and `intake` describe a cohort the
         practice/program accepts — labeled `Ages` (plural). Referral
         skips this row because its age lives in the headline; the
         `expanded` block below repeats it for the detail page. -#}
-    <div><dt>Ages</dt><dd>
-      {%- set ages = [] -%}
-      {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
-      {{ ages | join(", ") }}
-    </dd></div>
+    {%- set ages = [] -%}
+    {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
+    {{ fact('ages', 'Ages', ages | join(", ")) }}
     {%- endif %}
     {%- if view.genders and (expanded or view.kind != "referral") %}
     {#- Compact mode hides CR gender (it's in the headline). Expanded
         mode shows it for every kind that has one. -#}
-    <div><dt>{% if view.kind == "referral" %}Gender{% else %}Genders{% endif %}</dt><dd>
-      {%- set gs = [] -%}
-      {%- for g in view.genders -%}{%- set _ = gs.append(GENDER_LABELS[g]) -%}{%- endfor -%}
-      {{ gs | join(", ") }}
-    </dd></div>
+    {%- set gs = [] -%}
+    {%- for g in view.genders -%}{%- set _ = gs.append(GENDER_LABELS[g]) -%}{%- endfor -%}
+    {{ fact('genders', 'Gender' if view.kind == 'referral' else 'Genders', gs | join(", ")) }}
     {%- endif %}
     {%- if view.languages and (expanded or not (view.languages | length == 1 and view.languages[0] == "en")) %}
-    <div><dt>Languages</dt><dd>
-      {%- set langs = [] -%}
-      {%- for l in view.languages -%}{%- set _ = langs.append(LANGUAGE_LABELS[l]) -%}{%- endfor -%}
-      {{ langs | join(", ") }}
-    </dd></div>
+    {%- set langs = [] -%}
+    {%- for l in view.languages -%}{%- set _ = langs.append(LANGUAGE_LABELS[l]) -%}{%- endfor -%}
+    {{ fact('languages', 'Languages', langs | join(", ")) }}
     {%- endif %}
     {%- if view.insurance_posture %}
-    <div><dt>Insurance</dt><dd>{{ INSURANCE_POSTURE_LABELS[view.insurance_posture] }}</dd></div>
+    {{ fact('insurance', 'Insurance', INSURANCE_POSTURE_LABELS[view.insurance_posture]) }}
     {%- endif %}
     {%- if view.treatment_modality %}
-    <div><dt>Modality</dt><dd>{{ view.treatment_modality }}</dd></div>
+    {{ fact('modality', 'Modality', view.treatment_modality) }}
     {%- endif %}
 
     {#- Detail-only rows below. The expanded set surfaces fields the
@@ -125,51 +118,47 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
           this. The detail page is detail-y enough to repeat it as a
           labeled row (singular `Age` — a referral describes one
           seeker). -#}
-      <div><dt>Age</dt><dd>
-        {%- set ages = [] -%}
-        {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
-        {{ ages | join(", ") }}
-      </dd></div>
+      {%- set ages = [] -%}
+      {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
+      {{ fact('age', 'Age', ages | join(", ")) }}
       {%- endif %}
       {%- if view.practice_link %}
-      <div><dt>Practice</dt><dd><a href="{{ entity_url('clinician', id=view.practice_link.id) }}">{{ view.practice_link.name }}</a></dd></div>
+      {%- call fact('practice', 'Practice') %}<a href="{{ entity_url('clinician', id=view.practice_link.id) }}">{{ view.practice_link.name }}</a>{% endcall %}
       {%- endif %}
       {%- if view.program_link %}
-      <div><dt>Program</dt><dd><a href="{{ entity_url('program', id=view.program_link.id) }}">{{ view.program_link.name }}</a></dd></div>
+      {%- call fact('program', 'Program') %}<a href="{{ entity_url('program', id=view.program_link.id) }}">{{ view.program_link.name }}</a>{% endcall %}
       {%- endif %}
       {%- if view.organization_link %}
-      <div><dt>Organization</dt><dd><a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a></dd></div>
+      {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a>{% endcall %}
       {%- endif %}
       {%- if view.full_address %}
-      <div><dt>Address</dt><dd>{{ view.full_address }}</dd></div>
+      {{ fact('address', 'Address', view.full_address) }}
       {%- endif %}
       {%- if view.in_person is not none %}
-      <div><dt>In-person sessions</dt><dd>{{ LOCATION_AVAILABILITY_LABELS[view.in_person] }}</dd></div>
+      {{ fact('in_person_sessions', 'In-person sessions', LOCATION_AVAILABILITY_LABELS[view.in_person]) }}
       {%- endif %}
       {%- if view.virtual is not none %}
-      <div><dt>Virtual sessions</dt><dd>{{ LOCATION_AVAILABILITY_LABELS[view.virtual] }}</dd></div>
+      {{ fact('virtual_sessions', 'Virtual sessions', LOCATION_AVAILABILITY_LABELS[view.virtual]) }}
       {%- endif %}
       {%- if view.desired_times %}
-      <div><dt>Desired times</dt><dd>
-        {%- set times = [] -%}
-        {%- for slot in view.desired_times -%}{%- set _ = times.append(DESIRED_TIME_SLOT_LABELS[slot]) -%}{%- endfor -%}
-        {{ times | join(", ") }}
-      </dd></div>
+      {%- set times = [] -%}
+      {%- for slot in view.desired_times -%}{%- set _ = times.append(DESIRED_TIME_SLOT_LABELS[slot]) -%}{%- endfor -%}
+      {{ fact('desired_times', 'Desired times', times | join(", ")) }}
       {%- endif %}
       {%- if view.schedule_text %}
-      <div><dt>Schedule notes</dt><dd>{{ view.schedule_text }}</dd></div>
+      {{ fact('schedule_notes', 'Schedule notes', view.schedule_text) }}
       {%- endif %}
       {%- if view.network_preference %}
-      <div><dt>Network preference</dt><dd>{{ NETWORK_PREFERENCE_LABELS[view.network_preference] }}</dd></div>
+      {{ fact('network_preference', 'Network preference', NETWORK_PREFERENCE_LABELS[view.network_preference]) }}
       {%- endif %}
       {%- if view.insurance_carrier and view.network_preference and view.network_preference != "no_preference" %}
-      <div><dt>Insurance carrier</dt><dd>{{ INSURANCE_CARRIER_LABELS[view.insurance_carrier] }}</dd></div>
+      {{ fact('insurance_carrier', 'Insurance carrier', INSURANCE_CARRIER_LABELS[view.insurance_carrier]) }}
       {%- endif %}
       {%- if view.sliding_scale %}
-      <div><dt>Sliding scale</dt><dd>Yes</dd></div>
+      {{ fact('sliding_scale', 'Sliding scale', 'Yes') }}
       {%- endif %}
       {%- if view.cost %}
-      <div><dt>Cost</dt><dd>{{ view.cost }}</dd></div>
+      {{ fact('cost', 'Cost', view.cost) }}
       {%- endif %}
     {%- endif %}
   </dl>

--- a/src/domain/templates/programs/detail.html
+++ b/src/domain/templates/programs/detail.html
@@ -1,5 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions -%}
+{%- from "_shared/sections.html" import fact -%}
 
 
 {% block resource_label %}Programs{% endblock %}
@@ -31,17 +32,17 @@
 
   <section class="entity-facts">
     <dl>
-      <div><dt>Organization</dt><dd><a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a></dd></div>
+      {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a>{% endcall %}
       {%- if program.state_preference %}
-      <div><dt>State served</dt><dd>{{ program.state_preference }}</dd></div>
+      {{ fact('state_served', 'State served', program.state_preference) }}
       {%- endif %}
       {%- if program.start_date %}
-      <div><dt>Start date</dt><dd>{{ program.start_date }}</dd></div>
+      {{ fact('start_date', 'Start date', program.start_date) }}
       {%- endif %}
       {%- if program.end_date %}
-      <div><dt>End date</dt><dd>{{ program.end_date }}</dd></div>
+      {{ fact('end_date', 'End date', program.end_date) }}
       {%- endif %}
-      <div><dt>Accepting referrals</dt><dd>{{ "Yes" if program.accepting_referrals else "No" }}</dd></div>
+      {{ fact('accepting_referrals', 'Accepting referrals', "Yes" if program.accepting_referrals else "No") }}
     </dl>
   </section>
 </article>

--- a/src/domain/templates/programs/list.html
+++ b/src/domain/templates/programs/list.html
@@ -1,5 +1,6 @@
 {% extends "views/list.html" %}
 {%- from "_shared/_card.html" import card -%}
+{%- from "_shared/sections.html" import fact -%}
 
 {% block resource_label %}Programs{% endblock %}
 
@@ -22,7 +23,7 @@
        subtitle=subtitle) -%}
   <section class="entity-facts">
     <dl>
-      <div><dt>Organization</dt><dd><a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a></dd></div>
+      {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a>{% endcall %}
     </dl>
   </section>
   {%- endcall %}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -1,5 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions -%}
+{%- from "_shared/sections.html" import fact -%}
 {%- from "providers/_credential_row.html" import credential_row -%}
 
 {# The framework binds `context[spec.name] = target`; after #642 PR 4 the
@@ -104,14 +105,14 @@
   <section class="entity-facts">
     <dl>
       {%- if aff.full_address %}
-      <div><dt>Address</dt><dd>{{ aff.full_address }}</dd></div>
+      {{ fact('address', 'Address', aff.full_address) }}
       {%- endif %}
-      <div><dt>In-person sessions</dt><dd>{{ aff.in_person_label }}</dd></div>
-      <div><dt>Virtual sessions</dt><dd>{{ aff.virtual_label }}</dd></div>
-      <div><dt>Insurance</dt><dd>{{ aff.insurance_summary }}</dd></div>
-      <div><dt>Sliding scale</dt><dd>{{ aff.sliding_scale_label }}</dd></div>
+      {{ fact('in_person_sessions', 'In-person sessions', aff.in_person_label) }}
+      {{ fact('virtual_sessions', 'Virtual sessions', aff.virtual_label) }}
+      {{ fact('insurance', 'Insurance', aff.insurance_summary) }}
+      {{ fact('sliding_scale', 'Sliding scale', aff.sliding_scale_label) }}
       {%- if aff.cost %}
-      <div><dt>Cost</dt><dd>{{ aff.cost }}</dd></div>
+      {{ fact('cost', 'Cost', aff.cost) }}
       {%- endif %}
     </dl>
   </section>

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -1,5 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/_clinician_card.html" import clinician_card -%}
+{%- from "_shared/sections.html" import fact -%}
 
 
 {% block resource_label %}Users{% endblock %}
@@ -45,10 +46,10 @@
   {% if can_view_private %}
   <section class="entity-facts">
     <dl>
-      <div><dt>Email</dt><dd>{{ target_user.email }}</dd></div>
+      {{ fact('email', 'Email', target_user.email) }}
       {% if not is_self %}
-      <div><dt>Active</dt><dd>{{ "Yes" if target_user.is_active else "No" }}</dd></div>
-      <div><dt>Verified</dt><dd>{{ "Yes" if target_user.is_verified else "No" }}</dd></div>
+      {{ fact('active', 'Active', "Yes" if target_user.is_active else "No") }}
+      {{ fact('verified', 'Verified', "Yes" if target_user.is_verified else "No") }}
       {% endif %}
     </dl>
   </section>

--- a/src/framework/templates/_shared/_clinician_card.html
+++ b/src/framework/templates/_shared/_clinician_card.html
@@ -37,6 +37,7 @@
        `src.domain.logic.providers.view._insurance_summary`).
 #}
 {%- from "_shared/_card.html" import card -%}
+{%- from "_shared/sections.html" import fact -%}
 
 {% macro clinician_card(provider) -%}
 {%- set view = provider_card_view(provider) -%}
@@ -71,38 +72,34 @@
      id=provider.id,
      headline_url=entity_url('clinician', id=provider.id),
      headline=name | trim) -%}
-{# `data-fact` on each row's wrapping `<div>` is the stable test
-   selector — display labels in `<dt>` are presentation strings and may
-   change, but the data-fact keys form the contract tests rely on. #}
+{# Each row goes through the shared `fact(key, label, ...)` macro
+   from `_shared/sections.html` so the `data-fact` attribute and the
+   `<div>/<dt>/<dd>` shape stay in lockstep with every other card and
+   detail page. `dd_class="meta"` activates the `.meta` CSS rule
+   (adjacent chip siblings render with " · " separators) on the
+   Practice and Location rows. #}
 <section class="entity-facts">
   <dl>
-    <div data-fact="practice">
-      <dt>Practice</dt>
-      <dd class="meta">
-        {%- if affiliations -%}
-          {%- for aff in affiliations -%}
-            <a href="{{ entity_url('organization', id=aff.org_id) }}">{{ aff.org.name }}</a>
-          {%- endfor -%}
-        {%- else -%}
-          &mdash;
-        {%- endif -%}
-      </dd>
-    </div>
-    <div data-fact="location">
-      <dt>Location</dt>
-      <dd class="meta">
-        {%- if locations -%}
-          {%- for loc in locations -%}<span>{{ loc }}</span>{%- endfor -%}
-        {%- else -%}
-          &mdash;
-        {%- endif -%}
-      </dd>
-    </div>
-    <div data-fact="licensed_in">
-      <dt>Licensed in</dt>
-      <dd>{% if issuing_states %}{{ issuing_states | join(', ') }}{% else %}&mdash;{% endif %}</dd>
-    </div>
-    <div data-fact="insurance"><dt>Insurance</dt><dd>{{ view.insurance_summary }}</dd></div>
+    {%- call fact('practice', 'Practice', dd_class='meta') -%}
+      {%- if affiliations -%}
+        {%- for aff in affiliations -%}
+          <a href="{{ entity_url('organization', id=aff.org_id) }}">{{ aff.org.name }}</a>
+        {%- endfor -%}
+      {%- else -%}
+        &mdash;
+      {%- endif -%}
+    {%- endcall %}
+    {%- call fact('location', 'Location', dd_class='meta') -%}
+      {%- if locations -%}
+        {%- for loc in locations -%}<span>{{ loc }}</span>{%- endfor -%}
+      {%- else -%}
+        &mdash;
+      {%- endif -%}
+    {%- endcall %}
+    {%- call fact('licensed_in', 'Licensed in') -%}
+      {% if issuing_states %}{{ issuing_states | join(', ') }}{% else %}&mdash;{% endif %}
+    {%- endcall %}
+    {{ fact('insurance', 'Insurance', view.insurance_summary) }}
   </dl>
 </section>
 {%- endcall %}

--- a/src/framework/templates/_shared/sections.html
+++ b/src/framework/templates/_shared/sections.html
@@ -1,5 +1,32 @@
 {# Section-shape macros shared across CRUD detail/edit pages. #}
 
+{# Render one fact-row inside an `<section class="entity-facts">
+   <dl>` block. Each row is wrapped in a `<div>` (so the parent
+   grid treats the `<dt>`/`<dd>` pair as one logical row — see the
+   `dl > div { display: contents; }` rule in `base.html`).
+
+   `data-fact="<key>"` lives on the wrapping `<div>` and is the
+   stable test selector — `<dt>` text is presentation prose and
+   may shift; the key is the contract.
+
+   Two call styles:
+
+     - Simple value:
+         {{ fact('type', 'Type', org.type_label) }}
+
+     - Rich value (link, multi-element, etc.):
+         {% call fact('parent', 'Parent') -%}
+           <a href="…">View parent</a>
+         {%- endcall %}
+
+   When invoked via `{% call %}`, the caller body fills the `<dd>`
+   and the `value` argument is ignored. Without `{% call %}`, the
+   `value` argument fills the `<dd>` (escaped by Jinja by default).
+#}
+{% macro fact(key, label, value="", dd_class=None) -%}
+<div data-fact="{{ key }}"><dt>{{ label }}</dt><dd{% if dd_class %} class="{{ dd_class }}"{% endif %}>{{ caller() if caller else value }}</dd></div>
+{%- endmacro %}
+
 {# Render a `<ul>` of items or an empty-state `<p>`. The caller passes
 the per-item `<li>` body via `{% call(item) %}…{% endcall %}`. The macro
 owns the if/else split — callers own the row markup and the surrounding


### PR DESCRIPTION
## Summary

Every \`<dl>\` fact row across cards and detail pages used the same shape:

\`\`\`html
<div data-fact=\"key\"><dt>Label</dt><dd>Value</dd></div>
\`\`\`

…but \`data-fact\` was inconsistently applied (clinician card had it, detail pages didn't), and the \`<div>\` wrapping was repeated everywhere.

New \`fact(key, label, value=\"\", dd_class=None)\` macro in \`_shared/sections.html\` standardizes the shape. Two call styles:

- **Simple value** — \`{{ fact('type', 'Type', org.type_label) }}\`
- **Rich value** — \`{% call fact('parent', 'Parent') %}<a>View parent</a>{% endcall %}\`

\`dd_class=\"meta\"\` activates the CSS rule that joins adjacent chip siblings with \` · \` separators (used by the clinician card's Practice + Location rows).

## Sweep

- \`_shared/_clinician_card.html\` — 4 fact rows
- \`posts/_shared/_facts_block.html\` — 17 fact rows; the one-off \`entity-services\` class is dropped (no remaining consumer)
- \`organizations/{list,detail}.html\` — 2-3 rows each
- \`programs/{list,detail}.html\` — 1-5 rows each
- \`providers/detail.html\` — 6 rows in affiliation cards
- \`users/detail.html\` — 3 rows in the private-fields block

Every fact row now carries \`data-fact=\"<key>\"\`. Tests resolve cells via \`[data-fact=\"…\"]\` rather than the display-string \`<dt>\` text — pinned via the macro itself, so the next person who adds a fact gets the attribute automatically.

## Test plan

- [x] \`dev test\` — 1531 passed, 96 skipped, 0 failed
- [x] \`dev test contract\` — 36 passed
- [x] \`dev lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)