### PR TITLE
refactor(templates): reserve <article> for list items

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -234,7 +234,7 @@ async def test_get_register_page(test_client: AsyncClient):
     # Card wrapper — `.auth-page` caps the form at 28rem and centers it
     # so it doesn't stretch to the `<main class="container">` width on
     # tablet/desktop (#584). The `.auth-page` rule lives in `base.html`.
-    assert '<article class="auth-page">' in response.text
+    assert '<section class="auth-page">' in response.text
     # Subtitle must use plain language a first-time visitor can parse —
     # no bare model-jargon list ("openings, referrals, and intakes")
     # before any value framing (#694).
@@ -255,7 +255,7 @@ async def test_get_login_page(test_client: AsyncClient):
     assert "referrals" not in response.text
     assert "Sign in to your Bedlam Connect account" in response.text
     # See `test_get_register_page` for `.auth-page` rationale (#584).
-    assert '<article class="auth-page">' in response.text
+    assert '<section class="auth-page">' in response.text
     # Default subtitle must not assume a returning user (#693).
     assert "Welcome back" not in response.text
     # Default subtitle must not contain bare jargon without context (#693).
@@ -290,7 +290,7 @@ async def test_get_forgot_password_page(test_client: AsyncClient):
     # identify the page.
     assert "Send reset link" in response.text
     # See `test_get_register_page` for `.auth-page` rationale (#584).
-    assert '<article class="auth-page">' in response.text
+    assert '<section class="auth-page">' in response.text
     # The form MUST submit as JSON — fastapi-users' `/auth/forgot-password`
     # expects `{"email": "..."}`. A plain `<form method="post">` would
     # send `application/x-www-form-urlencoded` and the endpoint would
@@ -321,7 +321,7 @@ async def test_get_reset_password_page(test_client: AsyncClient):
     assert 'hx-post="/auth/reset-password"' in response.text
     assert 'hx-ext="json-enc"' in response.text
     # See `test_get_register_page` for `.auth-page` rationale (#584).
-    assert '<article class="auth-page">' in response.text
+    assert '<section class="auth-page">' in response.text
 
 
 async def test_get_verify_page_without_token_returns_error(test_client: AsyncClient):

