### PR TITLE
feat(orgs): type picker at /organizations/form

### DIFF
--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -240,6 +240,48 @@ async def test_get_organizations_form_resolves(
     assert response.status_code == 200
 
 
+# --- Type picker (issue #704) -------------------------------------------
+
+
+async def test_get_organizations_form_no_type_shows_picker(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """``GET /organizations/form`` (no ``?type=``) shows the type-picker,
+    not the create form.  Each card links to ``?type=<value>``."""
+    response = await authenticated_client.get("/organizations/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    # Picker links: one per org type.
+    hrefs = {a.attributes.get("href") for a in tree.css("a[href*='?type=']")}
+    assert "/organizations/form?type=solo_practice" in hrefs
+    assert "/organizations/form?type=group_practice" in hrefs
+    assert "/organizations/form?type=clinic" in hrefs
+    assert "/organizations/form?type=health_system" in hrefs
+    assert "/organizations/form?type=other" in hrefs
+    # No org create form — the picker should not render it.
+    assert tree.css_first('form[hx-post="/organizations"]') is None
+
+
+async def test_get_organizations_form_with_type_shows_form(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """``GET /organizations/form?type=solo_practice`` skips the picker and
+    renders the create form with the Type field pre-selected."""
+    response = await authenticated_client.get("/organizations/form?type=solo_practice")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    # Form is rendered.
+    assert tree.css_first("form") is not None
+    # Type dropdown pre-selects solo_practice.
+    selected = tree.css_first('select[name="type"] option[selected]')
+    assert selected is not None
+    assert selected.attributes.get("value") == "solo_practice"
+    # Parent-org picker present.
+    assert tree.css_first('select[name="parent_org_id"]') is not None
+
+
 # --- Parent-Org picker (issue #581) --------------------------------------
 
 
@@ -264,6 +306,9 @@ async def test_form_new_renders_parent_org_select_with_root_option(
     """Pins the new picker structure from issue #581: a ``<select
     name="parent_org_id">`` with a "(no parent)" default option plus
     one ``<option>`` per Org visible to the requesting user.
+
+    ``?type=solo_practice`` is required to bypass the type-picker and
+    render the create form (issue #704).
     """
     mine_a = await _seed_org(
         db_test_session_manager, owner_id=logged_in_user.id, name="Mine A"
@@ -272,7 +317,7 @@ async def test_form_new_renders_parent_org_select_with_root_option(
         db_test_session_manager, owner_id=logged_in_user.id, name="Mine B"
     )
 
-    response = await authenticated_client.get("/organizations/form")
+    response = await authenticated_client.get("/organizations/form?type=solo_practice")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     select = tree.css_first('select[name="parent_org_id"]')
@@ -298,7 +343,10 @@ async def test_form_new_scopes_to_owned_orgs(
     logged_in_user: User,
 ):
     """Non-superusers see only Orgs they own in the picker — same scope
-    as the Program/Provider form pickers (see ``_orgs_visible_to``)."""
+    as the Program/Provider form pickers (see ``_orgs_visible_to``).
+
+    ``?type=solo_practice`` bypasses the type-picker (issue #704).
+    """
     mine = await _seed_org(
         db_test_session_manager, owner_id=logged_in_user.id, name="Mine"
     )
@@ -310,7 +358,7 @@ async def test_form_new_scopes_to_owned_orgs(
         db_test_session_manager, owner_id=other.id, name="Other's"
     )
 
-    response = await authenticated_client.get("/organizations/form")
+    response = await authenticated_client.get("/organizations/form?type=solo_practice")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     values = {

--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -1,17 +1,54 @@
+{# Create-organization entry point.
+
+When no `?type=` query param is present the user sees a type-picker — one
+card per organization type, each linking to the same URL with `?type=<value>`
+appended.  Clicking a card (or following a deep link with `?type=` already
+set) skips the picker and renders the full create form with that type
+pre-selected in the Type dropdown.
+
+This mirrors the `/openings/form` picker pattern (issue #704).
+#}
 {% extends "views/form_new.html" %}
 {%- from "_shared/form_fields.html" import entity_select_field, select_field, text_field -%}
 {%- from "_shared/actions.html" import actions -%}
+{%- from "_shared/_picker.html" import picker -%}
 
 
 {% block resource_label %}Organizations{% endblock %}
 
 {% block content %}
+{%- set selected_type = request.query_params.get('type', '') -%}
+{% if not selected_type %}
+{# Type picker: shown when no ?type= param is present.  Each card links
+   to the same URL with ?type=<value> so the form renders with the Type
+   field pre-filled.  Deep links (?type=solo_practice) skip the picker
+   and land directly on the form. #}
+{{ picker([
+  {"href": entity_form_url('organization') + "?type=solo_practice",
+   "heading": "Solo practice",
+   "description": "Just you — a single clinician running their own practice."},
+  {"href": entity_form_url('organization') + "?type=group_practice",
+   "heading": "Group practice",
+   "description": "Multiple clinicians under one roof or brand."},
+  {"href": entity_form_url('organization') + "?type=clinic",
+   "heading": "Clinic, IOP, or inpatient program",
+   "description": "A facility offering structured or intensive programming."},
+  {"href": entity_form_url('organization') + "?type=health_system",
+   "heading": "Health system",
+   "description": "A network of clinics or hospitals."},
+  {"href": entity_form_url('organization') + "?type=other",
+   "heading": "Other",
+   "description": "Doesn't fit the above."},
+]) }}
+{% else %}
+{# Form: shown when ?type= is set (either via picker click or deep link).
+   The Type dropdown is pre-selected to the value from the query param. #}
 <form hx-post="{{ entity_url('organization') }}">
   <fieldset>
     <legend>Organization</legend>
     <div class="grid">
       {{ text_field("name", "Name", maxlength=200) }}
-      {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, placeholder=true) }}
+      {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, current=selected_type) }}
     </div>
     {# Parent-Org picker — replaces the free-text UUID input from #581.
        `parent_org_options` is populated by `organization_form_extras`
@@ -30,4 +67,5 @@
 
   {{ actions(entity_create_label('organization'), cancel_url=entity_url('organization')) }}
 </form>
+{% endif %}
 {% endblock %}

--- a/src/framework/templates/_shared/_picker.html
+++ b/src/framework/templates/_shared/_picker.html
@@ -1,0 +1,26 @@
+{# _picker(options) — renders a "choose your path" card grid.
+
+Adopted from the `/openings/form` picker pattern (issue #704). Use this
+macro anywhere a multi-option entry point needs to funnel the user to a
+kind- or type-specific sub-form before showing fields.
+
+Each option is a dict with keys:
+  href:        URL to navigate to on click
+  heading:     short label (e.g. "Solo practice")
+  description: one-line tagline
+
+The `<h2>` carries `<!-- title-case-ignore -->` because the linter's
+concatenated-text heuristic flags the heading + tagline as a
+mid-text-capital violation even though each element is correct sentence
+case in isolation. Scope is the same line as the violation.
+#}
+{%- macro picker(options) -%}
+{%- for opt in options %}
+<a href="{{ opt.href }}">
+  <hgroup>
+    <h2>{{ opt.heading }}</h2> <!-- title-case-ignore -->
+    <p>{{ opt.description }}</p>
+  </hgroup>
+</a>
+{%- endfor %}
+{%- endmacro %}

--- a/tests/test_contract/constants.py
+++ b/tests/test_contract/constants.py
@@ -40,8 +40,10 @@ PROVIDER_PATCH_API_PATH = f"/clinicians/{STUB_PROVIDER_ID}"
 PROVIDER_EDIT_FORM_PAGE_PATH = f"/clinicians/{STUB_PROVIDER_ID}/form"
 
 # Organization create form pact.
+# `?type=clinic` bypasses the type-picker added in #704 and lands
+# directly on the create form with the Type dropdown pre-selected.
 ORGANIZATION_CREATE_API_PATH = "/organizations"
-ORGANIZATION_CREATE_FORM_PAGE_PATH = "/organizations/form"
+ORGANIZATION_CREATE_FORM_PAGE_PATH = "/organizations/form?type=clinic"
 
 # Program create form pact. Programs attach to an existing Organization
 # via the form's `org_id` dropdown; the consumer stub seeds one Org

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -315,6 +315,11 @@ def _setup_organization_create_form_stub(app: FastAPI) -> None:
                 "current_user": current_user,
                 "ORGANIZATION_TYPES": ORGANIZATION_TYPES,
                 "ORGANIZATION_TYPES_LABELS": ORGANIZATION_TYPES_LABELS,
+                # The `?type=` picker bypasses this stub's no-db path;
+                # when `?type=` is set the form branch renders
+                # `parent_org_options`. Empty list = no parent choices,
+                # which is the correct stub default (no db).
+                "parent_org_options": [],
             },
             request=request,
         )


### PR DESCRIPTION
## Summary

- Adds a "choose your path" type-picker to `GET /organizations/form` (no `?type=` param) — one card per org type with a one-line description, each linking to `?type=<value>`
- Deep links with `?type=` already set skip the picker and land directly on the create form with that type pre-selected
- Extracts a shared `_picker.html` macro in `src/framework/templates/_shared/` so the same pattern is reusable (mirrors the existing `/openings/form` picker)

## Test plan

- [ ] `GET /organizations/form` (no `?type=`) renders picker cards with links to `?type=solo_practice`, `?type=group_practice`, `?type=clinic`, `?type=health_system`, `?type=other`; no `<form>` rendered
- [ ] `GET /organizations/form?type=solo_practice` renders the create form with solo_practice pre-selected in the Type dropdown
- [ ] Existing parent-org select tests pass (now use `?type=solo_practice` to bypass picker)
- [ ] Contract tests pass (consumer stub updated with `parent_org_options=[]`; form page path updated to `?type=clinic`)

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)