### PR TITLE
feat(auth): auto-login on HTMX register, redirect to /users/me

### DIFF
--- a/src/domain/routes/auth_routes.py
+++ b/src/domain/routes/auth_routes.py
@@ -5,7 +5,7 @@ from fastapi_users import models
 from fastapi_users.manager import BaseUserManager
 from fastapi_users.router.common import ErrorCode, ErrorModel
 
-from src.auth_config import get_user_manager
+from src.auth_config import auth_backend, get_strategy, get_user_manager
 from src.domain.logic.auth.handlers import handle_registration
 from src.domain.logic.users.schema import UserCreate, UserRead
 from src.framework import BaseRouter
@@ -73,10 +73,19 @@ async def register_request_handler(
     audit_repo: AuditRepository = Depends(get_audit_repository),
 ):
     logger.debug(f"Handling registration for email: {request_data.email}")
-    result = await handle_registration(
+    created_user = await handle_registration(
         request_data=request_data,
         request=request,
         user_manager=user_manager,
         audit_repo=audit_repo,
     )
-    return result
+
+    if request.headers.get("HX-Request") == "true":
+        # HTMX submit: auto-login and redirect instead of returning raw JSON.
+        # Mirrors the pattern in src/domain/routes/dev_auth.py.
+        login_response = await auth_backend.login(get_strategy(), created_user)
+        login_response.status_code = 200
+        login_response.headers["HX-Redirect"] = "/users/me"
+        return login_response
+
+    return created_user

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -44,6 +44,27 @@ async def test_register(
         assert created_user.email == email_to_test
 
 
+async def test_register_via_htmx_sets_cookie_and_redirects(test_client: AsyncClient):
+    """HTMX register should auto-login (cookie) and redirect, not return JSON."""
+    payload = {
+        "email": "htmx@example.com",
+        "username": "htmxuser",
+        "password": "Password123!",
+    }
+    response = await test_client.post(
+        "/auth/register",
+        json=payload,
+        headers={"HX-Request": "true", "Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.headers.get("HX-Redirect") == "/users/me"
+    # A session cookie must be set so the redirect lands authenticated.
+    assert (
+        "fastapiusersauth" in response.cookies
+        or "set-cookie" in str(response.headers).lower()
+    )
+
+
 async def test_register_duplicate_email(test_client: AsyncClient, logged_in_user: User):
     register_data = {
         "email": logged_in_user.email,


### PR DESCRIPTION
## Summary
- HTMX POST to `/auth/register` now auto-logs the new user in (sets the JWT cookie via `auth_backend.login`) and returns `HX-Redirect: /users/me` instead of raw JSON.
- Non-HTMX API clients still receive the original 201 JSON response — no breaking change.
- New test `test_register_via_htmx_sets_cookie_and_redirects` covers the HTMX path; all existing tests still pass.

Closes #695

## Test plan
- [x] `dev test src/domain/routes/test_auth_routes.py` — 20 passed, 1 skipped
- [x] `dev lint` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)