### PR TITLE
test(contract): pair forgot/reset password forms with Pact contracts (#771)

### DIFF
--- a/scripts/dev/contract_form_coverage_check.py
+++ b/scripts/dev/contract_form_coverage_check.py
@@ -72,16 +72,6 @@ FORMS_WITHOUT_PAIRS: dict[str, str] = {
         "Empty-body endpoint that reads the user from the session and "
         "re-mints a verify token. Nothing to pin beyond the path."
     ),
-    "POST /auth/forgot-password": (
-        "TODO(#771): write a Pact pair (consumer-side fills the form "
-        "in Playwright, provider verifies the JSON shape). The form "
-        "was fixed in PR #770 to emit JSON; the pair pins it structurally."
-    ),
-    "POST /auth/reset-password": (
-        "TODO(#771): write a Pact pair (consumer-side fills the "
-        "token+password fields, provider verifies the JSON shape). "
-        "Same situation as `/auth/forgot-password` above."
-    ),
 }
 
 

--- a/tests/test_contract/constants.py
+++ b/tests/test_contract/constants.py
@@ -9,6 +9,17 @@ TEST_USERNAME = "testuser"
 
 # API paths
 REGISTER_API_PATH = "/auth/register"
+FORGOT_PASSWORD_API_PATH = "/auth/forgot-password"
+RESET_PASSWORD_API_PATH = "/auth/reset-password"
+
+# Reset-password token surface. The token is a JWT produced by
+# `BaseUserManager.forgot_password` in production; for contract testing
+# we only care that the consumer's hidden input round-trips a token
+# string the route's body schema accepts (it's a plain `str`, no JWT
+# validation at the parsing layer — that's deferred to `reset_password`,
+# which the provider verification mocks out).
+TEST_RESET_PASSWORD_TOKEN = "test-reset-password-token"
+TEST_NEW_PASSWORD = "newpassword456"
 
 # Stable target-user id used by the admin-actions stub + activation pact.
 # Matches `STUB_TARGET_USER_ID` in `infrastructure/servers/consumer.py`.
@@ -54,6 +65,12 @@ STUB_PROGRAM_FORM_ORG_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
 
 # Provider states
 PROVIDER_STATE_USER_DOES_NOT_EXIST = f"User {TEST_EMAIL} does not exist"
