### PR TITLE
feat: SessionStart hook for branch-state visibility (#743)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/session_start_branch_check.py"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ If a relevant README or test file doesn't exist yet, **create it as part of the 
 
 A Stop hook checks the diff at end-of-turn and surfaces a reminder when source files change without their README/test. The hook is a soft prompt, not a hard block — but ignoring it should be a deliberate decision (e.g. typo fix, log message tweak), not an oversight.
 
+A SessionStart hook prints the real current branch, dirty state, and stash list at session start — and warns loudly if you've landed on `main`/`master` in the shared working tree. Multi-agent sessions in this repo share one working directory; trust the hook's output over any harness-provided "current branch" line. See [`scripts/README.md`](scripts/README.md) for both hooks.
+
 **Contract tests are not run by default.** `tests/test_contract` is excluded from the default `dev test` collection (see [`tests/test_contract/README.md`](tests/test_contract/README.md)). If you change templates, route response shapes, or anything mock data factories in `tests/test_contract` assume, also run `dev test contract` before pushing — otherwise CI is the first place the breakage surfaces.
 
 ## One source of truth — link, don't copy

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,8 @@ CLAUDE.md and other docs that want to mention a command link to `dev --help` rat
 - `dev/` — one file per `dev <command>` implementation, each with a colocated `test_*.py`.
 - `dev/title_case_check.py` / `dev/template_imports_check.py` / `dev/python_cluster_imports_check.py` — lint checks invoked by `dev lint`.
 - `runtime/` — container-entrypoint scripts: `start.sh` (production CMD: runs migrations, starts uvicorn) and `start-dev.sh` (dev: adds LiveReload + hot reload).
+- `check_doc_test_coupling.py` — Claude Code `Stop` hook; reminds the agent when `src/` code changed without touching colocated README/tests. Wired via [`.claude/settings.json`](../.claude/settings.json).
+- `session_start_branch_check.py` — Claude Code `SessionStart` hook; prints the real branch, dirty state, and stash list at session start, and warns loudly when the agent lands on `main`/`master` in the shared working tree. Wired via [`.claude/settings.json`](../.claude/settings.json).
 - `test_dev_cli.py` — tests for `dev_cli.py` itself.
 
 Deployment-specific scripts live in `deployment/scripts/` (see [`deployment/README.md`](../deployment/README.md)).

--- a/scripts/session_start_branch_check.py
+++ b/scripts/session_start_branch_check.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""SessionStart hook: print real branch + warn loudly on main/master.
+
+Multi-agent sessions in this repo share `/home/user/bedlam-connect`, and the
+harness-provided "Current branch:" line has been observed lying when another
+agent flipped HEAD between sessions. This hook is the first thing the agent
+sees: it states what `git` itself says, surfaces dirty state and prior-session
+stashes, and recommends moving to a worktree if we're on main.
+
+The hook never fails (always exits 0). Its job is visibility, not enforcement.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _git(args: list[str]) -> str:
+    try:
+        out = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return out.stdout.rstrip("\n")
+    except FileNotFoundError:
+        return ""
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    os.chdir(repo_root)
+
+    branch = _git(["branch", "--show-current"]) or "(detached HEAD)"
+    status = _git(["status", "--short", "--branch"])
+    stashes = _git(["stash", "list"])
+
+    lines: list[str] = ["[session-start branch check]"]
+    lines.append(f"  cwd:    {Path.cwd()}")
+    lines.append(f"  branch: {branch}")
+
+    status_lines = [s for s in status.splitlines() if s and not s.startswith("##")]
+    if status_lines:
+        truncated = status_lines[:10]
+        lines.append(f"  dirty:  {len(status_lines)} file(s) modified")
+        for s in truncated:
+            lines.append(f"          {s}")
+        if len(status_lines) > len(truncated):
+            lines.append(f"          ... and {len(status_lines) - len(truncated)} more")
+    else:
+        lines.append("  dirty:  clean working tree")
+
+    if stashes:
+        stash_count = len(stashes.splitlines())
+        lines.append(
+            f"  stash:  {stash_count} entry(ies) — prior-session work may be hiding here"
+        )
+        lines.append("          run `git stash list` to inspect")
+
+    if branch in {"main", "master"}:
+        lines.append("")
+        lines.append("  ⚠ You are on the trunk branch in the shared working tree.")
+        lines.append(
+            "    Other agents may flip HEAD under you. Move to a worktree before editing:"
+        )
+        lines.append(
+            "        git worktree add .claude/worktrees/<issue-name> -b fix/<N>-<slug> origin/main"
+        )
+
+    print("\n".join(lines), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_session_start_branch_check.py
+++ b/scripts/test_session_start_branch_check.py
@@ -1,0 +1,101 @@
+"""Tests for scripts/session_start_branch_check.py.
+
+The hook is purely informational — these tests pin the output shape so the
+warning about being on `main` (and the stash/dirty-state surfacing) doesn't
+silently disappear from the agent's first impression.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parent / "session_start_branch_check.py"
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    _git(repo, "config", "commit.gpgsign", "false")
+    _git(repo, "config", "gpg.format", "openpgp")
+    (repo / "pyproject.toml").write_text("[project]\nname='t'\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+def _run_in(repo: Path) -> subprocess.CompletedProcess:
+    # The hook resolves repo root by going parent.parent from its own path, so
+    # we invoke it with cwd=repo and rely on its internal chdir for the rest.
+    return subprocess.run(
+        ["python", str(HOOK)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin"},
+    )
+
+
+def _install_hook(repo: Path) -> Path:
+    fake_scripts = repo / "scripts"
+    fake_scripts.mkdir()
+    copy = fake_scripts / "session_start_branch_check.py"
+    copy.write_text(HOOK.read_text())
+    copy.chmod(0o755)
+    _git(repo, "add", "scripts/session_start_branch_check.py")
+    _git(repo, "commit", "-m", "install hook")
+    return copy
+
+
+def test_prints_branch_and_clean_state_on_feature_branch(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    copy = _install_hook(repo)
+    _git(repo, "checkout", "-b", "fix/123-foo")
+
+    result = subprocess.run(
+        ["python", str(copy)], capture_output=True, text=True, cwd=repo
+    )
+    assert result.returncode == 0
+    assert "branch: fix/123-foo" in result.stderr
+    assert "clean working tree" in result.stderr
+    assert "trunk branch" not in result.stderr
+
+
+def test_warns_loudly_on_main_branch(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    copy = _install_hook(repo)
+
+    result = subprocess.run(
+        ["python", str(copy)], capture_output=True, text=True, cwd=repo
+    )
+    assert result.returncode == 0
+    assert "branch: main" in result.stderr
+    assert "trunk branch" in result.stderr
+    assert "git worktree add" in result.stderr
+
+
+def test_surfaces_dirty_state_and_stashes(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    copy = _install_hook(repo)
+    _git(repo, "checkout", "-b", "fix/999")
+    (repo / "a.txt").write_text("a")
+    _git(repo, "add", "a.txt")
+    _git(repo, "stash", "push", "-u", "-m", "wip-from-prior-session")
+
+    # Leave one untracked file so dirty-state surfacing fires.
+    (repo / "c.txt").write_text("c")
+
+    result = subprocess.run(
+        ["python", str(copy)], capture_output=True, text=True, cwd=repo
+    )
+    assert result.returncode == 0
+    assert "file(s) modified" in result.stderr
+    assert "stash:" in result.stderr
+    assert "prior-session" in result.stderr


### PR DESCRIPTION
## Summary
- Adds `scripts/session_start_branch_check.py`, a Claude Code `SessionStart` hook that prints the real current branch, dirty state, and stash list at session start.
- Warns loudly when the agent lands on `main`/`master` in the shared working tree, with the worktree command to escape.
- Wires the hook into `.claude/settings.json` alongside the existing `Stop` hook.
- CLAUDE.md and `scripts/README.md` updated to point at the new hook (one source of truth — the hook docs live in `scripts/README.md`).

Closes #743.

## Why
Multiple agent retros reported the harness-provided "current branch" line lying when another agent had flipped HEAD between sessions, causing edits on the wrong branch. The hook makes the first thing the agent sees a true statement of where it actually is.

## Test plan
- [x] `python -m pytest scripts/test_session_start_branch_check.py` — 3 tests, covering feature-branch clean state, the main-branch warning, and dirty-state + stash surfacing.
- [x] `dev lint` clean.
- [x] Manual: ran the hook from this branch and confirmed it surfaces the modified files and the correct branch name.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8YG358AwFVc4xqcyWSSDa)_