### PR TITLE
feat(ci): auto-queue via CI job instead of Mergify pull_request_rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, contract-tests, linting, docker-health-check]
     if: success() && github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
     steps:
       - name: Add to Mergify queue
         run: gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "@mergifyio queue"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,6 @@ jobs:
     if: success() && github.event_name == 'pull_request'
     steps:
       - name: Add to Mergify queue
-        run: gh pr comment ${{ github.event.pull_request.number }} --body "@mergifyio queue"
+        run: gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "@mergifyio queue"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,3 +172,13 @@ jobs:
         run: |
           docker compose -f deployment/docker/docker-compose.test.yml down
           docker rmi test-image || true
+
+  queue:
+    runs-on: ubuntu-latest
+    needs: [tests, contract-tests, linting, docker-health-check]
+    if: success() && github.event_name == 'pull_request'
+    steps:
+      - name: Add to Mergify queue
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "@mergifyio queue"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,12 +13,3 @@ queue_rules:
     merge_method: squash
     batch_size: 3
     batch_max_wait_time: 2 minutes
-
-pull_request_rules:
-  - name: add to merge queue on open
-    conditions:
-      - base = main
-      - -draft
-    actions:
-      queue:
-        name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,10 @@
+commands_restrictions:
+  queue:
+    conditions:
+      - or:
+        - sender-permission >= write
+        - sender = github-actions[bot]
+
 queue_rules:
   - name: default
     queue_conditions:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,11 +32,11 @@ PRs land via [Mergify](https://mergify.com) on `main`. The full flow requires no
 **Flow:**
 
 1. `dev push` opens (or updates) a PR off your worktree branch.
-2. Mergify immediately registers the PR for the queue (triggered on PR open, not on CI completion).
-3. CI runs on the PR head (`pull_request` event). Mergify watches the `queue_conditions` and waits for all four checks to go green.
-4. Once CI is green, Mergify admits the PR to the active queue — batching with any other waiting PRs (up to 3).
+2. CI runs on the PR head (`pull_request` event) — four jobs in parallel.
+3. When all four pass, a fifth CI job (`queue`) automatically posts `@mergifyio queue` on the PR.
+4. Mergify admits the PR to the active queue, batching with any other waiting PRs (up to 3).
 5. Mergify creates a speculative branch combining the batch rebased onto current `main`, runs CI on that branch, and squash-merges when green.
-6. `dev merge [<pr>]` is optional — use it to watch and get notified when the PR lands or a check fails.
+6. `dev merge [<pr>]` is optional — use it to block and get notified when the PR lands or a check fails.
 
 **Queue config:**
 


### PR DESCRIPTION
Adds a `queue` job to `ci.yml` that posts `@mergifyio queue` when all four CI jobs pass. Replaces the flaky `pull_request_rules` approach.

**Flow after this lands:** `dev push` → CI runs → all green → `queue` job fires → Mergify admits to queue → speculative CI → squash merge. Zero manual steps.

Key fixes in this PR:
- `--repo` flag so no checkout needed
- `pull-requests: write` permission on the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)