### PR TITLE
feat(lint): contract-form coverage check (#771)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,15 @@ repos:
         language: python
         files: ^src/(models|schemas|repositories|logic)/.*\.py$
         pass_filenames: true
+
+      - id: contract-form-coverage-check
+        name: Check contract-form coverage
+        entry: python scripts/dev/contract_form_coverage_check.py
+        language: python
+        # Fires on changes to form templates OR the manifest — either a
+        # new uncovered form, or a manifest edit that removes coverage,
+        # is what we want to catch. The script itself walks the whole
+        # template tree on each invocation; the file filter is just
+        # the trigger.
+        files: ^(src/(framework|domain)/templates/.*\.(html|jinja|jinja2)|tests/test_contract/manifest\.py|scripts/dev/contract_form_coverage_check\.py)$
+        pass_filenames: false

--- a/scripts/dev/contract_form_coverage_check.py
+++ b/scripts/dev/contract_form_coverage_check.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Enforce: every literal-URL form template has a `ContractPair`.
+
+The systemic prevention for the forgot-password bug class
+(`/auth/forgot-password` was changed to take JSON, but the form was
+left form-encoded — no contract pair flagged the mismatch, so the
+bug shipped). The contract-test framework already verifies form ⇄
+endpoint protocol agreement (see `tests/test_contract/README.md`);
+this lint pins the rule that **every form** has a pair.
+
+What it checks
+--------------
+
+For every `.html`/`.jinja` file under `src/domain/templates/` and
+`src/framework/templates/`, find each `<form>` tag's submit URL. The
+extractor only handles **literal URLs** — `hx-post="/auth/x"` or
+`<form method="post" action="/auth/x">`. Forms whose URL is
+template-driven (`hx-{{ method }}="{{ action }}"`, used by the
+generic entity-form macros) are skipped: those flow through the
+entity dispatch layer and are covered by the per-entity contract
+pairs already in the manifest.
+
+Each `(METHOD, URL)` collected from templates must appear in EITHER
+`tests/test_contract/manifest.py:CONTRACT_PAIRS[*].endpoints` OR the
+`FORMS_WITHOUT_PAIRS` allowlist below.
+
+Why the allowlist
+-----------------
+
+Some endpoints are intentionally not contract-paired:
+
+- `POST /auth/jwt/login` — fastapi-users' OAuth2 password flow is
+  form-encoded by RFC, so there's no JSON contract to verify.
+- `POST /auth/sign-out`, `POST /auth/resend-verify` — empty-body
+  endpoints; nothing to pin beyond "the path exists".
+
+The allowlist makes the exemption visible and justified, not silent.
+Adding a new entry requires a one-line rationale.
+
+Exit code 0 = clean; 1 = violations (prints them).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATE_ROOTS = (
+    _REPO_ROOT / "src" / "domain" / "templates",
+    _REPO_ROOT / "src" / "framework" / "templates",
+)
+
+
+# Permanent exemptions: endpoints that POST/PUT/PATCH/DELETE but
+# intentionally don't have (and don't need) a Pact pair. Each entry's
+# value is the rationale shown on lint failure if someone tries to
+# remove it. Adding an entry requires a sentence-long justification.
+FORMS_WITHOUT_PAIRS: dict[str, str] = {
+    "POST /auth/jwt/login": (
+        "fastapi-users OAuth2 password flow is form-encoded by RFC 6749; "
+        "no JSON contract to verify."
+    ),
+    "POST /auth/sign-out": (
+        "Empty-body endpoint that clears the session cookie. Nothing "
+        "to pin beyond the path itself."
+    ),
+    "POST /auth/resend-verify": (
+        "Empty-body endpoint that reads the user from the session and "
+        "re-mints a verify token. Nothing to pin beyond the path."
+    ),
+    "POST /auth/forgot-password": (
+        "TODO(#771): write a Pact pair (consumer-side fills the form "
+        "in Playwright, provider verifies the JSON shape). The form "
+        "was fixed in PR #770 to emit JSON; the pair pins it structurally."
+    ),
+    "POST /auth/reset-password": (
+        "TODO(#771): write a Pact pair (consumer-side fills the "
+        "token+password fields, provider verifies the JSON shape). "
+        "Same situation as `/auth/forgot-password` above."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class FormSubmission:
+    """One form's submit target, located for diagnostics."""
+
+    file: Path
+    line: int
+    method: str  # POST / PUT / PATCH / DELETE
+    url: str  # literal URL
+
+    @property
+    def key(self) -> str:
+        return f"{self.method} {self.url}"
+
+
+# Strip Jinja {# ... #} comments only — keep statements and
+# expressions because we use them to detect dynamic URLs.
+_JINJA_COMMENT_RE = re.compile(r"\{#.*?#\}", re.DOTALL)
+
+# Match a `<form ...>` opening tag and capture the attribute block.
+_FORM_TAG_RE = re.compile(r"<form\b([^>]*)>", re.IGNORECASE | re.DOTALL)
+
+# Within a form's attributes:
+#   hx-post="..." / hx-put / hx-patch / hx-delete
+_HX_VERB_RE = re.compile(r'\bhx-(post|put|patch|delete)\s*=\s*"([^"]*)"', re.IGNORECASE)
+
+# Or the bare-HTML pattern: <form method="post|put|patch|delete" action="...">
+_METHOD_RE = re.compile(r'\bmethod\s*=\s*"(post|put|patch|delete)"', re.IGNORECASE)
+_ACTION_RE = re.compile(r'\baction\s*=\s*"([^"]*)"', re.IGNORECASE)
+
+
+_JINJA_STMT_OR_EXPR_RE = re.compile(r"\{%.*?%\}|\{\{.*?\}\}", re.DOTALL)
+
+
+def _static_prefix(url: str) -> str:
+    """Return the static prefix of a URL — everything before any
+    Jinja statement / expression. Used to recover the routable path
+    from URLs like `/auth/jwt/login{% if next %}?next={{ next }}{% endif %}`,
+    whose static prefix is `/auth/jwt/login`."""
+    m = _JINJA_STMT_OR_EXPR_RE.search(url)
+    return url[: m.start()] if m else url
+
+
+def _is_dynamic_url(url: str) -> bool:
+    """True if the URL has no static prefix the lint can match on.
+    A URL like `{{ entity_url('clinician') }}` has empty static
+    prefix and is out of scope. `/auth/jwt/login{% if next %}...{% endif %}`
+    has prefix `/auth/jwt/login` and is in scope."""
+    prefix = _static_prefix(url)
+    if not prefix.startswith("/"):
+        return True
+    if " ~ " in prefix:
+        # `"/foo" ~ var` string concatenation — the part after the
+        # prefix is dynamic. Treat the whole URL as dynamic.
+        return True
+    return False
+
+
+def _line_of(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+def _scan_file(path: Path) -> Iterable[FormSubmission]:
+    raw = path.read_text(encoding="utf-8")
+    content = _JINJA_COMMENT_RE.sub(lambda m: " " * len(m.group(0)), raw)
+
+    for form_match in _FORM_TAG_RE.finditer(content):
+        attrs = form_match.group(1)
+        line = _line_of(content, form_match.start())
+
+        # Prefer htmx attributes since the codebase's chosen pattern
+        # is `<form hx-post="...">`. If present, an htmx verb wins
+        # over `method=`.
+        hx_match = _HX_VERB_RE.search(attrs)
+        if hx_match:
+            verb, url = hx_match.group(1).upper(), hx_match.group(2)
+            if _is_dynamic_url(url):
+                continue
+            base = _static_prefix(url).split("?", 1)[0]
+            yield FormSubmission(file=path, line=line, method=verb, url=base)
+            continue
+
+        method_match = _METHOD_RE.search(attrs)
+        action_match = _ACTION_RE.search(attrs)
+        if method_match and action_match:
+            verb = method_match.group(1).upper()
+            url = action_match.group(1)
+            if _is_dynamic_url(url):
+                continue
+            base = _static_prefix(url).split("?", 1)[0]
+            yield FormSubmission(file=path, line=line, method=verb, url=base)
+
+
+def _gather_submissions() -> list[FormSubmission]:
+    out: list[FormSubmission] = []
+    for root in _TEMPLATE_ROOTS:
+        if not root.is_dir():
+            continue
+        for ext in ("*.html", "*.htm", "*.jinja", "*.jinja2"):
+            for path in root.rglob(ext):
+                out.extend(_scan_file(path))
+    return out
+
+
+_MANIFEST_PATH = _REPO_ROOT / "tests" / "test_contract" / "manifest.py"
+
+
+def _load_manifest_endpoints() -> set[str]:
+    """AST-parse the manifest source and collect every `endpoints=`
+    tuple literal.
+
+    Done via static analysis (not import) so the lint can run in a
+    pre-commit hook's isolated venv without the manifest's heavy
+    imports (pytest, pact, consumer-server stubs). The trade-off:
+    dynamic `endpoints` (computed at import time) wouldn't be seen.
+    The manifest's `endpoints` are always literal tuples by
+    convention, so this restriction is real but acceptable.
+    """
+    import ast
+
+    source = _MANIFEST_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Only `ContractPair(...)` constructor calls.
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr != "ContractPair":
+            continue
+        if isinstance(func, ast.Name) and func.id != "ContractPair":
+            continue
+        if not isinstance(func, (ast.Name, ast.Attribute)):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "endpoints":
+                continue
+            if not isinstance(kw.value, ast.Tuple):
+                continue
+            for elt in kw.value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    out.add(elt.value)
+    return out
+
+
+def main() -> int:
+    submissions = _gather_submissions()
+    paired = _load_manifest_endpoints()
+    allowlist = set(FORMS_WITHOUT_PAIRS)
+
+    violations: list[FormSubmission] = []
+    for sub in submissions:
+        if sub.key in paired:
+            continue
+        if sub.key in allowlist:
+            continue
+        violations.append(sub)
+
+    if not violations:
+        n = len(submissions)
+        print(
+            f"✅ Contract-form coverage: {n} literal-URL form submission(s) all covered."
+        )
+        return 0
+
+    print(f"❌ Contract-form coverage: {len(violations)} uncovered submission(s).")
+    print()
+    for v in violations:
+        try:
+            shown = v.file.relative_to(_REPO_ROOT)
+        except ValueError:
+            shown = v.file
+        print(f"📄 {shown}:{v.line}")
+        print(f"   Submits: {v.key}")
+        print(
+            f"   No matching entry in tests/test_contract/manifest.py:CONTRACT_PAIRS[*].endpoints"
+        )
+        print(f"   and not in FORMS_WITHOUT_PAIRS allowlist.")
+        print()
+    print("Options (pick one, deliberately):")
+    print('  • Add `endpoints=("<METHOD> <URL>",)` to an existing/new ContractPair')
+    print("    in `tests/test_contract/manifest.py` and write the Pact pair.")
+    print("    See tests/test_contract/README.md for the pattern.")
+    print("  • Add the `<METHOD> <URL>` key to FORMS_WITHOUT_PAIRS in")
+    print(f"    `scripts/dev/contract_form_coverage_check.py` with a one-line")
+    print('    rationale (e.g. "empty body, nothing to pin").')
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/test_contract_form_coverage_check.py
+++ b/scripts/dev/test_contract_form_coverage_check.py
@@ -1,0 +1,232 @@
+"""Tests for `scripts/dev/contract_form_coverage_check.py`.
+
+The lint's job is to flag a form whose submit URL has no matching
+`ContractPair.endpoints` entry and is not in `FORMS_WITHOUT_PAIRS`.
+The forgot-password bug that motivated this check would have been
+caught by this lint if it had existed; one of the tests below
+constructs that exact scenario and asserts the lint reports it.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from scripts.dev import contract_form_coverage_check as lint
+from scripts.dev.contract_form_coverage_check import (
+    _is_dynamic_url,
+    _scan_file,
+    _static_prefix,
+)
+
+
+def _write(tmp_path: Path, body: str, name: str = "page.html") -> Path:
+    file = tmp_path / name
+    file.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return file
+
+
+# --- URL parsing --------------------------------------------------------------
+
+
+def test_static_prefix_strips_jinja_block():
+    """A URL like `/auth/jwt/login{% if next %}?...{% endif %}` has
+    static prefix `/auth/jwt/login` — that's what providers route on."""
+    assert _static_prefix("/foo{% if x %}?a={{ b }}{% endif %}") == "/foo"
+    assert _static_prefix("/static/path") == "/static/path"
+    assert _static_prefix("{{ entity_url('x') }}") == ""
+
+
+def test_is_dynamic_url_recognises_template_only_urls():
+    """Pure-Jinja URLs (`{{ entity_url(...) }}`) are dynamic — the
+    lint can't resolve them statically so it skips them."""
+    assert _is_dynamic_url("{{ entity_url('clinician') }}") is True
+    # Has static prefix → in scope.
+    assert _is_dynamic_url("/auth/login{% if x %}?n={{ x }}{% endif %}") is False
+    # Plain literal → in scope.
+    assert _is_dynamic_url("/auth/forgot-password") is False
+    # String concatenation → dynamic.
+    assert _is_dynamic_url('"/clinicians/" ~ provider.id ~ "/licensures"') is True
+
+
+# --- Form extraction ----------------------------------------------------------
+
+
+def test_scan_extracts_htmx_post_url(tmp_path):
+    file = _write(
+        tmp_path,
+        """
+        <form hx-post="/auth/forgot-password" hx-ext="json-enc">
+          <input name="email" />
+        </form>
+        """,
+    )
+    subs = list(_scan_file(file))
+    assert len(subs) == 1
+    assert subs[0].key == "POST /auth/forgot-password"
+
+
+def test_scan_extracts_bare_html_form_method_action(tmp_path):
+    """Pre-htmx `<form method="post" action="/x">` is still in scope —
+    this shape is the original forgot-password bug. The lint must
+    catch it."""
+    file = _write(
+        tmp_path,
+        """
+        <form method="post" action="/auth/forgot-password">
+          <input name="email" />
+        </form>
+        """,
+    )
+    subs = list(_scan_file(file))
+    assert len(subs) == 1
+    assert subs[0].key == "POST /auth/forgot-password"
+
+
+def test_scan_skips_dynamic_macro_form(tmp_path):
+    """Entity-form macros use `hx-{{ method }}="{{ action }}"`. These
+    flow through the entity dispatch layer; coverage is handled by the
+    per-entity contract pairs already in the manifest. The lint stays
+    silent on them rather than producing false positives."""
+    file = _write(
+        tmp_path,
+        """
+        {% macro entity_form(method, action) %}
+        <form hx-{{ method }}="{{ action }}">
+        </form>
+        {% endmacro %}
+        """,
+    )
+    assert list(_scan_file(file)) == []
+
+
+def test_scan_recovers_static_prefix_from_jinja_block_in_action(tmp_path):
+    """The login form embeds a Jinja conditional inside the `action`
+    attribute. The static prefix `/auth/jwt/login` is still what the
+    provider routes on — pin that it gets extracted."""
+    file = _write(
+        tmp_path,
+        """
+        <form
+            method="post"
+            action="/auth/jwt/login{% if next %}?next={{ next }}{% endif %}">
+        </form>
+        """,
+    )
+    subs = list(_scan_file(file))
+    assert len(subs) == 1
+    assert subs[0].key == "POST /auth/jwt/login"
+
+
+def test_scan_handles_multiple_forms_in_one_file(tmp_path):
+    file = _write(
+        tmp_path,
+        """
+        <form hx-post="/auth/a"></form>
+        <form hx-delete="/auth/b"></form>
+        <form hx-patch="/auth/c"></form>
+        """,
+    )
+    keys = {s.key for s in _scan_file(file)}
+    assert keys == {"POST /auth/a", "DELETE /auth/b", "PATCH /auth/c"}
+
+
+def test_scan_ignores_get_forms(tmp_path):
+    """Search forms use `method=get` (or no method, defaulting to GET).
+    GETs have no body to encode; nothing for the contract layer to
+    pin. Out of scope."""
+    file = _write(
+        tmp_path,
+        """
+        <form action="/search" method="get">
+          <input name="q" />
+        </form>
+        """,
+    )
+    assert list(_scan_file(file)) == []
+
+
+# --- End-to-end main behavior ------------------------------------------------
+
+
+def test_main_passes_when_every_submission_is_paired(monkeypatch, capsys, tmp_path):
+    """End-to-end happy path: render a form whose URL is in the
+    pair list; main() exits 0."""
+    page = _write(
+        tmp_path,
+        '<form hx-post="/auth/special-route"></form>',
+    )
+    monkeypatch.setattr(lint, "_TEMPLATE_ROOTS", (tmp_path,))
+    monkeypatch.setattr(
+        lint,
+        "_load_manifest_endpoints",
+        lambda: {"POST /auth/special-route"},
+    )
+    monkeypatch.setattr(lint, "FORMS_WITHOUT_PAIRS", {})
+
+    assert lint.main() == 0
+    out = capsys.readouterr().out
+    assert "all covered" in out
+
+
+def test_main_passes_via_forms_without_pairs_allowlist(monkeypatch, capsys, tmp_path):
+    """The allowlist is the second escape hatch — entries here are
+    intentionally not paired with a justification. End-to-end: a form
+    whose URL is in the allowlist should pass."""
+    _write(
+        tmp_path,
+        '<form hx-post="/auth/sign-out"></form>',
+    )
+    monkeypatch.setattr(lint, "_TEMPLATE_ROOTS", (tmp_path,))
+    monkeypatch.setattr(lint, "_load_manifest_endpoints", lambda: set())
+    monkeypatch.setattr(
+        lint,
+        "FORMS_WITHOUT_PAIRS",
+        {"POST /auth/sign-out": "empty body; nothing to pin"},
+    )
+
+    assert lint.main() == 0
+
+
+def test_main_fails_when_submission_has_no_pair_or_allowlist_entry(
+    monkeypatch, capsys, tmp_path
+):
+    """The regression case the lint exists to catch: a literal-URL
+    form whose endpoint is not in any pair and not in the allowlist.
+    This is exactly the shape the original forgot-password bug had
+    on main before PR #770. The lint must report it and exit 1."""
+    _write(
+        tmp_path,
+        '<form hx-post="/auth/forgot-password" hx-ext="json-enc"></form>',
+    )
+    monkeypatch.setattr(lint, "_TEMPLATE_ROOTS", (tmp_path,))
+    monkeypatch.setattr(lint, "_load_manifest_endpoints", lambda: set())
+    monkeypatch.setattr(lint, "FORMS_WITHOUT_PAIRS", {})
+
+    rc = lint.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "POST /auth/forgot-password" in out
+    # Failure message should point at the two ways to resolve.
+    assert "ContractPair" in out
+    assert "FORMS_WITHOUT_PAIRS" in out
+
+
+# --- Manifest integration -----------------------------------------------------
+
+
+def test_real_manifest_covers_every_real_form():
+    """Smoke test against the live manifest + live templates: there
+    should be zero violations on main. If this test starts failing,
+    a real form has been added without a matching pair — the
+    structural prevention the lint is designed to give."""
+    submissions = lint._gather_submissions()
+    paired = lint._load_manifest_endpoints()
+    allowlist = set(lint.FORMS_WITHOUT_PAIRS)
+    uncovered = [
+        s for s in submissions if s.key not in paired and s.key not in allowlist
+    ]
+    assert uncovered == [], (
+        "Uncovered form submissions found — add to a ContractPair's "
+        "endpoints or to FORMS_WITHOUT_PAIRS: " + ", ".join(s.key for s in uncovered)
+    )

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -359,6 +359,10 @@ class QualityCommands:
                 "🔗 Checking template route literals...",
                 [sys.executable, "scripts/dev/template_route_check.py"],
             ),
+            (
+                "🤝 Checking contract-form coverage...",
+                [sys.executable, "scripts/dev/contract_form_coverage_check.py"],
+            ),
         ]
 
         exit_code = 0

--- a/tests/test_contract/README.md
+++ b/tests/test_contract/README.md
@@ -4,6 +4,8 @@ Pact-based contract tests verify that the **shape of the conversation** between 
 
 The current set of contract pairs lives in [`manifest.py`](manifest.py)'s `CONTRACT_PAIRS` — that's the registry. Per [`src/domain/routes/RESOURCE_GRAMMAR.md`](../../src/domain/routes/RESOURCE_GRAMMAR.md), every resource exposing an HTML form (or htmx-driven action partial) MUST have a contract pair; add new pairs there using the conventions below.
 
+The rule is enforced by [`scripts/dev/contract_form_coverage_check.py`](../../scripts/dev/contract_form_coverage_check.py), which runs in `dev lint` and as a pre-commit hook. It walks every `<form>` in `src/{domain,framework}/templates/` and asserts the submit URL appears in either `CONTRACT_PAIRS[*].endpoints` or that script's `FORMS_WITHOUT_PAIRS` allowlist. A new literal-URL form without a pair fails CI loudly — see the failure-message template in the script for the exact escape hatches.
+
 ## Why this directory exists outside the colocated convention
 
 The rest of the repo's tests live next to their source ([`tests/README.md`](../README.md)). Contract tests can't, because each test inherently spans **two** layers:

--- a/tests/test_contract/manifest.py
+++ b/tests/test_contract/manifest.py
@@ -30,6 +30,13 @@ class ContractPair:
     `provider_state` (optional) is the state string the consumer test's
     `pact.given(...)` uses; surfaced here so `KNOWN_PROVIDER_STATES`
     is derived rather than hand-maintained.
+    `endpoints` is the static-analysis source of truth: the
+    `("METHOD /path", ...)` tuples this pair covers. Read by
+    `scripts/dev/contract_form_coverage_check.py` to verify every
+    literal-URL form template has a corresponding pair. Forms whose
+    submit URL is dynamic (macro-driven `hx-{{ method }}="{{ action }}"`)
+    are skipped by the lint — they route through the entity dispatch
+    layer that the existing entity-form pairs already cover.
     `pytest_marks` is the tuple of pytest marks applied to the
     parametrized provider verification (e.g. `pytest.mark.provider`,
     `pytest.mark.posts`).
@@ -41,6 +48,7 @@ class ContractPair:
     handler_mocks_factory: Optional[Callable[[], dict]] = None
     consumer_setup_fn: Optional[Callable] = None
     provider_state: Optional[str] = None
+    endpoints: tuple = ()
     pytest_marks: tuple = ()
 
 
@@ -52,6 +60,10 @@ CONTRACT_PAIRS: list[ContractPair] = [
         handler_mocks_factory=MockDataFactory.create_registration_dependency_config,
         consumer_setup_fn=None,  # uses real auth_pages router
         provider_state="User test.user@example.com does not exist",
+        # Literal URL — `register.html` does `hx-post="/auth/register"`.
+        # Picked up by `scripts/dev/contract_form_coverage_check.py` so
+        # the form's URL never drifts away from a paired endpoint.
+        endpoints=("POST /auth/register",),
         pytest_marks=(pytest.mark.provider, pytest.mark.auth),
     ),
     ContractPair(


### PR DESCRIPTION
Structural prevention for the bug class behind PR #770 (forgot-password 422). A form posting JSON where the endpoint expects form-encoding (or vice-versa) shipped because no contract pair covered it, and the "every form needs a pair" rule was prose-only.

## What this PR ships

**`scripts/dev/contract_form_coverage_check.py`** — walks every `<form>` in `src/{domain,framework}/templates/`, extracts the submit URL where it's a literal (`hx-post=\"/path\"` or `<form method=\"post\" action=\"/path\">`), and asserts the `(METHOD, URL)` tuple appears in either:

1. `tests/test_contract/manifest.py:CONTRACT_PAIRS[*].endpoints` — new field on `ContractPair`, static-analysis source of truth.
2. `FORMS_WITHOUT_PAIRS` allowlist in the lint script itself, with a one-line rationale per entry.

Forms with template-driven URLs (`hx-{{ method }}=\"{{ action }}\"`, used by entity-form macros) are skipped — they flow through the entity dispatch layer and are covered by the per-entity pairs already in the manifest.

The lint reads the manifest via AST static analysis (not import) so pre-commit's isolated venv doesn't need pytest/pact/server-stub imports.

## What the failure looks like

Removing the TODO allowlist entries (simulating the original bug):

```
❌ Contract-form coverage: 2 uncovered submission(s).

📄 src/domain/templates/auth/forgot_password.html:9
   Submits: POST /auth/forgot-password
   No matching entry in tests/test_contract/manifest.py:CONTRACT_PAIRS[*].endpoints
   and not in FORMS_WITHOUT_PAIRS allowlist.

Options (pick one, deliberately):
  • Add `endpoints=(\"<METHOD> <URL>\",)` to an existing/new ContractPair
    in `tests/test_contract/manifest.py` and write the Pact pair.
  • Add the `<METHOD> <URL>` key to FORMS_WITHOUT_PAIRS in
    `scripts/dev/contract_form_coverage_check.py` with a one-line rationale.
```

## Wiring
- `dev lint` runs it via `scripts/dev_cli.py`.
- `.pre-commit-config.yaml` runs it on changes to form templates, the manifest, or the script itself.

## Allowlist ships with
- `POST /auth/jwt/login` — OAuth2 form-encoded by RFC.
- `POST /auth/sign-out`, `POST /auth/resend-verify` — empty-body endpoints.
- `POST /auth/forgot-password`, `POST /auth/reset-password` — `TODO(#771)` entries pending real Pact pairs. The follow-up issue tracks writing those (different mocking strategy needed than the existing pairs since the endpoints are fastapi-users-owned with no local handler to monkey-patch).

## Test plan
- [x] 12 new unit tests in `scripts/dev/test_contract_form_coverage_check.py` covering URL parsing edge cases, form extraction (htmx + bare HTML), allowlist semantics, dynamic-URL skipping, and an end-to-end smoke test against the live manifest + live templates.
- [x] `dev lint` green.
- [x] Full pytest suite: 1635 passed.
- [x] Verified the lint actually fires by removing the TODO allowlist entries.

## Follow-up
- Issue #771 — write real Pact pairs for `/auth/forgot-password` and `/auth/reset-password`, then remove their TODO entries from `FORMS_WITHOUT_PAIRS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)