### PR TITLE
fix(lint): preserve 'Bedlam Connect' brand without per-line ignores (#728)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bedlam CONNECT
+# Bedlam Connect
 
 FastAPI + server-side rendering + HTMX, with JWT cookie auth via fastapi-users. Python 3.11+; SQLite locally, Postgres in production; Docker-based dev and deploy.
 

--- a/scripts/dev/test_title_case_check.py
+++ b/scripts/dev/test_title_case_check.py
@@ -456,6 +456,57 @@ def test_genuinely_miscased_acronym_neighbour_still_flags(tmp_path):
     assert "ZIP Code Lookup" in originals
 
 
+def test_brand_phrase_bedlam_connect_passes_anywhere(tmp_path):
+    """Multi-word brand phrases (``BRAND_PHRASES``) are preserved verbatim
+    wherever they appear in prose — sentence-case lowercases every word
+    after the first ("Bedlam Connect" → "Bedlam connect"), so a post-pass
+    restores the canonical casing. Brand-name copy no longer needs
+    per-line ``title-case-ignore`` markers (#728)."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <title>Bedlam Connect</title>
+        <p>Sign in to your Bedlam Connect account.</p>
+        <p>Bedlam Connect helps clinicians share openings.</p>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_brand_mark_bedlam_alone_passes(tmp_path):
+    """The standalone brand mark (``<span>Bedlam</span>``) lives in
+    ``ALWAYS_CAPITALIZE`` so it stays capitalized in any position. The
+    base template emits both forms inside a single ``<a>`` so the deep
+    text is "Bedlam Connect Bedlam"; both halves must clear the linter."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <a href="/">
+          <span>Bedlam Connect</span>
+          <span>Bedlam</span>
+        </a>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_brand_phrase_does_not_creep_into_unrelated_prose(tmp_path):
+    """The brand-phrase post-pass only restores casing when the phrase
+    actually appears in the source — it must not over-capitalize random
+    occurrences of either word."""
+    file = _write_html(
+        tmp_path,
+        "<html><body><p>Connect with your peers.</p></body></html>",
+    )
+    # "Connect" alone is not a brand phrase and stays sentence-case
+    # ("Connect with your peers." is already correct at position 0).
+    assert _check(file) == []
+
+
 def test_main_exits_with_error_when_selectolax_missing(monkeypatch, capsys):
     """If selectolax isn't importable, the CLI must hard-fail rather than
     silently skip every HTML/Jinja file. Regression for #198 — the old

--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -137,6 +137,11 @@ class TitleCaseChecker:
         "PII",  # Personally identifiable information
         "DBT",  # Dialectical behavior therapy
         "EMDR",  # Eye movement desensitization and reprocessing
+        # Brand mark — the short form rendered on narrow viewports.
+        # Multi-word brand phrases (e.g. "Bedlam Connect") live in
+        # ``BRAND_PHRASES`` below; this entry covers the standalone
+        # ``<span class="brand-mark">Bedlam</span>`` shape.
+        "Bedlam",
         # Language names — surface in form labels ("non-English", "Spanish")
         # and standard sentence-case rules would lowercase them.
         "English",
@@ -155,6 +160,15 @@ class TitleCaseChecker:
         "Russian",
         "Italian",
         "Portuguese",
+    }
+
+    # Multi-word brand phrases preserved verbatim (case-sensitive) when
+    # they appear in source. Sentence-case conversion would lowercase the
+    # second word ("Bedlam Connect" → "Bedlam connect"); the post-pass
+    # in ``_convert_single_sentence`` restores the canonical casing. The
+    # single-word brand mark ("Bedlam") lives in ``ALWAYS_CAPITALIZE``.
+    BRAND_PHRASES = {
+        "Bedlam Connect",
     }
 
     # HTTP methods are ambiguous: they overlap with common English words
@@ -404,6 +418,17 @@ class TitleCaseChecker:
                     result_words.append(word.replace(clean_word, clean_word.lower()))
 
         sentence_case = emoji_prefix + " ".join(result_words)
+
+        # Restore multi-word brand phrases. Sentence-case lowercases every
+        # word after the first ("Bedlam Connect" → "Bedlam connect");
+        # this pass swaps any case-insensitive match back to the canonical
+        # form so brand-name copy doesn't need per-line `title-case-ignore`
+        # markers (#728).
+        for brand in self.BRAND_PHRASES:
+            if re.search(re.escape(brand), original_clean, re.IGNORECASE):
+                sentence_case = re.sub(
+                    re.escape(brand), brand, sentence_case, flags=re.IGNORECASE
+                )
 
         if "<" in text and ">" in text:
             return text.replace(original_clean, sentence_case)

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -3,7 +3,7 @@
 <article class="auth-page">
   <header>
     <h1>Log in</h1>
-    {% if just_registered %}<p>Account created — log in to continue.</p>{% else %}<p>Sign in to your Bedlam Connect account.</p>{% endif %} <!-- title-case-ignore: "Bedlam Connect" is a brand name -->
+    {% if just_registered %}<p>Account created — log in to continue.</p>{% else %}<p>Sign in to your Bedlam Connect account.</p>{% endif %}
   </header>
   <!-- FastAPI Users JWT login endpoint expects 'username' (which is email) and 'password' as form data. -->
   <form

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -3,7 +3,7 @@
 <section>
   <hgroup>
     <h1>Connect clinicians with the right clients</h1>
-    <p>Bedlam Connect helps mental health providers share available openings and receive referrals from their network.</p> <!-- title-case-ignore: "Bedlam Connect" is a brand name -->
+    <p>Bedlam Connect helps mental health providers share available openings and receive referrals from their network.</p>
   </hgroup>
   {# title-case-ignore: button labels below ("Create an account" / "Log in") are
      intentionally sentence-case verb phrases, not title-case headings. #}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    {# title-case-ignore: "Bedlam Connect" is a brand name #}
     <title>Bedlam Connect</title>
     <link
       rel="stylesheet"
@@ -636,7 +635,6 @@
     <header class="container">
       <nav aria-label="Primary">
         <ul>
-          {# title-case-ignore: "Bedlam Connect" is a brand name #}
           {# Brand wraps the full label and a short "mark" form; only
              one is visible at a time. CSS in the `<style>` block
              above swaps them at ≤540px so the brand stays on one


### PR DESCRIPTION
## Summary
- Add `BRAND_PHRASES = {\"Bedlam Connect\"}` to the title-case checker plus a post-pass that restores canonical casing after sentence-case conversion (only when the phrase actually appears in the source — won't over-capitalize stray \"Connect\" verbs).
- Add `\"Bedlam\"` to `ALWAYS_CAPITALIZE` to cover the brand-mark short form rendered at narrow viewports.
- Strip the three existing `<!-- title-case-ignore -->` markers that were only there for the brand name (`base.html` head + nav, `landing.html`, `auth/login.html`).
- Fix a typo the prior checker missed: `README.md` had \"Bedlam CONNECT\" — \"CONNECT\" matched the HTTP-method preservation path and slipped through.

Closes #728

## Test plan
- [x] 3 new unit tests in `scripts/dev/test_title_case_check.py`: brand phrase passes anywhere, brand mark alone passes, post-pass doesn't creep into unrelated prose
- [x] `dev lint` green
- [x] `pytest scripts/dev/test_title_case_check*.py src/domain/routes/test_users.py src/domain/routes/test_auth_routes.py` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)