### PR TITLE
feat(forms): default session-availability "yes" on add-affiliation form

### DIFF
--- a/src/domain/templates/providers/form_edit.html
+++ b/src/domain/templates/providers/form_edit.html
@@ -118,9 +118,13 @@
       {{ select_field("location_state", "State", US_STATES, placeholder=true) }}
       {{ text_field("location_zip", "ZIP", pattern="\\d{5}", maxlength=5) }}
     </div>
+    {# Inline "add affiliation" form pre-selects "yes" for both
+       arms — same rationale as the clinician create form's session-
+       availability fieldset (most common posture; users for whom
+       this is wrong can flip it). #}
     <div class="grid">
-      {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, placeholder=true) }}
-      {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, placeholder=true) }}
+      {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current="yes") }}
+      {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current="yes") }}
     </div>
     {{ multi_select_field("in_network_carriers", "In-network carriers", INSURANCE_CARRIERS, labels=INSURANCE_CARRIER_LABELS) }}
     <div class="grid">


### PR DESCRIPTION
Closes #720. Mirrors #701's create-form fix on the inline add-affiliation arm in the clinician edit page (which was out of #701's stated scope, so split off as #720). The main practice block's persisted-row path on edit is unchanged. 1 file, 6 lines.