### PR TITLE
fix(forms): Cancel prompts before discarding dirty form data (#703)

### DIFF
--- a/src/framework/templates/_shared/actions.html
+++ b/src/framework/templates/_shared/actions.html
@@ -103,7 +103,12 @@ Examples:
 {%- endif %}
 {%- if cancel_url %}
 {%- if is_toolbar %}<li>{% endif -%}
-<a href="{{ cancel_url }}" role="button" class="secondary outline">Cancel</a>
+{#- `data-cancel-link` is the hook the dirty-form confirm script in
+    `base.html` reads. If the click's nearest `<form>` ancestor has
+    `data-dirty="1"` (the script marks it on the first `input` event),
+    Cancel prompts "Discard changes?" before navigating. Untouched
+    forms skip the prompt — same instant-navigate behavior. -#}
+<a href="{{ cancel_url }}" role="button" class="secondary outline" data-cancel-link>Cancel</a>
 {%- if is_toolbar %}</li>{% endif %}
 {%- endif %}
 {%- if delete_url and delete_confirm %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -584,6 +584,28 @@
        `dist/ext/json-enc.js` is the htmx-1 build and logs a "v1 extension
        with htmx 2" console warning. Use the htmx-2 package instead. #}
     <script src="https://unpkg.com/htmx-ext-json-enc@2.0.2/json-enc.js"></script>
+    {# Dirty-form Cancel confirm — `_shared/actions.html` marks the
+       Cancel link with `data-cancel-link`. Any `input` event inside a
+       `<form>` marks the form `data-dirty="1"`; clicking Cancel on a
+       dirty form prompts before navigating. Untouched forms skip the
+       prompt. Document-scoped listeners survive HTMX swaps (no
+       per-mount rebinding needed). #}
+    <script>
+      document.addEventListener("input", (e) => {
+        const form = e.target.closest("form");
+        if (form) form.dataset.dirty = "1";
+      });
+      document.addEventListener("click", (e) => {
+        const cancel = e.target.closest("a[data-cancel-link]");
+        if (!cancel) return;
+        const form = cancel.closest("form");
+        if (form && form.dataset.dirty === "1") {
+          if (!confirm("Discard changes?")) {
+            e.preventDefault();
+          }
+        }
+      });
+    </script>
     {% block head %}{% endblock %} {% if is_development %}
     <!-- LiveReload script for development hot reloading -->
     <script>

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -408,6 +408,66 @@ def test_actions_macro_supports_cancel_only_for_page_level_clusters() -> None:
     assert cancel.attributes.get("href") == "/widgets/1"
 
 
+def test_cancel_link_carries_dirty_form_confirm_hook() -> None:
+    """Cancel links from the `actions` macro must carry
+    `data-cancel-link` — the hook the dirty-form confirm script in
+    `base.html` reads. The script marks forms as `data-dirty="1"` on
+    any `input` event and prompts "Discard changes?" when Cancel is
+    clicked on a dirty form. Without the attribute the prompt never
+    fires and users silently lose in-progress work (#703)."""
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% from "_shared/actions.html" import actions %}
+        <form>
+          {{ actions("Save", cancel_url="/widgets/1") }}
+        </form>
+        """,
+    )
+    html = env.get_template("stub.html").render()
+    tree = HTMLParser(html)
+    cancel = tree.css_first("a[role='button']")
+    assert cancel is not None
+    assert "data-cancel-link" in cancel.attributes, (
+        "Cancel link must carry data-cancel-link so the dirty-form "
+        "confirm script in base.html can intercept the click"
+    )
+
+
+def test_base_html_loads_dirty_form_confirm_script() -> None:
+    """The dirty-form confirm script lives in `base.html` so every
+    page that uses the `actions` macro's Cancel link gets the prompt
+    automatically. Pinned by string presence; the live behavior is
+    exercised in browsers (and could move to a Playwright contract
+    test if confirm-dialog interception becomes load-bearing). #703."""
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Stub{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+    )
+    # The form-dirty event listener.
+    assert (
+        'form.dataset.dirty = "1"' in html
+    ), "missing dirty-form input listener in base.html"
+    # The cancel-link interception.
+    assert (
+        "a[data-cancel-link]" in html
+    ), "missing cancel-link click interception in base.html"
+    assert '"Discard changes?"' in html, "missing confirm prompt text in base.html"
+
+
 def test_no_template_uses_danger_class() -> None:
     """The custom `.danger` button class was removed when its Pico-token
     overrides weren't taking effect. Guard against re-introducing


### PR DESCRIPTION
Closes #703.

## Summary

Cancel used to navigate immediately, silently throwing away any in-progress edits. Now: any `input` event inside a `<form>` marks it `data-dirty="1"`, and clicking Cancel prompts "Discard changes?" before navigating. Untouched forms skip the prompt — instant-navigate as before.

## How

- **`_shared/actions.html`** — Cancel link gains `data-cancel-link` (the hook the script reads). No visual change.
- **`base.html`** — one tiny vanilla-JS block (~12 lines). Document-scoped listeners; no library; survives HTMX swaps.

## Tests

- `test_cancel_link_carries_dirty_form_confirm_hook` — pins `data-cancel-link` on the Cancel link
- `test_base_html_loads_dirty_form_confirm_script` — pins the script is wired into `base.html`

Live confirm-dialog interception is exercised in browsers; could move to a Playwright contract test if it becomes load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)