### PR TITLE
chore(cd): add timeout-minutes to build-and-push job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Speculative CI test — PR A. Touches only cd.yml.