### PR TITLE
fix(lint): tighten title-case to remove false-positive ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ http://localhost:8000/dev/login-as-seed-user
 
 Hitting it issues the same session cookie a real login would (for the user named by `DEV_LOGIN_EMAIL`, defaulting to `admin@example.com`) and redirects to `/`, which forwards to the current default landing page (today: `/openings`). Saves a form submission every time you reopen the browser to the dev server. The route is only mounted when `ENVIRONMENT=development` — production never registers it. See [`src/domain/routes/dev_auth.py`](src/domain/routes/dev_auth.py) for the security guards.
 
-### Playwright MCP for design review <!-- title-case-ignore: "MCP" is the Anthropic acronym (Model Context Protocol) -->
+### Playwright MCP for design review
 
 Claude Code can drive a real browser against the dev server to navigate, click, resize, and screenshot — useful for "load `/openings` at iPhone width and check the location row" tasks. The MCP entry is pre-configured in [`.claude/settings.json`](.claude/settings.json); the one-time browser install is:
 

--- a/scripts/dev/test_title_case_check.py
+++ b/scripts/dev/test_title_case_check.py
@@ -556,6 +556,182 @@ def test_brand_phrase_does_not_creep_into_unrelated_prose(tmp_path):
     assert _check(file) == []
 
 
+def test_prose_text_skips_nested_lintable_subtrees(tmp_path):
+    """A structural wrapper like ``<a><hgroup><h2>...</h2><p>...</p></hgroup></a>``
+    must not be linted on its rolled-up deep text. ``<h2>`` and ``<p>`` are
+    themselves linted units; including their text in the outer ``<a>``'s
+    judgement creates the picker-pattern false positive that previously
+    required ``<!-- title-case-ignore -->`` markers on every card."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <a href="/x">
+          <hgroup>
+            <h2>Solo practice</h2>
+            <p>An individual clinician with availability.</p>
+          </hgroup>
+        </a>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_prose_text_still_flags_inner_heading_violation(tmp_path):
+    """The wrapper-skip must not hide real violations in nested lintable
+    children — each child is judged on its own."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <a href="/x">
+          <hgroup>
+            <h2>Solo Practice</h2>
+            <p>An individual clinician.</p>
+          </hgroup>
+        </a>
+        </body></html>
+        """,
+    )
+    originals = {v["original"] for v in _check(file)}
+    assert "Solo Practice" in originals
+
+
+def test_nested_li_dropdown_rollup_does_not_false_positive(tmp_path):
+    """A dropdown nav (outer ``<li>`` wrapping ``<details>``/``<summary>``/
+    inner ``<li><a>``) used to roll up to ``"Profile Sign out"`` on the
+    outer ``<li>`` and require a ``title-case-ignore`` marker. The inner
+    ``<a>`` tags are independent lintable units, so the outer wrapper
+    should now be empty for lint purposes."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <ul>
+          <li>
+            <details>
+              <summary aria-label="Profile menu">Profile</summary>
+              <ul>
+                <li><a href="/profile">Profile</a></li>
+                <li><a href="#" hx-post="/auth/sign-out">Sign out</a></li>
+              </ul>
+            </details>
+          </li>
+        </ul>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_inline_emphasis_still_treated_as_one_prose_unit(tmp_path):
+    """Non-lintable inline elements (``<em>``, ``<span>``) are still
+    descended into so ``<p>Some <em>bad</em> text</p>`` is judged as one
+    sentence — the wrapper-skip rule only fires on tags that are themselves
+    lintable."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <p>Welcome to <em>the</em> service.</p>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_aria_hook_value_breadcrumb_is_not_linted(tmp_path):
+    """``aria-label="breadcrumb"`` is a reserved ARIA landmark hook, not
+    prose — sentence-casing to ``"Breadcrumb"`` would defeat the screen
+    reader convention."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <nav aria-label="breadcrumb"><a href="/x">Posts</a></nav>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_aria_label_with_real_prose_still_linted(tmp_path):
+    """The hook allowlist is narrow — generic ``aria-label`` values that
+    aren't reserved landmark words remain prose."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <button aria-label="Close The Dialog">x</button>
+        </body></html>
+        """,
+    )
+    originals = {v["original"] for v in _check(file)}
+    assert "Close The Dialog" in originals
+
+
+def test_leading_symbol_yields_to_first_alpha_word(tmp_path):
+    """A leading non-alphanumeric token (``«``, ``»``, bullet glyphs)
+    doesn't have case and shouldn't consume the sentence-leading slot.
+    The pagination macro emits ``« Prev`` / ``Next »`` — both should
+    pass without per-line ignore markers."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <a href="/?page=1">&laquo; Prev</a>
+        <a href="/?page=3">Next &raquo;</a>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+
+def test_leading_symbol_does_not_hide_miscased_first_word(tmp_path):
+    """The symbol-yields rule still expects the first alpha word to start
+    the sentence — ``« back to home`` is wrong and must be flagged."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <a href="/">&laquo; back to home</a>
+        </body></html>
+        """,
+    )
+    violations = _check(file)
+    assert violations, "leading symbol must not silently capitalize the next word"
+
+
+def test_numbered_prefix_still_consumes_first_slot(tmp_path):
+    """A digit-led token like ``1.`` has a word character, so it does
+    consume the first-word slot — preserving the existing
+    ``1. ssh to droplet`` behaviour. This separates "no case at all"
+    (symbols) from "case fixed by source" (numbers)."""
+    file = _write_md(tmp_path, "### 1. ssh to droplet\n")
+    assert _check(file) == []
+
+
+def test_domain_acronyms_iop_npi_mcp_pass(tmp_path):
+    """``IOP`` (intensive outpatient program), ``NPI`` (National Provider
+    Identifier), and ``MCP`` (Model Context Protocol) appear in template
+    prose and dev docs — promoting them to ``ALWAYS_CAPITALIZE`` replaces
+    one-off ``title-case-ignore`` markers."""
+    file = _write_html(
+        tmp_path,
+        """
+        <html><body>
+        <p>For example a cohort, IOP, or day program.</p>
+        <p>NPI 1234567890.</p>
+        </body></html>
+        """,
+    )
+    assert _check(file) == []
+
+    md = _write_md(tmp_path, "### Playwright MCP for design review\n")
+    assert _check(md) == []
+
+
 def test_main_exits_with_error_when_selectolax_missing(monkeypatch, capsys):
     """If selectolax isn't importable, the CLI must hard-fail rather than
     silently skip every HTML/Jinja file. Regression for #198 — the old

