### PR TITLE
feat(ci): switch merge queue to Mergify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI - Test and lint
 on:
   pull_request:
     branches: [main]
-  merge_group:
   workflow_dispatch: # Allow manual runs
 
 env:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,27 @@
+queue_rules:
+  - name: default
+    queue_conditions:
+      - check-success = tests
+      - check-success = contract-tests
+      - check-success = linting
+      - check-success = docker-health-check
+    merge_conditions:
+      - check-success = tests
+      - check-success = contract-tests
+      - check-success = linting
+      - check-success = docker-health-check
+    merge_method: squash
+    batch_size: 3
+    batch_max_wait_time: 5 minutes
+
+pull_request_rules:
+  - name: add to merge queue when CI is green
+    conditions:
+      - base = main
+      - check-success = tests
+      - check-success = contract-tests
+      - check-success = linting
+      - check-success = docker-health-check
+    actions:
+      queue:
+        name: default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ A Stop hook checks the diff at end-of-turn and surfaces a reminder when source f
 
 A SessionStart hook prints the real current branch, dirty state, and stash list at session start — and warns loudly if you've landed on `main`/`master` in the shared working tree. Multi-agent sessions in this repo share one working directory; trust the hook's output over any harness-provided "current branch" line. A PreToolUse hook then enforces the rule: `Edit`/`Write`/`NotebookEdit` are refused on the main checkout when you're on `main`/`master`, so new work has to start on a worktree (`dev worktree add <slug>`). Feature branches on the main checkout are still allowed (for in-flight sessions); worktrees always are. See [`scripts/README.md`](scripts/README.md) for all three hooks.
 
