### PR TITLE
fix(copy): update org_picker_help link text (#734)

### DIFF
--- a/src/framework/templates/_shared/form_copy.html
+++ b/src/framework/templates/_shared/form_copy.html
@@ -23,9 +23,9 @@
 
 {# The Org-picker help — every create/edit form that takes a parent-Org
    or owning-Org FK renders this so the "I can't find my Org" path is
-   one click away. The link target is the Organization create form. #}
+   one click away. The link target is the Organization type picker (#704). #}
 {%- macro org_picker_help() -%}
-Don't see your organization? <a href="{{ entity_form_url('organization') }}">Create one first.</a>
+Don't see your organization? <a href="{{ entity_form_url('organization') }}">Create one.</a>
 {%- endmacro %}
 
 {# Treatment-modality help — referrals, clinician openings, and program


### PR DESCRIPTION
## Summary

- **#734** — Update `org_picker_help()` copy from "Create one first." → "Create one."

"First" implied a blocking prerequisite step that no longer matches the flow: since #704 the link lands on the org type picker, and since #699 solo practitioners bypass the Org step with the solo-practice toggle. Removing "first" makes the copy accurate without losing discoverability.

## Test plan

- [ ] `uv run pytest src/` passes (copy-only change)
- [ ] `GET /clinicians/form` org picker help text reads "Create one." (not "Create one first.")

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)