### PR TITLE
feat(clinicians): show verification badge on detail page (#707 stage 2)

### DIFF
--- a/src/domain/logic/providers/handlers.py
+++ b/src/domain/logic/providers/handlers.py
@@ -38,6 +38,7 @@ from src.domain.logic.favorites.repository import UserFavoriteRepository
 from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.providers.repository import ProviderRepository
 from src.domain.logic.users.repository import UserRepository
+from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.models import (
     Organization,
     Provider,
@@ -108,6 +109,7 @@ async def provider_detail_extras(
     target: Provider,
     requesting_user: User | None,
     user_favorite_repo: UserFavoriteRepository,
+    verification_repo: VerificationRepository,
     **_: Any,
 ) -> dict[str, Any]:
     """Per-viewer detail extras for `make_detail_handler(PROVIDER_ENTITY)`.
@@ -118,13 +120,27 @@ async def provider_detail_extras(
     get `False` without a DB round-trip; today `PROVIDER_ENTITY.read_user_dep`
     forces auth, but the None-check keeps the helper safe if that ever
     changes.
+
+    `verification_status` is a property of the provider (not the viewer),
+    but it lives in context so the template doesn't need a DB-aware
+    helper. The value is the latest `Verification.status` (one of
+    `"verified" / "needs_review" / "failed"`) or `None` when the
+    pipeline (see `domain/logic/verifications/handlers.py`) has not yet
+    run for this provider — the template renders "Pending" for `None`
+    so the badge always shows something (#707 stage 2).
     """
+    latest = await verification_repo.latest_for_provider(target.id)
+    verification_status = latest.status if latest is not None else None
     if requesting_user is None:
-        return {"is_favorited": False}
+        return {
+            "is_favorited": False,
+            "verification_status": verification_status,
+        }
     return {
         "is_favorited": await user_favorite_repo.is_favorited(
             user_id=requesting_user.id, provider_id=target.id
-        )
+        ),
+        "verification_status": verification_status,
     }
 
 

--- a/src/domain/logic/providers/test_handlers.py
+++ b/src/domain/logic/providers/test_handlers.py
@@ -28,6 +28,7 @@ from src.domain.logic.providers.schema import (
     ProviderLicensureCreate,
 )
 from src.domain.logic.users.repository import UserRepository
+from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.models import (
     Provider,
     ProviderLicensure,
@@ -244,7 +245,10 @@ async def test_get_provider_detail_returns_context(
             repo=ProviderRepository(session),
             requesting_user=user,
             extras=provider_detail_extras,
-            extra_kwargs={"user_favorite_repo": UserFavoriteRepository(session)},
+            extra_kwargs={
+                "user_favorite_repo": UserFavoriteRepository(session),
+                "verification_repo": VerificationRepository(session),
+            },
         )
         # Framework binds `context[spec.name] = target`; the spec name
         # flipped to "clinician" in #642 PR 4. The underlying row is
@@ -259,6 +263,52 @@ async def test_get_provider_detail_returns_context(
         # `is_favorited` is a per-viewer derived field; the owner here
         # has not favorited their own provider.
         assert context["is_favorited"] is False
+        # `verification_status` is `None` when no Verification row exists
+        # yet for the provider — the template renders the UI-only
+        # "Pending" state in that case (#707 stage 2).
+        assert context["verification_status"] is None
+
+
+async def test_get_provider_detail_surfaces_verification_status(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """The provider's `Verification.status` is forwarded to the
+    template context. "Newest wins" multi-row semantics are pinned
+    elsewhere by `VerificationRepository.latest_for_provider`'s own
+    tests; this only verifies that the handler threads the value
+    through (#707 stage 2)."""
+    from src.domain.models import Verification
+
+    user = await _seed_user(db_test_session_manager)
+    provider_id, *_ = await _seed_provider(db_test_session_manager, user_id=user.id)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                Verification(
+                    provider_id=provider_id,
+                    status="verified",
+                    flags=[],
+                    nppes_result={"NPI": "1234567890"},
+                    oig_match=False,
+                    name_match_score=1.0,
+                )
+            )
+
+    async with db_test_session_manager() as session:
+        context = await handle_detail(
+            PROVIDER_ENTITY,
+            request=_fake_request(),
+            target_id=provider_id,
+            repo=ProviderRepository(session),
+            requesting_user=user,
+            extras=provider_detail_extras,
+            extra_kwargs={
+                "user_favorite_repo": UserFavoriteRepository(session),
+                "verification_repo": VerificationRepository(session),
+            },
+        )
+        assert context["verification_status"] == "verified"
 
 
 async def test_get_provider_detail_404_for_unknown_id(
@@ -274,7 +324,10 @@ async def test_get_provider_detail_404_for_unknown_id(
                 repo=ProviderRepository(session),
                 requesting_user=user,
                 extras=provider_detail_extras,
-                extra_kwargs={"user_favorite_repo": UserFavoriteRepository(session)},
+                extra_kwargs={
+                    "user_favorite_repo": UserFavoriteRepository(session),
+                    "verification_repo": VerificationRepository(session),
+                },
             )
 
 
@@ -299,7 +352,10 @@ async def test_get_provider_detail_is_favorited_true_when_self_favorited(
             repo=ProviderRepository(session),
             requesting_user=user,
             extras=provider_detail_extras,
-            extra_kwargs={"user_favorite_repo": UserFavoriteRepository(session)},
+            extra_kwargs={
+                "user_favorite_repo": UserFavoriteRepository(session),
+                "verification_repo": VerificationRepository(session),
+            },
         )
         assert context["is_favorited"] is True
 
@@ -322,7 +378,10 @@ async def test_get_provider_detail_is_favorited_false_for_anonymous_viewer(
             repo=ProviderRepository(session),
             requesting_user=None,
             extras=provider_detail_extras,
-            extra_kwargs={"user_favorite_repo": UserFavoriteRepository(session)},
+            extra_kwargs={
+                "user_favorite_repo": UserFavoriteRepository(session),
+                "verification_repo": VerificationRepository(session),
+            },
         )
         assert context["is_favorited"] is False
 

--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -276,6 +276,63 @@ async def test_get_provider_renders_detail_page(
     assert "<dt>Practice name</dt>" not in response.text
 
 
+async def test_get_provider_detail_shows_pending_verification_badge_when_no_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A provider with no `Verification` row yet renders the UI-only
+    "Pending" badge (`data-status="pending"`). Pins the contract that
+    the badge always shows something, even before the nightly pipeline
+    has touched the row (#707 stage 2)."""
+    provider_id = await _seed_provider_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+    response = await authenticated_client.get(f"/clinicians/{provider_id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    badge = tree.css_first('[data-testid="verification-badge"]')
+    assert badge is not None, "verification badge should always render on detail"
+    assert badge.attributes.get("data-status") == "pending"
+    assert "Pending" in badge.text()
+
+
+async def test_get_provider_detail_shows_verified_badge_for_verified_row(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A provider with a `verified` `Verification` row renders the
+    "Verified" badge (`data-status="verified"`). Pins that the
+    template reads `verification_status` from the detail context the
+    handler now forwards (#707 stage 2)."""
+    from src.domain.models import Verification
+
+    provider_id = await _seed_provider_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                Verification(
+                    provider_id=provider_id,
+                    status="verified",
+                    flags=[],
+                    nppes_result={"NPI": "1234567890"},
+                    oig_match=False,
+                    name_match_score=1.0,
+                )
+            )
+
+    response = await authenticated_client.get(f"/clinicians/{provider_id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    badge = tree.css_first('[data-testid="verification-badge"]')
+    assert badge is not None
+    assert badge.attributes.get("data-status") == "verified"
+    assert "Verified" in badge.text()
+
+
 async def test_get_provider_detail_renders_stacked_affiliation_cards(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/specs/provider.py
+++ b/src/domain/specs/provider.py
@@ -37,6 +37,7 @@ from src.domain.logic.providers.schema import (
     ProviderRead,
     ProviderUpdate,
 )
+from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.models import Provider
 from src.domain.models.enums import (
     CERTIFICATION_TYPES,
@@ -129,7 +130,10 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     ),
     # Per-viewer detail extras live on the spec — see `EntitySpec`.
     detail_extras_path="src.domain.logic.providers.handlers.provider_detail_extras",
-    detail_extras_repos=(("user_favorite_repo", UserFavoriteRepository),),
+    detail_extras_repos=(
+        ("user_favorite_repo", UserFavoriteRepository),
+        ("verification_repo", VerificationRepository),
+    ),
     # The create/edit form's Org-picker dropdown is scoped per-viewer to
     # the user's owned Organizations. The framework invokes the extras
     # callable on both the create path (target=None) and the edit path

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -22,7 +22,19 @@
    while the name backfill is in progress. #}
 {% block current_label %}{% if provider.first_name and provider.last_name %}{{ provider.first_name }} {{ provider.last_name }}{% else %}{{ provider.org.name }}{% endif %}{% endblock %}
 {# title-case-ignore: NPI is an industry abbreviation (National Provider Identifier) #}
-{% block subtitle %}{% if view.npi %}<span>NPI {{ view.npi }}</span>{% endif %}{% endblock %}
+{# Verification status (#707 stage 2) — three nightly-pipeline states
+   (`verified` / `needs_review` / `failed`) plus a fourth UI-only
+   "Pending" rendered when no Verification row exists yet. The
+   `verification_status` context value comes from
+   `provider_detail_extras`; templates do not query the repo directly.
+   `data-status` lets CSS color the pill without parsing the label. #}
+{%- set _status_labels = {
+    "verified": "Verified",
+    "needs_review": "Needs review",
+    "failed": "Verification failed",
+} -%}
+{%- set _status_key = verification_status or "pending" -%}
+{% block subtitle %}<span class="verification-badge" data-testid="verification-badge" data-status="{{ _status_key }}">{{ _status_labels.get(verification_status, "Pending verification") }}</span>{% if view.npi %} · <span>NPI {{ view.npi }}</span>{% endif %}{% endblock %}
 
 {% block actions %}
 {# Primary resource actions (Favorite toggle, Edit, Delete) live in


### PR DESCRIPTION
## Summary
- Stage 2 of #707 — surfaces the nightly verification pipeline's outcome on \`/clinicians/{id}\`.
- Adds a badge near the H1 with four states: \`verified\` / \`needs_review\` / \`failed\` (driven by \`Verification.status\`) plus a UI-only \`pending\` rendered when no \`Verification\` row exists yet, so the badge always shows something.
- Wires \`VerificationRepository\` into \`PROVIDER_ENTITY.detail_extras_repos\` and threads the latest status through \`provider_detail_extras\` into the template context.
- \`data-status=\"<key>\"\` lets CSS style the pill without parsing the label; \`data-testid=\"verification-badge\"\` lets route tests find it without scraping text.

Why this UI choice (answering stage 1, \"decide what to show\"): a three-state pill is the smallest thing that's also reusable for stages 3 (\`/users/me\`) and 4 (listing filter). Picking a binary badge here would force a second copy decision later.

## Test plan
- [x] \`pytest src/domain/logic/providers/test_handlers.py src/domain/routes/test_providers.py\` — 62 passed.
- [x] \`pytest src/domain/specs/test_provider.py src/domain/specs/test_spec_conformance.py src/framework/dispatch/test_resource_routes.py\` — 223 passed, 95 skipped.
- [x] Pre-commit hooks (black/isort/autoflake/title-case/template-imports) pass.
- [x] Consumer contract tests for clinician forms pass in isolation. Full \`dev test contract\` had environmental errors during parallel runs with other agents' worktrees (shared playwright port :8999 / pact files); my change is detail-page only, no contract surfaces touched.

## Follow-ups
- Stage 3: surface the same status on \`/users/me\` so a clinician sees their own listing's state.
- Stage 4: \`?verified=true\` filter on \`/clinicians\`.
- CSS for \`.verification-badge[data-status=…]\` (styled inline as plain text today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)