### PR TITLE
fix(landing): drop how-it-works section, pin viewport-fit grid, use parent-site copy

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -373,28 +373,28 @@ async def test_failed_register_writes_no_audit_row(
 
 async def test_root_anonymous_returns_landing_page(test_client: AsyncClient):
     """Anonymous GET / returns the marketing landing page (200 HTML),
-    not a redirect to the login wall (#692). The H1 + audience-section
-    headings are pinned so the page-shape (brand-led hero → "how it
-    works" → footer, mirroring bedlamconnect.com) can't drift without
-    breaking a test."""
+    not a redirect to the login wall (#692). The H1 + tagline +
+    description copy are taken verbatim from the parent marketing
+    site at https://www.bedlamconnect.com/ — pinning them so a
+    well-meaning copy edit doesn't quietly drift the public-facing
+    page out of sync with the brand."""
     response = await test_client.get("/", follow_redirects=False)
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
-    # Brand-led H1 (matches the parent marketing site).
+    # Verbatim copy from bedlamconnect.com.
     assert "Welcome to Bedlam Connect" in response.text
-    # "How it works" anchor + the two audience-keyed cards must be
-    # present so the "Learn more" CTA has somewhere to land.
-    assert 'id="how-it-works"' in response.text
-    assert "For clinicians" in response.text
-    assert "For referrers" in response.text
-    # All three CTAs must be present so anonymous visitors can
-    # self-serve. "Sign in" / "Sign up" verbs match the parent
-    # marketing site and the rest of the auth flow (#693).
+    assert "Connecting providers, helping patients." in response.text
+    assert (
+        "Post referrals, find referrals, and maintain a network of "
+        "professional contacts." in response.text
+    )
+    # Both CTAs must be present so anonymous visitors can self-serve.
+    # "Sign in" / "Sign up" verbs match the parent marketing site and
+    # the rest of the auth flow (#693).
     assert "/auth/register" in response.text
     assert "/auth/login" in response.text
     assert "Sign in" in response.text
     assert "Sign up" in response.text
-    assert "Learn more" in response.text
 
 
 async def test_root_authenticated_redirects_to_referrals(

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -1,46 +1,54 @@
 {% extends "base.html" %}
+{% block head %}
+{# Landing-only layout. Scoped to `body:has(.landing-hero)` so these
+   rules don't leak to any other page — every other template extends
+   `base.html` without rendering a `.landing-hero`. On tablet+ the
+   page is exactly one viewport tall: header at top (natural row),
+   hero vertically centered, footer pinned to the bottom. On phones
+   the natural document flow is preferred (the dvh trick reads as
+   awkward at narrow widths where the hero already fills the screen). #}
+<style>
+  @media (min-width: 768px) {
+    body:has(.landing-hero) {
+      min-height: 100dvh;
+      display: grid;
+      grid-template-rows: auto 1fr;
+    }
+    body:has(.landing-hero) main.container {
+      display: grid;
+      grid-template-rows: 1fr auto;
+      gap: 2rem;
+      padding-block: 2rem;
+    }
+    .landing-hero { align-self: center; }
+  }
+  /* CTA cluster — Pico styles `<a role="button">` as block-level
+     100%-wide; inside a `.grid` utility we want them sitting in
+     their cells, not stretching the row. */
+  .landing-hero .grid > [role="button"] { margin: 0; }
+</style>
+{% endblock %}
 {% block content %}
-{# Public landing (anonymous `/`) — the structure mirrors the parent
-   marketing site at https://www.bedlamconnect.com/: a hero with
-   brand-led `<hgroup>` (H1 + tagline `<p>`), a one-line value
-   description, a three-CTA cluster (sign in / sign up / learn more),
-   then a "how it works" section with two `<article>` cards keyed by
-   role. The whole tree is plain semantic HTML — Pico styles
-   `<hgroup>`, `<article>`, `<footer>`, and `<a role="button">` out of
-   the box, so no per-page CSS is needed. #}
-<section>
+{# Public landing (anonymous `/`) — structure mirrors the parent
+   marketing site at https://www.bedlamconnect.com/: a brand-led
+   `<hgroup>` hero (H1 + tagline), a one-line value description, a
+   two-CTA cluster, and a page-level `<footer>`. Pico styles
+   `<hgroup>`, `<footer>`, `<a role="button">`, and `.grid` out of
+   the box; the page-level `<style>` above only handles the
+   vertical-center / footer-pinned viewport fit. #}
+<section class="landing-hero">
   <hgroup>
     <h1>Welcome to Bedlam Connect</h1>
-    <p>Connecting clinicians, helping clients find care.</p>
+    <p>Connecting providers, helping patients.</p>
   </hgroup>
-  <p>Post openings, share referrals, and maintain a network of trusted clinicians — all in one place.</p>
-  {# title-case-ignore: button labels below ("Sign in" / "Sign up" /
-     "Learn more") are intentionally sentence-case verb phrases, not
-     title-case headings. #}
-  <p>
+  <p>Post referrals, find referrals, and maintain a network of professional contacts.</p>
+  {# title-case-ignore: button labels below ("Sign in" / "Sign up")
+     are intentionally sentence-case verb phrases, not title-case
+     headings. #}
+  <div class="grid">
     <a href="/auth/login" role="button">Sign in</a>
     <a href="/auth/register" role="button" class="secondary">Sign up</a>
-    <a href="#how-it-works" role="button" class="outline">Learn more</a>
-  </p>
-</section>
-
-<section id="how-it-works">
-  <hgroup>
-    <h2>How it works</h2>
-    <p>Two surfaces, one network.</p>
-  </hgroup>
-  <article>
-    <hgroup>
-      <h3>For clinicians</h3>
-      <p>Post your availability, connect with referrers, and manage incoming referrals — all in one place.</p>
-    </hgroup>
-  </article>
-  <article>
-    <hgroup>
-      <h3>For referrers</h3>
-      <p>Find clinicians with open capacity, check availability, and send referrals directly.</p>
-    </hgroup>
-  </article>
+  </div>
 </section>
 
 <footer>


### PR DESCRIPTION
## Summary
Follow-up to merged #767 per feedback:

- **Removes** the \"How it works\" section and the \"Learn more\" CTA.
- **Pins** the page to fit the viewport on tablet+: hero vertically centered, footer pinned to the bottom. Scoped via \`body:has(.landing-hero)\` so no other page picks up the rules. Mobile keeps natural document flow (the dvh trick reads as awkward at narrow widths where the hero already fills the screen).
- **Uses the parent site's copy verbatim** (https://www.bedlamconnect.com/):
  - H1: \"Welcome to Bedlam Connect\"
  - Tagline (subhead): \"Connecting providers, helping patients.\"
  - Description: \"Post referrals, find referrals, and maintain a network of professional contacts.\"

Test pins the verbatim copy so a well-meaning edit doesn't quietly drift the public-facing page out of sync with the brand.

## Test plan
- [x] \`pytest src/domain/routes/test_auth_routes.py -k landing\` — passes.
- [x] Title-case + pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)