### PR TITLE
feat(title-case): accept ignore marker on preceding line (#749)

### DIFF
--- a/scripts/dev/test_title_case_check.py
+++ b/scripts/dev/test_title_case_check.py
@@ -369,6 +369,55 @@ def test_inline_title_case_ignore_marker_suppresses(tmp_path):
     assert _check(file) == []
 
 
+def test_title_case_ignore_on_preceding_line_suppresses_in_html(tmp_path):
+    """``{# title-case-ignore #}`` on the line *immediately above* the
+    violation also suppresses it. This is the natural Jinja-comment
+    placement and saves the agent from putting the marker inline; see
+    #749 for the trial-and-error friction that drove this."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        {# title-case-ignore: brand name #}
+        <h1>Bedlam Connect</h1>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_title_case_ignore_on_preceding_line_suppresses_in_markdown(tmp_path):
+    """Same preceding-line behaviour for Markdown headings — a
+    ``<!-- title-case-ignore -->`` HTML comment above the heading
+    suppresses it."""
+    file = _write_md(
+        tmp_path,
+        """
+        <!-- title-case-ignore: brand name -->
+        # Bedlam Connect Is Here
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_title_case_ignore_two_lines_above_does_not_suppress(tmp_path):
+    """Only the *immediately* preceding line is consulted. A marker two
+    lines above (with a content line in between) does not retroactively
+    suppress an unrelated violation downstream — that would let a single
+    stale marker silence unrelated lint."""
+    file = _write_md(
+        tmp_path,
+        """
+        <!-- title-case-ignore: this was for the line below -->
+        # Sentence case heading
+        # Another Bad Heading
+        """,
+    )
+    violations = _check(file)
+    assert len(violations) == 1
+    assert "Another Bad Heading" in violations[0]["original"]
+
+
 def test_titleignore_file_skips_whole_file(tmp_path):
     """A ``.titleignore`` listing a file pattern excludes that file even
     when it has clear violations."""

--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -5,7 +5,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 try:
     import pathspec
@@ -285,6 +285,30 @@ class TitleCaseChecker:
                 return True
         return False
 
+    def is_violation_suppressed(
+        self, content: str, line_num: int, lines: Optional[List[str]] = None
+    ) -> bool:
+        """Return True if line `line_num` (1-indexed) or its immediately
+        preceding line carries an ignore marker.
+
+        The preceding-line check is the lint equivalent of
+        `# eslint-disable-next-line` — it lets templates put the marker on
+        its own line so brand-name copy reads cleanly:
+
+            {# title-case-ignore: brand name #}
+            <h2>Bedlam Connect</h2>
+
+        Only the *immediately* preceding line is consulted (no blank-line
+        skipping) so a far-away comment can never attribute itself to an
+        unrelated violation. See #749 for the motivating friction."""
+        if lines is None:
+            lines = content.split("\n")
+        if 1 <= line_num <= len(lines) and self.should_ignore_line(lines[line_num - 1]):
+            return True
+        if line_num >= 2 and self.should_ignore_line(lines[line_num - 2]):
+            return True
+        return False
+
     def should_ignore_file(self, file_path: Path) -> bool:
         """Check if entire file should be ignored based on .titleignore file or gitignore."""
         # Skip known binary extensions silently — these are never text content
@@ -516,7 +540,7 @@ class TitleCaseChecker:
             if in_fenced_code_block:
                 continue
 
-            if self.should_ignore_line(line):
+            if self.is_violation_suppressed(content, line_num, lines):
                 continue
 
             for pattern, pattern_type in patterns:
@@ -746,12 +770,13 @@ class TitleCaseChecker:
         line_num = self._locate_in_source(locator_candidates, content, line_starts)
 
         # Honour the per-line escape hatch even in parsed mode: if the
-        # source line carries a ``title-case-ignore`` marker, suppress.
+        # source line — or the immediately preceding line, see #749 —
+        # carries a ``title-case-ignore`` marker, suppress.
         try:
             line_text = content.split("\n")[line_num - 1]
         except IndexError:
             line_text = ""
-        if self.should_ignore_line(line_text):
+        if self.is_violation_suppressed(content, line_num):
             return
 
         violations.append(
@@ -899,7 +924,10 @@ class TitleCaseChecker:
             return 0 if fixed_count == total_violations else 1
         else:
             print("💡 Run with --fix to automatically correct these violations")
-            print("💡 Add 'title-case-ignore' comment to ignore specific lines")
+            print(
+                "💡 Add 'title-case-ignore' on the violating line OR the line "
+                "immediately above it"
+            )
             print("💡 Create .titleignore file to ignore specific files/patterns")
             return 1
 
@@ -916,7 +944,10 @@ Examples:
     python scripts/dev/title_case_check.py README.md src/     # Check specific files/dirs
 
 Exception handling:
-  - Add 'title-case-ignore' in a comment to ignore specific lines
+  - Add 'title-case-ignore' in a comment on the violating line OR the
+    line immediately above it (e.g. `{# title-case-ignore: brand #}`
+    on its own line above an `<h2>` works the same as `<h2>...</h2>
+    {# title-case-ignore #}` inline).
   - Create .titleignore file with glob patterns to ignore files
   - Use --check-only to report without fixing
   - Use --no-gitignore to disable automatic gitignore support


### PR DESCRIPTION
## Summary
- `TitleCaseChecker.is_violation_suppressed(content, line_num)` — new helper that honours an ignore marker on the violating line *or* its immediately preceding line.
- Both callsites (HTML/Jinja parsed mode + Markdown line-based mode) now route through the helper.
- Help text and inline hint updated to document both placements.

Closes #749.

## Why
The retros report 3+ failed commits per encounter suppressing title-case false positives. The marker placement is non-obvious: inside `{# #}` looked plausible but the example text in the comment then matched itself; on the preceding line was the natural Jinja pattern but wasn't honoured.

The fix is the lint equivalent of `# eslint-disable-next-line` — only the *immediately* preceding line is consulted (no blank-line skipping) so a stale marker can never attribute itself to a downstream violation.

## Test plan
- [x] `pytest scripts/dev/test_title_case_check.py` — 3 new tests: HTML preceding-line, Markdown preceding-line, and a negative case proving a marker two lines above does not retroactively suppress. All existing tests still pass (31 total).
- [x] `dev lint` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8YG358AwFVc4xqcyWSSDa)_