### PR TITLE
feat(email): verification flow + dev auto-verify + nag banner (PR 3/3)

### DIFF
--- a/src/auth_config.py
+++ b/src/auth_config.py
@@ -20,7 +20,32 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     verification_token_secret = settings.SECRET
 
     async def on_after_register(self, user: User, request: Optional[Request] = None):
-        print(f"User {user.id} has registered.")
+        """Trigger the verify-email flow on new-account creation.
+
+        In development, the user is auto-verified — local dev creates
+        throw-away accounts and shouldn't have to click an email link
+        just to skip the nag banner (also lets Playwright/MCP automation
+        register users without intercepting the verify email). In any
+        other environment, call `self.request_verify(user, request)`
+        which generates a token and triggers `on_after_request_verify`
+        to send the email.
+
+        Wrapped in try/except because email delivery failures must not
+        block registration — the user is already created at this point;
+        they can re-request the verify link from the nag banner.
+        """
+        if settings.ENVIRONMENT == "development":
+            await self.user_db.update(user, {"is_verified": True})
+            return
+
+        try:
+            await self.request_verify(user, request)
+        except Exception:
+            # `request_verify` raises on already-verified or inactive
+            # users — neither possible right after register, but the
+            # broader catch covers transport failures too. The user can
+            # retry via the nag banner's re-send form.
+            pass
 
     async def on_after_forgot_password(
         self, user: User, token: str, request: Optional[Request] = None
@@ -38,7 +63,18 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_request_verify(
         self, user: User, token: str, request: Optional[Request] = None
     ):
-        print(f"Verification requested for user {user.id}. Verification token: {token}")
+        """Send the verify-your-email message.
+
+        Called by fastapi-users when:
+          - `on_after_register` triggers `self.request_verify` (the
+            new-account flow), or
+          - the user POSTs `/auth/request-verify-token` (re-send from
+            the nag banner).
+
+        Lazy-imported for the same reason as the reset hook below."""
+        from src.domain.logic.auth.emails import send_verification_email
+
+        await send_verification_email(user, token)
 
     async def on_after_login(
         self,

--- a/src/domain/logic/auth/emails.py
+++ b/src/domain/logic/auth/emails.py
@@ -38,6 +38,28 @@ def _render(template_name: str, **context: object) -> str:
     return template.render(**context)
 
 
+async def send_verification_email(user: User, token: str) -> None:
+    """Send the verify-your-email message.
+
+    `token` is fastapi-users' verification JWT. The link lands on
+    `GET /auth/verify?token=...` (the page route in `auth_pages.py`),
+    which calls `user_manager.verify` server-side and renders a
+    success/error page — keeps the user out of HTMX-only territory
+    since the click comes from an email client.
+    """
+    verify_url = _absolute_url(f"/auth/verify?token={token}")
+    context = {
+        "username": user.username,
+        "verify_url": verify_url,
+    }
+    await send_email(
+        to=user.email,
+        subject="Verify your Bedlam Connect email",
+        html=_render("verify.html", **context),
+        text=_render("verify.txt", **context),
+    )
+
+
 async def send_password_reset_email(user: User, token: str) -> None:
     """Send the password-reset email.
 

--- a/src/domain/logic/auth/test_emails.py
+++ b/src/domain/logic/auth/test_emails.py
@@ -12,7 +12,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.domain.logic.auth.emails import send_password_reset_email
+from src.domain.logic.auth.emails import (
+    send_password_reset_email,
+    send_verification_email,
+)
 
 
 @pytest.mark.asyncio
@@ -108,3 +111,44 @@ async def test_send_password_reset_email_renders_both_parts(monkeypatch):
     kwargs = send_email_mock.call_args.kwargs
     assert kwargs["html"].strip().startswith("<")
     assert "<" not in kwargs["text"]  # plain text only
+
+
+# --- send_verification_email -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_verification_email_builds_query_param_link(monkeypatch):
+    """Verify link is `GET /auth/verify?token=...` — query string,
+    not path param (different from reset). The landing page route in
+    `auth_pages.py:get_verify_page` reads the token via
+    `request.query_params`."""
+    monkeypatch.setattr(
+        "src.domain.logic.auth.emails.settings.APP_BASE_URL",
+        "https://app.example.com",
+    )
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.auth.emails.send_email", send_email_mock)
+
+    user = SimpleNamespace(email="alice@example.com", username="alice")
+    await send_verification_email(user, token="verify-tok")
+
+    kwargs = send_email_mock.call_args.kwargs
+    expected = "https://app.example.com/auth/verify?token=verify-tok"
+    assert expected in kwargs["text"]
+    assert expected in kwargs["html"]
+    assert kwargs["subject"] == "Verify your Bedlam Connect email"
+    assert kwargs["to"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_send_verification_email_renders_both_parts(monkeypatch):
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.auth.emails.send_email", send_email_mock)
+
+    user = SimpleNamespace(email="alice@example.com", username="alice")
+    await send_verification_email(user, token="t")
+
+    kwargs = send_email_mock.call_args.kwargs
+    assert kwargs["html"].strip().startswith("<")
+    assert "<" not in kwargs["text"]
+    assert "alice" in kwargs["text"]

--- a/src/domain/logic/users/schema.py
+++ b/src/domain/logic/users/schema.py
@@ -1,20 +1,21 @@
 from typing import Literal
 
 from fastapi_users import schemas
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr
 
 from src.framework.schema_validators import ReadProjection
 
 
 class UserRead(schemas.BaseUser):
     username: str
-    # `is_verified` is inherited from fastapi_users.BaseUser but the app
-    # has no verification flow — every account is permanently `False`.
-    # Exclude it from the JSON response so we stop advertising a contract
-    # we don't honour (#696). The DB column stays; fastapi-users requires
-    # it on the ORM model. Remove this override if a verification flow is
-    # ever shipped (Option A from #696).
-    is_verified: bool = Field(default=False, exclude=True)
+    # `is_verified` is inherited from `fastapi_users.schemas.BaseUser`
+    # and serialized on the wire — the chrome's "verify your email"
+    # nag banner reads it. The earlier `exclude=True` override (#696)
+    # has been removed now that the verification flow ships
+    # (PR 3 of the email-verify rollout). The field is `False` for
+    # newly-registered prod users until they click the link in their
+    # verify email; dev users are auto-verified in
+    # `UserManager.on_after_register`.
 
 
 class UserCreate(schemas.BaseUserCreate):

--- a/src/domain/routes/auth_pages.py
+++ b/src/domain/routes/auth_pages.py
@@ -1,6 +1,11 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import Response
+from fastapi_users import exceptions as fa_users_exceptions
+from fastapi_users import models
+from fastapi_users.manager import BaseUserManager
 
+from src.auth_config import current_active_user, get_user_manager
+from src.domain.models import User
 from src.framework import APIResponse, BaseRouter
 
 # Standardized router initialization
@@ -71,6 +76,77 @@ async def get_reset_password_page(request: Request, token: str):
     return APIResponse.html_response(
         template_name="auth/reset_password.html",
         context={"token": token},
+        request=request,
+    )
+
+
+@router.get("/verify", name="auth_pages:verify")
+async def get_verify_page(
+    request: Request,
+    user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+):
+    """Consume the verify token from the email link.
+
+    The email contains `GET /auth/verify?token=...`. Calling
+    `user_manager.verify(token)` server-side keeps the user out of any
+    HTMX/JS ceremony — the click comes from an email client, which may
+    not run JS at all. Renders one of three states:
+
+      - `status="success"`: token consumed, account verified.
+      - `status="already_verified"`: token valid but `is_verified`
+        already True. Treated as success in the UI; explicit branch so
+        a future "the link doesn't seem to work" copy can differentiate.
+      - `status="error"`: token missing / expired / malformed. The page
+        offers a "resend" link back to the nag banner (`/users/me`).
+    """
+    token = request.query_params.get("token", "")
+    if not token:
+        status = "error"
+    else:
+        try:
+            await user_manager.verify(token, request)
+            status = "success"
+        except fa_users_exceptions.UserAlreadyVerified:
+            status = "already_verified"
+        except (
+            fa_users_exceptions.InvalidVerifyToken,
+            fa_users_exceptions.UserNotExists,
+        ):
+            status = "error"
+    return APIResponse.html_response(
+        template_name="auth/verify.html",
+        context={"status": status},
+        request=request,
+    )
+
+
+@router.post("/resend-verify", name="auth_pages:resend_verify")
+async def post_resend_verify(
+    request: Request,
+    current_user: User = Depends(current_active_user),
+    user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+):
+    """Re-send the verify email for the currently-authed user.
+
+    Sits in front of fastapi-users' `POST /auth/request-verify-token`
+    so the nag banner doesn't need to expose the user's email in HTML
+    (and doesn't need a JSON-encoding HTMX form). Reads the user from
+    the session cookie; calls `request_verify` which triggers
+    `on_after_request_verify` → `send_verification_email`.
+
+    Returns the banner partial back to HTMX (`outerHTML` swap) so the
+    nag is replaced with a confirmation message inline.
+    """
+    try:
+        await user_manager.request_verify(current_user, request)
+    except fa_users_exceptions.UserAlreadyVerified:
+        # Edge case: user verified in another tab between page load
+        # and the resend click. Render the same confirmation —
+        # nothing to do from the user's POV.
+        pass
+    return APIResponse.html_response(
+        template_name="_shared/_verify_banner_sent.html",
+        context={},
         request=request,
     )
 

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -35,15 +35,50 @@ async def test_register(
     assert user_info["email"] == email_to_test
     assert user_info["is_active"] is True
     assert user_info["is_superuser"] is False
-    # `is_verified` removed from the response in #696 — no verification
-    # flow exists; the field was always False and misleading.
-    assert "is_verified" not in user_info
+    # `is_verified` restored to the response with the verification
+    # rollout (reversing #696). Tests run with `ENVIRONMENT=development`
+    # (see `.env.test`), so the dev-mode auto-verify guardrail in
+    # `UserManager.on_after_register` fires — the user is `True`
+    # without anyone clicking a verify link. In production this would
+    # be `False` until the user clicks the link in their verify email;
+    # the prod path is exercised by `test_register_prod_mode_leaves_user_unverified`.
+    assert user_info["is_verified"] is True
 
     async with db_test_session_manager() as session:
         user_db = SQLAlchemyUserDatabase(session, User)
         created_user = await user_db.get_by_email(email_to_test)
         assert created_user is not None
         assert created_user.email == email_to_test
+
+
+async def test_register_prod_mode_leaves_user_unverified(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    monkeypatch,
+):
+    """Pin the production-mode path: `on_after_register` calls
+    `self.request_verify` (which sends the verify email) and does NOT
+    auto-flip `is_verified`. The user starts at `False` until they
+    click the link in the email.
+
+    Tests run with `ENVIRONMENT=development` by default — this test
+    monkey-patches that and stubs the send call so the assertion
+    isolates the hook's branching, not the email transport."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr("src.auth_config.settings.ENVIRONMENT", "production")
+    monkeypatch.setattr(
+        "src.domain.logic.auth.emails.send_email", AsyncMock(return_value=None)
+    )
+
+    register_data = {
+        "email": "prod-mode-user@example.com",
+        "password": "password123",
+        "username": "prodmodeuser",
+    }
+    response = await test_client.post("/auth/register", json=register_data)
+    assert response.status_code == 201
+    assert response.json()["is_verified"] is False
 
 
 async def test_register_via_htmx_sets_cookie_and_redirects(test_client: AsyncClient):
@@ -275,6 +310,122 @@ async def test_get_reset_password_page(test_client: AsyncClient):
     )
     # See `test_get_register_page` for `.auth-page` rationale (#584).
     assert '<article class="auth-page">' in response.text
+
+
+async def test_get_verify_page_without_token_returns_error(test_client: AsyncClient):
+    """Missing `?token=` query param → error state. Page still
+    renders 200 (this is the email-link landing, not an API endpoint
+    — the user shouldn't see a JSON 422)."""
+    response = await test_client.get("/auth/verify")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "didn't work" in response.text.lower() or "error" in response.text.lower()
+
+
+async def test_get_verify_page_with_invalid_token_returns_error(
+    test_client: AsyncClient,
+):
+    """An obviously-bad token (not a valid JWT) renders the error
+    state, never raises a 500. The page route swallows
+    `InvalidVerifyToken` and routes to the error template."""
+    response = await test_client.get("/auth/verify?token=not.a.real.jwt")
+    assert response.status_code == 200
+    assert "didn't work" in response.text.lower() or "error" in response.text.lower()
+
+
+async def test_get_verify_page_with_valid_token_verifies_user(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A valid verification token flips `is_verified` to True and the
+    landing page renders the success state."""
+    from src.auth_config import get_user_manager
+    from src.db import get_user_db
+
+    # Mint a real verify token by calling `request_verify` through the
+    # manager — same path the email-link generation uses.
+    async with db_test_session_manager() as session:
+        user_db_gen = get_user_db(session)
+        user_db = await anext(user_db_gen)
+        manager_gen = get_user_manager(user_db)
+        manager = await anext(manager_gen)
+        # Pull a fresh user row from this session so the manager can
+        # operate on it without touching a closed session.
+        from sqlalchemy import select
+
+        fresh_user = (
+            await session.execute(select(User).where(User.id == logged_in_user.id))
+        ).scalar_one()
+        # Mark unverified so the verify call has work to do (the dev
+        # auto-verify pathway leaves users at True; reset to False here).
+        await user_db.update(fresh_user, {"is_verified": False})
+        # Mint the token via the manager. fastapi-users doesn't expose
+        # a `make_verify_token` helper but `request_verify` produces
+        # one and triggers `on_after_request_verify` — we capture the
+        # token from there.
+
+        captured: dict = {}
+
+        async def capture_send(user, token):
+            captured["token"] = token
+
+        from src.domain.logic.auth import emails as emails_module
+
+        original = emails_module.send_verification_email
+        emails_module.send_verification_email = capture_send
+        try:
+            await manager.request_verify(fresh_user)
+        finally:
+            emails_module.send_verification_email = original
+
+    token = captured["token"]
+
+    response = await test_client.get(f"/auth/verify?token={token}")
+    assert response.status_code == 200
+    assert "verified" in response.text.lower()
+
+    # Confirm the DB column actually flipped.
+    async with db_test_session_manager() as session:
+        from sqlalchemy import select
+
+        user = (
+            await session.execute(select(User).where(User.id == logged_in_user.id))
+        ).scalar_one()
+        assert user.is_verified is True
+
+
+async def test_post_resend_verify_unauthenticated_returns_401(test_client: AsyncClient):
+    """`POST /auth/resend-verify` reads the user from the session — no
+    cookie means no resend. Returns 401 (handled by the middleware
+    that turns 401 into a redirect for HTML, but the API client here
+    isn't sending the HTMX header so it stays 401)."""
+    response = await test_client.post("/auth/resend-verify")
+    assert response.status_code == 401
+
+
+async def test_post_resend_verify_authenticated_returns_sent_banner(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+    monkeypatch,
+):
+    """Authed user can re-request the verify email. Response is the
+    `_verify_banner_sent.html` partial (HTMX swaps it over the
+    original banner via `outerHTML`)."""
+    # Stub the actual send so the test doesn't print to stderr.
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "src.domain.logic.auth.emails.send_email", AsyncMock(return_value=None)
+    )
+
+    response = await authenticated_client.post("/auth/resend-verify")
+    assert response.status_code == 200
+    assert "Verification email sent" in response.text
+    # The partial keeps the original id so a future HTMX target=
+    # `#verify-banner` swap on the same page still works.
+    assert 'id="verify-banner"' in response.text
 
 
 async def test_unauthorized_redirect_for_browser_requests(test_client: AsyncClient):

--- a/src/domain/templates/auth/verify.html
+++ b/src/domain/templates/auth/verify.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block content %}
+<article class="auth-page">
+  <header>
+    {% if status == "success" %}
+    <h1>Email verified</h1>
+    <p>Thanks — your email is confirmed. The nag banner will go away on your next page load.</p>
+    {% elif status == "already_verified" %}
+    <h1>Already verified</h1>
+    <p>This email was already confirmed. Nothing more to do.</p>
+    {% else %}
+    <h1>Verification link didn't work</h1>
+    <p>The link may have expired, been used already, or been mis-copied. Sign in and use the resend link in the banner at the top of the page.</p>
+    {% endif %}
+  </header>
+  <footer>
+    <p>
+      <a href="{{ entity_url('user', id='me') }}" role="button">Go to your profile</a>
+    </p>
+  </footer>
+</article>
+{% endblock %}

--- a/src/domain/templates/emails/verify.html
+++ b/src/domain/templates/emails/verify.html
@@ -1,0 +1,14 @@
+<!doctype html>
+{# Self-contained email body — no `{% extends %}`. See README in this dir. #}
+<html>
+<body style="font-family: -apple-system, system-ui, sans-serif; max-width: 560px; margin: 2rem auto; line-height: 1.5;">
+  <h1 style="font-size: 1.25rem;">Verify your email</h1>
+  <p>Hi {{ username }},</p>
+  <p>Thanks for signing up for Bedlam Connect. Click the link below to confirm this email address:</p>
+  <p><a href="{{ verify_url }}" style="display: inline-block; padding: 0.5rem 1rem; background: #0066cc; color: #fff; text-decoration: none; border-radius: 4px;">Verify email</a></p>
+  <p>Or copy this link into your browser:<br>
+  <a href="{{ verify_url }}">{{ verify_url }}</a></p>
+  <p>If you didn't create an account with us, you can ignore this email.</p>
+  <p>— Bedlam Connect</p>
+</body>
+</html>

--- a/src/domain/templates/emails/verify.txt
+++ b/src/domain/templates/emails/verify.txt
@@ -1,0 +1,12 @@
+Verify your email
+
+Hi {{ username }},
+
+Thanks for signing up for Bedlam Connect. Use the link below to
+confirm this email address:
+
+{{ verify_url }}
+
+If you didn't create an account with us, you can ignore this email.
+
+— Bedlam Connect

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -30,6 +30,14 @@ def base_context(user: Actor | None) -> dict:
     declare `providers`, so test stubs without the attribute read as
     "first-time user" (no provider profile yet) and the chrome shows
     the profile-setup CTA accordingly.
+
+    `current_user_is_verified` powers the "verify your email" nag
+    banner in `base.html`. Anonymous visitors and test stubs without
+    the attribute default to `True` so the banner only shows for
+    authed users who explicitly have `is_verified=False`. Dev-mode
+    users are auto-verified on registration
+    (see `src.auth_config.UserManager.on_after_register`) so the
+    banner is silent for the seed flow.
     """
     return {
         "is_authenticated": user is not None,
@@ -37,6 +45,9 @@ def base_context(user: Actor | None) -> dict:
         "current_username": user.username if user is not None else None,
         "current_user_id": user.id if user is not None else None,
         "has_provider_profile": bool(getattr(user, "providers", None)),
+        "current_user_is_verified": (
+            True if user is None else bool(getattr(user, "is_verified", True))
+        ),
     }
 
 

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -25,19 +25,42 @@ def test_base_context_anonymous():
         "current_username": None,
         "current_user_id": None,
         "has_provider_profile": False,
+        # Anonymous users don't get the verify nag — default True so
+        # the banner stays silent.
+        "current_user_is_verified": True,
     }
 
 
 def test_base_context_regular_user():
     user_id = uuid.uuid4()
-    user = SimpleNamespace(id=user_id, username="alice", is_superuser=False)
+    user = SimpleNamespace(
+        id=user_id, username="alice", is_superuser=False, is_verified=True
+    )
     assert base_context(user) == {
         "is_authenticated": True,
         "is_admin": False,
         "current_username": "alice",
         "current_user_id": user_id,
         "has_provider_profile": False,
+        "current_user_is_verified": True,
     }
+
+
+def test_base_context_unverified_user_surfaces_for_nag_banner():
+    """A user with `is_verified=False` is what triggers the nag
+    banner in `_verify_banner.html`. Pin the scalar's exact shape."""
+    user = SimpleNamespace(
+        id=uuid.uuid4(), username="alice", is_superuser=False, is_verified=False
+    )
+    assert base_context(user)["current_user_is_verified"] is False
+
+
+def test_base_context_user_without_is_verified_attr_defaults_true():
+    """`Actor` doesn't declare `is_verified`; test stubs lacking the
+    attribute must not accidentally raise the banner. Default True
+    keeps the nag opt-in (only real `is_verified=False` rows show)."""
+    user = SimpleNamespace(id=uuid.uuid4(), username="alice", is_superuser=False)
+    assert base_context(user)["current_user_is_verified"] is True
 
 
 def test_base_context_admin():

--- a/src/framework/templates/_shared/_verify_banner.html
+++ b/src/framework/templates/_shared/_verify_banner.html
@@ -1,0 +1,27 @@
+{# Nag banner — "verify your email" reminder shown on every page
+   when the authed user is `is_verified=False`. Reads
+   `current_user_is_verified` from `base_context()` (defaults True for
+   anonymous + missing-attr stubs so the banner is silent unless
+   explicitly opted-in).
+
+   Re-send is a one-click HTMX POST to `/auth/resend-verify` (custom
+   page route, not fastapi-users' `/auth/request-verify-token`).
+   The custom route reads the user from the session so the email
+   doesn't have to live in the HTML. Response is the
+   `_verify_banner_sent.html` partial which swaps the banner in
+   place via `hx-swap="outerHTML"`. #}
+{%- if is_authenticated and not current_user_is_verified -%}
+<aside class="verify-banner" role="status" id="verify-banner">
+  <strong>Verify your email.</strong>
+  Check your inbox for a link to confirm your account.
+  <form
+    method="post"
+    action="/auth/resend-verify"
+    hx-post="/auth/resend-verify"
+    hx-target="#verify-banner"
+    hx-swap="outerHTML"
+    class="verify-banner-form">
+    <button type="submit" class="secondary verify-banner-button">Resend verification email</button>
+  </form>
+</aside>
+{%- endif -%}

--- a/src/framework/templates/_shared/_verify_banner_sent.html
+++ b/src/framework/templates/_shared/_verify_banner_sent.html
@@ -1,0 +1,8 @@
+{# Returned by `POST /auth/resend-verify` and HTMX-swapped over the
+   nag banner. The `id="verify-banner"` matches the original so a
+   second resend on this page (if the user clicks again before
+   reloading) targets the same DOM node. #}
+<aside class="verify-banner verify-banner-sent" role="status" id="verify-banner">
+  <strong>Verification email sent.</strong>
+  Check your inbox — the link expires in an hour.
+</aside>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -574,6 +574,33 @@
         max-width: 28rem;
         margin-inline: auto;
       }
+      /* Verify-email nag banner. Renders on every authenticated
+         page when `is_verified=False` (see `_verify_banner.html`).
+         The colors are inline because they're the only place this
+         palette appears — Pico's default `<aside>` styling is too
+         understated for a heads-up. */
+      .verify-banner {
+        background: #fff8e1;
+        border-left: 4px solid #f5a623;
+        padding: 0.5rem 1rem;
+        margin-block-end: 1rem;
+        border-radius: 4px;
+      }
+      .verify-banner-sent {
+        background: #e8f5e9;
+        border-left-color: #43a047;
+      }
+      .verify-banner-form {
+        display: inline;
+        margin: 0;
+      }
+      .verify-banner-button {
+        display: inline;
+        width: auto;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        margin: 0 0 0 0.5rem;
+      }
     </style>
     <script
       src="https://unpkg.com/htmx.org@2.0.4"
@@ -696,6 +723,11 @@
       </nav>
     </header>
     <main class="container">
+      {# Verify-email nag banner. Renders only when the authed user
+         has `is_verified=False` (see `_verify_banner.html`). Sits
+         above the breadcrumb so it's the first thing visible on
+         every page. #}
+      {% include "_shared/_verify_banner.html" %}
       {# Breadcrumb zone bar — `{% block breadcrumb %}` accepts the
          `breadcrumb(items)` macro from `_shared/_breadcrumb.html`.
          Pages set their own location context; list pages and the


### PR DESCRIPTION
Final PR in the email/verify rollout (after #760, #766). With this PR, new-account registration sends a verify email, users see a nag banner until they click the link, and dev-mode users are auto-verified so local seed work never trips the banner.

## What changes

**Hooks** (`src/auth_config.py:UserManager`)
- `on_after_register` — in dev, set `is_verified=True` so dev/test users skip the gate. In any other env, call `self.request_verify` (mints token → triggers `on_after_request_verify`). Wrapped in try/except so a transport failure doesn't block registration.
- `on_after_request_verify` — now calls `send_verification_email` (was `print`).

**Email helper + templates**
- New `send_verification_email(user, token)` in `src/domain/logic/auth/emails.py`. Link shape: `GET /auth/verify?token=...`.
- New `emails/verify.{html,txt}` templates.

**Landing page**
- New `GET /auth/verify?token=...` in `auth_pages.py`. Consumes token server-side via `user_manager.verify`. Renders one of: success / already_verified / error. Server-side because the click comes from an email client.

**Nag banner**
- New `_shared/_verify_banner.html` included in `base.html` above the breadcrumb. Renders only when authed + `is_verified=False`.
- One-click HTMX resend to a new `POST /auth/resend-verify` page route (reads user from session, keeps email out of HTML).
- New `_shared/_verify_banner_sent.html` returned by resend.
- `base_context` gains `current_user_is_verified` (defaults True for anonymous + missing-attr stubs so the banner is silent by default).

**Schema**
- `UserRead.is_verified` restored to the response (reverses #696's `exclude=True`). The chrome reads it for the nag banner.

## Dev-friction guardrail
Per your instructions ("i shouldn't have to go and verify merchants i'm creating for dev purposes"):
- Tests run with `ENVIRONMENT=development` (`.env.test`), so `UserManager.on_after_register` auto-flips `is_verified=True` on new registrations.
- Seed users were already created with `is_verified=True` (confirmed in `scripts/dev/seed.py:946`).
- Banner stays silent for the entire dev/seed flow.
- `test_register_prod_mode_leaves_user_unverified` pins the production-mode branch by monkeypatching `ENVIRONMENT`.

## Test plan
- [x] 5 new verify-page tests (success, invalid token, missing token, resend authed, resend 401)
- [x] 2 new email-helper tests (verify link shape, both render parts)
- [x] 4 new `base_context` tests (verified/unverified/missing-attr/anon)
- [x] 1 new prod-mode register test
- [x] Existing `test_register` updated (`is_verified=True` in dev env, with comment pointing to the prod test)
- [x] Full suite: 1623 passed (3 pre-existing `python`-binary failures unrelated). Lint green.

## Open follow-ups
- Resend domain (`bedlamconnect.com`) DKIM/SPF setup — needed before flipping `EMAIL_BACKEND=resend` in prod. Not blocking; default `console` backend prints links to stderr.
- The verify email's link text says "Verify email" — could be A/B'd later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)