### PR TITLE
chore(cd): add timeout-minutes to deploy job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,6 +50,7 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.ref == 'refs/heads/main'
 
     steps:


### PR DESCRIPTION
Auto-queue flow test — opened with no manual queue step. Mergify should register for the queue on open, then admit once CI is green.