### PR TITLE
fix(pagination): lower DEFAULT_PAGE_SIZE from 25 to 15

### DIFF
--- a/src/framework/dispatch/pagination.py
+++ b/src/framework/dispatch/pagination.py
@@ -22,7 +22,7 @@ from urllib.parse import parse_qsl, urlencode
 
 from starlette.requests import Request
 
-DEFAULT_PAGE_SIZE = 25
+DEFAULT_PAGE_SIZE = 15
 
 T = TypeVar("T")
 

--- a/src/framework/dispatch/test_handlers.py
+++ b/src/framework/dispatch/test_handlers.py
@@ -2460,8 +2460,8 @@ async def test_handle_list_threads_filter_values_into_repo_call():
         filter_values={"kind": "beta"},
     )
     # `offset` + `limit` come from the pagination layer (`page=1`,
-    # `per_page=DEFAULT_PAGE_SIZE=25`, asked-for-rows=`per_page + 1`).
-    assert captured == {"kind": "beta", "offset": 0, "limit": 26}
+    # `per_page=DEFAULT_PAGE_SIZE=15`, asked-for-rows=`per_page + 1`).
+    assert captured == {"kind": "beta", "offset": 0, "limit": 16}
 
 
 async def test_handle_list_extras_merges_into_context():
@@ -2858,9 +2858,9 @@ async def test_handle_list_passes_exclude_self_when_spec_opts_in():
         filter_values={},
     )
 
-    # `offset` + `limit` come from the pagination layer (page 1 of 25).
-    assert captured[0] == {"exclude_self": viewer, "offset": 0, "limit": 26}
-    assert captured[1] == {"offset": 0, "limit": 26}
+    # `offset` + `limit` come from the pagination layer (page 1 of 15).
+    assert captured[0] == {"exclude_self": viewer, "offset": 0, "limit": 16}
+    assert captured[1] == {"offset": 0, "limit": 16}
 
 
 @pytest.mark.asyncio
@@ -2885,8 +2885,8 @@ async def test_handle_list_omits_exclude_self_when_spec_opts_out():
         filter_values={"kind": "alpha"},
     )
 
-    # `offset` + `limit` come from the pagination layer (page 1 of 25).
-    assert captured[0] == {"kind": "alpha", "offset": 0, "limit": 26}
+    # `offset` + `limit` come from the pagination layer (page 1 of 15).
+    assert captured[0] == {"kind": "alpha", "offset": 0, "limit": 16}
     assert "exclude_self" not in captured[0]
 
 
@@ -2926,8 +2926,8 @@ async def test_handle_list_falls_back_to_list_default_when_no_bespoke_method():
 
     assert captured["model"] is _FixtureRow
     assert captured["order_by"] == "ORDER_BY_SENTINEL"
-    # `offset` + `limit` come from the pagination layer (page 1 of 25).
-    assert captured["kwargs"] == {"offset": 0, "limit": 26}
+    # `offset` + `limit` come from the pagination layer (page 1 of 15).
+    assert captured["kwargs"] == {"offset": 0, "limit": 16}
 
 
 @pytest.mark.asyncio

--- a/src/framework/dispatch/test_pagination.py
+++ b/src/framework/dispatch/test_pagination.py
@@ -58,7 +58,7 @@ def test_offset_for_first_page_is_zero() -> None:
 
 
 def test_offset_for_third_page_with_default_size() -> None:
-    assert offset_for(3, DEFAULT_PAGE_SIZE) == 50
+    assert offset_for(3, DEFAULT_PAGE_SIZE) == 30
 
 
 def test_paginate_full_page_with_overflow_signals_has_next() -> None:


### PR DESCRIPTION
## Summary
- Pagination chrome wasn't appearing on prod list pages because most collections have fewer than 25 rows, so both `has_prev` and `has_next` were false and `_shared/pagination.html` correctly emitted nothing.
- Drops the framework default page size from 25 to 15. Hits all generic `handle_list` consumers (posts, users, organizations, programs, …) and the two bespoke handlers (`/users/me/favorites`, `/users/{id}/clinicians`) which read `DEFAULT_PAGE_SIZE` directly.
- Updated the three pinning tests that referenced the old constant.

## Test plan
- [x] `dev test` (1658 passed, 96 skipped)
- [x] `dev lint`
- [ ] Smoke-check a list page on staging with ≥16 rows to confirm prev/next renders