### PR TITLE
feat(forms): dirty-form cancel confirmation

### DIFF
--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -94,7 +94,7 @@ Public auth-flow pages (`/auth/login`, `/auth/register`, …) opt out — they a
 
 Inline / subresource actions inside the page body (per-row delete buttons on `provider/form_edit.html`'s licensure list, inline-add-form submits) are **not** primary resource actions and stay where they are — they act on a single subentity, not on the page's resource.
 
-Edit forms keep a bottom `<a class="secondary outline">Cancel</a>` pointing at the resource's detail page — a deliberate "abandon this edit" affordance.
+Edit forms keep a bottom `<a class="secondary outline">Cancel</a>` pointing at the resource's detail page — a deliberate "abandon this edit" affordance. The Cancel link carries a `data-cancel-btn` attribute; the `actions` macro injects a tiny inline script that marks the form dirty on the first `input` event and shows a `confirm("Discard changes?")` dialog on Cancel click when the form is dirty. Untouched forms navigate immediately. The script is only emitted in form layout (`wrapper="form"`) — toolbar Cancel links (detail-page Edit/Delete clusters) are not guarded because they never sit adjacent to an editable form.
 
 ## Partial convention
 

--- a/src/framework/templates/_shared/actions.html
+++ b/src/framework/templates/_shared/actions.html
@@ -103,7 +103,7 @@ Examples:
 {%- endif %}
 {%- if cancel_url %}
 {%- if is_toolbar %}<li>{% endif -%}
-<a href="{{ cancel_url }}" role="button" class="secondary outline">Cancel</a>
+<a href="{{ cancel_url }}" role="button" class="secondary outline" data-cancel-btn>Cancel</a>
 {%- if is_toolbar %}</li>{% endif %}
 {%- endif %}
 {%- if delete_url and delete_confirm %}
@@ -111,7 +111,18 @@ Examples:
 <button type="button" class="secondary outline{% if not is_toolbar %} form-actions-destructive{% endif %}" hx-delete="{{ delete_url }}" hx-confirm="{{ delete_confirm }}">{{ delete_label }}</button>
 {%- if is_toolbar %}</li>{% endif %}
 {%- endif %}
-{%- if not is_toolbar %}</div>{% endif -%}
+{%- if not is_toolbar %}</div>
+{%- if cancel_url %}<script>
+(function(){
+  var form=document.querySelector('form');
+  if(!form)return;
+  form.addEventListener('input',function(){form.dataset.dirty='1';});
+  var btn=document.querySelector('[data-cancel-btn]');
+  if(btn)btn.addEventListener('click',function(e){
+    if(form.dataset.dirty&&!confirm('Discard changes?'))e.preventDefault();
+  });
+})();
+</script>{% endif %}{% endif -%}
 {%- endmacro %}
 
 {# Confirm-then-delete button. Renders an `hx-delete` button with an

--- a/src/framework/templates/_shared/test_actions.py
+++ b/src/framework/templates/_shared/test_actions.py
@@ -1,0 +1,93 @@
+"""Tests for the ``actions`` macro in ``_shared/actions.html``.
+
+Covers the dirty-form cancel confirmation added in #703:
+- The Cancel link carries ``data-cancel-btn`` so the inline script can
+  find it via a stable selector.
+- The ``<script>`` block is emitted in form layout (``wrapper="form"``)
+  when a ``cancel_url`` is supplied.
+- The script is *not* emitted in toolbar layout or when ``cancel_url``
+  is absent.
+
+JS behaviour (the confirm dialog itself) cannot be exercised in unit
+tests; a browser (Playwright) test would be needed for full coverage.
+The assertions here pin the HTML structure the JS depends on so a
+refactor can't silently break the selector.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from jinja2 import ChoiceLoader, DictLoader, Environment, FileSystemLoader
+from selectolax.parser import HTMLParser
+
+
+def _make_env() -> Environment:
+    stub = DictLoader({})
+    framework = FileSystemLoader(
+        str(Path(__file__).resolve().parents[1])
+    )  # src/framework/templates
+    return Environment(loader=ChoiceLoader([stub, framework]))
+
+
+def _render_actions(env: Environment, **kwargs: object) -> str:
+    args = ", ".join(f"{k}={v!r}" for k, v in kwargs.items())
+    template = textwrap.dedent(f"""\
+        {{%- from "_shared/actions.html" import actions -%}}
+        {{{{ actions({args}) }}}}
+        """)
+    return env.from_string(template).render()
+
+
+# ---------------------------------------------------------------------------
+# data-cancel-btn attribute
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_link_carries_data_cancel_btn_in_form_layout() -> None:
+    """Cancel link must expose ``data-cancel-btn`` so the inline script can
+    bind a click listener to it without relying on class or text."""
+    html = _render_actions(_make_env(), cancel_url="/things/1", submit_label="Save")
+    tree = HTMLParser(html)
+    cancel = tree.css_first("a[data-cancel-btn]")
+    assert cancel is not None, "expected <a data-cancel-btn> in form layout"
+    assert cancel.attributes.get("href") == "/things/1"
+
+
+def test_cancel_link_carries_data_cancel_btn_in_toolbar_layout() -> None:
+    """``data-cancel-btn`` is present in toolbar layout too — the attribute
+    is on the element, not conditional on the wrapper."""
+    html = _render_actions(_make_env(), cancel_url="/things/1", wrapper="toolbar")
+    cancel = HTMLParser(html).css_first("a[data-cancel-btn]")
+    assert cancel is not None
+
+
+# ---------------------------------------------------------------------------
+# <script> block presence / absence
+# ---------------------------------------------------------------------------
+
+
+def test_dirty_form_script_emitted_in_form_layout_with_cancel_url() -> None:
+    """The inline script must be emitted when ``wrapper="form"`` (default)
+    and a ``cancel_url`` is provided."""
+    html = _render_actions(_make_env(), cancel_url="/things/1", submit_label="Save")
+    tree = HTMLParser(html)
+    script = tree.css_first("script")
+    assert script is not None, "expected <script> block in form layout with cancel_url"
+    text = script.text()
+    assert "data-cancel-btn" in text, "<script> must reference data-cancel-btn selector"
+    assert "Discard changes?" in text, "<script> must contain the confirm message"
+
+
+def test_dirty_form_script_not_emitted_without_cancel_url() -> None:
+    """No ``cancel_url`` → no script (nothing to guard against)."""
+    html = _render_actions(_make_env(), submit_label="Save")
+    assert HTMLParser(html).css_first("script") is None
+
+
+def test_dirty_form_script_not_emitted_in_toolbar_layout() -> None:
+    """In toolbar layout the script must be suppressed — the cancel link
+    appears in a ``<menu>`` toolbar, not adjacent to a ``<form>``."""
+    html = _render_actions(_make_env(), cancel_url="/things/1", wrapper="toolbar")
+    assert HTMLParser(html).css_first("script") is None


### PR DESCRIPTION
## Summary
- Adds a `data-cancel-btn` attribute to the Cancel link in `_shared/actions.html`
- Injects a minimal inline script that marks the form dirty on first `input` event
- Shows `"Discard changes?"` confirm on Cancel click when dirty; untouched forms navigate immediately
- Script emitted only in form layout (not toolbar); 5 new unit tests

Closes #703

## Test plan
- [x] `dev test` passes
- [x] `dev lint` passes
- [ ] Manual: make changes in a form → click Cancel → confirm dialog appears
- [ ] Manual: untouched form → click Cancel → navigates immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)