### PR TITLE
chore(mergify): reduce batch_max_wait_time to 1 minute

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,4 +19,4 @@ queue_rules:
       - check-success = docker-health-check
     merge_method: squash
     batch_size: 3
-    batch_max_wait_time: 2 minutes
+    batch_max_wait_time: 1 minute


### PR DESCRIPTION
End-to-end auto-queue test. No manual steps — should queue automatically via CI job when all checks pass.