### PR TITLE
feat(ci): hand PRs to GitHub Merge Queue via dev merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI - Test and lnt
 on:
   pull_request:
     branches: [main]
+  merge_group:
   workflow_dispatch: # Allow manual runs
 
 env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ A Stop hook checks the diff at end-of-turn and surfaces a reminder when source f
 
 A SessionStart hook prints the real current branch, dirty state, and stash list at session start — and warns loudly if you've landed on `main`/`master` in the shared working tree. Multi-agent sessions in this repo share one working directory; trust the hook's output over any harness-provided "current branch" line. A PreToolUse hook then enforces the rule: `Edit`/`Write`/`NotebookEdit` are refused on the main checkout when you're on `main`/`master`, so new work has to start on a worktree (`dev worktree add <slug>`). Feature branches on the main checkout are still allowed (for in-flight sessions); worktrees always are. See [`scripts/README.md`](scripts/README.md) for all three hooks.
 
+PRs land via GitHub Merge Queue on `main` — use `dev merge` rather than merging directly. See [`scripts/README.md#merging-prs`](scripts/README.md) for the flow, queue config, and recovery.
+
 **Contract tests are not run by default.** `tests/test_contract` is excluded from the default `dev test` collection (see [`tests/test_contract/README.md`](tests/test_contract/README.md)). If you change templates, route response shapes, or anything mock data factories in `tests/test_contract` assume, also run `dev test contract` before pushing — otherwise CI is the first place the breakage surfaces.
 
 ## One source of truth — link, don't copy

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,42 @@ CLAUDE.md and other docs that want to mention a command link to `dev --help` rat
 
 Deployment-specific scripts live in `deployment/scripts/` (see [`deployment/README.md`](../deployment/README.md)).
 
+<!-- title-case-ignore: PRs is an acronym -->
+## Merging PRs
+
+PRs land via [GitHub Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) on `main`. The flow is:
+
+1. `dev push` opens (or updates) a PR off your worktree branch.
+2. `dev merge [<pr>]` enables auto-merge via `gh pr merge --auto --squash`, then polls until the queue lands the PR or a required check fails.
+3. The queue rebases the PR onto current `main` itself, runs CI in `merge_group` context against the speculative merge commit, and merges when green. No manual `gh pr update-branch --rebase`.
+
+**When CI runs in each context:**
+
+- `pull_request` event — runs against the PR head, on every push. Required checks for the PR-ready state.
+- `merge_group` event — runs against the queue's speculative merge commit (PR rebased onto current `main`). Same four required checks (`tests`, `contract-tests`, `linting`, `docker-health-check`); see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+
+The required-check names are identical across both contexts, so branch protection is satisfied by either.
+
+**Queue config and tuning:**
+
+The queue config lives on the `main` branch protection rule, not in this repo. Inspect with:
+
+```bash
+gh api /repos/willthefirst/bedlam-connect/branches/main/protection/required_merge_queue
+```
+
+Knobs worth knowing:
+
+- `merge_method=squash` — matches `required_linear_history: true` on the branch rule.
+- `max_entries_to_build` — how many PRs the queue speculatively rebases and tests in parallel. Start small (3); raise once CI is stable.
+- `min_entries_to_merge_wait_minutes` — how long the queue waits for siblings before merging a lone entry. Set low for solo work, higher to amortize CI across batches.
+
+**Recovery:**
+
+- See what's queued: `gh api /repos/willthefirst/bedlam-connect/actions/runs?event=merge_group --jq '.workflow_runs[] | {id, status, head_branch}'`.
+- Pull a PR out of the queue: `gh pr merge --disable-auto <pr>`. Re-queue with `dev merge <pr>` when ready.
+- If the queue is jammed (stuck PR with no clear failure), GitHub UI → Settings → Branches → `main` → "Merge queue" exposes the queue dashboard.
+
 ## Tests
 
 Tests for `scripts/dev/*` live colocated as `scripts/dev/test_*.py`. Tests for `dev_cli.py` itself live as `scripts/test_dev_cli*.py`. Pytest discovers them via the `scripts` entry in `pyproject.toml`'s `testpaths`. Run only the CLI tests with `dev test scripts/`.

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -900,15 +900,12 @@ class PushCommands:
 
 
 class MergeCommands:
-    """`dev merge [<pr-number>]` — auto-rebase-then-merge loop.
+    """`dev merge [<pr-number>]` — hand off to GitHub Merge Queue.
 
