### PR TITLE
fix(ci): correct workflow name typo (lnt → lint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI - Test and lnt
+name: CI - Test and lint
 
 on:
   pull_request:


### PR DESCRIPTION
Merge queue smoke test — fixes the CI workflow name typo and verifies the new `merge_group:` trigger fires end-to-end.

## What to watch for
- `pull_request` CI runs on this PR head as usual (four jobs).
- Once queued via `dev merge`, a `merge_group` workflow run should appear in the Actions tab with all four jobs green on the speculative merge commit.
- PR should land without a manual rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)