-PRs land via GitHub Merge Queue on `main` — use `dev merge` rather than merging directly. See [`scripts/README.md#merging-prs`](scripts/README.md) for the flow, queue config, and recovery.
+PRs land via Mergify on `main` — use `dev merge` to watch a PR until Mergify queues and merges it. See [`scripts/README.md#merging-prs`](scripts/README.md) for the flow, queue config, and recovery.
 
 **Contract tests are not run by default.** `tests/test_contract` is excluded from the default `dev test` collection (see [`tests/test_contract/README.md`](tests/test_contract/README.md)). If you change templates, route response shapes, or anything mock data factories in `tests/test_contract` assume, also run `dev test contract` before pushing — otherwise CI is the first place the breakage surfaces.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,38 +28,28 @@ Deployment-specific scripts live in `deployment/scripts/` (see [`deployment/READ
 <!-- title-case-ignore: PRs is an acronym -->
 ## Merging PRs
 
-PRs land via [GitHub Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) on `main`. The flow is:
+PRs land via [Mergify](https://mergify.com) on `main`. Mergify is a GitHub App that watches for PRs with green CI, queues them, runs speculative CI on the rebased merge commit, and squash-merges when green.
+
+**Flow:**
 
 1. `dev push` opens (or updates) a PR off your worktree branch.
-2. `dev merge [<pr>]` enables auto-merge via `gh pr merge --auto --squash`, then polls until the queue lands the PR or a required check fails.
-3. The queue rebases the PR onto current `main` itself, runs CI in `merge_group` context against the speculative merge commit, and merges when green. No manual `gh pr update-branch --rebase`.
+2. CI runs on the PR head (`pull_request` event). When all four checks go green, Mergify automatically adds the PR to the queue — no manual step needed.
+3. Mergify rebases the PR onto current `main` (batching up to 3 queued PRs together), runs CI on that speculative commit, and squash-merges when green.
+4. `dev merge [<pr>]` watches and reports until Mergify lands it or a check fails. It issues no `gh` commands — Mergify does the work.
 
-**When CI runs in each context:**
+**Queue config:**
 
-- `pull_request` event — runs against the PR head, on every push. Required checks for the PR-ready state.
-- `merge_group` event — runs against the queue's speculative merge commit (PR rebased onto current `main`). Same four required checks (`tests`, `contract-tests`, `linting`, `docker-health-check`); see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+Config lives in [`.mergify.yml`](../.mergify.yml) at the repo root. Key knobs:
 
-The required-check names are identical across both contexts, so branch protection is satisfied by either.
-
-**Queue config and tuning:**
-
-The queue config lives on the `main` branch protection rule, not in this repo. Inspect with:
-
-```bash
-gh api /repos/willthefirst/bedlam-connect/branches/main/protection/required_merge_queue
-```
-
-Knobs worth knowing:
-
-- `merge_method=squash` — matches `required_linear_history: true` on the branch rule.
-- `max_entries_to_build` — how many PRs the queue speculatively rebases and tests in parallel. Start small (3); raise once CI is stable.
-- `min_entries_to_merge_wait_minutes` — how long the queue waits for siblings before merging a lone entry. Set low for solo work, higher to amortize CI across batches.
+- `merge_method: squash` — matches `required_linear_history: true` on the branch rule.
+- `batch_size: 3` — up to 3 PRs share one speculative CI run. Raise if throughput increases.
+- `batch_max_wait_time: 5 minutes` — a lone PR in the queue won't wait more than 5 min for siblings before merging solo.
 
 **Recovery:**
 
-- See what's queued: `gh api /repos/willthefirst/bedlam-connect/actions/runs?event=merge_group --jq '.workflow_runs[] | {id, status, head_branch}'`.
-- Pull a PR out of the queue: `gh pr merge --disable-auto <pr>`. Re-queue with `dev merge <pr>` when ready.
-- If the queue is jammed (stuck PR with no clear failure), GitHub UI → Settings → Branches → `main` → "Merge queue" exposes the queue dashboard.
+- See what's queued: Mergify dashboard at [app.mergify.com](https://app.mergify.com) or the "Mergify" check on any PR.
+- Pull a PR out of the queue: comment `@mergifyio dequeue` on the PR. Re-add by pushing a new commit (re-triggering CI) or commenting `@mergifyio queue`.
+- If Mergify is dequeuing PRs unexpectedly, check the "Checks" tab on the speculative merge commit Mergify created — that's where the failing CI run lives.
 
 ## Tests
 

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -900,12 +900,12 @@ class PushCommands:
 
 
 class MergeCommands:
-    """`dev merge [<pr-number>]` — hand off to GitHub Merge Queue.
+    """`dev merge [<pr-number>]` — watch a PR until Mergify lands it.
 
-    With the merge queue enabled on `main`, the queue handles rebase and
-    CI-in-merge_group itself. This command's job is to enable auto-merge
-    (`gh pr merge --auto`), then watch the PR until the queue lands it
-    or a check fails. See scripts/README.md#merging-prs.
+    Mergify auto-queues PRs whose CI is green (see .mergify.yml), runs
+    speculative CI on the rebased commit, and squash-merges when green.
+    This command's job is to watch and report until that happens, or
+    exit non-zero when a check fails. See scripts/README.md#merging-prs.
     """
 
     POLL_SECONDS = 30
@@ -969,15 +969,9 @@ class MergeCommands:
                 failed.append(name)
         return failed
 
-    def _enable_auto_merge(self, pr: int, method: str) -> int:
-        return self.runner.run_command(
-            ["gh", "pr", "merge", str(pr), "--auto", f"--{method}"]
-        )
-
     def merge(
         self,
         pr: Optional[int] = None,
-        method: str = "squash",
         timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     ) -> int:
         import time
@@ -990,20 +984,7 @@ class MergeCommands:
             )
             return 1
 
-        print(f"🔄 Handing PR #{number} to merge queue (method: {method})")
-        # Short-circuit on already-failing checks so we don't burn a queue slot.
-        initial = self._pr_status(number)
-        if (initial.get("state") or "").upper() == "MERGED":
-            print(f"✅ PR #{number} is already merged.")
-            return 0
-        failing = self._checks_failing(initial)
-        if failing:
-            print(f"❌ PR #{number} has failing checks: {', '.join(failing)}")
-            return 3
-        rc = self._enable_auto_merge(number, method)
-        if rc != 0:
-            return rc
-
+        print(f"⏳ Watching PR #{number} — Mergify will queue it when CI is green.")
         deadline = time.monotonic() + timeout_seconds
         last_state: Optional[str] = None
         while time.monotonic() < deadline:
@@ -1603,11 +1584,11 @@ Examples:
     def _add_merge_parser(self, subparsers):
         parser = subparsers.add_parser(
             "merge",
-            help="Hand a PR to the merge queue and watch it land",
+            help="Watch a PR until Mergify queues and lands it",
             description=(
-                "Enables auto-merge via `gh pr merge --auto`, then polls the "
-                "PR until the queue lands it or a check fails. The queue does "
-                "the rebase-onto-main and CI-in-merge_group itself. See "
+                "Polls the PR until Mergify squash-merges it or a check fails. "
+                "Mergify auto-queues PRs whose CI is green (see .mergify.yml); "
+                "this command just watches and reports. See "
                 "scripts/README.md#merging-prs."
             ),
         )
@@ -1616,12 +1597,6 @@ Examples:
             type=int,
             nargs="?",
             help="PR number. Defaults to the PR for the current branch.",
-        )
-        parser.add_argument(
-            "--method",
-            choices=["rebase", "merge", "squash"],
-            default="squash",
-            help="Merge method (default: squash, matches branch-protection queue config).",
         )
         parser.add_argument(
             "--timeout",
@@ -1633,7 +1608,7 @@ Examples:
             ),
         )
         parser.set_defaults(
-            func=lambda args: self.merge_cmd.merge(args.pr, args.method, args.timeout)
+            func=lambda args: self.merge_cmd.merge(args.pr, args.timeout)
         )
 
     def _add_claim_parser(self, subparsers):

--- a/scripts/test_dev_cli_merge.py
+++ b/scripts/test_dev_cli_merge.py
@@ -1,9 +1,9 @@
 """Tests for `dev merge` in scripts/dev_cli.py.
 
-With the merge queue enabled, `dev merge` enables auto-merge via
-`gh pr merge --auto` and then polls until the queue lands the PR or a
-check fails. The shell-out boundary (gh, time) is stubbed so we can
-drive the loop deterministically without sleeping.
+With Mergify handling queue and merge, `dev merge` is a pure poller:
+it watches the PR until merged or a check fails. No gh commands are
+issued — Mergify does the work. The shell-out boundary (gh, time) is
+stubbed so we can drive the loop deterministically without sleeping.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ def _merge_cmd(statuses: list) -> MergeCommands:
     return cmd
 
 
-def _green(state: str) -> dict:
+def _open(state: str) -> dict:
     return {
         "state": "OPEN",
         "mergeStateStatus": state,
@@ -48,28 +48,22 @@ def _merged() -> dict:
     return {"state": "MERGED", "mergeStateStatus": "CLEAN"}
 
 
-def test_enables_auto_merge_and_waits_for_queue_to_land():
-    # initial check (clean) → enable auto-merge → poll once and see MERGED.
-    cmd = _merge_cmd([_green("CLEAN"), _merged()])
+def test_exits_zero_when_mergify_lands_pr():
+    cmd = _merge_cmd([_open("BLOCKED"), _merged()])
     rc = cmd.merge(pr=123)
     assert rc == 0
-    assert ["gh", "pr", "merge", "123", "--auto", "--squash"] in cmd.runner.commands
+    # Pure watcher — no gh commands issued.
+    assert cmd.runner.commands == []
 
 
-def test_default_method_is_squash():
-    cmd = _merge_cmd([_green("CLEAN"), _merged()])
-    cmd.merge(pr=123)
-    # Squash is the queue-configured method; default must match.
-    assert ["gh", "pr", "merge", "123", "--auto", "--squash"] in cmd.runner.commands
+def test_recognises_already_merged_pr():
+    cmd = _merge_cmd([_merged()])
+    rc = cmd.merge(pr=123)
+    assert rc == 0
+    assert cmd.runner.commands == []
 
 
-def test_method_flag_is_forwarded():
-    cmd = _merge_cmd([_green("CLEAN"), _merged()])
-    cmd.merge(pr=123, method="rebase")
-    assert ["gh", "pr", "merge", "123", "--auto", "--rebase"] in cmd.runner.commands
-
-
-def test_aborts_on_failing_checks_before_enabling_auto_merge():
+def test_aborts_on_failing_checks():
     failing = {
         "state": "OPEN",
         "mergeStateStatus": "BLOCKED",
@@ -80,32 +74,15 @@ def test_aborts_on_failing_checks_before_enabling_auto_merge():
     cmd = _merge_cmd([failing])
     rc = cmd.merge(pr=123)
     assert rc == 3
-    # Did NOT attempt to enable auto-merge — would have burned a queue slot.
     assert cmd.runner.commands == []
 
 
-def test_detects_failure_while_waiting_in_queue():
-    failing = {
-        "state": "OPEN",
-        "mergeStateStatus": "BLOCKED",
-        "statusCheckRollup": [
-            {"name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"}
-        ],
-    }
-    # initial clean, auto-merge submitted, then a queued CI run fails.
-    cmd = _merge_cmd([_green("CLEAN"), failing])
-    rc = cmd.merge(pr=123)
-    assert rc == 3
-    # Auto-merge was attempted before the failure showed up.
-    assert ["gh", "pr", "merge", "123", "--auto", "--squash"] in cmd.runner.commands
-
-
-def test_recognises_already_merged_pr():
-    cmd = _merge_cmd([_merged()])
-    rc = cmd.merge(pr=123)
-    assert rc == 0
-    # No auto-merge call — PR is already merged.
-    assert cmd.runner.commands == []
+def test_reports_state_changes_while_waiting(capsys):
+    cmd = _merge_cmd([_open("BLOCKED"), _open("QUEUED"), _merged()])
+    cmd.merge(pr=123)
+    out = capsys.readouterr().out
+    assert "BLOCKED" in out
+    assert "QUEUED" in out
 
 
 def test_fails_fast_when_no_pr_number_resolvable(capsys):
@@ -114,5 +91,4 @@ def test_fails_fast_when_no_pr_number_resolvable(capsys):
     cmd._resolve_pr_number = lambda explicit: None
     rc = cmd.merge(pr=None)
     assert rc == 1
-    out = capsys.readouterr().out
-    assert "Could not determine PR number" in out
+    assert "Could not determine PR number" in capsys.readouterr().out


### PR DESCRIPTION
Replaces the GitHub-native merge queue (requires Enterprise) with [Mergify](https://mergify.com), which works on free personal repos.

## How it works

Mergify auto-queues PRs when all four CI checks go green, creates a speculative merge branch, runs CI on it, and squash-merges when green — no manual step needed.

## Changes

- **`.mergify.yml`** (new) — queue rule: batch_size=3, squash merge, auto-queue when `tests` + `contract-tests` + `linting` + `docker-health-check` are all green.
- **`ci.yml`** — removes `merge_group:` trigger (Mergify creates its own speculative PRs; the existing `pull_request: branches: [main]` trigger already covers them).
- **`dev merge`** — simplified to a pure poller. Mergify does the queuing and merging; this command just watches and reports.
- **`scripts/README.md`** and **`CLAUDE.md`** — updated to reference Mergify.

## Required manual step

Install the Mergify GitHub App on this repo before merging:
https://github.com/marketplace/mergify

Once installed, Mergify will validate `.mergify.yml` on this PR and the queue will be live.

## Test plan

- [x] `dev test` passes (1658 passed, 96 skipped).
- [x] `dev lint` passes.
- [ ] Install Mergify app on repo.
- [ ] Open a follow-up PR with green CI and confirm Mergify auto-queues it, runs speculative CI, and squash-merges.

Closes #780 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)