### PR TITLE
fix(auth): rewrite login page subtitle for first-timers

### DIFF
--- a/src/domain/routes/auth_pages.py
+++ b/src/domain/routes/auth_pages.py
@@ -32,8 +32,12 @@ async def get_login_page(request: Request):
     """
     # Extract the 'next' parameter from query string for redirect after login
     next_url = request.query_params.get("next", "")
+    # Show a contextual message when arriving from the registration flow
+    just_registered = request.query_params.get("registered") == "1"
     return APIResponse.html_response(
-        template_name="auth/login.html", context={"next_url": next_url}, request=request
+        template_name="auth/login.html",
+        context={"next_url": next_url, "just_registered": just_registered},
+        request=request,
     )
 
 

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -172,8 +172,22 @@ async def test_get_login_page(test_client: AsyncClient):
     # noun "Login"). See `test_get_register_page` for the H1 pin
     # rationale.
     assert "Log in" in response.text
+    # Default subtitle must not assume a returning user (#693).
+    assert "Welcome back" not in response.text
+    assert "referrals" not in response.text
+    assert "Sign in to your Bedlam Connect account" in response.text
     # See `test_get_register_page` for `.auth-page` rationale (#584).
     assert '<article class="auth-page">' in response.text
+
+
+async def test_get_login_page_just_registered(test_client: AsyncClient):
+    """GET /auth/login?registered=1 shows the post-registration banner (#693)."""
+    response = await test_client.get("/auth/login?registered=1")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Account created" in response.text
+    # Default subtitle is replaced by the contextual message.
+    assert "Sign in to your Bedlam Connect account" not in response.text
 
 
 async def test_get_forgot_password_page(test_client: AsyncClient):

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -3,7 +3,7 @@
 <article class="auth-page">
   <header>
     <h1>Log in</h1>
-    <p>Welcome back. Log in to post or browse referrals.</p>
+    {% if just_registered %}<p>Account created — log in to continue.</p>{% else %}<p>Sign in to your Bedlam Connect account.</p>{% endif %} <!-- title-case-ignore: "Bedlam Connect" is a brand name -->
   </header>
   <!-- FastAPI Users JWT login endpoint expects 'username' (which is email) and 'password' as form data. -->
   <form


### PR DESCRIPTION
Closes #693

## Summary
- Replaced "Welcome back. Log in to post or browse referrals." with a neutral default: "Sign in to your Bedlam Connect account."
- Added a contextual post-registration banner ("Account created — log in to continue.") shown when `?registered=1` is in the URL
- Route now passes `just_registered` flag derived from `request.query_params.get("registered") == "1"`

## Test plan
- [x] `test_get_login_page` asserts "Welcome back" and "referrals" are absent and new default copy is present
- [x] `test_get_login_page_just_registered` asserts `?registered=1` shows the "Account created" banner instead of the default copy
- [x] `dev test src/domain/routes/test_auth_routes.py` passes (20 passed, 1 skipped)
- [x] `dev lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)