### PR TITLE
fix(tests): sign-out form selector convention + is_verified clarification (#730 #731)

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -673,7 +673,12 @@
               <ul role="listbox">
                 <li><a href="{{ entity_url('user', id='me') }}">Profile</a></li>
                 <li>
-                  <form method="post" action="/auth/sign-out" hx-post="/auth/sign-out" style="margin:0;">
+                  {# `data-form="sign-out"` distinguishes this chrome
+                     form from resource forms in the `<main>` content
+                     area. Tests asserting "no resource form present"
+                     should scope to `main form` or use a specific
+                     `form[hx-post="/resource-url"]` selector (#730). #}
+                  <form method="post" action="/auth/sign-out" hx-post="/auth/sign-out" data-form="sign-out" style="margin:0;">
                     <button type="submit" style="width:100%;text-align:left;background:none;border:none;padding:0;cursor:pointer;color:inherit;">Sign out</button>
                   </form>
                 </li>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,7 +27,12 @@ def create_test_user(
     hashed_password: Optional[str] = None,
     is_active: bool = True,  # Added fastapi-users default
     is_superuser: bool = False,  # Added fastapi-users default
-    is_verified: bool = True,  # Added fastapi-users default
+    # `is_verified` is a fastapi-users ORM column on the `User` model.
+    # It was excluded from `UserRead` in PR #724 (#696) — it is NOT an
+    # API response field. Setting it True in tests bypasses any future
+    # email-verification gate; that's intentional for unit tests that
+    # don't exercise the verification flow itself.
+    is_verified: bool = True,
 ) -> User:
     """Creates a User instance with default values for testing."""
     unique_suffix = uuid.uuid4()


### PR DESCRIPTION
## Summary
- **#730**: Adds `data-form="sign-out"` to the base.html sign-out form so tests can distinguish it from resource forms. Adds an inline comment explaining the convention: scope selectors to `main form` or use specific resource URLs like `form[hx-post="/organizations"]`, not bare `form[hx-post]`.
- **#731**: Clarifies that `is_verified` in `create_test_user` (tests/helpers.py) is the fastapi-users ORM column, not the API response field that was removed from `UserRead` in PR #724 (#696).

Closes #730, closes #731

## Test plan
- [ ] `dev test` passes (1552 passed, no regressions)
- [ ] No bare `form[hx-post]` selectors in tests (all use specific URLs already)

🤖 Generated with [Claude Code](https://claude.com/claude-code)