### PR TITLE
fix(auth): forgot/reset password forms submit as JSON

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -288,10 +288,17 @@ async def test_get_forgot_password_page(test_client: AsyncClient):
     # H1 was removed app-wide; the page no longer carries the literal
     # "Forgot password" text. The submit button and body copy still
     # identify the page.
-    assert "/auth/forgot-password" in response.text
     assert "Send reset link" in response.text
     # See `test_get_register_page` for `.auth-page` rationale (#584).
     assert '<article class="auth-page">' in response.text
+    # The form MUST submit as JSON — fastapi-users' `/auth/forgot-password`
+    # expects `{"email": "..."}`. A plain `<form method="post">` would
+    # send `application/x-www-form-urlencoded` and the endpoint would
+    # 422 with "email field required" in production. Pin both the
+    # htmx submit attribute and the json-enc extension so the next
+    # rewrite can't silently regress to form-encoding.
+    assert 'hx-post="/auth/forgot-password"' in response.text
+    assert 'hx-ext="json-enc"' in response.text
 
 
 async def test_get_reset_password_page(test_client: AsyncClient):
@@ -308,6 +315,11 @@ async def test_get_reset_password_page(test_client: AsyncClient):
         f'value="{reset_token}"' in response.text
         or f'data-token="{reset_token}"' in response.text
     )
+    # Same JSON-submit contract as `test_get_forgot_password_page`:
+    # the endpoint expects `{"token": "...", "password": "..."}` and
+    # form-encoding would 422.
+    assert 'hx-post="/auth/reset-password"' in response.text
+    assert 'hx-ext="json-enc"' in response.text
     # See `test_get_register_page` for `.auth-page` rationale (#584).
     assert '<article class="auth-page">' in response.text
 

--- a/src/domain/templates/auth/forgot_password.html
+++ b/src/domain/templates/auth/forgot_password.html
@@ -5,8 +5,13 @@
     <h1>Reset your password</h1>
     <p>Enter your email and we'll send you a reset link.</p>
   </header>
-  <!-- POSTs to the FastAPI Users forgot-password endpoint. -->
-  <form method="post" action="/auth/forgot-password">
+  {# fastapi-users' `/auth/forgot-password` expects a JSON body
+     ({"email": "..."}). The htmx `json-enc` extension (loaded
+     globally in `base.html`) encodes the form values as JSON on
+     submit. Plain `<form method="post" action="...">` would send
+     `application/x-www-form-urlencoded` and the endpoint would 422
+     with "email field required". Pattern mirrors `register.html`. #}
+  <form hx-post="/auth/forgot-password" hx-ext="json-enc">
     <label for="email">
       Email
       <input type="email" id="email" name="email" required />

--- a/src/domain/templates/auth/reset_password.html
+++ b/src/domain/templates/auth/reset_password.html
@@ -5,10 +5,12 @@
     <h1>Set a new password</h1>
     <p>Pick something memorable. You'll use it next time you log in.</p>
   </header>
-  <!-- POSTs to the FastAPI Users reset-password endpoint.
-       The endpoint expects JSON {"token": "...", "password": "..."}; a real
-       integration would submit via JS so the body is JSON, not form data. -->
-  <form method="post" action="/auth/reset-password">
+  {# fastapi-users' `/auth/reset-password` expects a JSON body
+     ({"token": "...", "password": "..."}). htmx `json-enc` (loaded
+     globally in `base.html`) encodes the form as JSON. The token
+     rides in a hidden input so json-enc picks it up alongside the
+     password. Pattern mirrors `register.html` + `forgot_password.html`. #}
+  <form hx-post="/auth/reset-password" hx-ext="json-enc">
     <input type="hidden" name="token" value="{{ token }}" />
     <label for="password">
       New password


### PR DESCRIPTION
## The bug
Submitting `/auth/forgot-password` or `/auth/reset-password` in production returns:

```json
{"detail":[{"type":"missing","loc":["body","email"],"msg":"Field required","input":null}]}
```

The forms were plain `<form method=\"post\" action=\"...\">`, which the browser submits as `application/x-www-form-urlencoded`. The fastapi-users endpoints expect JSON.

## The fix
Switch both forms to `<form hx-post=\"...\" hx-ext=\"json-enc\">` — same pattern `register.html` already uses. The `json-enc` htmx extension is loaded globally in `base.html`.

Also strengthen the unit tests so a regression fails locally, not in prod:

```python
assert 'hx-post=\"/auth/forgot-password\"' in response.text
assert 'hx-ext=\"json-enc\"' in response.text
```

Without these new assertions, the previous tests passed even though the form was broken — they only checked copy + class name presence.

## What I told the user about why tests didn't catch this
- The API test (`test_forgot_password_request`) called `httpx.post(json=...)` directly, bypassing the form entirely. It tested the API in isolation, not the form's submission shape.
- The page-render test only verified copy/class, not the form's submit machinery.
- The repo's contract-test infrastructure is **exactly designed** to catch this (Playwright submits the rendered form, Pact verifies the wire shape) — but `manifest.py:CONTRACT_PAIRS` had no entry for forgot-password or reset-password. The rule \"every form needs a pair\" was prose-only, not enforced.

A follow-up PR will add the missing contract pairs **and** a `contract_form_coverage_check.py` lint that fails CI if any rendered form's submit URL isn't covered by a `ContractPair`. That structurally prevents the class.

## Test plan
- [x] `pytest`: 1623 passed (3 pre-existing `python`-binary failures unrelated).
- [x] `dev lint`: green.
- [x] Tested locally — both forms now submit correctly to the JSON endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)