### PR TITLE
feat(email): wire forgot-password to send reset email (PR 2/3)

### DIFF
--- a/src/auth_config.py
+++ b/src/auth_config.py
@@ -25,7 +25,15 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_forgot_password(
         self, user: User, token: str, request: Optional[Request] = None
     ):
-        print(f"User {user.id} has forgot their password. Reset token: {token}")
+        """Send the password-reset email.
+
+        Lazy-imported so the framework layer can be exercised in
+        isolation without loading domain modules. Domain wrapper owns
+        link construction + template rendering — single home for the
+        URL shape (`src/domain/logic/auth/emails.py`)."""
+        from src.domain.logic.auth.emails import send_password_reset_email
+
+        await send_password_reset_email(user, token)
 
     async def on_after_request_verify(
         self, user: User, token: str, request: Optional[Request] = None

--- a/src/domain/logic/auth/emails.py
+++ b/src/domain/logic/auth/emails.py
@@ -1,0 +1,59 @@
+"""Auth-flow transactional emails — link construction + render + send.
+
+Domain-layer wrapper around `src.framework.email.send_email`. Owns:
+
+  - URL shape for verify / reset links (so the routes can move without
+    the email module knowing about them — single source of truth for
+    the link template).
+  - Jinja rendering of `src/domain/templates/emails/*.{html,txt}`.
+
+Hooks in `src.auth_config.UserManager` call these — never the
+framework's `send_email` directly — so verify/reset link construction
+stays in one place. Adding a new transactional email is a new function
+here, not a hook-body rewrite.
+"""
+
+from __future__ import annotations
+
+from src.domain.models import User
+from src.framework.config import settings
+from src.framework.email import send_email
+from src.framework.rendering.templating import templates
+
+
+def _absolute_url(path: str) -> str:
+    """Join `APP_BASE_URL` with a path. Strip trailing/leading slashes
+    to avoid `//` collisions when `APP_BASE_URL` is set with a trailing
+    slash in `.env`."""
+    base = settings.APP_BASE_URL.rstrip("/")
+    return f"{base}/{path.lstrip('/')}"
+
+
+def _render(template_name: str, **context: object) -> str:
+    """Render one of the email templates to a string. The Jinja env
+    is the same one HTTP responses use — keeps autoescape behavior
+    consistent (.html files autoescape, .txt files don't, by
+    extension)."""
+    template = templates.env.get_template(f"emails/{template_name}")
+    return template.render(**context)
+
+
+async def send_password_reset_email(user: User, token: str) -> None:
+    """Send the password-reset email.
+
+    `token` is the JWT minted by fastapi-users' reset router; it's
+    consumed by `POST /auth/reset-password` (the same router) when
+    the user submits the form on `/auth/reset-password/{token}`. Link
+    shape must match the GET page route in `auth_pages.py`.
+    """
+    reset_url = _absolute_url(f"/auth/reset-password/{token}")
+    context = {
+        "username": user.username,
+        "reset_url": reset_url,
+    }
+    await send_email(
+        to=user.email,
+        subject="Reset your Bedlam Connect password",
+        html=_render("reset_password.html", **context),
+        text=_render("reset_password.txt", **context),
+    )

--- a/src/domain/logic/auth/test_emails.py
+++ b/src/domain/logic/auth/test_emails.py
@@ -1,0 +1,110 @@
+"""Tests for `src/domain/logic/auth/emails.py`.
+
+Pin the link shape + send-call contract. The framework's `send_email`
+is mocked — these tests don't exercise the transport layer (covered
+in `src/framework/email/test_sender.py`)."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.domain.logic.auth.emails import send_password_reset_email
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_calls_send_email_with_user_email(monkeypatch):
+    """The user's `email` is the recipient (not `username` — username
+    is a display field; email is the wire-level identity for
+    fastapi-users)."""
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.auth.emails.send_email", send_email_mock)
+
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        email="alice@example.com",
+        username="alice",
+    )
+    await send_password_reset_email(user, token="abc.def.ghi")
+
+    assert send_email_mock.call_count == 1
+    kwargs = send_email_mock.call_args.kwargs
+    assert kwargs["to"] == "alice@example.com"
+    assert kwargs["subject"] == "Reset your Bedlam Connect password"
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_builds_absolute_url_with_token(monkeypatch):
+    """The link in the email must be an absolute URL — `APP_BASE_URL`
+    + the reset path + the token. Email clients can't resolve relative
+    paths since they aren't running inside the request scope. The token
+    is passed verbatim — fastapi-users' reset router consumes it via
+    the path param, not a query string."""
+    monkeypatch.setattr(
+        "src.domain.logic.auth.emails.settings.APP_BASE_URL",
+        "https://app.example.com",
+    )
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.auth.emails.send_email", send_email_mock)
+
+    user = SimpleNamespace(email="alice@example.com", username="alice")
+    await send_password_reset_email(user, token="my-token")
+
+    kwargs = send_email_mock.call_args.kwargs
+    expected_url = "https://app.example.com/auth/reset-password/my-token"
+    assert expected_url in kwargs["text"]
+    assert expected_url in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_handles_base_url_trailing_slash(monkeypatch):
+    """`APP_BASE_URL` set in `.env` with a trailing slash must not
+    produce `//` in the link — the helper strips both edges."""
+    monkeypatch.setattr(
+        "src.domain.logic.auth.emails.settings.APP_BASE_URL",
+        "https://app.example.com/",
+    )
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.auth.emails.send_email", send_email_mock)
+
+    user = SimpleNamespace(email="alice@example.com", username="alice")
+    await send_password_reset_email(user, token="t")
+
+    kwargs = send_email_mock.call_args.kwargs
+    assert "https://app.example.com/auth/reset-password/t" in kwargs["text"]
+    assert "//auth/reset-password" not in kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_renders_username_in_body(monkeypatch):
+    """The greeting line references the user's `username` — small
+    personalization, also a tripwire for empty/null username if a
+    future schema change loosens the field."""
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.auth.emails.send_email", send_email_mock)
+
+    user = SimpleNamespace(email="alice@example.com", username="alice")
+    await send_password_reset_email(user, token="t")
+
+    kwargs = send_email_mock.call_args.kwargs
+    assert "alice" in kwargs["text"]
+    assert "alice" in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_send_password_reset_email_renders_both_parts(monkeypatch):
+    """Both `html` and `text` are non-empty — the framework's
+    `send_email` requires both, and the template pair must both
+    exist."""
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.auth.emails.send_email", send_email_mock)
+
+    user = SimpleNamespace(email="alice@example.com", username="alice")
+    await send_password_reset_email(user, token="t")
+
+    kwargs = send_email_mock.call_args.kwargs
+    assert kwargs["html"].strip().startswith("<")
+    assert "<" not in kwargs["text"]  # plain text only

--- a/src/domain/templates/emails/README.md
+++ b/src/domain/templates/emails/README.md
@@ -1,0 +1,28 @@
+# Domain templates: transactional emails
+
+Templates rendered as email bodies, not HTTP responses. Each pair is
+`<name>.html` + `<name>.txt` — both parts required for deliverability
+(text/plain keeps the spam score down at strict providers).
+
+## Grammar (deviates from `src/domain/templates/`)
+
+These templates **do not extend** `base.html` and do not pull in
+shared partials. Each file is fully self-contained — inline CSS only,
+no JS, no `{% include %}`. Email clients (especially Gmail / Outlook)
+strip `<head>`-level styles and reject anything that smells like a
+web page, so the chrome-portable patterns the rest of the templates
+use don't apply here.
+
+The Jinja env that renders these is the same one used for HTTP
+responses (`src.framework.rendering.templating.templates.env`); the
+`.html` autoescape rule still applies, so user-supplied values like
+`{{ username }}` are HTML-safe in the HTML part. `.txt` files do not
+autoescape (extension-based), so the plain-text part should never
+embed untrusted attribute-shaped content.
+
+## Where these are rendered
+
+Domain wrappers in [`src/domain/logic/auth/emails.py`](../../logic/auth/emails.py)
+render both parts of a pair, then hand off to the framework's
+`send_email`. Hooks in `src.auth_config.UserManager` call those
+wrappers — never `_render` or `send_email` directly.

--- a/src/domain/templates/emails/reset_password.html
+++ b/src/domain/templates/emails/reset_password.html
@@ -1,0 +1,15 @@
+<!doctype html>
+{# Standalone email template — no `{% extends %}`. Inline only;
+   no Pico, no JS, no shared partials. See README in this dir. #}
+<html>
+<body style="font-family: -apple-system, system-ui, sans-serif; max-width: 560px; margin: 2rem auto; line-height: 1.5;">
+  <h1 style="font-size: 1.25rem;">Reset your password</h1>
+  <p>Hi {{ username }},</p>
+  <p>Someone — hopefully you — asked to reset the password on your Bedlam Connect account. Click the link below to choose a new one:</p>
+  <p><a href="{{ reset_url }}" style="display: inline-block; padding: 0.5rem 1rem; background: #0066cc; color: #fff; text-decoration: none; border-radius: 4px;">Reset password</a></p>
+  <p>Or copy this link into your browser:<br>
+  <a href="{{ reset_url }}">{{ reset_url }}</a></p>
+  <p>If you didn't ask for this, you can ignore the email — your password won't change.</p>
+  <p>— Bedlam Connect</p>
+</body>
+</html>

--- a/src/domain/templates/emails/reset_password.txt
+++ b/src/domain/templates/emails/reset_password.txt
@@ -1,0 +1,13 @@
+Reset your password
+
+Hi {{ username }},
+
+Someone — hopefully you — asked to reset the password on your Bedlam
+Connect account. Use the link below to choose a new one:
+
+{{ reset_url }}
+
+If you didn't ask for this, you can ignore the email — your password
+won't change.
+
+— Bedlam Connect


### PR DESCRIPTION
Second of three PRs. With this PR, requesting a password reset actually delivers an email (default backend is `console`, so the link still lands in the terminal in dev).

## Summary
- New `src/domain/logic/auth/emails.py` — owns link construction + template rendering. `send_password_reset_email(user, token)` is the public surface. Hooks call this, never the framework's `send_email` directly.
- New `src/domain/templates/emails/` — first transactional-email templates. `reset_password.{html,txt}`. Each pair is self-contained (no `{% extends %}`, no shared partials) since email clients strip web-page chrome.
- `on_after_forgot_password` in `UserManager` now calls `send_password_reset_email` (was `print`).

## Test plan
- [x] 5 new unit tests in `src/domain/logic/auth/test_emails.py` covering link construction, both render parts, trailing-slash handling, recipient field, username personalization.
- [x] Full suite: 1613 passed (3 pre-existing `python`-binary failures unrelated).
- [x] Lint green.

## Next
PR 3 will wire `on_after_register` to send the verify email, add a `GET /auth/verify` landing page, restore `is_verified` on `UserRead`, add the nag banner, and add the dev auto-verify guardrail so dev users never see the banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)