### PR TITLE
fix(chrome): remove Create-clinician header button (#697)

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -26,23 +26,20 @@ async def test_base_template_renders_primary_nav_when_authenticated(
 ):
     """Authenticated pages render the primary nav with the two Journey
     surfaces on the left (Referrals = "find new clients", Openings =
-    "refer out a client") and on the right an adaptive primary CTA
-    (Create-clinician for first-time users without a provider profile,
-    Create-opening for returning users) plus the `/users/me` profile
-    icon. Other URL families — `/intakes`, `/clinicians`,
+    "refer out a client") and on the right the `/users/me` profile
+    dropdown. Other URL families — `/intakes`, `/clinicians`,
     `/organizations`, `/programs`, `/users` — stay live and reachable
-    by URL/bookmark, but are no longer chrome-promoted."""
+    by URL/bookmark, but are no longer chrome-promoted.
+
+    The "Create clinician" chrome CTA was removed in #697 — the
+    /users/me onboarding checklist is the discoverable entry point."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    # CTA link is a direct `> li > a`; profile link is nested inside the
-    # sign-out dropdown so use a descendant selector for it (#702).
-    cta_items = tree.css("#primary-nav > li > a")
-    cta_hrefs = {a.attributes.get("href") for a in cta_items}
-    # First-time user (no `Provider` row yet) — the CTA points at
-    # `/clinicians/form` so they can unblock posting.
-    assert "/clinicians/form" in cta_hrefs
+    # "Create clinician" button no longer lives in the nav (#697).
+    cta_items = tree.css("#primary-nav > li > a[href='/clinicians/form']")
+    assert len(cta_items) == 0, "Create-clinician CTA should be removed from nav (#697)"
     # Profile link lives inside the dropdown — descendant selector.
     assert tree.css_first('#primary-nav a[href="/users/me"]') is not None
     section_items = tree.css('nav[aria-label="Primary"] > ul:first-of-type > li > a')

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -652,18 +652,11 @@
         </ul>
         <ul id="primary-nav">
           {% if is_authenticated %}
-          {# Onboarding-only chrome CTA — first-time users (no provider
-             profile yet) see "Create clinician", which takes them to
-             `/clinicians/form` so they can unblock posting. Returning
-             users with a profile see no CTA in the nav: the page-level
-             "Create opening" / "Create referral" buttons on the
-             respective list views are the right surface for those
-             actions (one CTA per page, not duplicated in chrome).
-             `has_provider_profile` is a chrome scalar in
-             `src.framework.http.responses.base_context`. #}
-          {% if not has_provider_profile %}
-          <li><a role="button" href="{{ entity_form_url('clinician') }}">{{ entity_create_label('clinician') }}</a></li>
-          {% endif %}
+          {# "Create clinician" chrome CTA removed in #697: the rebuilt
+             /users/me onboarding home carries that CTA in the checklist,
+             so duplicating it in the nav adds clutter without orientation.
+             `has_provider_profile` is still set in base_context but is no
+             longer read here. #}
           <li>
             {# title-case-ignore — Profile dropdown: Pico `<details role="list">` gives us a
                disclosure widget with no JS. Contains two items — Profile


### PR DESCRIPTION
## Summary

- **#697** — Remove the "Create clinician" nav CTA from the header. The rebuilt `/users/me` onboarding home (#698) now carries the "Create clinician profile" step in an oriented checklist, making the chrome button redundant.

The `{% if not has_provider_profile %}` block that rendered `<a role="button">Create clinician</a>` in the top-right nav is removed. `has_provider_profile` is still computed in `base_context.py` and remains available for future use.

Note: this replaces the conflicting PR #714 which predated the solo-practice feature merge and would have reverted those changes.

## Test plan

- [ ] `uv run pytest src/domain/routes/test_users.py` — all pass
- [ ] `uv run pytest src/` — 1435 passed
- [ ] Manually: authenticated pages no longer show "Create clinician" in the top-right nav; `/users/me` still shows the checklist CTA

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)