### PR TITLE
fix: brand-name capitalization and sign-out form data attribute

### DIFF
--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -125,6 +125,11 @@ class TitleCaseChecker:
         "JavaScript",
         "TypeScript",
         "Pact",  # Contract testing framework
+        # Brand / product names — never lowercased regardless of position.
+        # Add the product name parts here so per-template ignore comments
+        # aren't needed on every page that displays the brand (#728).
+        "Bedlam",  # "Bedlam Connect" app name — first word
+        "Connect",  # "Bedlam Connect" app name — second word
         # General-domain acronyms
         "CRUD",
         "TDD",

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -673,7 +673,10 @@
               <ul role="listbox">
                 <li><a href="{{ entity_url('user', id='me') }}">Profile</a></li>
                 <li>
-                  <form method="post" action="/auth/sign-out" hx-post="/auth/sign-out" style="margin:0;">
+                  {# data-form="sign-out" distinguishes this chrome form from
+                     page-specific resource forms so tests can scope selectors
+                     like `form:not([data-form="sign-out"])` (#730). #}
+                  <form method="post" action="/auth/sign-out" hx-post="/auth/sign-out" data-form="sign-out" style="margin:0;">
                     <button type="submit" style="width:100%;text-align:left;background:none;border:none;padding:0;cursor:pointer;color:inherit;">Sign out</button>
                   </form>
                 </li>


### PR DESCRIPTION
## Summary

- **#728**: Add `"Bedlam"` and `"Connect"` to `ALWAYS_CAPITALIZE` in `scripts/dev/title_case_check.py` so the brand name "Bedlam Connect" never needs per-template `title-case-ignore` comments. The escape hatch still works for one-off annotations.
- **#730**: Add `data-form="sign-out"` to the chrome sign-out form in `base.html`. Tests can now scope form selectors with `:not([data-form="sign-out"])` when checking for resource-specific forms — the sign-out form present on every authenticated page won't shadow them.

## Test plan

- [x] `dev test scripts/ src/domain/routes/test_organizations.py` — 125 passed, 0 failed
- [x] Title case checker passes with `"Bedlam Connect"` present in templates without ignore comments
- [x] No existing tests broken by the data attribute addition

Closes #728
Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)