### PR TITLE
feat(landing): mirror parent marketing site's semantic shape

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -373,15 +373,28 @@ async def test_failed_register_writes_no_audit_row(
 
 async def test_root_anonymous_returns_landing_page(test_client: AsyncClient):
     """Anonymous GET / returns the marketing landing page (200 HTML),
-    not a redirect to the login wall (#692)."""
+    not a redirect to the login wall (#692). The H1 + audience-section
+    headings are pinned so the page-shape (brand-led hero → "how it
+    works" → footer, mirroring bedlamconnect.com) can't drift without
+    breaking a test."""
     response = await test_client.get("/", follow_redirects=False)
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
-    # Pin the headline copy so it can't drift without breaking a test.
-    assert "Connect clinicians with the right clients" in response.text
-    # Both CTAs must be present so anonymous visitors can self-serve.
+    # Brand-led H1 (matches the parent marketing site).
+    assert "Welcome to Bedlam Connect" in response.text
+    # "How it works" anchor + the two audience-keyed cards must be
+    # present so the "Learn more" CTA has somewhere to land.
+    assert 'id="how-it-works"' in response.text
+    assert "For clinicians" in response.text
+    assert "For referrers" in response.text
+    # All three CTAs must be present so anonymous visitors can
+    # self-serve. "Sign in" / "Sign up" verbs match the parent
+    # marketing site and the rest of the auth flow (#693).
     assert "/auth/register" in response.text
     assert "/auth/login" in response.text
+    assert "Sign in" in response.text
+    assert "Sign up" in response.text
+    assert "Learn more" in response.text
 
 
 async def test_root_authenticated_redirects_to_referrals(

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -1,22 +1,49 @@
 {% extends "base.html" %}
 {% block content %}
+{# Public landing (anonymous `/`) — the structure mirrors the parent
+   marketing site at https://www.bedlamconnect.com/: a hero with
+   brand-led `<hgroup>` (H1 + tagline `<p>`), a one-line value
+   description, a three-CTA cluster (sign in / sign up / learn more),
+   then a "how it works" section with two `<article>` cards keyed by
+   role. The whole tree is plain semantic HTML — Pico styles
+   `<hgroup>`, `<article>`, `<footer>`, and `<a role="button">` out of
+   the box, so no per-page CSS is needed. #}
 <section>
   <hgroup>
-    <h1>Connect clinicians with the right clients</h1>
-    <p>Bedlam Connect helps mental health providers share available openings and receive referrals from their network.</p>
+    <h1>Welcome to Bedlam Connect</h1>
+    <p>Connecting clinicians, helping clients find care.</p>
   </hgroup>
-  {# title-case-ignore: button labels below ("Create an account" / "Log in") are
-     intentionally sentence-case verb phrases, not title-case headings. #}
+  <p>Post openings, share referrals, and maintain a network of trusted clinicians — all in one place.</p>
+  {# title-case-ignore: button labels below ("Sign in" / "Sign up" /
+     "Learn more") are intentionally sentence-case verb phrases, not
+     title-case headings. #}
   <p>
-    <a href="/auth/register" role="button">Create an account</a>
-    &nbsp;
-    <a href="/auth/login" role="button" class="outline">Log in</a>
+    <a href="/auth/login" role="button">Sign in</a>
+    <a href="/auth/register" role="button" class="secondary">Sign up</a>
+    <a href="#how-it-works" role="button" class="outline">Learn more</a>
   </p>
-  <section>
-    <h2>For clinicians</h2>
-    <p>Post your availability, connect with referrers, and manage incoming referrals — all in one place.</p>
-    <h2>For referrers</h2>
-    <p>Find clinicians with open capacity, check availability, and send referrals directly.</p>
-  </section>
 </section>
+
+<section id="how-it-works">
+  <hgroup>
+    <h2>How it works</h2>
+    <p>Two surfaces, one network.</p>
+  </hgroup>
+  <article>
+    <hgroup>
+      <h3>For clinicians</h3>
+      <p>Post your availability, connect with referrers, and manage incoming referrals — all in one place.</p>
+    </hgroup>
+  </article>
+  <article>
+    <hgroup>
+      <h3>For referrers</h3>
+      <p>Find clinicians with open capacity, check availability, and send referrals directly.</p>
+    </hgroup>
+  </article>
+</section>
+
+<footer>
+  <small>&copy; 2026 Bedlam Health &middot; <a href="mailto:support@bedlamhealth.com">support@bedlamhealth.com</a></small>
+</footer>
 {% endblock %}


### PR DESCRIPTION
## Summary
Reshapes the anonymous \`/\` landing page so it semantically mirrors the parent marketing site at https://www.bedlamconnect.com/. No new CSS — every element (\`hgroup\`, \`article\`, \`footer\`, \`a[role=\"button\"]\`) is styled by Pico's defaults already loaded in \`base.html\`.

### Structural changes
- **Hero**: brand-led \`<hgroup>\` (H1 \"Welcome to Bedlam Connect\" + tagline) replaces the previous action-led H1.
- **CTAs**: three buttons (Sign in / Sign up / Learn more) instead of two; the third is an in-page anchor to \`#how-it-works\`.
- **\"How it works\" section**: new \`<section id=\"how-it-works\">\` with its own \`<hgroup>\` heading + two \`<article>\` cards keyed by audience (For clinicians / For referrers).
- **Footer**: page-level \`<footer>\` with copyright + \`mailto:\` support contact, matching the parent site.

### Copy changes
- H1: \"Connect clinicians with the right clients\" → \"Welcome to Bedlam Connect\".
- Tagline (subhead): \"Connecting clinicians, helping clients find care.\"
- Button verbs: \"Create an account\" / \"Log in\" → \"Sign up\" / \"Sign in\" — matches the parent site and the rest of the auth flow (the login page subtitle already reads \"Sign in to your Bedlam Connect account\" after #693).

## Test plan
- [x] \`test_root_anonymous_returns_landing_page\` updated to pin the new H1, the \`#how-it-works\` anchor, both audience-card headings, and all three CTAs.
- [x] \`test_root_authenticated_redirects_to_referrals\` unchanged — authed users still bypass the landing.
- [x] \`pytest src/domain/routes/test_auth_routes.py\` — 25 passed, 1 skipped.
- [x] Title-case check + pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)