### PR TITLE
feat(dev): per-worktree docker compose project name (#748)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,8 @@ This directory holds the project's developer CLI plus a handful of standalone sc
 
 `dev_cli.py` is the source of truth for `dev <command>`. It's installed as a console script via `pip install -e .` and auto-detects the current project root by walking up to `pyproject.toml`, so it operates on the worktree you're sitting in.
 
+Each worktree also runs under its own `docker compose` project name (derived from the project-root directory), so `dev up` / `dev seed` / `dev logs` in a worktree never collide with the main checkout. Export `COMPOSE_PROJECT_NAME` to override.
+
 Run `dev --help` for the command list and `dev <command> --help` for per-command details. Help strings are co-located with the argparse definitions in [`dev_cli.py`](dev_cli.py), so they cannot drift from the implementation.
 
 CLAUDE.md and other docs that want to mention a command link to `dev --help` rather than restating it.

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -68,6 +68,17 @@ class CLIRunner:
             env.update(extra)
         return env
 
+    def _is_compose_cmd(self, cmd: List[str]) -> bool:
+        # Recognize `docker compose` and `docker-compose` invocations
+        # — those are the only ones that consult COMPOSE_PROJECT_NAME.
+        # Everything else (alembic, pytest, gh, git, python, …) runs
+        # with the inherited parent env so its behaviour is unchanged.
+        if not cmd:
+            return False
+        if cmd[0] == "docker-compose":
+            return True
+        return cmd[0] == "docker" and len(cmd) > 1 and cmd[1] == "compose"
+
     def run_command(self, cmd: List[str], cwd: Optional[Path] = None) -> int:
         if cwd is None:
             cwd = self.project_root
@@ -75,8 +86,9 @@ class CLIRunner:
         print(f"🚀 Running: {' '.join(cmd)}")
         print(f"📁 Working directory: {cwd}")
 
+        env = self._compose_env() if self._is_compose_cmd(cmd) else None
         try:
-            result = subprocess.run(cmd, cwd=cwd, env=self._compose_env(), check=False)
+            result = subprocess.run(cmd, cwd=cwd, env=env, check=False)
             return result.returncode
         except KeyboardInterrupt:
             print("\n⚠️ Interrupted by user")

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -2,6 +2,7 @@
 """Development CLI."""
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -42,6 +43,30 @@ def _resolve_project_root() -> Path:
 class CLIRunner:
     def __init__(self):
         self.project_root = _resolve_project_root()
+        # Per-worktree `docker compose` project name (see #748). Each
+        # worktree gets its own container stack — containers, volumes,
+        # network — so two worktrees can run the dev container in
+        # parallel and `dev seed` from a worktree targets the worktree's
+        # own volume instead of leaking into the main checkout. The user
+        # can still override by exporting COMPOSE_PROJECT_NAME themselves;
+        # we only set it when nothing else has.
+        self.compose_project_name = self._derive_compose_project_name()
+
+    def _derive_compose_project_name(self) -> str:
+        # docker-compose project names must be lowercase alnum + `-`/`_`,
+        # so slugify the project-root directory name. `bedlam-` prefix
+        # keeps the namespace human-grep-able across docker installs that
+        # also host other compose projects.
+        raw = self.project_root.name.lower()
+        slug = re.sub(r"[^a-z0-9_-]+", "-", raw).strip("-") or "bedlam"
+        return f"bedlam-{slug}" if not slug.startswith("bedlam") else slug
+
+    def _compose_env(self, extra: Optional[dict] = None) -> dict:
+        env = os.environ.copy()
+        env.setdefault("COMPOSE_PROJECT_NAME", self.compose_project_name)
+        if extra:
+            env.update(extra)
+        return env
 
     def run_command(self, cmd: List[str], cwd: Optional[Path] = None) -> int:
         if cwd is None:
@@ -51,7 +76,7 @@ class CLIRunner:
         print(f"📁 Working directory: {cwd}")
 
         try:
-            result = subprocess.run(cmd, cwd=cwd, check=False)
+            result = subprocess.run(cmd, cwd=cwd, env=self._compose_env(), check=False)
             return result.returncode
         except KeyboardInterrupt:
             print("\n⚠️ Interrupted by user")
@@ -74,6 +99,7 @@ class CLIRunner:
             capture_output=True,
             text=True,
             cwd=self.project_root,
+            env=self._compose_env(),
         )
         return bool(result.stdout.strip())
 

--- a/scripts/test_dev_cli_compose_project.py
+++ b/scripts/test_dev_cli_compose_project.py
@@ -61,6 +61,19 @@ def test_compose_env_respects_user_override(monkeypatch):
     assert env["COMPOSE_PROJECT_NAME"] == "user-pick"
 
 
