### PR TITLE
feat(dev): push subcommand with duplicate-PR pre-check (#746)

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -2,6 +2,7 @@
 """Development CLI."""
 
 import argparse
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -706,6 +707,156 @@ class WorktreeCommands:
         return entries
 
 
+class PushCommands:
+    """`dev push` — `git push -u` with a pre-flight duplicate-PR check.
+
+    Multi-agent retros (#746) reported the same loss-of-30-minutes pattern:
+    claim an issue, build the fix, open a PR, then discover at rebase time
+    that another agent had already merged the same fix. The label-based
+    claim primitive doesn't gate work-in-progress between agents.
+
+    This wrapper parses the current branch for an issue number and, if
+    found, asks GitHub whether a PR for that issue already exists or
+    whether a merge commit mentioning it is already on origin/main.
+    The user is prompted before push so a real overlap can be reviewed
+    and cancelled, but `--yes` (or `--force`) bypasses the prompt for
+    the no-issue-number case.
+    """
+
+    # Branch-name patterns that carry an issue number. The capture group
+    # is the issue number itself. Order matters — most-specific first.
+    _BRANCH_PATTERNS = [
+        re.compile(r"(?:^|/)fix[-/](\d+)(?:[-/]|$)"),
+        re.compile(r"(?:^|/)issue[-/](\d+)(?:[-/]|$)"),
+        re.compile(r"(?:^|/)claude/[^/]*-(\d+)-"),
+    ]
+
+    def __init__(self, runner: CLIRunner) -> None:
+        self.runner = runner
+
+    def _current_branch(self) -> Optional[str]:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=self.runner.project_root,
+        )
+        return result.stdout.strip() or None
+
+    def _issue_number_from_branch(self, branch: str) -> Optional[int]:
+        for pat in self._BRANCH_PATTERNS:
+            m = pat.search(branch)
+            if m:
+                return int(m.group(1))
+        return None
+
+    def _gh_existing_prs(self, issue: int) -> List[dict]:
+        # Best-effort: if `gh` isn't installed or the call fails, return
+        # [] so push isn't blocked by tooling absence.
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--search",
+                f"#{issue} in:title,body",
+                "--state",
+                "all",
+                "--json",
+                "number,state,title,url",
+                "--limit",
+                "10",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=self.runner.project_root,
+        )
+        if result.returncode != 0:
+            return []
+        try:
+            import json
+
+            data = json.loads(result.stdout or "[]")
+        except (ValueError, json.JSONDecodeError):
+            return []
+        return data if isinstance(data, list) else []
+
+    def _grep_main_log(self, issue: int) -> List[str]:
+        result = subprocess.run(
+            [
+                "git",
+                "log",
+                "--grep",
+                f"#{issue}",
+                "origin/main",
+                "--oneline",
+                "-5",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=self.runner.project_root,
+        )
+        if result.returncode != 0:
+            return []
+        return [ln for ln in result.stdout.splitlines() if ln.strip()]
+
+    def push(
+        self,
+        force: bool = False,
+        yes: bool = False,
+        extra_args: Optional[List[str]] = None,
+    ) -> int:
+        branch = self._current_branch()
+        if not branch:
+            print("❌ Could not resolve current branch.")
+            return 1
+
+        issue = self._issue_number_from_branch(branch)
+        if issue is not None and not yes:
+            overlaps = self._collect_overlaps(issue)
+            if overlaps and not self._confirm_push(branch, issue, overlaps):
+                return 2
+
+        cmd = ["git", "push", "-u", "origin", branch]
+        if force:
+            cmd.append("--force-with-lease")
+        if extra_args:
+            cmd.extend(extra_args)
+        return self.runner.run_command(cmd)
+
+    def _collect_overlaps(self, issue: int) -> dict:
+        return {
+            "prs": self._gh_existing_prs(issue),
+            "commits": self._grep_main_log(issue),
+        }
+
+    def _confirm_push(self, branch: str, issue: int, overlaps: dict) -> bool:
+        prs = overlaps.get("prs") or []
+        commits = overlaps.get("commits") or []
+        if not prs and not commits:
+            return True
+        print(f"⚠  Issue #{issue} may already be addressed elsewhere:")
+        for pr in prs:
+            number = pr.get("number")
+            state = (pr.get("state") or "?").upper()
+            title = pr.get("title", "")
+            print(f"    PR #{number} ({state}): {title}")
+        for line in commits:
+            print(f"    commit on main: {line}")
+        print(
+            "Push anyway? Re-run with --yes to skip this prompt, or "
+            "Ctrl-C / answer 'n' to abort."
+        )
+        try:
+            answer = input(f"Push branch '{branch}'? [y/N] ").strip().lower()
+        except EOFError:
+            answer = "n"
+        return answer in {"y", "yes"}
+
+
 class SetupCommands:
     def __init__(self, runner: CLIRunner):
         self.runner = runner
@@ -761,6 +912,7 @@ class DevCLI:
         self.migrate_cmd = MigrateCommands(self.runner)
         self.playwright_cmd = PlaywrightCommands(self.runner)
         self.worktree_cmd = WorktreeCommands(self.runner)
+        self.push_cmd = PushCommands(self.runner)
 
     def create_parser(self) -> argparse.ArgumentParser:
         """Create the argument parser with all commands."""
@@ -798,6 +950,7 @@ Examples:
         self._add_migrate_parser(subparsers)
         self._add_playwright_setup_parser(subparsers)
         self._add_worktree_parser(subparsers)
+        self._add_push_parser(subparsers)
 
         return parser
 
@@ -1108,6 +1261,32 @@ Examples:
             return 1
 
         parser.set_defaults(func=_print_help)
+
+    def _add_push_parser(self, subparsers):
+        parser = subparsers.add_parser(
+            "push",
+            help="`git push -u` with a pre-flight duplicate-PR check",
+            description=(
+                "Wraps `git push -u origin <current-branch>`. If the branch "
+                "name carries an issue number (e.g. `fix/697-foo`, "
+                "`claude/fix-697-foo`), first checks whether a PR for that "
+                "issue already exists and whether origin/main already has a "
+                "merge commit mentioning it. If so, prompts before pushing. "
+                "Use --yes to skip the prompt non-interactively. See #746."
+            ),
+        )
+        parser.add_argument(
+            "--yes",
+            "-y",
+            action="store_true",
+            help="Skip the duplicate-PR prompt and push regardless.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Forward --force-with-lease to git push.",
+        )
+        parser.set_defaults(func=lambda args: self.push_cmd.push(args.force, args.yes))
 
     def run(self) -> int:
         """Run the CLI application."""

--- a/scripts/test_dev_cli_push.py
+++ b/scripts/test_dev_cli_push.py
@@ -1,0 +1,142 @@
+"""Tests for `dev push` in scripts/dev_cli.py.
+
+The command shells out to `git`, `gh`, and `input()`. Tests stub the
+external interactions directly on the PushCommands instance — the
+contract under test is "given these overlap signals, do we prompt and
+do we honour the answer?", not the shell incantations themselves.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from scripts.dev_cli import PushCommands
+
+
+class _RecordingRunner:
+    def __init__(self) -> None:
+        self.last_cmd: Optional[List[str]] = None
+        self.project_root = Path("/tmp")
+
+    def run_command(self, cmd: List[str], cwd: Optional[Path] = None) -> int:
+        self.last_cmd = cmd
+        return 0
+
+
+def _push_cmd(branch: str, prs: list, commits: list) -> PushCommands:
+    runner = _RecordingRunner()
+    cmd = PushCommands(runner)
+    cmd._current_branch = lambda: branch
+    cmd._gh_existing_prs = lambda issue: prs
+    cmd._grep_main_log = lambda issue: commits
+    return cmd
+
+
+# --- branch-name parsing ------------------------------------------------
+
+
+def test_extracts_issue_number_from_fix_branch():
+    cmd = _push_cmd("fix/697-foo", [], [])
+    assert cmd._issue_number_from_branch("fix/697-foo") == 697
+
+
+def test_extracts_issue_number_from_issue_branch():
+    cmd = _push_cmd("issue-697-foo", [], [])
+    assert cmd._issue_number_from_branch("issue-697-foo") == 697
+
+
+def test_extracts_issue_number_from_claude_branch():
+    cmd = _push_cmd("claude/fix-697-foo", [], [])
+    assert cmd._issue_number_from_branch("claude/fix-697-foo") == 697
+
+
+def test_returns_none_when_no_issue_number_in_branch():
+    cmd = _push_cmd("misc-refactor", [], [])
+    assert cmd._issue_number_from_branch("misc-refactor") is None
+
+
+# --- prompt + push behavior --------------------------------------------
+
+
+def test_pushes_without_prompt_when_no_overlaps(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
+    cmd = _push_cmd("fix/697-foo", prs=[], commits=[])
+    rc = cmd.push()
+    assert rc == 0
+    assert cmd.runner.last_cmd == ["git", "push", "-u", "origin", "fix/697-foo"]
+
+
+def test_prompts_and_aborts_when_pr_already_exists(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
+    cmd = _push_cmd(
+        "fix/697-foo",
+        prs=[{"number": 723, "state": "merged", "title": "fix: foo"}],
+        commits=[],
+    )
+    rc = cmd.push()
+    assert rc == 2
+    assert cmd.runner.last_cmd is None  # never reached git push
+    out = capsys.readouterr().out
+    assert "Issue #697 may already be addressed" in out
+    assert "PR #723" in out
+
+
+def test_prompts_and_pushes_when_user_confirms(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+    cmd = _push_cmd(
+        "fix/697-foo",
+        prs=[{"number": 723, "state": "open", "title": "fix: foo"}],
+        commits=[],
+    )
+    rc = cmd.push()
+    assert rc == 0
+    assert cmd.runner.last_cmd == ["git", "push", "-u", "origin", "fix/697-foo"]
+
+
+def test_yes_flag_bypasses_prompt_entirely(monkeypatch, capsys):
+    # If the prompt code runs at all, input() will raise — proves we skip it.
+    def _boom(_prompt=""):
+        raise AssertionError("prompt should not be called")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    cmd = _push_cmd(
+        "fix/697-foo",
+        prs=[{"number": 723, "state": "merged", "title": "fix: foo"}],
+        commits=["abc123 fix: foo (#697)"],
+    )
+    rc = cmd.push(yes=True)
+    assert rc == 0
+    assert cmd.runner.last_cmd == ["git", "push", "-u", "origin", "fix/697-foo"]
+
+
+def test_main_log_overlap_also_triggers_prompt(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
+    cmd = _push_cmd(
+        "fix/697-foo",
+        prs=[],
+        commits=["abc123 fix: foo (#697)"],
+    )
+    rc = cmd.push()
+    assert rc == 2
+    out = capsys.readouterr().out
+    assert "abc123 fix: foo (#697)" in out
+
+
+def test_force_flag_adds_force_with_lease(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+    cmd = _push_cmd("fix/697-foo", prs=[], commits=[])
+    cmd.push(force=True)
+    assert cmd.runner.last_cmd[-1] == "--force-with-lease"
+
+
+def test_branch_without_issue_number_pushes_unconditionally(monkeypatch):
+    # No issue number in branch → no API calls, no prompt.
+    def _boom(_prompt=""):
+        raise AssertionError("prompt should not be called")
+
+    monkeypatch.setattr("builtins.input", _boom)
+    cmd = _push_cmd("misc-refactor", prs=[], commits=[])
+    rc = cmd.push()
+    assert rc == 0
+    assert cmd.runner.last_cmd == ["git", "push", "-u", "origin", "misc-refactor"]


### PR DESCRIPTION
## Summary
- New `dev push` subcommand. Wraps `git push -u origin <branch>` with a pre-flight check that, when the branch name carries an issue number, queries `gh pr list` and `git log --grep` for that issue before pushing.
- If either signal turns up a hit, prompts; `--yes` bypasses non-interactively, `--force` adds `--force-with-lease`.
- Recognizes `fix/<N>-…`, `issue-<N>-…`, and `claude/fix-<N>-…` patterns.

Closes #746.

## Why
The duplicate-PR-after-30-minutes-of-work pattern was the most-cited friction in the retros after the claim primitive itself. This is the last line of defense — even if the claim was lost, the push-time check catches it before the conflict materializes at rebase.

## Test plan
- [x] `pytest scripts/test_dev_cli_push.py` — 11 tests covering branch-name parsing (3 valid patterns + 1 no-match), prompt behavior (no overlap, PR overlap → abort, PR overlap → confirm push, `--yes` bypasses), `git log` overlap also triggers prompt, `--force` adds `--force-with-lease`, no-issue-number branches push unconditionally.
- [x] `dev lint` clean.
- [x] All other `scripts/test_dev_cli*.py` tests still pass (29 total).


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8YG358AwFVc4xqcyWSSDa)_