### PR TITLE
refactor(providers): extract credential_list wrapper macro

### DIFF
--- a/src/domain/templates/providers/_credential_list.html
+++ b/src/domain/templates/providers/_credential_list.html
@@ -1,0 +1,37 @@
+{# `credential_list(items, empty_message)` — the wrapper macro for
+   clinician credential sections (licensures, educations,
+   certifications, and affiliations on the edit page).
+
+   Every credential section follows the same shape: an `<div
+   class="credential-list">` of rows when items exist, a plain `<p>`
+   empty state otherwise. The macro owns the if/else branch and the
+   wrapping div; the caller's body renders one row per item via
+   `{% call(item) credential_list(...) %}`.
+
+   Shaped like the framework's `_shared/sections.html::list_or_empty`
+   but emits `<div class="credential-list">` instead of `<ul>`,
+   matching the visual treatment that distinguishes credentials from
+   ordinary lists. Lives in `providers/` (not `_shared/`) because no
+   non-provider page renders this shape.
+
+   Usage:
+     {% call(lic) credential_list(provider.licensures, "No licensures yet.") %}
+       {{ credential_row(
+           LICENSE_TYPES_LABELS[lic.license_type],
+           ["#" ~ lic.license_number, lic.issuing_state, …],
+           delete_url=…,
+           delete_confirm=…,
+       ) }}
+     {% endcall %}
+#}
+{% macro credential_list(items, empty_message) -%}
+{% if items %}
+<div class="credential-list">
+  {%- for item in items %}
+  {{ caller(item) }}
+  {%- endfor %}
+</div>
+{% else %}
+<p>{{ empty_message }}</p>
+{% endif %}
+{%- endmacro %}

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -1,6 +1,7 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions -%}
 {%- from "_shared/sections.html" import fact -%}
+{%- from "providers/_credential_list.html" import credential_list -%}
 {%- from "providers/_credential_row.html" import credential_row -%}
 
 {# The framework binds `context[spec.name] = target`; after #642 PR 4 the
@@ -127,50 +128,32 @@
 <article class="entity-card">
   <section>
     <h4>Licensures</h4>
-    {% if view.licensures %}
-    <div class="credential-list">
-      {%- for lic in view.licensures %}
+    {% call(lic) credential_list(view.licensures, "No licensures listed.") %}
       {{ credential_row(
           LICENSE_TYPES_LABELS[lic.license_type],
           ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None],
       ) }}
-      {%- endfor %}
-    </div>
-    {% else %}
-    <p><small>No licensures listed.</small></p>
-    {% endif %}
+    {% endcall %}
   </section>
 
   <section>
     <h4>Education</h4>
-    {% if view.educations %}
-    <div class="credential-list">
-      {%- for edu in view.educations %}
+    {% call(edu) credential_list(view.educations, "No education entries listed.") %}
       {{ credential_row(
           EDUCATION_TYPES_LABELS[edu.education_type],
           [edu.institution, edu.month_completed],
       ) }}
-      {%- endfor %}
-    </div>
-    {% else %}
-    <p><small>No education entries listed.</small></p>
-    {% endif %}
+    {% endcall %}
   </section>
 
   <section>
     <h4>Certifications</h4>
-    {% if view.certifications %}
-    <div class="credential-list">
-      {%- for cert in view.certifications %}
+    {% call(cert) credential_list(view.certifications, "No certifications listed.") %}
       {{ credential_row(
           CERTIFICATION_TYPES_LABELS[cert.certification_type],
           [cert.certifying_body, ("Expires " ~ cert.expiration_date) if cert.expiration_date else None],
       ) }}
-      {%- endfor %}
-    </div>
-    {% else %}
-    <p><small>No certifications listed.</small></p>
-    {% endif %}
+    {% endcall %}
   </section>
 </article>
 {% endblock %}

--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -3,6 +3,7 @@
 {%- from "_shared/form_copy.html" import cost_help, npi_help, org_picker_help -%}
 {%- from "_shared/forms.html" import inline_add_form -%}
 {%- from "_shared/actions.html" import actions -%}
