### PR TITLE
fix(chrome): drop top-right Create clinician header CTA (#697)

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -26,21 +26,20 @@ async def test_base_template_renders_primary_nav_when_authenticated(
 ):
     """Authenticated pages render the primary nav with the two Journey
     surfaces on the left (Referrals = "find new clients", Openings =
-    "refer out a client") and on the right an adaptive primary CTA
-    (Create-clinician for first-time users without a provider profile,
-    Create-opening for returning users) plus the `/users/me` profile
-    icon. Other URL families — `/intakes`, `/clinicians`,
-    `/organizations`, `/programs`, `/users` — stay live and reachable
-    by URL/bookmark, but are no longer chrome-promoted."""
+    "refer out a client") and on the right only the `/users/me`
+    profile icon — no chrome-level CTA (see issue #697; onboarding
+    nudges live in dedicated surfaces, not in chrome that follows the
+    user across every page). Other URL families — `/intakes`,
+    `/clinicians`, `/organizations`, `/programs`, `/users` — stay live
+    and reachable by URL/bookmark, but are no longer chrome-promoted."""
     response = await authenticated_client.get("/users")
 
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     profile_items = tree.css("#primary-nav > li > a")
     profile_hrefs = {a.attributes.get("href") for a in profile_items}
-    # First-time user (no `Provider` row yet) — the CTA points at
-    # `/clinicians/form` so they can unblock posting.
-    assert profile_hrefs == {"/clinicians/form", "/users/me"}
+    # Right-side slot is profile-icon only — no Create-clinician CTA.
+    assert profile_hrefs == {"/users/me"}
     section_items = tree.css('nav[aria-label="Primary"] > ul:first-of-type > li > a')
     section_hrefs = [a.attributes.get("href") for a in section_items]
     # Brand link is `<li><strong><a>` so the `> li > a` direct-child

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -22,21 +22,12 @@ def base_context(user: Actor | None) -> dict:
 
     `is_admin` is computed via `src.framework.authz.is_admin` so the rule
     has a single home; templates never re-derive it.
-
-    `has_provider_profile` is duck-typed off the user's `providers`
-    relationship (eagerly loaded on `User` via `lazy="selectin"`, see
-    `src/domain/models/users/user.py`). It defaults to `False` when the
-    attribute is missing — Actor is a structural Protocol that doesn't
-    declare `providers`, so test stubs without the attribute read as
-    "first-time user" (no provider profile yet) and the chrome shows
-    the profile-setup CTA accordingly.
     """
     return {
         "is_authenticated": user is not None,
         "is_admin": is_admin(user),
         "current_username": user.username if user is not None else None,
         "current_user_id": user.id if user is not None else None,
-        "has_provider_profile": bool(getattr(user, "providers", None)),
     }
 
 

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -24,7 +24,6 @@ def test_base_context_anonymous():
         "is_admin": False,
         "current_username": None,
         "current_user_id": None,
-        "has_provider_profile": False,
     }
 
 
@@ -36,7 +35,6 @@ def test_base_context_regular_user():
         "is_admin": False,
         "current_username": "alice",
         "current_user_id": user_id,
-        "has_provider_profile": False,
     }
 
 
@@ -45,28 +43,6 @@ def test_base_context_admin():
     ctx = base_context(user)
     assert ctx["is_admin"] is True
     assert ctx["is_authenticated"] is True
-
-
-def test_base_context_user_with_provider_profile():
-    """A user whose `providers` relationship is non-empty reads as
-    `has_provider_profile=True` — the chrome uses this to swap the
-    primary CTA from "Set up your profile" to "+ Post availability"."""
-    user = SimpleNamespace(
-        id=uuid.uuid4(),
-        username="alice",
-        is_superuser=False,
-        providers=[SimpleNamespace(id=uuid.uuid4())],
-    )
-    ctx = base_context(user)
-    assert ctx["has_provider_profile"] is True
-
-
-def test_base_context_user_without_providers_attr_defaults_false():
-    """Missing `providers` attribute (Actor protocol doesn't declare it)
-    defaults to `False` — same shape as a brand-new user who hasn't
-    created a clinician profile yet."""
-    user = SimpleNamespace(id=uuid.uuid4(), username="alice", is_superuser=False)
-    assert base_context(user)["has_provider_profile"] is False
 
 
 # --- existing helpers ----------------------------------------------------

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -652,18 +652,11 @@
         </ul>
         <ul id="primary-nav">
           {% if is_authenticated %}
-          {# Onboarding-only chrome CTA — first-time users (no provider
-             profile yet) see "Create clinician", which takes them to
-             `/clinicians/form` so they can unblock posting. Returning
-             users with a profile see no CTA in the nav: the page-level
-             "Create opening" / "Create referral" buttons on the
-             respective list views are the right surface for those
-             actions (one CTA per page, not duplicated in chrome).
-             `has_provider_profile` is a chrome scalar in
-             `src.framework.http.responses.base_context`. #}
-          {% if not has_provider_profile %}
-          <li><a role="button" href="{{ entity_form_url('clinician') }}">{{ entity_create_label('clinician') }}</a></li>
-          {% endif %}
+          {# No chrome-level CTA — onboarding nudges belong in dedicated
+             surfaces (`/users/me`, the `/openings` empty state, etc.),
+             not in chrome that follows the user across every page (see
+             issue #697). The right-side slot carries only the profile
+             link for authed users. #}
           <li>
             <a href="{{ entity_url('user', id='me') }}" aria-label="Profile"{% if _on_profile %} aria-current="page"{% endif %}>
               {# Lucide `user` icon, inlined. `currentColor` makes it


### PR DESCRIPTION
## Summary
- Remove the persistent "Create clinician" button from `#primary-nav` in `base.html`. It shows on every page for every authenticated user (regardless of whether they're a referrer/intake coordinator who doesn't need a clinician profile) and the UX walkthrough decided: remove, don't make context-aware.
- Onboarding cues remain elsewhere — `/users/me`'s Providers card surfaces an inline "Create clinician" link, `/clinicians` (Directory) has its toolbar CTA, and `/clinicians/form` stays reachable by URL.
- Drop the now-unused `has_provider_profile` chrome scalar from `base_context` (single template caller; no other consumers).

Closes #697

## Test plan
- [x] `pytest` full suite: 1529 passed, 96 skipped
- [x] Updated `test_base_template_renders_primary_nav_when_authenticated` to assert the right-side slot is profile-icon only
- [x] Updated `test_base_context_*` to drop `has_provider_profile`
- [x] Pre-commit hooks (black/isort/autoflake/title-case/template-imports) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)