### PR TITLE
fix(chrome): use Pico v2 nav-dropdown pattern for profile menu

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -134,13 +134,14 @@ async def test_authenticated_page_has_sign_out_affordance(
 ):
     """Any authenticated page must expose the sign-out endpoint in the
     header chrome so the user can end their session within 2 clicks.
-    The logout form targets POST /auth/jwt/logout — assert it is present
-    on the profile page (a representative authenticated response)."""
+    The header dropdown uses `<a hx-post="/auth/sign-out">` (Pico v2
+    nav-dropdown pattern) — assert the target is present on the profile
+    page (a representative authenticated response)."""
     response = await authenticated_client.get(
         "/users/me", headers={"Accept": "text/html"}
     )
     assert response.status_code == 200
-    assert 'action="/auth/sign-out"' in response.text
+    assert 'hx-post="/auth/sign-out"' in response.text
 
 
 async def test_forgot_password_request(test_client: AsyncClient, logged_in_user: User):

--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -310,7 +310,9 @@ async def test_get_provider_renders_detail_page(
     # Licensure section renders the seeded row.
     assert "L-99999" in response.text
     # Owner sees an Edit link, no edit forms (read-only) in the page body.
-    # (The header contains the sign-out form — limit to main content only.)
+    # (The header dropdown link is not a form — scoping to main is still
+    #  the right approach for future-proofing, but the original reason no
+    #  longer applies.)
     assert tree.css_first(f'a[href="/clinicians/{provider_id}/form"]') is not None
     assert tree.css_first("main form") is None
     # Regression for #594 — the practice name lives in the header
@@ -1357,8 +1359,8 @@ async def test_get_provider_form_renders(
     response = await authenticated_client.get("/clinicians/form")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    # The sign-out nav dropdown adds a <form> in the header; target the
-    # main-content form specifically.
+    # The header uses a link (`<a hx-post>`), not a form; targeting
+    # `main form` is still the right scope for the clinician create form.
     form = tree.css_first("main form")
     assert form is not None
     assert form.attributes.get("hx-post") == "/clinicians"

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -656,25 +656,23 @@
              `has_provider_profile` is still set in base_context but is no
              longer read here. #}
           <li>
-            {# title-case-ignore — Profile dropdown: Pico `<details role="list">` gives us a
-               disclosure widget with no JS. Contains two items — Profile
-               (links to /users/me) and Sign out (POSTs to /auth/sign-out
-               which clears the fastapiusersauth cookie and returns
-               HX-Redirect → /auth/login). #}
-            <details role="list"{% if _on_profile %} aria-current="page"{% endif %}>
-              <summary aria-haspopup="listbox" aria-label="Profile menu" style="list-style:none;cursor:pointer;">
+            {# Profile dropdown — canonical Pico v2 nav-dropdown pattern
+               (https://picocss.com/docs/nav#dropdowns): `<details
+               class="dropdown">` / `<summary>` / `<ul dir="rtl">` /
+               `<li><a>`. `dir="rtl"` right-aligns the panel so it doesn't
+               overflow the viewport edge. Sign-out uses `hx-post` on the
+               `<a>` because the route returns `HX-Redirect`; HTMX handles
+               the full-page navigation to `/auth/login`. #}
+            <details class="dropdown"{% if _on_profile %} aria-current="page"{% endif %}>
+              <summary aria-label="Profile menu">
                 {# Lucide `user` icon, inlined. `currentColor` inherits
-                   the summary color so Pico's aria-current treatment
-                   propagates to the icon automatically. #}
+                   the summary's link color, including Pico's
+                   aria-current treatment. #}
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
               </summary>
-              <ul role="listbox">
+              <ul dir="rtl">
                 <li><a href="{{ entity_url('user', id='me') }}">Profile</a></li>
-                <li>
-                  <form method="post" action="/auth/sign-out" hx-post="/auth/sign-out" style="margin:0;">
-                    <button type="submit" style="width:100%;text-align:left;background:none;border:none;padding:0;cursor:pointer;color:inherit;">Sign out</button>
-                  </form>
-                </li>
+                <li><a href="#" hx-post="/auth/sign-out">Sign out</a></li>
               </ul>
             </details>
           </li>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -656,7 +656,7 @@
              `has_provider_profile` is still set in base_context but is no
              longer read here. #}
           <li>
-            {# Profile dropdown — canonical Pico v2 nav-dropdown pattern
+            {# title-case-ignore: Profile dropdown — canonical Pico v2 nav-dropdown pattern
                (https://picocss.com/docs/nav#dropdowns): `<details
                class="dropdown">` / `<summary>` / `<ul dir="rtl">` /
                `<li><a>`. `dir="rtl"` right-aligns the panel so it doesn't


### PR DESCRIPTION
## Summary
- Replaces Pico v1 `<details role="list">` / `role="listbox"` / inline-style hacks with the canonical [Pico v2 nav-dropdown](https://picocss.com/docs/nav#dropdowns): `<details class="dropdown">` / plain `<summary>` / `<ul dir="rtl">` / `<li><a>` items.
- `dir="rtl"` right-aligns the panel so it doesn't clip the viewport edge.
- Sign-out item becomes `<a hx-post="/auth/sign-out">` (was a `<form>` + heavily-styled `<button>`). The route returns `HX-Redirect` so HTMX handles navigation — no extra JS needed.
- Updates `test_auth_routes` assertion from `action=` (form attr) → `hx-post=` (link attr). Updates two stale "sign-out form in header" comments in `test_providers`.

## Test plan
- [x] `pytest` full suite: 1602 passed, 96 skipped (3 pre-existing `python`-binary failures in `test_session_start_branch_check.py`, unrelated to this change)
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)