### PR TITLE
feat(dev test): surface files rewritten by the fmt pre-step (#745)

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -217,6 +217,7 @@ class TestCommands:
         # lint surprise. `--skip-lint` is the escape hatch for the
         # "I know my code's dirty, I'm debugging a failing test" case.
         if not skip_lint:
+            pre_fmt_dirty = self._dirty_files()
             fmt_rc = self.quality.fmt()
             if fmt_rc != 0:
                 print(
@@ -225,6 +226,7 @@ class TestCommands:
                     "to bypass the pre-step."
                 )
                 return fmt_rc
+            self._warn_on_fmt_mutations(pre_fmt_dirty)
             lint_rc = self.quality.lint()
             if lint_rc != 0:
                 print(
@@ -249,6 +251,44 @@ class TestCommands:
             cmd.extend(self.PATH_ALIASES.get(p, p) for p in paths)
 
         return self.runner.run_command(cmd)
+
+    def _dirty_files(self) -> set:
+        # Snapshot `git status --porcelain` as a set of paths. Used by the
+        # fmt-mutation surfacing below: if a file is dirty AFTER fmt but
+        # was clean BEFORE, fmt rewrote it — and if the agent has an
+        # in-flight Edit on that file, the next Edit will fail with a
+        # generic "modified since read" error. We surface what fmt
+        # actually touched so the cause is obvious. See #745.
+        try:
+            out = subprocess.run(
+                ["git", "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=self.runner.project_root,
+            )
+        except FileNotFoundError:
+            return set()
+        return {line[3:] for line in out.stdout.splitlines() if line[3:]}
+
+    def _warn_on_fmt_mutations(self, pre_fmt_dirty: set) -> None:
+        post_fmt_dirty = self._dirty_files()
+        newly_dirty = sorted(post_fmt_dirty - pre_fmt_dirty)
+        if not newly_dirty:
+            return
+        print("")
+        print(
+            f"⚠  `dev fmt` rewrote {len(newly_dirty)} file(s) "
+            f"while preparing to run tests:"
+        )
+        for path in newly_dirty:
+            print(f"     {path}")
+        print(
+            "   If you have in-flight edits to these files, re-read them "
+            "before editing further."
+        )
+        print("   Pass --skip-lint to bypass the auto-fmt step.")
+        print("")
 
 
 class QualityCommands:

--- a/scripts/test_dev_cli.py
+++ b/scripts/test_dev_cli.py
@@ -25,6 +25,11 @@ class _RecordingRunner:
 
     def __init__(self) -> None:
         self.last_cmd: Optional[List[str]] = None
+        # `_dirty_files` in TestCommands shells out to `git status` against
+        # this directory. Tests that don't care about fmt-mutation surfacing
+        # rely on the lookup returning an empty set silently — pointing at
+        # /tmp does that without contaminating the repo.
+        self.project_root = Path("/tmp")
 
     def run_command(self, cmd: List[str], cwd: Optional[Path] = None) -> int:
         self.last_cmd = cmd
@@ -130,3 +135,51 @@ def test_run_tests_stops_when_fmt_fails_and_does_not_invoke_lint_or_pytest():
     assert quality.calls == ["fmt"]
     assert runner.last_cmd is None
     assert rc == 1
+
+
+# --- #745: surface fmt-step mutations -----------------------------------
+
+
+def test_run_tests_warns_when_fmt_modifies_a_previously_clean_file(capsys):
+    """When `dev fmt` rewrites a file that was clean before, surface the
+    path explicitly. Agents had been hitting "Edit failed: file modified
+    since read" with no visible cause; the cause is fmt, and naming it
+    saves the diagnose-from-scratch round trip. See #745."""
+    runner, quality = _quality_aware_runner()
+    cmd = TestCommands(runner, quality)
+    # Simulate fmt rewriting one file mid-step.
+    dirty_states = iter([set(), {"src/templates/login.html"}])
+    cmd._dirty_files = lambda: next(dirty_states)
+    rc = cmd.run_tests()
+    out = capsys.readouterr().out
+    assert "src/templates/login.html" in out
+    assert "rewrote 1 file" in out
+    assert "re-read" in out
+    assert rc == 0
+
+
+def test_run_tests_does_not_warn_when_fmt_changes_nothing(capsys):
+    """If fmt is a no-op, no warning — silence is fine, the case we care
+    about is the surprise mutation."""
+    runner, quality = _quality_aware_runner()
+    cmd = TestCommands(runner, quality)
+    cmd._dirty_files = lambda: set()
+    cmd.run_tests()
+    out = capsys.readouterr().out
+    assert "rewrote" not in out
+
+
+def test_run_tests_does_not_warn_for_files_dirty_before_fmt(capsys):
+    """Files the agent had already edited are dirty BEFORE fmt — that's
+    not a fmt mutation, just the agent's own in-flight work. Only
+    newly-dirty paths get surfaced."""
+    runner, quality = _quality_aware_runner()
+    cmd = TestCommands(runner, quality)
+    pre = {"src/foo.py"}
+    dirty_states = iter([pre, pre | {"src/templates/login.html"}])
+    cmd._dirty_files = lambda: next(dirty_states)
+    cmd.run_tests()
+    out = capsys.readouterr().out
+    assert "src/templates/login.html" in out
+    assert "src/foo.py" not in out
+    assert "rewrote 1 file" in out


### PR DESCRIPTION
## Summary
- `TestCommands.run_tests` now snapshots `git status --porcelain` before and after the fmt pre-step. If fmt makes a previously clean file dirty, print the paths with a one-line remediation hint.
- Purely visibility — no exit-code change, no behavioral change to which files fmt touches.

Closes #745.

## Why
Multiple agent retros reported the same confusing failure mode: Edit succeeded, then the next Edit on the same file failed with "modified since read." Cause: `dev fmt` (run automatically as the `dev test` pre-step, see #648) had rewritten the file in between. Naming the mutation removes the diagnose-from-scratch round-trip.

## Test plan
- [x] `pytest scripts/test_dev_cli.py` — 3 new tests covering: warning fires on newly-dirty files, no warning on no-op fmt, files dirty before fmt are excluded from the warning. All existing tests still pass (10 total).
- [x] `dev lint` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8YG358AwFVc4xqcyWSSDa)_