### PR TITLE
feat(landing): public landing page for anonymous visitors

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -366,3 +366,26 @@ async def test_failed_register_writes_no_audit_row(
         )
         rows = result.scalars().all()
         assert rows == []
+
+
+async def test_root_anonymous_returns_landing_page(test_client: AsyncClient):
+    """Anonymous GET / returns the marketing landing page (200 HTML),
+    not a redirect to the login wall (#692)."""
+    response = await test_client.get("/", follow_redirects=False)
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    # Pin the headline copy so it can't drift without breaking a test.
+    assert "Connect clinicians with the right clients" in response.text
+    # Both CTAs must be present so anonymous visitors can self-serve.
+    assert "/auth/register" in response.text
+    assert "/auth/login" in response.text
+
+
+async def test_root_authenticated_redirects_to_referrals(
+    authenticated_client: AsyncClient,
+):
+    """Authenticated GET / still redirects to /referrals — the
+    "find new clients" home (#692)."""
+    response = await authenticated_client.get("/", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/referrals"

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -5,10 +5,12 @@
     <h1>Connect clinicians with the right clients</h1>
     <p>Bedlam Connect helps mental health providers share available openings and receive referrals from their network.</p> <!-- title-case-ignore: "Bedlam Connect" is a brand name -->
   </hgroup>
+  {# title-case-ignore: button labels below ("Create an account" / "Log in") are
+     intentionally sentence-case verb phrases, not title-case headings. #}
   <p>
-    <a href="/auth/register" role="button">Create an account</a> <!-- title-case-ignore: sentence-case button text -->
+    <a href="/auth/register" role="button">Create an account</a>
     &nbsp;
-    <a href="/auth/login" role="button" class="outline">Log in</a> <!-- title-case-ignore: "Log in" is a verb phrase, not a title -->
+    <a href="/auth/login" role="button" class="outline">Log in</a>
   </p>
   <section>
     <h2>For clinicians</h2>

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -6,7 +6,7 @@
     <p>Bedlam Connect helps mental health providers share available openings and receive referrals from their network.</p> <!-- title-case-ignore: "Bedlam Connect" is a brand name -->
   </hgroup>
   <p>
-    <a href="/auth/register" role="button">Create an account</a>
+    <a href="/auth/register" role="button">Create an account</a> <!-- title-case-ignore: sentence-case button text -->
     &nbsp;
     <a href="/auth/login" role="button" class="outline">Log in</a> <!-- title-case-ignore: "Log in" is a verb phrase, not a title -->
   </p>

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<section>
+  <hgroup>
+    <h1>Connect clinicians with the right clients</h1>
+    <p>Bedlam Connect helps mental health providers share available openings and receive referrals from their network.</p> <!-- title-case-ignore: "Bedlam Connect" is a brand name -->
+  </hgroup>
+  <p>
+    <a href="/auth/register" role="button">Create an account</a>
+    &nbsp;
+    <a href="/auth/login" role="button" class="outline">Log in</a> <!-- title-case-ignore: "Log in" is a verb phrase, not a title -->
+  </p>
+  <section>
+    <h2>For clinicians</h2>
+    <p>Post your availability, connect with referrers, and manage incoming referrals — all in one place.</p>
+    <h2>For referrers</h2>
+    <p>Find clinicians with open capacity, check availability, and send referrals directly.</p>
+  </section>
+</section>
+{% endblock %}

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import datetime
 
-from fastapi import FastAPI, HTTPException, Request, status
+from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from src.auth_config import auth_backend, fastapi_users
@@ -14,6 +14,7 @@ from src.domain.routes import auth_pages, auth_routes, dev_auth, verifications
 from src.framework.config import settings
 from src.framework.dispatch.registry import entity_registry
 from src.framework.http.middleware import StripEmptyQueryParamsMiddleware
+from src.framework.http.responses import APIResponse
 from src.jobs.scheduler import make_scheduler, register_jobs
 
 logging.basicConfig(level=logging.INFO)
@@ -86,15 +87,22 @@ async def unauthorized_exception_handler(request: Request, exc: HTTPException):
     return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
 
+_optional_current_user = fastapi_users.current_user(optional=True)
+
+
 @app.get("/")
-def read_root():
-    # Home biases to the "find new clients" journey: `/referrals` is the
-    # list of clients other clinicians are looking to place — the surface
-    # a working clinician scans to fill their caseload. The mirror
-    # journey ("refer out") still has a top-level nav tab to `/openings`.
-    # Anonymous visitors landing on `/` redirect here; auth gating
-    # happens at the route, not at root.
-    return RedirectResponse(url="/referrals", status_code=302)
+async def read_root(request: Request, user=Depends(_optional_current_user)):
+    # Authenticated users land on `/referrals` — the "find new clients"
+    # home (see `src/auth_config.py:on_after_login` for the same bias).
+    # Anonymous visitors see the public landing page instead of being
+    # redirected to the login wall.
+    if user is not None:
+        return RedirectResponse(url="/referrals", status_code=302)
+    return APIResponse.html_response(
+        template_name="landing.html",
+        context={},
+        request=request,
+    )
 
 
 app.include_router(


### PR DESCRIPTION
## Summary
- Anonymous `GET /` now returns a public marketing page instead of redirecting to the login wall
- Authenticated `GET /` still redirects to `/referrals`
- New `landing.html` template with plain-language copy, Sign up + Log in CTAs
- Two new tests pin the anonymous (200) and authenticated (302) behaviors

Closes #692

## Test plan
- [x] `dev test` passes
- [x] `dev lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)