### PR TITLE
feat(email): framework email module + console/file/resend backends (PR 1/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ coverage.xml
 .pytest_cache/
 
 
+# Local dev mail dump — `EMAIL_BACKEND=file` writes .eml-shaped files
+# here for HTML inspection. See `src/framework/email/README.md`.
+.mail/
+
 # Environments
 .env
 .env.development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ app = [
     # (`src/domain/logic/verifications/nppes.py`). Runtime dep — must
     # ship in the production image, not just `[test]`.
     "httpx",
+    # Transactional email provider. Only imported when
+    # `EMAIL_BACKEND=resend`; the console/file backends don't load it.
+    # See `src/framework/email/README.md`.
+    "resend",
 ]
 
 dev = [

--- a/src/framework/config.py
+++ b/src/framework/config.py
@@ -20,6 +20,18 @@ class Settings(BaseSettings):
     # extra config.
     DEV_LOGIN_EMAIL: str = "admin@example.com"
 
+    # Transactional email — see `src/framework/email/README.md` for the
+    # backend dispatch rule. `console` is the safe default: no real
+    # mail sent without an explicit env-var flip. `EMAIL_FROM` is read
+    # by every backend (including `console`, which prints it). The
+    # `APP_BASE_URL` is needed to build absolute links in emails
+    # (verify, password reset) — relative paths don't work outside the
+    # request scope.
+    EMAIL_BACKEND: str = "console"
+    EMAIL_FROM: str = "no-reply@bedlamconnect.com"
+    APP_BASE_URL: str = "http://localhost:8000"
+    RESEND_API_KEY: str | None = None
+
     model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     @classmethod

--- a/src/framework/email/README.md
+++ b/src/framework/email/README.md
@@ -1,0 +1,55 @@
+# Framework: email transport
+
+One async function (`send_email`) dispatched to one of three backends
+behind it. Callers don't know the provider.
+
+## Backend dispatch
+
+`settings.EMAIL_BACKEND` selects the transport at call time:
+
+- `console` (default) — prints subject + recipient + plain-text body to
+  stderr. Used in dev so verify/reset links land in the terminal,
+  clickable, with zero external dependencies.
+- `file` — writes a timestamped `.eml`-shaped file under `./.mail/`
+  (gitignored). Useful when you want to inspect the HTML version of
+  the email a render produced.
+- `resend` — calls the Resend HTTP API. Production. Requires
+  `RESEND_API_KEY` to be set and `EMAIL_FROM` to live on a
+  DKIM/SPF-verified domain.
+
+The `console` default means a fresh checkout never sends real mail by
+accident — flipping to `resend` requires both an env-var change and a
+valid API key.
+
+## Public surface
+
+```python
+from src.framework.email import send_email
+
+await send_email(
+    to="user@example.com",
+    subject="Verify your email",
+    html="<p>…</p>",
+    text="…",
+)
+```
+
+Both `html` and `text` parts are required — text/plain is what keeps
+the spam score down at deliverability-strict providers. Callers
+render both from the same template pair (see
+`src/domain/templates/emails/`).
+
+## Why provider-shaped
+
+`send_email` is the only public function. Backends live behind it.
+Swapping Resend for Postmark / SES / anything else is a single
+`_send_resend` rewrite in [`sender.py`](sender.py), not a
+touch-every-caller refactor. This is why callers never `import resend`
+directly.
+
+## Errors
+
+Errors propagate. fastapi-users hooks (the primary callers) don't
+expose a retry surface — and adding one would be the wrong layer. If a
+provider call fails, the user sees a generic error; they can
+re-request the email via the standard re-send route.

--- a/src/framework/email/__init__.py
+++ b/src/framework/email/__init__.py
@@ -1,0 +1,18 @@
+"""Transactional email — provider-shaped transport.
+
+Public surface:
+    `send_email(to, subject, html, text)` — single async call. Dispatches
+    to one of three backends keyed off `settings.EMAIL_BACKEND`:
+      - `console` (default) prints to stdout. Dev-friendly; clickable
+        links land in the terminal.
+      - `file` writes timestamped files under `./.mail/` for HTML
+        inspection.
+      - `resend` calls the Resend HTTP API.
+
+Callers don't import the backend; the dispatch is internal so swapping
+providers later is a one-file edit. See `sender.py` for the rule.
+"""
+
+from src.framework.email.sender import send_email
+
+__all__ = ["send_email"]

--- a/src/framework/email/sender.py
+++ b/src/framework/email/sender.py
@@ -1,0 +1,114 @@
+"""Email dispatch — three backends behind one async function.
+
+`send_email` is the only public entry point. The `console` backend is
+the default so a fresh checkout sends nothing real; `file` is a
+heavier dev option (writes `.eml`-shaped files under `./.mail/` for
+HTML inspection); `resend` is the production transport.
+
+Provider-shaped (not Resend-shaped) on purpose — swapping providers
+later is a single `_send_resend` rewrite, not a touch every caller.
+Higher-level callers like `domain/logic/auth/emails.py` own templating
++ link construction; this layer is pure transport.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+from src.framework.config import settings
+
+EmailBackend = Literal["console", "file", "resend"]
+
+
+async def send_email(*, to: str, subject: str, html: str, text: str) -> None:
+    """Send a transactional email via the configured backend.
+
+    Both `html` and `text` parts are required — text/plain is what keeps
+    the spam score down at deliverability-strict providers. Callers
+    render both from the same template pair (see
+    `domain/templates/emails/`).
+
+    Errors propagate. Email send is best-effort by design — fastapi-users
+    hooks don't expose a retry surface and adding one would be the wrong
+    layer. If a provider call fails, the user sees a generic error; they
+    can re-request the email via the standard re-send route.
+    """
+    backend: EmailBackend = settings.EMAIL_BACKEND  # type: ignore[assignment]
+
+    if backend == "console":
+        _send_console(to=to, subject=subject, html=html, text=text)
+    elif backend == "file":
+        _send_file(to=to, subject=subject, html=html, text=text)
+    elif backend == "resend":
+        await _send_resend(to=to, subject=subject, html=html, text=text)
+    else:
+        raise ValueError(
+            f"Unknown EMAIL_BACKEND={backend!r}; expected one of "
+            "'console', 'file', 'resend'"
+        )
+
+
+def _send_console(*, to: str, subject: str, html: str, text: str) -> None:
+    print("=" * 60, file=sys.stderr)
+    print(f"[email:console] To: {to}", file=sys.stderr)
+    print(f"[email:console] From: {settings.EMAIL_FROM}", file=sys.stderr)
+    print(f"[email:console] Subject: {subject}", file=sys.stderr)
+    print("-" * 60, file=sys.stderr)
+    print(text, file=sys.stderr)
+    print("=" * 60, file=sys.stderr)
+
+
+def _send_file(*, to: str, subject: str, html: str, text: str) -> None:
+    out_dir = Path(".mail")
+    out_dir.mkdir(exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    # Sanitize subject for the filename — keep ASCII letters/digits/`-`/`_`,
+    # collapse runs, cap length. Avoids surprises on Windows-friendly checkouts.
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "-", subject).strip("-")[:50] or "email"
+    path = out_dir / f"{ts}-{slug}.eml"
+    body = (
+        f"To: {to}\n"
+        f"From: {settings.EMAIL_FROM}\n"
+        f"Subject: {subject}\n"
+        f"Content-Type: multipart/alternative\n"
+        f"\n"
+        f"--text--\n{text}\n"
+        f"--html--\n{html}\n"
+    )
+    path.write_text(body, encoding="utf-8")
+
+
+async def _send_resend(*, to: str, subject: str, html: str, text: str) -> None:
+    """Resend HTTP API call.
+
+    Imported lazily so the `resend` package is only required when this
+    backend is actually selected — keeps the console default zero-dep
+    in case anyone strips `[app]` extras.
+    """
+    if not settings.RESEND_API_KEY:
+        raise RuntimeError(
+            "EMAIL_BACKEND=resend but RESEND_API_KEY is not set. "
+            "Set the env var or switch to EMAIL_BACKEND=console."
+        )
+
+    import resend  # type: ignore[import-untyped]
+
+    resend.api_key = settings.RESEND_API_KEY
+    # Resend's send() is sync; running it in the default thread pool
+    # keeps the caller async without pulling in an async HTTP client.
+    import asyncio
+
+    await asyncio.to_thread(
+        resend.Emails.send,
+        {
+            "from": settings.EMAIL_FROM,
+            "to": [to],
+            "subject": subject,
+            "html": html,
+            "text": text,
+        },
+    )

--- a/src/framework/email/test_sender.py
+++ b/src/framework/email/test_sender.py
@@ -1,0 +1,165 @@
+"""Tests for `src/framework/email/sender.py`.
+
+Pin the backend-dispatch behavior (the production-mode call shape is
+covered via a mocked import — we don't talk to Resend in CI).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.framework.email import send_email
+
+
+@pytest.mark.asyncio
+async def test_console_backend_prints_subject_to_stderr(capsys, monkeypatch):
+    """`console` is the safe default. A successful send writes the
+    recipient + subject + text body to stderr (the linter/tests can
+    capture it) and returns without touching the network."""
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "console")
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.EMAIL_FROM", "no-reply@example.com"
+    )
+
+    await send_email(
+        to="alice@example.com",
+        subject="Hello",
+        html="<p>Hi</p>",
+        text="Hi",
+    )
+
+    err = capsys.readouterr().err
+    assert "alice@example.com" in err
+    assert "Hello" in err
+    assert "Hi" in err
+    # `From:` line is also part of the dev terminal output so the dev
+    # can confirm which sending address they're using without re-reading
+    # `.env`.
+    assert "no-reply@example.com" in err
+
+
+@pytest.mark.asyncio
+async def test_file_backend_writes_eml_under_mail_dir(tmp_path, monkeypatch):
+    """`file` writes a timestamped file under `./.mail/`. The file
+    contains the subject, recipient, and both body parts so the dev
+    can inspect HTML rendering."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "file")
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.EMAIL_FROM", "no-reply@example.com"
+    )
+
+    await send_email(
+        to="bob@example.com",
+        subject="Reset your password",
+        html="<p>HTML</p>",
+        text="Plain",
+    )
+
+    mail_dir = Path(".mail")
+    assert mail_dir.is_dir()
+    files = list(mail_dir.glob("*.eml"))
+    assert len(files) == 1
+    body = files[0].read_text(encoding="utf-8")
+    assert "bob@example.com" in body
+    assert "Reset your password" in body
+    assert "Plain" in body
+    assert "<p>HTML</p>" in body
+
+
+@pytest.mark.asyncio
+async def test_file_backend_slugifies_subject_safely(tmp_path, monkeypatch):
+    """Subject becomes part of the filename — strip anything that
+    isn't `[A-Za-z0-9_-]` so weird subjects don't break the path on
+    case-sensitive filesystems. Empty-after-strip falls back to
+    `email`."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "file")
+
+    await send_email(
+        to="x@example.com",
+        subject="!!! ;;;",
+        html="<p/>",
+        text="t",
+    )
+
+    files = list(Path(".mail").glob("*.eml"))
+    assert len(files) == 1
+    # Filename ends in `-email.eml` (the fallback slug) — pin this so
+    # a future regex tweak that produces an empty slug doesn't silently
+    # write a file with a dangling trailing dash.
+    assert files[0].name.endswith("-email.eml")
+
+
+@pytest.mark.asyncio
+async def test_resend_backend_requires_api_key(monkeypatch):
+    """Setting `EMAIL_BACKEND=resend` without `RESEND_API_KEY` is a
+    misconfiguration we want to surface loudly — better an exception
+    at first send than a silent no-op that drops verification mails."""
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "resend")
+    monkeypatch.setattr("src.framework.email.sender.settings.RESEND_API_KEY", None)
+
+    with pytest.raises(RuntimeError, match="RESEND_API_KEY"):
+        await send_email(to="x@example.com", subject="s", html="h", text="t")
+
+
+@pytest.mark.asyncio
+async def test_resend_backend_calls_resend_sdk(monkeypatch):
+    """When configured, the resend backend hands the message off to
+    `resend.Emails.send` with the canonical payload shape (from, to,
+    subject, html, text). Mock the import so CI never touches the
+    network."""
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "resend")
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.RESEND_API_KEY", "test-key"
+    )
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.EMAIL_FROM", "no-reply@example.com"
+    )
+
+    fake_resend = type(sys)("resend")
+    fake_resend.api_key = None
+    fake_resend.Emails = type(sys)("Emails")
+    send_mock = AsyncMock()
+    # Resend's send() is sync — `asyncio.to_thread` will await its
+    # return — so the mock can also be sync. Use a plain Mock here
+    # to mirror the SDK's actual call shape.
+    from unittest.mock import Mock
+
+    send_mock = Mock(return_value={"id": "msg_123"})
+    fake_resend.Emails.send = send_mock
+
+    with patch.dict(sys.modules, {"resend": fake_resend}):
+        await send_email(
+            to="alice@example.com",
+            subject="Verify",
+            html="<p>link</p>",
+            text="link",
+        )
+
+    assert send_mock.call_count == 1
+    payload = send_mock.call_args[0][0]
+    assert payload == {
+        "from": "no-reply@example.com",
+        "to": ["alice@example.com"],
+        "subject": "Verify",
+        "html": "<p>link</p>",
+        "text": "link",
+    }
+    assert fake_resend.api_key == "test-key"
+
+
+@pytest.mark.asyncio
+async def test_unknown_backend_raises(monkeypatch):
+    """An unknown `EMAIL_BACKEND` value is a config typo — better to
+    fail fast at first send than swallow it and lose mail."""
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.EMAIL_BACKEND", "carrier-pigeon"
+    )
+
+    with pytest.raises(ValueError, match="Unknown EMAIL_BACKEND"):
+        await send_email(to="x@example.com", subject="s", html="h", text="t")


