### PR TITLE
refactor(forms): centralize three more help strings in form_copy.html

### DIFF
--- a/src/domain/templates/posts/openings/_form_clinician_opening.html
+++ b/src/domain/templates/posts/openings/_form_clinician_opening.html
@@ -19,7 +19,7 @@ when `current_user.providers` is empty, so this macro always renders
 with at least one provider available.
 #}
 {%- from "_shared/form_fields.html" import entity_select_field, text_field, textarea_field, select_field, time_grid_field, multi_select_field, field_for -%}
-{%- from "_shared/form_copy.html" import modality_help, select_all_help -%}
+{%- from "_shared/form_copy.html" import modality_help, schedule_notes_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro opening_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
 {%- set d = post.opening_detail if post else None -%}
@@ -64,7 +64,7 @@ with at least one provider available.
   <fieldset>
     <legend>Availability</legend>
     {{ time_grid_field("desired_times", "Desired times", current=d.desired_times if d else None) }}
-    {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help="For example: start date, cohort dates, fixed program hours.") }}
+    {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help()) }}
   </fieldset>
 
   <fieldset>

--- a/src/domain/templates/posts/openings/_form_program_intake.html
+++ b/src/domain/templates/posts/openings/_form_program_intake.html
@@ -19,7 +19,7 @@ when `current_user.programs` is empty, so this macro always renders
 with at least one Program available.
 #}
 {%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, time_grid_field, multi_select_field, field_for -%}
-{%- from "_shared/form_copy.html" import modality_help, select_all_help -%}
+{%- from "_shared/form_copy.html" import modality_help, schedule_notes_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro intake_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
 {%- set d = post.intake_detail if post else None -%}
@@ -49,7 +49,7 @@ with at least one Program available.
   <fieldset>
     <legend>Availability</legend>
     {{ time_grid_field("desired_times", "Desired times", current=d.desired_times if d else None) }}
-    {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help="For example: start date, cohort dates, fixed program hours.") }}
+    {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help()) }}
   </fieldset>
 
   <fieldset>

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -1,6 +1,6 @@
 {% extends "views/form_edit.html" %}
 {%- from "_shared/form_fields.html" import entity_select_field, text_field, select_field, radio_bool_field, multi_select_field -%}
-{%- from "_shared/form_copy.html" import org_picker_help -%}
+{%- from "_shared/form_copy.html" import cost_help, npi_help, org_picker_help -%}
 {%- from "_shared/forms.html" import inline_add_form -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- from "providers/_credential_row.html" import credential_row -%}
@@ -35,7 +35,7 @@
         {{ text_field("first_name", "First name", current=provider.first_name, required=false, maxlength=120) }}
         {{ text_field("last_name", "Last name", current=provider.last_name, required=false, maxlength=120) }}
       </div>
-      {{ text_field("npi", "NPI", current=provider.npi, required=false, pattern="\\d{10}", maxlength=10, help="10-digit National Provider Identifier.") }}
+      {{ text_field("npi", "NPI", current=provider.npi, required=false, pattern="\\d{10}", maxlength=10, help=npi_help()) }}
     </fieldset>
     <fieldset>
       <legend>Practice location</legend>
@@ -61,7 +61,7 @@
         {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", current=provider.accepts_out_of_network, required=false) }}
         {{ radio_bool_field("sliding_scale", "Sliding scale?", current=provider.sliding_scale, required=false) }}
       </div>
-      {{ text_field("cost", "Cost", current=provider.cost, required=false, help="Free text — for example, &quot;$200/session&quot; or &quot;sliding 80–200&quot;.") }}
+      {{ text_field("cost", "Cost", current=provider.cost, required=false, help=cost_help()) }}
     </fieldset>
     {# Practice-details form keeps its own action cluster; credentials
        are managed via the inline add/remove forms below. Delete for

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -1,6 +1,6 @@
 {% extends "views/form_new.html" %}
 {%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field -%}
-{%- from "_shared/form_copy.html" import org_picker_help -%}
+{%- from "_shared/form_copy.html" import cost_help, npi_help, org_picker_help -%}
 {%- from "_shared/actions.html" import actions -%}
 
 
@@ -28,7 +28,7 @@
       {{ field_for(schema, "first_name", "First name") }}
       {{ field_for(schema, "last_name", "Last name") }}
     </div>
-    {{ field_for(schema, "npi", "NPI", required=false, help="10-digit National Provider Identifier.") }}
+    {{ field_for(schema, "npi", "NPI", required=false, help=npi_help()) }}
   </fieldset>
 
   <fieldset>
@@ -59,7 +59,7 @@
       {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", required=false) }}
       {{ radio_bool_field("sliding_scale", "Sliding scale?", required=false) }}
     </div>
-    {{ text_field("cost", "Cost", required=false, help="Free text — for example, &quot;$200/session&quot; or &quot;sliding 80–200&quot;.") }}
+    {{ text_field("cost", "Cost", required=false, help=cost_help()) }}
   </fieldset>
 
   {{ actions(entity_create_label('clinician'), cancel_url=entity_url('clinician')) }}

--- a/src/framework/templates/_shared/form_copy.html
+++ b/src/framework/templates/_shared/form_copy.html
@@ -44,3 +44,26 @@ For example: DBT, EMDR, IFS.
 {%- macro select_all_help() -%}
 Select all that apply.
 {%- endmacro %}
+
+{# NPI help — the clinician create/edit forms both render this on the
+   `npi` field. The field validation (10 ASCII digits) lives in the
+   schema; the help text just describes what NPI stands for. #}
+{%- macro npi_help() -%}
+10-digit National Provider Identifier.
+{%- endmacro %}
+
+{# Cost-field help — clinician create/edit forms both expose `cost`
+   as a free-text field (no controlled vocabulary; practices price
+   sessions in idiosyncratic ways). The hint shows the two most
+   common shapes. Quotes pre-escaped because the macro output is
+   passed through `|safe` in `_help_small`. #}
+{%- macro cost_help() -%}
+Free text — for example, &quot;$200/session&quot; or &quot;sliding 80–200&quot;.
+{%- endmacro %}
+
+{# Schedule-notes help — clinician openings and program intakes both
+   carry a free-text `schedule_text` field for cohort dates / fixed
+   program hours. Same examples on both forms. #}
+{%- macro schedule_notes_help() -%}
+For example: start date, cohort dates, fixed program hours.
+{%- endmacro %}


### PR DESCRIPTION
## Summary

Audit of \`help=\` strings across form templates found three duplications worth centralizing:

- **NPI** — clinician create + edit forms.
- **Cost** — clinician create + edit forms.
- **Schedule notes** — clinician_opening + program_intake form bodies.

Each becomes a \`*_help()\` macro in \`_shared/form_copy.html\`, joining the existing \`org_picker_help()\`, \`modality_help()\`, and \`select_all_help()\` macros.

Parent-org help (\`organizations/form_new\` vs \`form_edit\`) was the fourth candidate but the two strings diverge by a leading sentence on the create form — intentionally context-specific, left as-is.

## Test plan

- [x] \`dev test\` — 1531 passed
- [x] \`dev test contract\` — 36 passed
- [x] \`dev lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)