--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -895,8 +895,8 @@ async def test_provider_detail_favorite_toggle_lives_in_toolbar(
     logged_in_user: User,
 ):
     """The favorite/unfavorite button is a primary resource action and
-    renders inside the toolbar, not in `<footer>` or `<article>`. Pins
-    the chrome rule in `src/framework/templates/README.md`."""
+    renders inside the toolbar, not in `<footer>` or any `.entity-card`
+    body. Pins the chrome rule in `src/framework/templates/README.md`."""
     other = create_test_user(username=f"other-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -908,8 +908,8 @@ async def test_provider_detail_favorite_toggle_lives_in_toolbar(
     tree = HTMLParser(response.text)
     favorite_selector = f'button[hx-post="/users/me/favorites/{provider_id}"]'
     assert tree.css_first(f".toolbar {favorite_selector}") is not None
-    # The favorite button is not duplicated inside <article>.
-    assert tree.css_first(f"article {favorite_selector}") is None
+    # The favorite button is not duplicated inside any detail-card body.
+    assert tree.css_first(f".entity-card {favorite_selector}") is None
 
 
 async def test_provider_form_new_renders_form_actions_cluster(

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -409,9 +409,9 @@ async def test_detail_admin_actions_render_inside_toolbar(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """Admin actions render inside the page toolbar (not the `<article>`
-    body). This pins the "primary resource actions live in the toolbar"
-    rule documented in `src/framework/templates/README.md`."""
+    """Admin actions render inside the page toolbar (not the
+    `.entity-card` body). This pins the "primary resource actions live
+    in the toolbar" rule documented in `src/framework/templates/README.md`."""
     await promote_to_admin(db_test_session_manager, logged_in_user.email)
     target = create_test_user(username=f"target-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
@@ -422,8 +422,44 @@ async def test_detail_admin_actions_render_inside_toolbar(
     tree = HTMLParser(response.text)
     activation_selector = f"button[hx-put='/users/{target.id}/activation']"
     assert tree.css_first(f".toolbar {activation_selector}") is not None
-    # Sanity: not duplicated inside <article>.
-    assert tree.css_first(f"article {activation_selector}") is None
+    # Sanity: not duplicated inside the detail-page card body.
+    assert tree.css_first(f".entity-card {activation_selector}") is None
+
+
+async def test_self_detail_renders_favorites_link_in_body_not_toolbar(
+    authenticated_client: AsyncClient,
+):
+    """Favorites is navigation, not an Action — the toolbar is reserved
+    for Actions (Sign out, admin Deactivate/Delete). The link to the
+    viewer's favorites list lives in the detail-page body."""
+    response = await authenticated_client.get("/users/me")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    favorites_selector = "a[href='/users/me/favorites']"
+    assert tree.css_first(f".toolbar {favorites_selector}") is None, (
+        "Favorites link must not appear in the toolbar — toolbar is for " "Actions only"
+    )
+    assert (
+        tree.css_first(f"main {favorites_selector}") is not None
+    ), "Favorites link must appear in the page body for the self viewer"
+
+
+async def test_other_user_detail_hides_favorites_link(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Viewing someone else's profile must not expose their private
+    favorites list — the Favorites body section is self-only."""
+    target = create_test_user(username=f"target-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(target)
+
+    response = await authenticated_client.get(f"/users/{target.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first("a[href='/users/me/favorites']") is None
 
 
 async def test_detail_hides_admin_actions_for_non_admin(
@@ -532,17 +568,19 @@ async def test_users_me_shows_onboarding_create_clinician_cta_when_no_profile(
     response = await authenticated_client.get("/users/me")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    # The onboarding "Getting started" card must be present.
+    # The onboarding "Getting started" card must be present. Detail-page
+    # cards are `<section class="entity-card">` (article is reserved for
+    # list items); list-item cards inside still use `article` (no overlap).
     headings = [
         el.text(strip=True)
-        for el in tree.css("article.entity-card header.entity-header strong")
+        for el in tree.css("section.entity-card header.entity-header strong")
     ]
     assert (
         "Getting started" in headings
     ), "/users/me is missing the 'Getting started' onboarding card"
     # The create-clinician CTA must link to the clinician form.
     cta = tree.css_first(
-        "article.entity-card a[href='/clinicians/form'][role='button']"
+        "section.entity-card a[href='/clinicians/form'][role='button']"
     )
     assert (
         cta is not None
@@ -567,7 +605,7 @@ async def test_users_me_onboarding_not_shown_for_other_users(
     tree = HTMLParser(response.text)
     headings = [
         el.text(strip=True)
-        for el in tree.css("article.entity-card header.entity-header strong")
+        for el in tree.css("section.entity-card header.entity-header strong")
     ]
     assert (
         "Getting started" not in headings

--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -40,7 +40,7 @@ The cross-resource import lint ([`scripts/dev/template_imports_check.py`](../../
 
 The services list is the first row of `_facts_block`'s `<dl>` rather than its own partial (see #628).
 
-The auth-flow pages (`auth/login.html`, `auth/register.html`, `auth/forgot_password.html`, `auth/reset_password.html`) each render a single `<article class="auth-page">` card. The `.auth-page` rule in [`../../framework/templates/base.html`](../../framework/templates/base.html) caps the card at 28rem and centers it horizontally — without the class the card stretches to the full `<main class="container">` width on tablet/desktop.
+The auth-flow pages (`auth/login.html`, `auth/register.html`, `auth/forgot_password.html`, `auth/reset_password.html`) each render a single `<section class="auth-page">` card. The shared card-chrome rules in [`../../framework/templates/base.html`](../../framework/templates/base.html) apply Pico's article framing (background, border, padding, header/footer bands) to the class, and the `.auth-page` rule caps the card at 28rem centered horizontally. `<article>` is reserved for items inside a list of items (post-list cards, the per-affiliation loop in `providers/detail.html`); single-form pages use `<section>`.
 
 ## Copy style guide
 

--- a/src/domain/templates/auth/forgot_password.html
+++ b/src/domain/templates/auth/forgot_password.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article class="auth-page">
+<section class="auth-page">
   <header>
     <h1>Reset your password</h1>
     <p>Enter your email and we'll send you a reset link.</p>
@@ -24,5 +24,5 @@
       <a href="/auth/login">Log in.</a>
     </p>
   </footer>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article class="auth-page">
+<section class="auth-page">
   <header>
     <h1>Log in</h1>
     {% if just_registered %}<p>Account created — log in to continue.</p>{% else %}<p>Sign in to your Bedlam Connect account.</p>{% endif %}
@@ -29,5 +29,5 @@
       <a href="/auth/register">Create an account.</a>
     </p>
   </footer>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/auth/register.html
+++ b/src/domain/templates/auth/register.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article class="auth-page">
+<section class="auth-page">
   <header>
     <h1>Create an account</h1>
     <p>Create your clinician profile and start sharing available openings with referrers in your network.</p>
@@ -26,5 +26,5 @@
       <a href="/auth/login">Log in.</a>
     </p>
   </footer>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/auth/reset_password.html
+++ b/src/domain/templates/auth/reset_password.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article class="auth-page">
+<section class="auth-page">
   <header>
     <h1>Set a new password</h1>
     <p>Pick something memorable. You'll use it next time you log in.</p>
@@ -18,5 +18,5 @@
     </label>
     <button type="submit">Save password</button>
   </form>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/auth/verify.html
+++ b/src/domain/templates/auth/verify.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<article class="auth-page">
+<section class="auth-page">
   <header>
     {% if status == "success" %}
     <h1>Email verified</h1>
@@ -18,5 +18,5 @@
       <a href="{{ entity_url('user', id='me') }}" role="button">Go to your profile</a>
     </p>
   </footer>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/organizations/detail.html
+++ b/src/domain/templates/organizations/detail.html
@@ -34,7 +34,7 @@
    already conveyed by absence; a "— (root)" placeholder mixed two
    empty-state conventions (em-dash + parenthetical). #}
 {% block content %}
-<article class="entity-card">
+<section class="entity-card">
   <section class="entity-facts">
     <dl>
       {{ fact('type', 'Type', ORGANIZATION_TYPES_LABELS[organization.type]) }}
@@ -45,5 +45,5 @@
       {%- endif %}
     </dl>
   </section>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/posts/openings/detail.html
+++ b/src/domain/templates/posts/openings/detail.html
@@ -25,7 +25,7 @@
    card. Per-kind branching lives in `post_card_view` (one place);
    every visual element in the card reads from `view`. #}
 {% block content %}
-<article class="entity-card" data-kind="{{ opening.kind }}">
+<section class="entity-card" data-kind="{{ opening.kind }}">
   {%- if view.description %}
   <p>{{ view.description }}</p>
   {%- endif %}
@@ -39,5 +39,5 @@
   <footer>
     <a href="mailto:{{ opening.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/posts/referrals/detail.html
+++ b/src/domain/templates/posts/referrals/detail.html
@@ -25,7 +25,7 @@
    card. Per-kind branching lives in `post_card_view` (one place);
    every visual element in the card reads from `view`. #}
 {% block content %}
-<article class="entity-card" data-kind="{{ referral.kind }}">
+<section class="entity-card" data-kind="{{ referral.kind }}">
   {%- if view.description %}
   <p>{{ view.description }}</p>
   {%- endif %}
@@ -39,5 +39,5 @@
   <footer>
     <a href="mailto:{{ referral.owner.email }}" target="_blank" rel="noopener noreferrer" role="button" class="secondary outline">Email</a>
   </footer>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/programs/detail.html
+++ b/src/domain/templates/programs/detail.html
@@ -25,7 +25,7 @@
    carries `program.name`, and `state_preference` is already a
    `<dt>State served</dt>` row in the facts list. #}
 {% block content %}
-<article class="entity-card">
+<section class="entity-card">
   {%- if program.description %}
   <p class="entity-description">{{ program.description }}</p>
   {%- endif %}
@@ -45,5 +45,5 @@
       {{ fact('accepting_referrals', 'Accepting referrals', "Yes" if program.accepting_referrals else "No") }}
     </dl>
   </section>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/providers/_credential_row.html
+++ b/src/domain/templates/providers/_credential_row.html
@@ -4,8 +4,8 @@
    read-only).
 
    Why a flat row, not a card-shaped `<article>`: the credentials list
-   sits inside an outer `<section>` (form_edit) or `<article>` (detail).
-   Nesting cards inside cards reads as visual noise; a flat row with a
+   sits inside an outer `<section>` (form_edit or detail). Nesting
+   cards inside cards reads as visual noise; a flat row with a
    hairline divider between entries keeps the credential lists legible
    in either container without competing chrome.
 

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -133,7 +133,7 @@
    so they render once below the stacked affiliation cards. The
    list-per-section grammar is the same the old single-card layout
    used; only the parent card changed. #}
-<article class="entity-card">
+<section class="entity-card">
   <section>
     <h4>Licensures</h4>
     {% call(lic) credential_list(view.licensures, "No licensures listed.") %}
@@ -163,5 +163,5 @@
       ) }}
     {% endcall %}
   </section>
-</article>
+</section>
 {% endblock %}

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -7,13 +7,9 @@
 {% block current_label %}{{ target_user.username }}{% endblock %}
 
 {% block actions %}
-{# Favorites moved into the toolbar action menu (was buried in a
-   `<p><a>` inside content). Self-only — viewing someone else's
-   profile shouldn't expose their private favorites list. The admin
-   actions partial appends Deactivate / Delete after this when the
-   viewer is an admin looking at someone else. #}
+{# Toolbar is reserved for Actions (Sign out, admin Deactivate/Delete).
+   Favorites is navigation and lives in the body content below. #}
 {% if is_self %}
-<li><a href="{{ entity_url('user_favorite') }}" role="button" class="outline">Favorites</a></li>
 {# Sign out — self-only. fastapi-users' POST /auth/jwt/logout returns
    204 (cookie deleted, no body); the `hx-on::after-request` shim
    redirects the browser to `/` on success since the library doesn't
@@ -45,7 +41,7 @@
    `<strong>Clinicians</strong>` is a section label, not a duplicate
    of any heading above. #}
 {% block content %}
-<article class="entity-card">
+<section class="entity-card">
   {# Private rows (email, active) are gated by `can_view_private`,
      computed in handle_get_user_detail as `is_self OR is_admin(viewer)`.
      The handler also omits these fields from the `target_user`
@@ -70,14 +66,29 @@
     </dl>
   </section>
   {% endif %}
-</article>
+</section>
+
+{# Favorites — self-only navigation to the viewer's private favorites
+   list. Lives in the body, not the toolbar: toolbar is reserved for
+   Actions (Sign out, admin Deactivate/Delete), and viewing someone
+   else's profile must not expose their private favorites. #}
+{% if is_self %}
+<section class="entity-card">
+  <header class="entity-header">
+    <strong>Favorites</strong>
+  </header>
+  <footer class="entity-footer">
+    <a href="{{ entity_url('user_favorite') }}" role="button" class="outline">View favorites</a>
+  </footer>
+</section>
+{% endif %}
 
 {# Onboarding checklist — visible only to the user viewing their own
    profile. Shows status-based CTAs: create a clinician profile first,
    then post an opening. Other users' profiles (/users/{id}) are
    unchanged — they keep the Clinicians card below without this section. #}
 {% if is_self %}
-<article class="entity-card">
+<section class="entity-card">
   <header class="entity-header">
     <strong>Getting started</strong>
   </header>
@@ -95,10 +106,10 @@
     </li>
     {% endif %}
   </ul>
-</article>
+</section>
 {% endif %}
 
-<article class="entity-card">
+<section class="entity-card">
   <header class="entity-header">
     <strong>Clinicians</strong>
   </header>
@@ -121,5 +132,5 @@
     <a href="{{ entity_form_url('clinician') }}" role="button">{{ entity_create_label('clinician') }}</a>
   </footer>
   {% endif %}
-</article>
+</section>
 {% endblock %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -65,15 +65,49 @@
         --pico-font-size-h3: 1.125rem;
         --pico-font-size-h4: 1rem;
       }
-      /* Entity cards (`<article class="entity-card">`) intentionally
-         carry no custom CSS — they rely on Pico's default `<article>`
-         framing (background, border, padding, rounded corners) plus
-         semantic HTML inside (`<header>`, `<h3>`, `<small>`, `<dl>`,
-         etc.) so the chrome stays framework-portable. The
-         `entity-card` / `entity-header` / `entity-facts` / etc.
-         class names are kept on the markup as DOM hooks (tests query
-         them and they may pick up styles if Pico ever needs to be
-         supplemented), but no rule below targets them. */
+      /* Card chrome. Replicates Pico's default `<article>` framing
+         (background, border, padding, rounded corners, tinted header/
+         footer bands) on a class so the wrapping element doesn't have
+         to be `<article>`. `<article>` is reserved for items inside a
+         possible list of items (post-list cards, the per-affiliation
+         loop in `providers/detail.html`); single-item containers —
+         the detail-page wrapper, the auth-page form card — use
+         `<section>` and pick up chrome via these rules. The Pico
+         article element rule still applies to the list-card form;
+         the values are identical, so list cards see no change. */
+      .entity-card,
+      .auth-page {
+        margin-bottom: var(--pico-block-spacing-vertical);
+        padding: var(--pico-block-spacing-vertical) var(--pico-block-spacing-horizontal);
+        border-radius: var(--pico-border-radius);
+        background: var(--pico-card-background-color);
+        box-shadow: var(--pico-card-box-shadow);
+      }
+      .entity-card > header,
+      .entity-card > footer,
+      .auth-page > header,
+      .auth-page > footer {
+        margin-right: calc(var(--pico-block-spacing-horizontal) * -1);
+        margin-left: calc(var(--pico-block-spacing-horizontal) * -1);
+        padding: calc(var(--pico-block-spacing-vertical) * 0.66) var(--pico-block-spacing-horizontal);
+        background-color: var(--pico-card-sectioning-background-color);
+      }
+      .entity-card > header,
+      .auth-page > header {
+        margin-top: calc(var(--pico-block-spacing-vertical) * -1);
+        margin-bottom: var(--pico-block-spacing-vertical);
+        border-bottom: var(--pico-border-width) solid var(--pico-card-border-color);
+        border-top-right-radius: var(--pico-border-radius);
+        border-top-left-radius: var(--pico-border-radius);
+      }
+      .entity-card > footer,
+      .auth-page > footer {
+        margin-top: var(--pico-block-spacing-vertical);
+        margin-bottom: calc(var(--pico-block-spacing-vertical) * -1);
+        border-top: var(--pico-border-width) solid var(--pico-card-border-color);
+        border-bottom-right-radius: var(--pico-border-radius);
+        border-bottom-left-radius: var(--pico-border-radius);
+      }
       /* Lucide icons — single source of truth for sizing AND
          spacing. `color: inherit` lets each icon pick up the
          surrounding text color (so an icon inside a `<small>` or a
@@ -512,9 +546,9 @@
         }
       }
       /* Credential rows (provider licensures / education / certifications)
-         render as flat rows inside an outer `<section>` (edit) or
-         `<article>` (detail), so a card-on-card pattern would read as
-         visual noise. The row's vocabulary is just a stacked
+         render as flat rows inside an outer `<section>` (edit or
+         detail), so a card-on-card pattern would read as visual
+         noise. The row's vocabulary is just a stacked
          `<strong>` + muted `<small>` on the left, optional Delete on
          the right, with a hairline divider between entries. */
       .credential-list {
@@ -545,11 +579,12 @@
       /* Auth-page form card — `/auth/login`, `/auth/register`,
          `/auth/forgot-password`, `/auth/reset-password/<token>`. Each
          page extends `base.html` directly (not the entity-form grammar)
-         and renders a single `<article class="auth-page">` card. The
-         article sits inside the `<main class="container">` which Pico
-         already centers and caps; without the rules below the card
-         itself still stretches to the container's full width (~720px
-         on tablet, ~1300px on desktop, #584). Cap at 28rem (~448px) —
+         and renders a single `<section class="auth-page">` card; chrome
+         comes from the shared card-chrome rules above. The section sits
+         inside the `<main class="container">` which Pico already
+         centers and caps; without the rules below the card itself
+         still stretches to the container's full width (~720px on
+         tablet, ~1300px on desktop, #584). Cap at 28rem (~448px) —
          narrower than `--form-max-width` since the auth forms are
          visually dense (2–3 short fields) and a tighter card reads as
          a clear focal point on landing. Centered via `margin-inline:


### PR DESCRIPTION
## Summary

\`<article>\` is HTML5's element for self-contained, syndicatable items — appropriate for cards inside a list of items, not for single-item containers. The detail-page wrappers and auth-page form cards were rendering as \`<article>\` despite being one-of-a-kind on their page.

- **Detail-page card wrappers** (organizations, programs, openings, referrals, the provider credentials block, the user-detail sections) move from \`<article class=\"entity-card\">\` to \`<section class=\"entity-card\">\`.
- **Auth-page form cards** (login, register, forgot/reset password, verify) move from \`<article class=\"auth-page\">\` to \`<section class=\"auth-page\">\`.
- **Per-affiliation cards** on the clinician detail page **stay \`<article>\`** — the \`{% for aff in view.affiliations %}\` loop renders a list of items, which is what \`<article>\` is for.
- The list-item \`card()\` macro in \`_shared/_card.html\` is unchanged; every list page still renders \`<article class=\"entity-card\">\` items.

\`base.html\` grows a card-chrome CSS block on \`.entity-card\` / \`.auth-page\` that replicates Pico's default \`<article>\` framing (background, border, padding, rounded corners, tinted header/footer bands) so the wrapping element no longer has to be \`<article>\`. Values match Pico exactly, so existing list cards see no visual change.

Test selectors that referenced the detail-page body (\`article {selector}\` not-duplicated-here assertions in \`test_users.py\` and \`test_providers.py\`) move to \`.entity-card {selector}\` to cover both shapes. The four \`<article class=\"auth-page\">\` assertions in \`test_auth_routes.py\` update in lockstep.

### Also riding along

The \`users/detail.html\` diff also includes an in-flight Favorites-card move (toolbar → body section) plus its two new colocated tests in \`test_users.py\`. Those changes were already present in the shared workspace when this branch was cut and were already passing tests, so they ride along rather than risk a merge conflict on the same file.

## Test plan
- [x] \`dev lint\` passes
- [x] \`dev test\` — 1637 passed, 96 skipped (the 3 pre-existing \`scripts/test_session_start_branch_check.py\` failures are an environment issue unrelated to this PR — the test subprocess invokes the missing \`python\` binary instead of \`python3\`)
- [ ] Spot-check: visit \`/clinicians/<id>\`, \`/users/me\`, \`/auth/login\`, \`/openings/<id>\` and confirm cards still render with chrome (background, border, header/footer bands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)