+def test_is_compose_cmd_recognises_docker_compose_invocations():
+    runner = _make_runner_at(Path("/x"))
+    assert runner._is_compose_cmd(["docker", "compose", "-f", "x.yml", "up"])
+    assert runner._is_compose_cmd(["docker-compose", "up"])
+    # Not compose:
+    assert not runner._is_compose_cmd(["pytest", "-v"])
+    assert not runner._is_compose_cmd(["alembic", "upgrade", "head"])
+    assert not runner._is_compose_cmd(["docker", "build", "."])
+    assert not runner._is_compose_cmd(["docker", "ps"])
+    assert not runner._is_compose_cmd(["git", "status"])
+    assert not runner._is_compose_cmd([])
+
+
 def test_slugifies_uppercase_and_punctuation():
     runner = _make_runner_at(Path("/tmp/MY Project Dir!"))
     name = runner.compose_project_name

--- a/scripts/test_dev_cli_compose_project.py
+++ b/scripts/test_dev_cli_compose_project.py
@@ -1,0 +1,71 @@
+"""Tests for the per-worktree COMPOSE_PROJECT_NAME plumbing (#748).
+
+`docker compose` is namespaced by `COMPOSE_PROJECT_NAME`. Without it,
+two worktrees that both try to `dev up` collide on container/volume/
+network names, and `dev seed` invoked from a worktree silently leaks
+into the main checkout's volume. The CLIRunner now derives a project
+name from the project-root directory and injects it into every
+subprocess.run env.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from scripts.dev_cli import CLIRunner
+
+
+def _make_runner_at(root: Path) -> CLIRunner:
+    # CLIRunner.__init__ resolves project_root by walking up from cwd to
+    # the first pyproject.toml. We construct the runner then override
+    # project_root so we can exercise different worktree paths without
+    # chdir tricks.
+    runner = CLIRunner.__new__(CLIRunner)
+    runner.project_root = root
+    runner.compose_project_name = runner._derive_compose_project_name()
+    return runner
+
+
+def test_main_checkout_yields_bedlam_named_project():
+    # Project root is `bedlam-connect`; the slug already starts with
+    # `bedlam`, so we don't double-prefix.
+    runner = _make_runner_at(Path("/home/user/bedlam-connect"))
+    assert runner.compose_project_name == "bedlam-connect"
+
+
+def test_worktree_directory_yields_unique_name():
+    runner = _make_runner_at(
+        Path("/home/user/bedlam-connect/.claude/worktrees/issue-707-foo")
+    )
+    assert runner.compose_project_name == "bedlam-issue-707-foo"
+
+
+def test_two_worktrees_yield_distinct_names():
+    a = _make_runner_at(Path("/x/.claude/worktrees/issue-707-foo"))
+    b = _make_runner_at(Path("/x/.claude/worktrees/issue-708-bar"))
+    assert a.compose_project_name != b.compose_project_name
+
+
+def test_compose_env_injects_project_name():
+    runner = _make_runner_at(Path("/x/.claude/worktrees/issue-707-foo"))
+    env = runner._compose_env()
+    assert env.get("COMPOSE_PROJECT_NAME") == "bedlam-issue-707-foo"
+
+
+def test_compose_env_respects_user_override(monkeypatch):
+    monkeypatch.setenv("COMPOSE_PROJECT_NAME", "user-pick")
+    runner = _make_runner_at(Path("/x/.claude/worktrees/issue-707-foo"))
+    env = runner._compose_env()
+    # User's choice wins — we never silently rewrite a value they set.
+    assert env["COMPOSE_PROJECT_NAME"] == "user-pick"
+
+
+def test_slugifies_uppercase_and_punctuation():
+    runner = _make_runner_at(Path("/tmp/MY Project Dir!"))
+    name = runner.compose_project_name
+    # No spaces, no '!', lowercase only.
+    assert " " not in name
+    assert "!" not in name
+    assert name == name.lower()
+    assert name.startswith("bedlam-")


### PR DESCRIPTION
## Summary
- `CLIRunner` now derives a `COMPOSE_PROJECT_NAME` from the project-root directory name (e.g. `bedlam-connect`, `bedlam-issue-707-foo`) and injects it into every subprocess env via `_compose_env()`.
- Applies to `run_command` and `is_dev_container_running`, which are the two paths every `docker compose` invocation in `dev_cli.py` goes through (DevCommands.up/down/logs/restart, SeedCommands, MigrateCommands, PromoteAdminCommands).
- A user-set `COMPOSE_PROJECT_NAME` always wins; we only fill in via `setdefault`.

Closes #748.

## Why
Today every worktree shares one global compose stack, which means:
- two worktrees can't `dev up` in parallel (port + container-name collisions);
- `dev seed` from a worktree silently writes to the main checkout's volume because compose uses the project name (not the bind-mount path) to namespace volumes;
- "verify a UI change" forces agents back into the main checkout.

Per-worktree project names let worktrees be genuinely isolated stacks.

## Test plan
- [x] `pytest scripts/test_dev_cli_compose_project.py` — 6 tests: main checkout name, worktree name, two worktrees yield distinct names, env-var injection, user override is respected, slugifier handles uppercase + punctuation.
- [x] `dev lint` clean.
- [x] All other `scripts/test_dev_cli*.py` tests still pass (48 total).


---
_Generated by [Claude Code](https://claude.ai/code/session_01G8YG358AwFVc4xqcyWSSDa)_