-    `gh pr merge --auto` only merges once the PR is up-to-date with the
-    base. When main is moving (multi-PR sessions), PRs land in BEHIND
-    with all checks green and stay there until someone runs
-    `gh pr update-branch --rebase`. The retros named this the single
-    biggest cycle-time tax. This command closes the loop: poll status,
-    rebase when behind + green, merge when clean + green, exit non-zero
-    on a real check failure. See #747.
+    With the merge queue enabled on `main`, the queue handles rebase and
+    CI-in-merge_group itself. This command's job is to enable auto-merge
+    (`gh pr merge --auto`), then watch the PR until the queue lands it
+    or a check fails. See scripts/README.md#merging-prs.
     """
 
     POLL_SECONDS = 30
@@ -972,26 +969,15 @@ class MergeCommands:
                 failed.append(name)
         return failed
 
-    def _checks_done(self, status: dict) -> bool:
-        rollup = status.get("statusCheckRollup") or []
-        if not rollup:
-            return True  # no required checks
-        return all(
-            (check.get("status") or "").upper() == "COMPLETED" for check in rollup
-        )
-
-    def _update_branch(self, pr: int) -> int:
+    def _enable_auto_merge(self, pr: int, method: str) -> int:
         return self.runner.run_command(
-            ["gh", "pr", "update-branch", "--rebase", str(pr)]
+            ["gh", "pr", "merge", str(pr), "--auto", f"--{method}"]
         )
-
-    def _merge(self, pr: int, method: str) -> int:
-        return self.runner.run_command(["gh", "pr", "merge", f"--{method}", str(pr)])
 
     def merge(
         self,
         pr: Optional[int] = None,
-        method: str = "rebase",
+        method: str = "squash",
         timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     ) -> int:
         import time
@@ -1004,7 +990,20 @@ class MergeCommands:
             )
             return 1
 
-        print(f"🔄 Driving PR #{number} to merge (method: {method})")
+        print(f"🔄 Handing PR #{number} to merge queue (method: {method})")
+        # Short-circuit on already-failing checks so we don't burn a queue slot.
+        initial = self._pr_status(number)
+        if (initial.get("state") or "").upper() == "MERGED":
+            print(f"✅ PR #{number} is already merged.")
+            return 0
+        failing = self._checks_failing(initial)
+        if failing:
+            print(f"❌ PR #{number} has failing checks: {', '.join(failing)}")
+            return 3
+        rc = self._enable_auto_merge(number, method)
+        if rc != 0:
+            return rc
+
         deadline = time.monotonic() + timeout_seconds
         last_state: Optional[str] = None
         while time.monotonic() < deadline:
@@ -1016,23 +1015,14 @@ class MergeCommands:
             if (status.get("state") or "").upper() == "MERGED":
                 print(f"✅ PR #{number} is merged.")
                 return 0
-            state = (status.get("mergeStateStatus") or "").upper()
             failing = self._checks_failing(status)
             if failing:
                 print(f"❌ PR #{number} has failing checks: {', '.join(failing)}")
                 return 3
+            state = (status.get("mergeStateStatus") or "").upper()
             if state != last_state:
                 print(f"  state: {state}")
                 last_state = state
-            if state == "CLEAN" and self._checks_done(status):
-                rc = self._merge(number, method)
-                if rc == 0:
-                    print(f"✅ PR #{number} merge submitted.")
-                return rc
-            if state == "BEHIND" and self._checks_done(status):
-                print("  branch is behind main — rebasing…")
-                self._update_branch(number)
-                # Loop continues; CI will rerun, state will transition.
             time.sleep(self.POLL_SECONDS)
         print(f"⏰ Timed out after {timeout_seconds}s waiting on PR #{number}.")
         return 4
@@ -1613,13 +1603,12 @@ Examples:
     def _add_merge_parser(self, subparsers):
         parser = subparsers.add_parser(
             "merge",
-            help="Drive a PR to merge, auto-rebasing whenever it falls behind",
+            help="Hand a PR to the merge queue and watch it land",
             description=(
-                "Polls `gh pr view` and, when the PR is BEHIND with green "
-                "checks, runs `gh pr update-branch --rebase` automatically. "
-                "When the PR is CLEAN with green checks, merges. Closes the "
-                "stall where `gh pr merge --auto` waits forever because the "
-                "branch never gets rebased. See #747."
+                "Enables auto-merge via `gh pr merge --auto`, then polls the "
+                "PR until the queue lands it or a check fails. The queue does "
+                "the rebase-onto-main and CI-in-merge_group itself. See "
+                "scripts/README.md#merging-prs."
             ),
         )
         parser.add_argument(
@@ -1631,8 +1620,8 @@ Examples:
         parser.add_argument(
             "--method",
             choices=["rebase", "merge", "squash"],
-            default="rebase",
-            help="Merge method to use when ready (default: rebase).",
+            default="squash",
+            help="Merge method (default: squash, matches branch-protection queue config).",
         )
         parser.add_argument(
             "--timeout",

--- a/scripts/test_dev_cli_merge.py
+++ b/scripts/test_dev_cli_merge.py
@@ -1,9 +1,9 @@
 """Tests for `dev merge` in scripts/dev_cli.py.
 
