### PR TITLE
fix(breadcrumb): use back-arrow affordance at every viewport

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -288,11 +288,11 @@ async def test_get_user_detail_renders_breadcrumb_and_heading(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """User detail uses the consolidated chrome: a one-segment
-    breadcrumb that links back to `/users` and a toolbar `<h1>` that
-    carries the current user's name. The current item is NOT
-    repeated as a non-link crumb — every visible breadcrumb item is
-    an actionable link (GOV.UK pattern)."""
+    """User detail uses the consolidated chrome: a back affordance that
+    links to `/users` (the deepest clickable parent) and a toolbar
+    `<h1>` that carries the current user's name. The current item is
+    NOT repeated in the breadcrumb — every visible breadcrumb element
+    is an actionable link (GOV.UK pattern)."""
     target_username = f"target-{uuid.uuid4()}"
     target = create_test_user(username=target_username)
     async with db_test_session_manager() as session:
@@ -302,11 +302,11 @@ async def test_get_user_detail_renders_breadcrumb_and_heading(
     response = await authenticated_client.get(f"/users/{target.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    items = tree.css('nav[aria-label="breadcrumb"] ul > li')
-    assert [li.text(strip=True) for li in items] == ["Users"]
-    parent = items[0].css_first("a")
-    assert parent is not None
-    assert parent.attributes.get("href") == "/users"
+    back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
+    assert back is not None
+    assert back.attributes.get("href") == "/users"
+    label = back.css_first("span.breadcrumb-back-label")
+    assert label is not None and label.text(strip=True) == "Users"
     # Current item lives in the toolbar <h1>, not the breadcrumb.
     h1 = tree.css_first("div.toolbar h1")
     assert h1 is not None

--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -15,7 +15,7 @@ A resource cluster `<entity>/` typically contains:
 - `form_edit.html` — extends `views/form_edit.html`. Declares `resource_label`, `current_label`, `resource_url`, `resource_detail_url`, and the form body in `content`.
 - `_<role>_actions.html` (cluster-local partial) — owner/admin action button clusters for the entity, `{% include %}`d from the detail page's `actions` block or the card footer on the list page.
 
-Subresource lists (e.g. `/users/{id}/clinicians`) override `{% block breadcrumb %}` to land a multi-segment chain (`Users › <username> › Clinicians`) while still inheriting the list view's toolbar + content shape from `views/list.html`. See `users/providers_list.html` (file name retained — the directory cluster is still `providers/` because the model class is `Provider`; only the user-facing surface flipped in #642 PR 4).
+Subresource lists (e.g. `/users/{id}/clinicians`) override `{% block breadcrumb %}` to pass a multi-segment chain (`[("Users", …), (username, /users/<id>), ("Clinicians", None)]`); the breadcrumb macro renders only the deepest clickable parent as a back link, so the override's job is to shift the back target one level up the tree (here: back to the user) rather than to the collection. The page still inherits the list view's toolbar + content shape from `views/list.html`. See `users/providers_list.html` (file name retained — the directory cluster is still `providers/` because the model class is `Provider`; only the user-facing surface flipped in #642 PR 4).
 
 Pages that don't fit the resource grammar — the `/auth/*` flow's centered single-card layout — extend `base.html` directly and compose the `_shared/` macros by hand.
 

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -32,15 +32,15 @@ A template under `<resource>/` in either root may only `{% extends %}` / `{% inc
 
 Each view-type template wires the same three-strip chrome (nav + breadcrumb + toolbar + content) from `base.html` with the breadcrumb and toolbar shape that matches the verb. A child template extending one of these declares only what's unique: a label, a URL, the body markup, and an optional action cluster.
 
-| View type     | Breadcrumb shape                          | Toolbar                                    | Child must declare                                       |
+| View type     | Breadcrumb back target                    | Toolbar                                    | Child must declare                                       |
 | ------------- | ----------------------------------------- | ------------------------------------------ | -------------------------------------------------------- |
-| `list.html`   | `Resource`                                | optional filter widget + actions cluster   | `resource_label`, `content`. Optional: `actions`, `filters`/`filter_action`/`filter_values` (context). |
-| `detail.html` | `Resource › <current>`                    | optional actions cluster                   | `resource_label`, `current_label`, `content`, `resource_url` (context). Optional: `actions`. |
-| `form_new.html` | `Resource`                              | none — form's submit button is the action  | `resource_label`, `content`, `resource_url` (context). H1 = `create_heading`, sourced from `entity_create_label(spec.name, kind=...)` via the form handler — children don't override the H1. |
-| `form_edit.html` | `Resource › <current> › Edit`          | none — form's Save/Cancel buttons are the actions | `resource_label`, `current_label`, `content`, `resource_url`, `resource_detail_url` (context). `current_label` is the **specific resource being edited** (e.g. `{{ organization.name }}`, `{{ view.headline }}`) — not a generic kind noun. |
-| `search.html` | `Resource`                                | none — form's submit button is the action  | `resource_label` (context). H1 = `filter_heading`, sourced from `entity_filter_label(spec.name)` via the search handler. |
+| `list.html`   | _(none — list pages omit the breadcrumb)_ | optional filter widget + actions cluster   | `resource_label`, `content`. Optional: `actions`, `filters`/`filter_action`/`filter_values` (context). |
+| `detail.html` | `← Resource`                              | optional actions cluster                   | `resource_label`, `current_label`, `content`, `resource_url` (context). Optional: `actions`. |
+| `form_new.html` | `← Resource`                            | none — form's submit button is the action  | `resource_label`, `content`, `resource_url` (context). H1 = `create_heading`, sourced from `entity_create_label(spec.name, kind=...)` via the form handler — children don't override the H1. |
+| `form_edit.html` | `← <current>`                          | none — form's Save/Cancel buttons are the actions | `resource_label`, `current_label`, `content`, `resource_url`, `resource_detail_url` (context). `current_label` is the **specific resource being edited** (e.g. `{{ organization.name }}`, `{{ view.headline }}`) — not a generic kind noun. |
+| `search.html` | `← Resource`                              | none — form's submit button is the action  | `resource_label` (context). H1 = `filter_heading`, sourced from `entity_filter_label(spec.name)` via the search handler. |
 
-Every view-type template also exposes its `breadcrumb` block for full override, so subresource lists with multi-segment chains (e.g. `Users › <username> › Providers` on `/users/{id}/providers`) keep the chrome by overriding one block while still inheriting the toolbar/content shape.
+The breadcrumb is always a single back affordance — a left chevron + the deepest clickable parent's label — at every viewport. The macro picks the back target by walking the chain backward to the last item with a non-`None` href, so a child template can override `{% block breadcrumb %}` with a multi-item chain (e.g. `[("Users", …), (username, /users/<id>), ("Clinicians", None)]` on `/users/{id}/clinicians`) to shift the back link one level up the tree without changing the visible shape.
 
 ### Create / filter labels — single source of truth
 

--- a/src/framework/templates/_shared/_breadcrumb.html
+++ b/src/framework/templates/_shared/_breadcrumb.html
@@ -1,24 +1,17 @@
 {# Breadcrumb zone bar primitive.
    title-case-ignore: the literal ARIA value `breadcrumb` is Pico's hook.
 
-Renders the page's location chain as Pico's native breadcrumb nav
-above the page toolbar — see the `breadcrumb` block slot wired in
-[`../base.html`](../base.html). Pico styles the markup automatically
-(horizontal inline list, `›` separator via CSS on `li + li::before`)
-so no classes are added to the `<ul>`; the divider character is set
-globally in `base.html` via `--pico-nav-breadcrumb-divider`.
+Renders the page's location as a single "back" affordance — a
+Lucide arrow-left chevron plus the deepest clickable parent's
+label. Sits in the `breadcrumb` block slot wired in
+[`../base.html`](../base.html). No band chrome (background, border,
+padding); just inline text with an icon.
 
 Each item is a `(label, href)` tuple. The last item's `href` is
-typically `None` — it renders as plain text (the current page) and
-carries `aria-current="page"` for screen readers.
-
-On narrow viewports (≤540px) the full chain collapses to a single
-back affordance: a Lucide arrow-left chevron plus the deepest
-clickable parent's label (the last item with a non-None href). The
-`<ul>` chain is hidden and the `<a class="breadcrumb-back">` is
-shown — see the `@media` block in `base.html`. Both elements are
-emitted unconditionally; CSS does the swapping so no JS branches on
-viewport.
+typically `None` (the current page); the back target is the
+deepest item with a non-None `href` — for two-level chains
+(collection → current) that's the collection link, for nested
+chains (collection → row → edit) that's the row link.
 
 When every item has `href=None` (theoretical edge case — a page
 with no parent), the back affordance falls back to the first
@@ -29,33 +22,21 @@ item's label as plain text so the markup stays valid.
         ("Post", "/posts/" ~ post.id),
         ("Edit", None),
     ]) }}
-
-Pico's docs at https://picocss.com/docs/nav#breadcrumb require an
-inner `<ul>` specifically — the built-in style hooks off the nav's
-descendant `ul`. Picking `<ol>` (semantically tempting, since
-breadcrumbs are ordered) loses Pico's auto-styling.
 #}
 
 {# title-case-ignore: literal aria-label value `breadcrumb` is the Pico hook #}
 {% macro breadcrumb(items) -%}
 {%- if items %}
-{# Deepest clickable parent — the back target on mobile. Walk from the
-   end backward; the current page (last item) typically has `href=None`
-   so its parent is at index -2. For single-item crumbs (detail pages)
-   the only item carries the href. #}
+{# Deepest clickable parent — the back target. Walk from the end
+   backward; the current page (last item) typically has `href=None`
+   so its parent is at index -2. For single-item crumbs (detail
+   pages) the only item carries the href. #}
 {%- set _linkable = items | selectattr(1) | list -%}
 {%- set _back = _linkable[-1] if _linkable else items[0] -%}
 <nav aria-label="breadcrumb">
   <a class="breadcrumb-back"{% if _back[1] %} href="{{ _back[1] }}"{% endif %}>
     <i class="icon-arrow-left" aria-hidden="true"></i><span class="breadcrumb-back-label">{{ _back[0] }}</span>
   </a>
-  <ul>
-    {%- for label, href in items %}
-    <li{% if loop.last %} aria-current="page"{% endif %}>
-      {%- if href %}<a href="{{ href }}">{{ label }}</a>{% else %}{{ label }}{% endif -%}
-    </li>
-    {%- endfor %}
-  </ul>
 </nav>
 {%- endif %}
 {%- endmacro %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -341,24 +341,12 @@
         padding-inline: 0.5rem;
         font-size: 0.875rem;
       }
-      /* Breadcrumb. Inline text only — no band chrome (background,
-         border, padding). Pico already styles `nav[aria-label="breadcrumb"]
-         ul` as an inline list with a separator via `li + li::before`;
-         we just set the divider character via the Pico-exposed
-         `--pico-nav-breadcrumb-divider`. The breadcrumb sits as a thin
-         line above the toolbar row that carries the `<h1>`, so the
-         chrome between the global nav and the content is one band
-         instead of two. */
-      nav[aria-label="breadcrumb"] {
-        --pico-nav-breadcrumb-divider: '›';
-      }
-      /* Mobile back affordance. On narrow viewports the breadcrumb
-         macro's full `<ul>` chain is hidden and the inline
-         `<a class="breadcrumb-back">` is shown: a Lucide arrow-left
-         glyph plus the deepest clickable parent's label. On desktop
-         the `<a>` is hidden and the chain renders normally. The
-         macro emits both elements unconditionally; CSS does the
-         swapping (no JS).
+      /* Breadcrumb back affordance. The macro emits a single
+         `<a class="breadcrumb-back">` — a Lucide arrow-left glyph plus
+         the deepest clickable parent's label — at every viewport
+         width. The breadcrumb sits as a thin line above the toolbar
+         row that carries the `<h1>`, so the chrome between the
+         global nav and the content is one band instead of two.
 
          Pico's default `<a>` underline ran across both the icon and
          the label, and the icon's `vertical-align: -0.15em` made it
@@ -367,19 +355,16 @@
          a whole, scope the underline to the label `<span>` on hover/
          focus, and use a flex `gap` for the chevron-to-label spacing
          (overriding the icon's universal `margin-inline-end`). */
-      .breadcrumb-back { display: none; text-decoration: none; }
-      @media (max-width: 540px) {
-        nav[aria-label="breadcrumb"] > ul { display: none; }
-        .breadcrumb-back {
-          display: inline-flex;
-          align-items: center;
-          gap: 0.25rem;
-        }
-        .breadcrumb-back > i { margin-inline-end: 0; }
-        .breadcrumb-back:hover .breadcrumb-back-label,
-        .breadcrumb-back:focus .breadcrumb-back-label {
-          text-decoration: underline;
-        }
+      .breadcrumb-back {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        text-decoration: none;
+      }
+      .breadcrumb-back > i { margin-inline-end: 0; }
+      .breadcrumb-back:hover .breadcrumb-back-label,
+      .breadcrumb-back:focus .breadcrumb-back-label {
+        text-decoration: underline;
       }
       /* Brand collapse on mobile. The two-word "Bedlam Connect" wraps
          to two lines on narrow viewports once the primary nav fills the

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -155,13 +155,15 @@ def test_list_view_renders_actions_block_in_toolbar_right() -> None:
     assert '<li><a id="create" href="/posts/form">Create</a></li>' in html
 
 
-def test_detail_view_renders_two_segment_breadcrumb_and_actions() -> None:
-    """``views/detail.html`` builds `[(resource_label, resource_url),
-    (current_label, None)]` and renders actions inside the shared
-    two-zone toolbar — empty left zone (no search link), and a
-    `<menu class="toolbar-right">` carrying the `<li>` commands. Pins
-    the "detail actions land at the same right edge as list-page
-    actions" rule (no per-view-type toolbar shape)."""
+def test_detail_view_renders_back_affordance_and_actions() -> None:
+    """``views/detail.html`` builds `[(resource_label, resource_url)]`
+    and the breadcrumb macro renders it as a single back affordance —
+    `<a class="breadcrumb-back" href="/providers">…Providers</a>`.
+    Actions land inside the shared two-zone toolbar — empty left zone
+    (no search link), and a `<menu class="toolbar-right">` carrying
+    the `<li>` commands. Pins the "detail actions land at the same
+    right edge as list-page actions" rule (no per-view-type toolbar
+    shape)."""
     env = _make_env()
     _add_child(
         env,
@@ -182,7 +184,11 @@ def test_detail_view_renders_two_segment_breadcrumb_and_actions() -> None:
         is_development=False,
     )
 
-    assert 'href="/providers"' in html and ">Providers</a>" in html
+    tree = HTMLParser(html)
+    back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
+    assert back is not None and back.attributes.get("href") == "/providers"
+    label = back.css_first("span.breadcrumb-back-label")
+    assert label is not None and label.text(strip=True) == "Providers"
     assert "Sunrise Therapy" in html
     assert '<div class="toolbar">' in html
     assert '<menu class="toolbar-right">' in html
@@ -216,7 +222,11 @@ def test_form_new_view_renders_create_heading_from_context() -> None:
         create_heading="Create clinician",
     )
 
-    assert 'href="/providers"' in html and ">Providers</a>" in html
+    tree = HTMLParser(html)
+    back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
+    assert back is not None and back.attributes.get("href") == "/providers"
+    label = back.css_first("span.breadcrumb-back-label")
+    assert label is not None and label.text(strip=True) == "Providers"
     assert "<h1>Create clinician</h1>" in html
     assert '<form id="x"></form>' in html
 
@@ -269,14 +279,14 @@ def test_primary_nav_excludes_non_journey_links_for_all_viewers() -> None:
 
 
 def test_form_edit_view_renders_breadcrumb_and_edit_heading() -> None:
-    """``views/form_edit.html`` renders a two-segment breadcrumb
-    (collection link › detail link, the latter carrying the row's
-    identity as `current_label`) above an `<h1>"Edit <noun>"` sourced
-    from `edit_heading`. The H1 reads the resource noun ("clinician",
-    "clinician opening", "client referral") rather than the row's
-    identity — that lives on the breadcrumb's middle segment, where
-    "back to <row>" is the natural verb. Mirrors the create-page
-    contract where `create_heading` sources the H1."""
+    """``views/form_edit.html`` renders a single-link back affordance
+    pointing at the row's detail page (the deepest clickable parent of
+    an edit view) above an `<h1>"Edit <noun>"` sourced from
+    `edit_heading`. The back link's label is the row's identity
+    (`current_label`) — "back to Sunrise Therapy" is the natural verb.
+    The H1 reads the resource noun ("clinician", "clinician opening",
+    "client referral") rather than the row's identity, mirroring the
+    create-page contract where `create_heading` sources the H1."""
     env = _make_env()
     _add_child(
         env,
@@ -299,13 +309,13 @@ def test_form_edit_view_renders_breadcrumb_and_edit_heading() -> None:
     )
 
     tree = HTMLParser(html)
-    crumbs = tree.css('nav[aria-label="breadcrumb"] li')
-    assert [li.css_first("a").attributes.get("href") for li in crumbs] == [
-        "/providers",
-        "/providers/42",
-    ], "form-edit breadcrumb must be exactly two link segments"
-    # Middle crumb's link text is the row's identity (current_label).
-    assert crumbs[1].css_first("a").text(strip=True) == "Sunrise Therapy"
+    back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
+    assert back is not None, "form-edit must render a back affordance"
+    assert (
+        back.attributes.get("href") == "/providers/42"
+    ), "back link points at the deepest clickable parent (the row's detail page)"
+    label = back.css_first("span.breadcrumb-back-label")
+    assert label is not None and label.text(strip=True) == "Sunrise Therapy"
     # H1 in the toolbar reads `edit_heading`, NOT "Edit <current_label>".
     h1 = tree.css_first("div.toolbar h1")
     assert h1 is not None


### PR DESCRIPTION
## Summary
- Mobile rendered a "← <parent>" back link while desktop rendered the full Pico chain with "›" separators.
- The chevron back affordance reads clearly at any width — render it everywhere.
- Drops the `<ul>` chain from the macro and the `@media` swap from base.html.

## Test plan
- [x] `dev test` — colocated tests updated (`test_views.py`, `test_users.py`) pass
- [x] `dev lint` — passes
- [ ] Visual: load `/users/<id>` and `/users/<id>/form` on desktop; back arrow + label visible above toolbar
- [ ] Visual: load same pages on a narrow viewport; identical chrome