### PR TITLE
feat(users): self-only Sign out button on /users/me

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -597,6 +597,65 @@ async def test_detail_omits_inline_create_provider_for_other_user(
     assert _inline_create_provider_link(tree) is None
 
 
+# --- Sign out -----------------------------------------------------------
+
+
+def _signout_button(tree: HTMLParser):
+    """Find the Sign out button in the toolbar action menu — keyed off
+    `hx-post="/auth/jwt/logout"` rather than text because the button
+    label is the only visible signal of the action and the test should
+    pin the wire contract (the htmx POST target), not the copy."""
+    for button in tree.css("button[hx-post]"):
+        if button.attributes.get("hx-post") == "/auth/jwt/logout":
+            return button
+    return None
+
+
+async def test_detail_shows_signout_for_self(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`/users/me` exposes a Sign out button in the toolbar action menu
+    so a user can end their session from somewhere visible (was
+    previously only reachable by knowing the POST /auth/jwt/logout
+    endpoint exists). Pin the htmx POST target + the after-request
+    redirect hook so the button's wire behavior stays in lockstep."""
+    response = await authenticated_client.get("/users/me")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    button = _signout_button(tree)
+    assert button is not None, "self profile is missing the Sign out button"
+    on_after = button.attributes.get("hx-on::after-request") or ""
+    assert "window.location" in on_after, (
+        "Sign out button must redirect after the 204 logout response — "
+        "fastapi-users' logout returns 204 with no body, so the htmx "
+        "swap alone leaves the browser on /users/me."
+    )
+
+
+async def test_detail_omits_signout_for_other_user(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Viewing another user's profile (including as admin) does NOT
+    surface the Sign out button — that affordance is self-only.
+    Otherwise an admin could accidentally sign out the user they're
+    auditing, which is both confusing and would do nothing useful (the
+    admin's own session would also end since cookies are per-browser).
+    """
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    target = create_test_user(username=f"target-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(target)
+
+    response = await authenticated_client.get(f"/users/{target.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert _signout_button(tree) is None
+
+
 # --- Chrome: font preload (icon-flicker fix) ----------------------------
 
 

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -14,6 +14,21 @@
    viewer is an admin looking at someone else. #}
 {% if is_self %}
 <li><a href="{{ entity_url('user_favorite') }}" role="button" class="outline">Favorites</a></li>
+{# Sign out — self-only. fastapi-users' POST /auth/jwt/logout returns
+   204 (cookie deleted, no body); the `hx-on::after-request` shim
+   redirects the browser to `/` on success since the library doesn't
+   ship a `?next=` for logout the way login does. Don't move this
+   above the admin block — Sign out reads as the last action in the
+   self view, and the admin actions only render for admins viewing
+   someone else. #}
+<li>
+  <button type="button"
+          class="secondary outline"
+          hx-post="/auth/jwt/logout"
+          hx-on::after-request="if(event.detail.successful){window.location='/'}">
+    Sign out
+  </button>
+</li>
 {% endif %}
 {% include "users/_admin_actions.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
Closes #702.

A logged-in user had no visible way to sign out — the header's person icon links to `/users/me`, but that page exposed no logout affordance either. The only path was knowing `POST /auth/jwt/logout` exists.

Add a **Sign out** button to the `/users/me` toolbar action menu, scoped self-only so an admin viewing someone else's profile can't accidentally end that user's session.

## Why client-side redirect
fastapi-users' `POST /auth/jwt/logout` returns 204 with no body. The htmx swap alone leaves the browser on `/users/me` (now a half-stale page since the cookie is gone). Use `hx-on::after-request="if(event.detail.successful){window.location='/'}"` to hard-redirect on success; root then forwards anonymous users to `/auth/login`.

## Scope
- `src/domain/templates/users/detail.html` — add the `<li><button hx-post=...></button></li>` inside the existing `{% if is_self %}` block.
- `src/domain/routes/test_users.py` — two new tests:
  - `test_detail_shows_signout_for_self` pins the wire contract (hx-post target + after-request redirect hook).
  - `test_detail_omits_signout_for_other_user` confirms admins viewing another profile don't see the button.

## Out of scope
Header-dropdown placement (also mentioned in #702) — overlaps with #697's "remove the global Create clinician button" work that's in flight. The toolbar slot is the natural home for per-page actions; if higher visibility is needed later, the header dropdown can be a follow-up.

## Test plan
- [x] `dev test src/domain/routes/test_users.py` — 45 passed
- [x] `dev lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)