-The merge loop is mostly about state-machine behaviour: given a sequence
-of PR statuses, what does it do next? The shell-out boundary (gh, time)
-is stubbed at the method level so we can drive the loop deterministically
-without sleeping.
+With the merge queue enabled, `dev merge` enables auto-merge via
+`gh pr merge --auto` and then polls until the queue lands the PR or a
+check fails. The shell-out boundary (gh, time) is stubbed so we can
+drive the loop deterministically without sleeping.
 """
 
 from __future__ import annotations
@@ -27,7 +27,7 @@ class _RecordingRunner:
 def _merge_cmd(statuses: list) -> MergeCommands:
     runner = _RecordingRunner()
     cmd = MergeCommands(runner)
-    cmd.POLL_SECONDS = 0  # don't sleep in tests
+    cmd.POLL_SECONDS = 0
     iterator = iter(statuses)
     cmd._pr_status = lambda pr: next(iterator)
     cmd._resolve_pr_number = lambda explicit: explicit if explicit else 999
@@ -44,29 +44,32 @@ def _green(state: str) -> dict:
     }
 
 
-def test_merges_when_clean_and_checks_green():
-    cmd = _merge_cmd([_green("CLEAN")])
+def _merged() -> dict:
+    return {"state": "MERGED", "mergeStateStatus": "CLEAN"}
+
+
+def test_enables_auto_merge_and_waits_for_queue_to_land():
+    # initial check (clean) → enable auto-merge → poll once and see MERGED.
+    cmd = _merge_cmd([_green("CLEAN"), _merged()])
     rc = cmd.merge(pr=123)
     assert rc == 0
-    assert ["gh", "pr", "merge", "--rebase", "123"] in cmd.runner.commands
+    assert ["gh", "pr", "merge", "123", "--auto", "--squash"] in cmd.runner.commands
 
 
-def test_rebases_then_merges_when_behind_then_clean():
-    cmd = _merge_cmd([_green("BEHIND"), _green("CLEAN")])
-    rc = cmd.merge(pr=123)
-    assert rc == 0
-    # Should have called update-branch once, then merged.
-    assert ["gh", "pr", "update-branch", "--rebase", "123"] in cmd.runner.commands
-    assert ["gh", "pr", "merge", "--rebase", "123"] in cmd.runner.commands
-    # And the rebase came first.
-    rebase_idx = cmd.runner.commands.index(
-        ["gh", "pr", "update-branch", "--rebase", "123"]
-    )
-    merge_idx = cmd.runner.commands.index(["gh", "pr", "merge", "--rebase", "123"])
-    assert rebase_idx < merge_idx
+def test_default_method_is_squash():
+    cmd = _merge_cmd([_green("CLEAN"), _merged()])
+    cmd.merge(pr=123)
+    # Squash is the queue-configured method; default must match.
+    assert ["gh", "pr", "merge", "123", "--auto", "--squash"] in cmd.runner.commands
 
 
-def test_aborts_on_failing_checks():
+def test_method_flag_is_forwarded():
+    cmd = _merge_cmd([_green("CLEAN"), _merged()])
+    cmd.merge(pr=123, method="rebase")
+    assert ["gh", "pr", "merge", "123", "--auto", "--rebase"] in cmd.runner.commands
+
+
+def test_aborts_on_failing_checks_before_enabling_auto_merge():
     failing = {
         "state": "OPEN",
         "mergeStateStatus": "BLOCKED",
@@ -77,23 +80,32 @@ def test_aborts_on_failing_checks():
     cmd = _merge_cmd([failing])
     rc = cmd.merge(pr=123)
     assert rc == 3
-    # Did NOT attempt merge or update-branch.
-    assert all("merge" not in c[2] for c in cmd.runner.commands if len(c) >= 3)
-    assert not any("update-branch" in c for c in cmd.runner.commands)
-
-
-def test_recognises_already_merged_pr():
-    cmd = _merge_cmd([{"state": "MERGED", "mergeStateStatus": "CLEAN"}])
-    rc = cmd.merge(pr=123)
-    assert rc == 0
-    # No further action — PR is already merged.
+    # Did NOT attempt to enable auto-merge — would have burned a queue slot.
     assert cmd.runner.commands == []
 
 
-def test_method_flag_is_forwarded_to_gh_pr_merge():
-    cmd = _merge_cmd([_green("CLEAN")])
-    cmd.merge(pr=123, method="merge")
-    assert ["gh", "pr", "merge", "--merge", "123"] in cmd.runner.commands
+def test_detects_failure_while_waiting_in_queue():
+    failing = {
+        "state": "OPEN",
+        "mergeStateStatus": "BLOCKED",
+        "statusCheckRollup": [
+            {"name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"}
+        ],
+    }
+    # initial clean, auto-merge submitted, then a queued CI run fails.
+    cmd = _merge_cmd([_green("CLEAN"), failing])
+    rc = cmd.merge(pr=123)
+    assert rc == 3
+    # Auto-merge was attempted before the failure showed up.
+    assert ["gh", "pr", "merge", "123", "--auto", "--squash"] in cmd.runner.commands
+
+
+def test_recognises_already_merged_pr():
+    cmd = _merge_cmd([_merged()])
+    rc = cmd.merge(pr=123)
+    assert rc == 0
+    # No auto-merge call — PR is already merged.
+    assert cmd.runner.commands == []
 
 
 def test_fails_fast_when_no_pr_number_resolvable(capsys):


### PR DESCRIPTION
## Summary

Phase 1 of #780 — wires this repo for GitHub Merge Queue so concurrent agent PRs stop invalidating each other's CI.

- `.github/workflows/ci.yml` — added `merge_group:` trigger so the four required checks run in queue context against the speculative merge commit.
- `dev merge` (`scripts/dev_cli.py`) — now enables auto-merge (`gh pr merge --auto --squash`), then polls until the queue lands the PR or a check fails. Default method is `squash` to match the queue's configured method. Initial-status short-circuit avoids burning a queue slot on already-failing PRs.
- `scripts/test_dev_cli_merge.py` — rewritten to pin the new command shape and queue-handoff semantics.
- `scripts/README.md` — new "Merging PRs" section: flow, queue config inspection, tuning knobs (`max_entries_to_build`, `min_entries_to_merge_wait_minutes`), recovery.
- `CLAUDE.md` — one-line pointer into `scripts/README.md#merging-prs`.

The queue itself is not enabled by this PR. Once this lands and `merge_group:` is on `main`, enable the queue via:

```bash
gh api -X PUT /repos/willthefirst/bedlam-connect/branches/main/protection/required_merge_queue \
  -f merge_method=squash \
  -F max_entries_to_build=3 \
  -F max_entries_to_merge=5 \
  -F min_entries_to_merge=1 \
  -F min_entries_to_merge_wait_minutes=5
```

## CI baseline (for Phase 2 reference)

Across the last 27 successful workflow runs and 8 sampled per-job:

| | wall time |
|---|---|
| workflow p50 | 119s |
| workflow p95 | 140s |

| Job | mean | range |
|---|---|---|
| tests | 115s | 108–122s |
| contract-tests | 90s | 82–102s |
| docker-health-check | 52s | 47–69s |
| linting | 29s | 25–36s |

`tests` is the long pole — Phase 2 (selective CI) should target it first.

## Test plan

- [x] `dev test` passes (1660 passed, 96 skipped, 72s).
- [x] `dev lint` passes.
- [x] `scripts/test_dev_cli_merge.py` covers: enables auto-merge, default method is squash, method flag forwarded, short-circuits failing checks pre-queue, detects failure mid-queue, recognises already-merged PRs, fails fast with no PR.
- [ ] Post-merge: verify queue-enablement API call succeeds and `gh api .../required_merge_queue` returns the configured object.
- [ ] Post-enablement: open a small follow-up PR and confirm a `merge_group` workflow run fires with all four jobs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)