+PROVIDER_STATE_USER_CAN_REQUEST_PASSWORD_RESET = (
+    f"User {TEST_EMAIL} can request a password reset"
+)
+PROVIDER_STATE_RESET_PASSWORD_TOKEN_IS_VALID = (
+    "Reset password token is valid for an active user"
+)
 PROVIDER_STATE_USER_EXISTS_AND_ACTIVE = f"User {TARGET_USER_ID} exists and is active"
 PROVIDER_STATE_POST_EXISTS_AND_OWNED = (
     f"Post {STUB_POST_ID} exists and is owned by the requester"
@@ -67,6 +84,8 @@ PROVIDER_STATE_USER_CAN_CREATE_PROGRAM = "User can create a program"
 
 # Consumer / provider Pact identifiers
 CONSUMER_NAME_REGISTRATION = "registration-form"
+CONSUMER_NAME_FORGOT_PASSWORD = "forgot-password-form"
+CONSUMER_NAME_RESET_PASSWORD = "reset-password-form"
 PROVIDER_NAME_AUTH = "auth-api"
 
 CONSUMER_NAME_USER_ADMIN_ACTIONS = "user-admin-actions"
@@ -96,3 +115,5 @@ PACT_PORT_PROVIDER_CREATE = 1239
 PACT_PORT_PROVIDER_EDIT = 1240
 PACT_PORT_ORGANIZATION_CREATE = 1241
 PACT_PORT_PROGRAM_CREATE = 1242
+PACT_PORT_FORGOT_PASSWORD = 1243
+PACT_PORT_RESET_PASSWORD = 1244

--- a/tests/test_contract/manifest.py
+++ b/tests/test_contract/manifest.py
@@ -66,6 +66,33 @@ CONTRACT_PAIRS: list[ContractPair] = [
         endpoints=("POST /auth/register",),
         pytest_marks=(pytest.mark.provider, pytest.mark.auth),
     ),
+    # `forgot-password-form` and `reset-password-form` differ from the
+    # other auth-api pair: fastapi-users' `get_reset_password_router()`
+    # routes call `BaseUserManager.{get_by_email,forgot_password,
+    # reset_password}` directly — there is no local handler to patch.
+    # The provider verification therefore mocks methods on our concrete
+    # `src.auth_config.UserManager` (see the corresponding
+    # `MockDataFactory.create_*_dependency_config` entries).
+    ContractPair(
+        consumer_name="forgot-password-form",
+        provider_name="auth-api",
+        pact_port=1243,
+        handler_mocks_factory=MockDataFactory.create_forgot_password_dependency_config,
+        consumer_setup_fn=None,  # uses real auth_pages router
+        provider_state="User test.user@example.com can request a password reset",
+        endpoints=("POST /auth/forgot-password",),
+        pytest_marks=(pytest.mark.provider, pytest.mark.auth),
+    ),
+    ContractPair(
+        consumer_name="reset-password-form",
+        provider_name="auth-api",
+        pact_port=1244,
+        handler_mocks_factory=MockDataFactory.create_reset_password_dependency_config,
+        consumer_setup_fn=None,  # uses real auth_pages router
+        provider_state="Reset password token is valid for an active user",
+        endpoints=("POST /auth/reset-password",),
+        pytest_marks=(pytest.mark.provider, pytest.mark.auth),
+    ),
     ContractPair(
         consumer_name="user-admin-actions",
         provider_name="users-api",

--- a/tests/test_contract/tests/consumer/test_forgot_password_form.py
+++ b/tests/test_contract/tests/consumer/test_forgot_password_form.py
@@ -1,0 +1,65 @@
+import pytest
+from pact import Like
+from playwright.async_api import Page
+
+from tests.test_contract.constants import (
+    CONSUMER_NAME_FORGOT_PASSWORD,
+    FORGOT_PASSWORD_API_PATH,
+    NETWORK_TIMEOUT_MS,
+    PACT_PORT_FORGOT_PASSWORD,
+    PROVIDER_NAME_AUTH,
+    PROVIDER_STATE_USER_CAN_REQUEST_PASSWORD_RESET,
+    TEST_EMAIL,
+)
+from tests.test_contract.tests.shared.helpers import (
+    setup_pact,
+    setup_playwright_pact_interception,
+)
+
+
+@pytest.mark.parametrize("origin_with_routes", [{"auth_pages": True}], indirect=True)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_consumer_forgot_password_form_interaction(
+    origin_with_routes: str, page: Page
+):
+    """The forgot-password form must POST JSON `{"email": ...}` to
+    `/auth/forgot-password`. PR #770 fixed the form to emit JSON
+    instead of form-encoded; this pair pins the wire shape structurally
+    so a regression flips the contract test before it ships."""
+    pact = setup_pact(
+        CONSUMER_NAME_FORGOT_PASSWORD,
+        PROVIDER_NAME_AUTH,
+        port=PACT_PORT_FORGOT_PASSWORD,
+    )
+    mock_server_uri = pact.uri
+    forgot_page_url = f"{origin_with_routes}{FORGOT_PASSWORD_API_PATH}"
+    full_mock_url = f"{mock_server_uri}{FORGOT_PASSWORD_API_PATH}"
+
+    expected_request_headers = {"Content-Type": "application/json"}
+    expected_request_body = {"email": Like(TEST_EMAIL)}
+
+    (
+        pact.given(PROVIDER_STATE_USER_CAN_REQUEST_PASSWORD_RESET)
+        .upon_receiving("a request to forgot-password via web form")
+        .with_request(
+            method="POST",
+            path=FORGOT_PASSWORD_API_PATH,
+            headers=expected_request_headers,
+            body=expected_request_body,
+        )
+        .will_respond_with(202)
+    )
+
+    await setup_playwright_pact_interception(
+        page=page,
+        api_path_to_intercept=FORGOT_PASSWORD_API_PATH,
+        mock_pact_url=full_mock_url,
+        http_method="POST",
+    )
+
+    with pact:
+        await page.goto(forgot_page_url)
+        await page.wait_for_selector("#email")
+        await page.locator("#email").fill(TEST_EMAIL)
+        await page.locator("button[type='submit']").click()
+        await page.wait_for_timeout(NETWORK_TIMEOUT_MS)

--- a/tests/test_contract/tests/consumer/test_reset_password_form.py
+++ b/tests/test_contract/tests/consumer/test_reset_password_form.py
@@ -1,0 +1,75 @@
+import pytest
+from pact import Like
+from playwright.async_api import Page
+
+from tests.test_contract.constants import (
+    CONSUMER_NAME_RESET_PASSWORD,
+    NETWORK_TIMEOUT_MS,
+    PACT_PORT_RESET_PASSWORD,
+    PROVIDER_NAME_AUTH,
+    PROVIDER_STATE_RESET_PASSWORD_TOKEN_IS_VALID,
+    RESET_PASSWORD_API_PATH,
+    TEST_NEW_PASSWORD,
+    TEST_RESET_PASSWORD_TOKEN,
+)
+from tests.test_contract.tests.shared.helpers import (
+    setup_pact,
+    setup_playwright_pact_interception,
+)
+
+
+@pytest.mark.parametrize("origin_with_routes", [{"auth_pages": True}], indirect=True)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_consumer_reset_password_form_interaction(
+    origin_with_routes: str, page: Page
+):
+    """The reset-password form must POST JSON
+    `{"token": ..., "password": ...}` to `/auth/reset-password`. The
+    token rides in a hidden input populated by the page route; the
+    Pact pair pins both the JSON Content-Type and the body shape so
+    a regression to form-encoding (or to a missing field) flips this
+    test before it ships."""
+    pact = setup_pact(
+        CONSUMER_NAME_RESET_PASSWORD,
+        PROVIDER_NAME_AUTH,
+        port=PACT_PORT_RESET_PASSWORD,
+    )
+    mock_server_uri = pact.uri
+    # `/auth/reset-password/{token}` is the GET page route; the form
+    # submits to the unsuffixed `/auth/reset-password` endpoint.
+    reset_page_url = (
+        f"{origin_with_routes}{RESET_PASSWORD_API_PATH}/{TEST_RESET_PASSWORD_TOKEN}"
+    )
+    full_mock_url = f"{mock_server_uri}{RESET_PASSWORD_API_PATH}"
+
+    expected_request_headers = {"Content-Type": "application/json"}
+    expected_request_body = {
+        "token": Like(TEST_RESET_PASSWORD_TOKEN),
+        "password": Like(TEST_NEW_PASSWORD),
+    }
+
+    (
+        pact.given(PROVIDER_STATE_RESET_PASSWORD_TOKEN_IS_VALID)
+        .upon_receiving("a request to reset-password via web form")
+        .with_request(
+            method="POST",
+            path=RESET_PASSWORD_API_PATH,
+            headers=expected_request_headers,
+            body=expected_request_body,
+        )
+        .will_respond_with(200)
+    )
+
+    await setup_playwright_pact_interception(
+        page=page,
+        api_path_to_intercept=RESET_PASSWORD_API_PATH,
+        mock_pact_url=full_mock_url,
+        http_method="POST",
+    )
+
+    with pact:
+        await page.goto(reset_page_url)
+        await page.wait_for_selector("#password")
+        await page.locator("#password").fill(TEST_NEW_PASSWORD)
+        await page.locator("button[type='submit']").click()
+        await page.wait_for_timeout(NETWORK_TIMEOUT_MS)

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -217,6 +217,51 @@ class MockDataFactory:
         }
 
     @classmethod
+    def create_forgot_password_dependency_config(cls) -> Dict[str, Any]:
+        """Mocks for `POST /auth/forgot-password`.
+
+        Unlike the local-handler pairs above, fastapi-users' bundled
+        `get_reset_password_router()` calls `BaseUserManager.get_by_email`
+        and then `BaseUserManager.forgot_password` directly — there is
+        no local wrapper to patch. Mock both methods on our concrete
+        `UserManager` subclass so the route returns 202 without
+        touching the (empty) test database or attempting to send an
+        email.
+
+        `get_by_email` returns a Post-shaped `SimpleNamespace` standing
+        in for a User row; `forgot_password` is a no-op AsyncMock. The
+        route discards both return values, so the stub shape is
+        irrelevant beyond "not None / no exception."
+        """
+        stub_user = SimpleNamespace(
+            id=UUID("00000000-0000-0000-0000-000000000007"),
+            email=cls.TEST_EMAIL,
+            is_active=True,
+            is_verified=True,
+        )
+        return {
+            "src.auth_config.UserManager.get_by_email": {
+                "return_value_config": stub_user
+            },
+            "src.auth_config.UserManager.forgot_password": {
+                "return_value_config": None
+            },
+        }
+
+    @classmethod
+    def create_reset_password_dependency_config(cls) -> Dict[str, Any]:
+        """Mock for `POST /auth/reset-password`.
+
+        Same rationale as `create_forgot_password_dependency_config` —
+        fastapi-users' router calls `BaseUserManager.reset_password`
+        directly, no local handler in between. The mock returns None;
+        the route discards the return value and emits 200 on success.
+        """
+        return {
+            "src.auth_config.UserManager.reset_password": {"return_value_config": None},
+        }
+
+    @classmethod
     def create_user_activation_dependency_config(
         cls, user_read: UserRead = None
     ) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Closes #771 — the two `TODO(#771)` entries in `FORMS_WITHOUT_PAIRS` are gone and `dev test contract` runs both pairs green.
- `forgot-password-form` and `reset-password-form` pairs pin the JSON wire shape (`{"email": ...}` / `{"token": ..., "password": ...}`) on both consumer (Playwright fills the form) and provider sides.
- The provider verification mocks `UserManager.{get_by_email, forgot_password, reset_password}` directly because fastapi-users' bundled `get_reset_password_router()` calls those manager methods with no local handler in between — the existing local-handler patch pattern doesn't apply.

## Test plan
- [x] `dev test contract` — 40 passed (both new consumer + provider pairs included).
- [x] `dev test` — full suite, 1659 passed, 96 skipped.
- [x] `dev lint` — green; `contract_form_coverage_check.py` now sees both endpoints as paired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)