### PR TITLE
fix(auth): rewrite register subtitle in plain language (#694)

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -162,6 +162,11 @@ async def test_get_register_page(test_client: AsyncClient):
     # so it doesn't stretch to the `<main class="container">` width on
     # tablet/desktop (#584). The `.auth-page` rule lives in `base.html`.
     assert '<article class="auth-page">' in response.text
+    # Subtitle must use plain language a first-time visitor can parse —
+    # no bare model-jargon list ("openings, referrals, and intakes")
+    # before any value framing (#694).
+    assert "openings, referrals, and intakes" not in response.text
+    assert "clinician profile" in response.text
 
 
 async def test_get_login_page(test_client: AsyncClient):

--- a/src/domain/templates/auth/register.html
+++ b/src/domain/templates/auth/register.html
@@ -3,7 +3,7 @@
 <article class="auth-page">
   <header>
     <h1>Create an account</h1>
-    <p>Set up your account to post openings, referrals, and intakes.</p>
+    <p>Create your clinician profile and start sharing available openings with referrers in your network.</p>
   </header>
   <form hx-post="/auth/register" hx-ext="json-enc">
     <label for="email">


### PR DESCRIPTION
## Summary
- Closes #694.
- `/auth/register` subtitle no longer drops three model words ("openings, referrals, and intakes") on a first-time visitor before any value framing.
- New copy: *"Create your clinician profile and start sharing available openings with referrers in your network."* — chosen from the issue's suggested options because it leads with the user's own action ("create your profile") before naming a deliverable ("openings"), and uses one model noun in context rather than three out of it.
- Pinned in `test_get_register_page` with both a positive assertion (`"clinician profile" in response.text`) and a negative assertion that the old jargon list never reappears.

## Test plan
- [x] `pytest src/domain/routes/test_auth_routes.py` — 19 passed, 1 skipped.
- [x] Pre-commit hooks (black/isort/autoflake/title-case/template-imports) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)