### PR TITLE
fix(chrome): remove Create-clinician header button

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -26,21 +26,22 @@ async def test_base_template_renders_primary_nav_when_authenticated(
 ):
     """Authenticated pages render the primary nav with the two Journey
     surfaces on the left (Referrals = "find new clients", Openings =
-    "refer out a client") and on the right an adaptive primary CTA
-    (Create-clinician for first-time users without a provider profile,
-    Create-opening for returning users) plus the `/users/me` profile
-    icon. Other URL families — `/intakes`, `/clinicians`,
+    "refer out a client") and on the right only the `/users/me` profile
+    icon. No "Create clinician" CTA appears in the header chrome —
+    onboarding cues live on `/users/me` and list-page empty states
+    (#697). Other URL families — `/intakes`, `/clinicians`,
     `/organizations`, `/programs`, `/users` — stay live and reachable
-    by URL/bookmark, but are no longer chrome-promoted."""
+    by URL/bookmark, but are not chrome-promoted."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     profile_items = tree.css("#primary-nav > li > a")
     profile_hrefs = {a.attributes.get("href") for a in profile_items}
-    # First-time user (no `Provider` row yet) — the CTA points at
-    # `/clinicians/form` so they can unblock posting.
-    assert profile_hrefs == {"/clinicians/form", "/users/me"}
+    # Only the profile icon link — no "Create clinician" CTA in header.
+    assert profile_hrefs == {"/users/me"}
+    # The header must NOT contain a Create clinician link (#697).
+    assert "/clinicians/form" not in profile_hrefs
     section_items = tree.css('nav[aria-label="Primary"] > ul:first-of-type > li > a')
     section_hrefs = [a.attributes.get("href") for a in section_items]
     # Brand link is `<li><strong><a>` so the `> li > a` direct-child

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -28,8 +28,8 @@ def base_context(user: Actor | None) -> dict:
     `src/domain/models/users/user.py`). It defaults to `False` when the
     attribute is missing — Actor is a structural Protocol that doesn't
     declare `providers`, so test stubs without the attribute read as
-    "first-time user" (no provider profile yet) and the chrome shows
-    the profile-setup CTA accordingly.
+    "first-time user" (no provider profile yet). Templates use this
+    scalar to conditionally show provider-related affordances.
     """
     return {
         "is_authenticated": user is not None,

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -49,8 +49,8 @@ def test_base_context_admin():
 
 def test_base_context_user_with_provider_profile():
     """A user whose `providers` relationship is non-empty reads as
-    `has_provider_profile=True` — the chrome uses this to swap the
-    primary CTA from "Set up your profile" to "+ Post availability"."""
+    `has_provider_profile=True` — templates can use this scalar to
+    conditionally show or hide provider-related affordances."""
     user = SimpleNamespace(
         id=uuid.uuid4(),
         username="alice",

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -652,18 +652,6 @@
         </ul>
         <ul id="primary-nav">
           {% if is_authenticated %}
-          {# Onboarding-only chrome CTA — first-time users (no provider
-             profile yet) see "Create clinician", which takes them to
-             `/clinicians/form` so they can unblock posting. Returning
-             users with a profile see no CTA in the nav: the page-level
-             "Create opening" / "Create referral" buttons on the
-             respective list views are the right surface for those
-             actions (one CTA per page, not duplicated in chrome).
-             `has_provider_profile` is a chrome scalar in
-             `src.framework.http.responses.base_context`. #}
-          {% if not has_provider_profile %}
-          <li><a role="button" href="{{ entity_form_url('clinician') }}">{{ entity_create_label('clinician') }}</a></li>
-          {% endif %}
           <li>
             <a href="{{ entity_url('user', id='me') }}" aria-label="Profile"{% if _on_profile %} aria-current="page"{% endif %}>
               {# Lucide `user` icon, inlined. `currentColor` makes it


### PR DESCRIPTION
## Summary
- Removes the onboarding-only "Create clinician" CTA from the header nav entirely
- Per the UX decision (#697): onboarding nudges belong on `/users/me` and list-page empty states, not in persistent header chrome
- A new user can still reach `/clinicians/form` via the Getting Started checklist on `/users/me` (see PR for #698)
- Tests that asserted the button's presence are updated

Closes #697

## Test plan
- [x] `dev test` passes
- [x] `dev lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)