--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -71,6 +71,15 @@ class TitleCaseChecker:
     # CSS/JS). The walker never descends into these.
     NEVER_DESCEND_TAGS = {"script", "style", "code", "pre", "kbd"}
 
+    # Reserved ARIA landmark/role hook values — document-structure
+    # vocabulary, not user-facing prose. They appear in ``aria-label`` so
+    # assistive tech announces a familiar region name; sentence-casing
+    # them ("Breadcrumb") would defeat the hook.
+    ARIA_HOOK_VALUES = {
+        "breadcrumb",
+        "pagination",
+    }
+
     FILE_EXTENSIONS = {
         ".md": "markdown",
         ".markdown": "markdown",
@@ -137,6 +146,9 @@ class TitleCaseChecker:
         "PII",  # Personally identifiable information
         "DBT",  # Dialectical behavior therapy
         "EMDR",  # Eye movement desensitization and reprocessing
+        "IOP",  # Intensive outpatient program
+        "NPI",  # National Provider Identifier
+        "MCP",  # Model Context Protocol (referenced in dev docs)
         # Brand mark — the short form rendered on narrow viewports.
         # Multi-word brand phrases (e.g. "Bedlam Connect") live in
         # ``BRAND_PHRASES`` below; this entry covers the standalone
@@ -404,13 +416,21 @@ class TitleCaseChecker:
         if not words:
             return text
 
+        # Pure-symbol prefixes (``«``, ``»``, bullets) don't have case and
+        # shouldn't consume the sentence-leading slot — the first *word with
+        # alphanumeric content* is what the sentence starts on. A digit-led
+        # token like ``1.`` does have a word character and does consume the
+        # slot, preserving the existing "1. ssh to droplet" behaviour.
+        sentence_started = False
         result_words = []
-        for i, word in enumerate(words):
+        for word in words:
             # Backtick-wrapped code spans (`.env`, `BaseRepository`) are
             # identifiers, not prose — preserve verbatim, including for the
             # first-word rule that would otherwise mangle "`.env` vs `.env.test`".
             if "`" in word:
                 result_words.append(word)
+                if re.search(r"\w", word):
+                    sentence_started = True
                 continue
 
             clean_word = re.sub(r"[^\w]", "", word)
@@ -420,26 +440,28 @@ class TitleCaseChecker:
             is_http_method = clean_word.upper() in self.HTTP_METHODS
             if is_http_method and clean_word.isupper():
                 result_words.append(word)
+                if clean_word:
+                    sentence_started = True
                 continue
 
-            if i == 0:
+            if not sentence_started and clean_word:
                 if not is_http_method and clean_word.upper() in capitalize_map:
                     proper_case = capitalize_map[clean_word.upper()]
                     result_words.append(word.replace(clean_word, proper_case))
                 else:
-                    if clean_word:
-                        new_word = word.replace(
-                            clean_word, clean_word[0].upper() + clean_word[1:].lower()
-                        )
-                        result_words.append(new_word)
-                    else:
-                        result_words.append(word)
+                    new_word = word.replace(
+                        clean_word, clean_word[0].upper() + clean_word[1:].lower()
+                    )
+                    result_words.append(new_word)
+                sentence_started = True
             else:
                 if not is_http_method and clean_word.upper() in capitalize_map:
                     proper_case = capitalize_map[clean_word.upper()]
                     result_words.append(word.replace(clean_word, proper_case))
-                else:
+                elif clean_word:
                     result_words.append(word.replace(clean_word, clean_word.lower()))
+                else:
+                    result_words.append(word)
 
         sentence_case = emoji_prefix + " ".join(result_words)
 
@@ -685,6 +707,13 @@ class TitleCaseChecker:
                     continue
                 if not attr_value:
                     continue
+                if (
+                    attr_name in ("aria-label", "aria-description")
+                    and attr_value.strip().lower() in self.ARIA_HOOK_VALUES
+                ):
+                    # Reserved ARIA landmark hook (e.g. ``aria-label="breadcrumb"``)
+                    # — not prose.
+                    continue
                 self._maybe_record(
                     text=attr_value,
                     header_level=f"@{attr_name}",
@@ -695,19 +724,19 @@ class TitleCaseChecker:
                     locator_candidates=[attr_value],
                 )
 
-        # Lint the deep text content of recognised content elements. We use
-        # deep text so that ``<p>Some <em>bad</em> phrase</p>`` is judged as
-        # one prose unit; nested lintable elements (``<a>`` inside ``<p>``)
-        # are also linted independently when the walker reaches them.
+        # Lint the prose text of recognised content elements. ``_prose_text``
+        # treats other ``LINTABLE_TEXT_TAGS`` as boundaries — those subtrees
+        # are linted as independent units when the walker reaches them, so
+        # including their text in the outer rollup double-counts and creates
+        # false positives (e.g. ``<a><hgroup><h2>X</h2><p>Y</p></hgroup></a>``
+        # used to flag the joined ``"X Y"`` even when X and Y were each
+        # correct in isolation).
         if tag in self.LINTABLE_TEXT_TAGS:
-            try:
-                deep_text = node.text(deep=True)
-            except Exception:
-                deep_text = None
-            if deep_text:
-                normalized = " ".join(deep_text.split())
+            prose = self._prose_text(node)
+            if prose:
+                normalized = " ".join(prose.split())
                 if normalized:
-                    locator_candidates = [normalized, deep_text]
+                    locator_candidates = [normalized, prose]
                     leaf = self._first_leaf_text(node)
                     if leaf:
                         locator_candidates.append(leaf)
@@ -724,6 +753,32 @@ class TitleCaseChecker:
         # Descend.
         for child in node.iter(include_text=False):
             self._walk(child, file_path, content, line_starts, violations)
+
+    def _prose_text(self, node) -> str:
+        """Concatenated text inside ``node``, stopping at any nested element
+        that's itself in ``LINTABLE_TEXT_TAGS``.
+
+        Those subtrees are linted as independent prose units when the walker
+        reaches them; including their text in the outer rollup creates
+        false positives on structural wrappers like
+        ``<a><hgroup><h2>...</h2><p>...</p></hgroup></a>``. Inline emphasis
+        elements that aren't lintable (e.g. ``<em>``, ``<span>``) are still
+        descended into so ``<p>Some <em>bad</em> text</p>`` is judged as
+        one prose unit.
+        """
+        fragments: List[str] = []
+        for child in node.iter(include_text=True):
+            if child.tag == "-text":
+                fragments.append(child.text() or "")
+            elif child.tag in self.NEVER_DESCEND_TAGS:
+                continue
+            elif child.tag in self.LINTABLE_TEXT_TAGS:
+                continue
+            else:
+                inner = self._prose_text(child)
+                if inner:
+                    fragments.append(inner)
+        return "".join(fragments)
 
     def _first_leaf_text(self, node) -> str:
         """Return the first non-empty text-node descendant's content.

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -42,9 +42,6 @@
     <p>Connecting providers, helping patients.</p>
   </hgroup>
   <p>Post referrals, find referrals, and maintain a network of professional contacts.</p>
-  {# title-case-ignore: button labels below ("Sign in" / "Sign up")
-     are intentionally sentence-case verb phrases, not title-case
-     headings. #}
   <div class="grid">
     <a href="/auth/login" role="button">Sign in</a>
     <a href="/auth/register" role="button" class="secondary">Sign up</a>

--- a/src/domain/templates/posts/openings/form_new.html
+++ b/src/domain/templates/posts/openings/form_new.html
@@ -20,24 +20,17 @@ styles that didn't fit the "pick a kind to post" intent).
    the text on the picker matches the H1 the user lands on after
    clicking (e.g. "Create clinician opening"). Same helper the
    kind-specific form page reads from — see
-   `src/framework/rendering/labels.py`.
-
-   `title-case-ignore` markers: the linter's concatenated-text heuristic
-   flags the heading+tagline as mid-text-capital ("Heading An individual…")
-   even though each element is correct sentence case in isolation, and
-   resolves the violation against the first leaf text-node (the `<h2>`).
-   The marker scope is the same line as the violation, so it sits on
-   the `<h2>`, not the parent `<a>`. #}
+   `src/framework/rendering/labels.py`. #}
 <a href="{{ entity_form_url('opening') }}?kind=clinician_opening">
   <hgroup>
-    <h2>{{ entity_create_label('opening', kind='clinician_opening') }}</h2> <!-- title-case-ignore -->
+    <h2>{{ entity_create_label('opening', kind='clinician_opening') }}</h2>
     <p>An individual clinician with availability on their caseload.</p>
   </hgroup>
 </a>
 
 <a href="{{ entity_form_url('opening') }}?kind=program_intake">
   <hgroup>
-    <h2>{{ entity_create_label('opening', kind='program_intake') }}</h2> <!-- title-case-ignore -->
+    <h2>{{ entity_create_label('opening', kind='program_intake') }}</h2>
     <p>An organization's program announcing open intake slots.</p>
   </hgroup>
 </a>

--- a/src/domain/templates/programs/form_new.html
+++ b/src/domain/templates/programs/form_new.html
@@ -7,7 +7,7 @@
 {% block resource_label %}Programs{% endblock %}
 
 {% block content %}
-<p>A program is a treatment offering owned by an organization — for example a cohort, IOP, or day program.</p> <!-- title-case-ignore -->
+<p>A program is a treatment offering owned by an organization — for example a cohort, IOP, or day program.</p>
 
 
 {# `org_id` is the FK to the owning Organization. The dropdown is

--- a/src/domain/templates/providers/detail.html
+++ b/src/domain/templates/providers/detail.html
@@ -21,7 +21,6 @@
    clinician practices at, so the org-as-H1 fallback only matters
    while the name backfill is in progress. #}
 {% block current_label %}{% if provider.first_name and provider.last_name %}{{ provider.first_name }} {{ provider.last_name }}{% else %}{{ provider.org.name }}{% endif %}{% endblock %}
-{# title-case-ignore: NPI is an industry abbreviation (National Provider Identifier) #}
 {% block subtitle %}{% if view.npi %}<span>NPI {{ view.npi }}</span>{% endif %}
 {%- if verification_status == "verified" %}
 <small><i class="icon-shield-check"></i>Verified</small>

--- a/src/framework/templates/_shared/_breadcrumb.html
+++ b/src/framework/templates/_shared/_breadcrumb.html
@@ -1,5 +1,4 @@
 {# Breadcrumb zone bar primitive.
-   title-case-ignore: the literal ARIA value `breadcrumb` is Pico's hook.
 
 Renders the page's location as a single "back" affordance — a
 Lucide arrow-left chevron plus the deepest clickable parent's
@@ -24,7 +23,6 @@ item's label as plain text so the markup stays valid.
     ]) }}
 #}
 
-{# title-case-ignore: literal aria-label value `breadcrumb` is the Pico hook #}
 {% macro breadcrumb(items) -%}
 {%- if items %}
 {# Deepest clickable parent — the back target. Walk from the end

--- a/src/framework/templates/_shared/_picker.html
+++ b/src/framework/templates/_shared/_picker.html
@@ -8,17 +8,12 @@ Each option is a dict with keys:
   href:        URL to navigate to on click
   heading:     short label (e.g. "Solo practice")
   description: one-line tagline
-
-The `<h2>` carries `<!-- title-case-ignore -->` because the linter's
-concatenated-text heuristic flags the heading + tagline as a
-mid-text-capital violation even though each element is correct sentence
-case in isolation. Scope is the same line as the violation.
 #}
 {%- macro picker(options) -%}
 {%- for opt in options %}
 <a href="{{ opt.href }}">
   <hgroup>
-    <h2>{{ opt.heading }}</h2> <!-- title-case-ignore -->
+    <h2>{{ opt.heading }}</h2>
     <p>{{ opt.description }}</p>
   </hgroup>
 </a>

--- a/src/framework/templates/_shared/pagination.html
+++ b/src/framework/templates/_shared/pagination.html
@@ -1,5 +1,4 @@
-{# title-case-ignore: "Prev" / "Next" are conventional pagination labels.
-   Page-navigation footer for a list view.
+{# Page-navigation footer for a list view.
 
 `views/list.html` renders this macro after the content block from the
 `page_meta` context var (a `Page` from

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -703,7 +703,7 @@
              `has_provider_profile` is still set in base_context but is no
              longer read here. #}
           <li>
-            {# title-case-ignore: Profile dropdown — canonical Pico v2 nav-dropdown pattern
+            {# Profile dropdown — canonical Pico v2 nav-dropdown pattern
                (https://picocss.com/docs/nav#dropdowns): `<details
                class="dropdown">` / `<summary>` / `<ul dir="rtl">` /
                `<li><a>`. `dir="rtl"` right-aligns the panel so it doesn't


### PR DESCRIPTION
## Summary

An audit of the codebase found 9 inline `title-case-ignore` markers across 8 files. Five were **dead** (suppressing nothing — the JINJA_SENTINEL skip or already-correct casing meant the marker had no effect) and four worked only by **locator-fallback coincidence** (the line-1 marker happened to absorb the violation because the linter couldn't find the offending text verbatim in source). Both shapes are fragile and noisy.

Rather than rewrite the templates, this PR tightens the linter so the underlying false positives don't fire — and all 9 markers can be deleted.

Changes:
- **Prose text, not deep text** — when computing the text a `LINTABLE_TEXT_TAGS` element gets judged on, skip subtrees rooted at another lintable element. Those subtrees are linted as independent prose units when the walker reaches them; rolling them up double-counted and produced `<a><hgroup><h2>X</h2><p>Y</p></hgroup></a>` → `"X Y"` false positives (the picker, openings, and base.html dropdown patterns).
- **ARIA hook value allowlist** — `aria-label="breadcrumb"` is a reserved landmark vocabulary, not prose; sentence-casing to `"Breadcrumb"` would defeat the screen-reader convention.
- **First-alpha-word handling** — a pure-symbol prefix like `«` doesn't have case and shouldn't consume the sentence-leading slot. The first word with alphanumeric content does. Digit-led tokens like `1.` still consume the slot (preserves `1. ssh to droplet` behaviour).
- **Vocabulary additions** — promote `IOP`, `NPI`, `MCP` to `ALWAYS_CAPITALIZE` (domain/dev-doc acronyms that surface in user-facing copy).

Markers removed: README.md, base.html, pagination.html, _breadcrumb.html (×2), _picker.html, landing.html, openings/form_new.html (×2), providers/detail.html, programs/form_new.html.

Added 9 new tests pinning each fix; existing 32 tests still green.

## Test plan

- [x] `dev lint` clean (title-case linter reports no violations after marker removal)
- [x] `dev test` passes (1658 passed, 96 skipped)
- [x] All 41 title-case unit tests pass
- [x] No inline `title-case-ignore` markers remain outside the linter source/tests
- [x] No `.titleignore` files exist in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)