### PR TITLE
fix(lint): add common acronyms to title-case allowlist

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,7 +25,6 @@ CLAUDE.md and other docs that want to mention a command link to `dev --help` rat
 
 Deployment-specific scripts live in `deployment/scripts/` (see [`deployment/README.md`](../deployment/README.md)).
 
-<!-- title-case-ignore: PRs is an acronym -->
 ## Merging PRs
 
 PRs land via [Mergify](https://mergify.com) on `main`. Mergify is a GitHub App that watches for PRs with green CI, queues them, runs speculative CI on the rebased merge commit, and squash-merges when green.

--- a/scripts/dev/title_case_check.py
+++ b/scripts/dev/title_case_check.py
@@ -141,6 +141,16 @@ class TitleCaseChecker:
         "LLMs",
         "AI",
         "MVP",
+        "PR",
+        "PRs",
+        "API",
+        "APIs",
+        "URL",
+        "URLs",
+        "ID",
+        "IDs",
+        "UUID",
+        "UUIDs",
         # App-domain acronyms (intake forms, public-facing copy)
         "ZIP",  # Postal code field
         "PII",  # Personally identifiable information


### PR DESCRIPTION
Adds PR, PRs, API, APIs, URL, URLs, ID, IDs, UUID, UUIDs to the title-case checker's `ALWAYS_CAPITALIZE` set so headings containing these don't need `<!-- title-case-ignore -->` markers.

Also removes the now-redundant ignore comment from `scripts/README.md#merging-prs`.

**This is the Mergify smoke test** — if all four CI checks go green, Mergify should auto-queue this PR and squash-merge it without any manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)