+{%- from "providers/_credential_list.html" import credential_list -%}
 {%- from "providers/_credential_row.html" import credential_row -%}
 
 {# The framework binds `context[spec.name] = target`; after #642 PR 4 the
@@ -82,9 +83,7 @@
      with stacked affiliations; PR 2 (#642) rewrites the detail page
      to render the same stacked sections. #}
   <h2>Affiliations</h2>
-  {% if provider.affiliations %}
-  <div class="credential-list">
-    {%- for aff in provider.affiliations %}
+  {% call(aff) credential_list(provider.affiliations, "No affiliations yet.") %}
     {%- set meta_parts = [
         aff.location_city,
         aff.location_state,
@@ -102,11 +101,7 @@
         delete_url=entity_url('clinician', id=provider.id) ~ "/affiliations/" ~ aff.id|string,
         delete_confirm="Remove this affiliation?",
     ) }}
-    {%- endfor %}
-  </div>
-  {% else %}
-  <p>No affiliations yet.</p>
-  {% endif %}
+  {% endcall %}
 
   {% call inline_add_form(entity_url('clinician', id=provider.id) ~ "/affiliations", "Add affiliation", "Add affiliation") %}
     <label for="aff_org_id">
@@ -138,20 +133,14 @@
 
 <section>
   <h2>Licensures</h2>
-  {% if provider.licensures %}
-  <div class="credential-list">
-    {%- for lic in provider.licensures %}
+  {% call(lic) credential_list(provider.licensures, "No licensures yet.") %}
     {{ credential_row(
         LICENSE_TYPES_LABELS[lic.license_type],
         ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None],
         delete_url=entity_url('clinician', id=provider.id) ~ "/licensures/" ~ lic.id|string,
         delete_confirm="Remove this licensure?",
     ) }}
-    {%- endfor %}
-  </div>
-  {% else %}
-  <p>No licensures yet.</p>
-  {% endif %}
+  {% endcall %}
 
   {% call inline_add_form(entity_url('clinician', id=provider.id) ~ "/licensures", "Add licensure", "Add licensure") %}
     {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
@@ -163,20 +152,14 @@
 
 <section>
   <h2>Education</h2>
-  {% if provider.educations %}
-  <div class="credential-list">
-    {%- for edu in provider.educations %}
+  {% call(edu) credential_list(provider.educations, "No education entries yet.") %}
     {{ credential_row(
         EDUCATION_TYPES_LABELS[edu.education_type],
         [edu.institution, edu.month_completed],
         delete_url=entity_url('clinician', id=provider.id) ~ "/educations/" ~ edu.id|string,
         delete_confirm="Remove this education entry?",
     ) }}
-    {%- endfor %}
-  </div>
-  {% else %}
-  <p>No education entries yet.</p>
-  {% endif %}
+  {% endcall %}
 
   {% call inline_add_form(entity_url('clinician', id=provider.id) ~ "/educations", "Add education", "Add education") %}
     {{ select_field("education_type", "Education type", EDUCATION_TYPES, labels=EDUCATION_TYPES_LABELS, placeholder=true) }}
@@ -187,20 +170,14 @@
 
 <section>
   <h2>Certifications</h2>
-  {% if provider.certifications %}
-  <div class="credential-list">
-    {%- for cert in provider.certifications %}
+  {% call(cert) credential_list(provider.certifications, "No certifications yet.") %}
     {{ credential_row(
         CERTIFICATION_TYPES_LABELS[cert.certification_type],
         [cert.certifying_body, ("Expires " ~ cert.expiration_date) if cert.expiration_date else None],
         delete_url=entity_url('clinician', id=provider.id) ~ "/certifications/" ~ cert.id|string,
         delete_confirm="Remove this certification?",
     ) }}
-    {%- endfor %}
-  </div>
-  {% else %}
-  <p>No certifications yet.</p>
-  {% endif %}
+  {% endcall %}
 
   {% call inline_add_form(entity_url('clinician', id=provider.id) ~ "/certifications", "Add certification", "Add certification") %}
     {{ select_field("certification_type", "Certification type", CERTIFICATION_TYPES, labels=CERTIFICATION_TYPES_LABELS, placeholder=true) }}


### PR DESCRIPTION
## Summary

Each credential section on the clinician detail/edit pages followed the same shape:

\`\`\`jinja
{% if items %}
<div class=\"credential-list\">
  {%- for item in items %}
  {{ credential_row(...) }}
  {%- endfor %}
</div>
{% else %}
<p>No X yet.</p>
{% endif %}
\`\`\`

…repeated 7 times across detail.html (3 sections: licensures / educations / certifications) and form_edit.html (4 sections: affiliations + the above three).

New \`credential_list(items, empty_message)\` macro in \`providers/_credential_list.html\` owns the if/else branch and the wrapping div. Same shape as \`_shared/sections.html::list_or_empty\` but emits \`<div class=\"credential-list\">\` instead of \`<ul>\` so the visual treatment that distinguishes credentials from ordinary lists is preserved. Lives in \`providers/\` (not \`_shared/\`) because no non-provider page renders this shape.

## Test plan

- [x] \`dev test\` — 1531 passed
- [x] \`dev test contract\` — 36 passed
- [x] \`dev lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)