### PR DESCRIPTION
First of three PRs adding email verification + password-reset flows. **No behavior change in this PR** — the hooks in `UserManager` still `print()`; PR 2 wires forgot-password, PR 3 wires verification.

## Summary
- New `src/framework/email/` with single public `send_email(to, subject, html, text)` async function.
- Three backends keyed off `settings.EMAIL_BACKEND`:
  - `console` (default): prints to stderr — clickable links in the terminal.
  - `file`: writes `.eml` to `./.mail/` (gitignored) for HTML inspection.
  - `resend`: calls Resend HTTP API. Lazy-imported.
- Settings: `EMAIL_BACKEND`, `EMAIL_FROM`, `APP_BASE_URL`, `RESEND_API_KEY` (all safe defaults).
- `resend` added to `[app]` deps.

## Why this shape
- Provider-shaped (not Resend-shaped). Swapping providers later is a one-file edit (`_send_resend`).
- Console default means a fresh checkout never sends real mail by accident.
- Resend's API key absence is rejected loudly (RuntimeError at first send) rather than silently no-op'ing — better to crash than to drop verification mail in prod.

## Test plan
- [x] 6 new unit tests in `src/framework/email/test_sender.py` covering all three backends + error paths.
- [x] Full suite: 1608 passed (3 pre-existing `python`-binary failures in `test_session_start_branch_check.py` unrelated to this PR).
- [x] Lint green.

## Next
- PR 2 will add `src/domain/logic/auth/emails.py` (link construction) + email templates + wire `on_after_forgot_password`.
- PR 3 will wire `on_after_register` + add verify landing page + nag banner + dev auto-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)