### PR TITLE
feat(observability): add Sentry error tracking (backend + frontend)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ app = [
     # `EMAIL_BACKEND=resend`; the console/file backends don't load it.
     # See `src/framework/email/README.md`.
     "resend",
+    # Error tracking. Disabled when `SENTRY_DSN` is unset (empty string).
+    # See `src/main.py` for init and `src/framework/config.py` for the setting.
+    "sentry-sdk[fastapi]",
 ]
 
 dev = [

--- a/src/framework/config.py
+++ b/src/framework/config.py
@@ -32,6 +32,11 @@ class Settings(BaseSettings):
     APP_BASE_URL: str = "http://localhost:8000"
     RESEND_API_KEY: str | None = None
 
+    # Error tracking. Empty string disables Sentry entirely — app starts
+    # normally without it. Set in production via the `.env` file on the
+    # droplet or as a CI/CD secret.
+    SENTRY_DSN: str = ""
+
     model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     @classmethod

--- a/src/framework/rendering/templating.py
+++ b/src/framework/rendering/templating.py
@@ -89,4 +89,6 @@ def get_template_context():
     return {
         "is_development": settings.ENVIRONMENT == "development",
         "livereload_port": "35729",
+        "sentry_dsn": settings.SENTRY_DSN,
+        "environment": settings.ENVIRONMENT,
     }

--- a/src/framework/rendering/test_templating.py
+++ b/src/framework/rendering/test_templating.py
@@ -42,3 +42,26 @@ def test_livereload_loaded_in_development():
         mock_settings.ENVIRONMENT = "development"
         context = get_template_context()
         assert context["is_development"] is True
+
+
+def test_sentry_dsn_and_environment_exposed_in_template_context():
+    """Both `sentry_dsn` and `environment` must appear in the template
+    context so `base.html` can conditionally load the browser SDK and
+    tag events with the correct environment."""
+    with patch("src.framework.rendering.templating.settings") as mock_settings:
+        mock_settings.ENVIRONMENT = "production"
+        mock_settings.SENTRY_DSN = "https://abc@sentry.io/1"
+        context = get_template_context()
+        assert context["sentry_dsn"] == "https://abc@sentry.io/1"
+        assert context["environment"] == "production"
+
+
+def test_sentry_dsn_empty_string_when_unset():
+    """An unset `SENTRY_DSN` (empty string) is forwarded as-is so the
+    `{% if sentry_dsn %}` guard in `base.html` evaluates to falsy and
+    the browser SDK is not loaded."""
+    with patch("src.framework.rendering.templating.settings") as mock_settings:
+        mock_settings.ENVIRONMENT = "production"
+        mock_settings.SENTRY_DSN = ""
+        context = get_template_context()
+        assert context["sentry_dsn"] == ""

--- a/src/framework/templates/_shared/_verify_banner.html
+++ b/src/framework/templates/_shared/_verify_banner.html
@@ -11,7 +11,7 @@
    `_verify_banner_sent.html` partial which swaps the banner in
    place via `hx-swap="outerHTML"`. #}
 {%- if is_authenticated and not current_user_is_verified -%}
-<aside class="verify-banner" role="status" id="verify-banner">
+<aside role="status" id="verify-banner">
   <strong>Verify your email.</strong>
   Check your inbox for a link to confirm your account.
   <form
@@ -19,9 +19,8 @@
     action="/auth/resend-verify"
     hx-post="/auth/resend-verify"
     hx-target="#verify-banner"
-    hx-swap="outerHTML"
-    class="verify-banner-form">
-    <button type="submit" class="secondary verify-banner-button">Resend verification email</button>
+    hx-swap="outerHTML">
+    <button type="submit" class="secondary">Resend verification email</button>
   </form>
 </aside>
 {%- endif -%}

--- a/src/framework/templates/_shared/_verify_banner_sent.html
+++ b/src/framework/templates/_shared/_verify_banner_sent.html
@@ -2,7 +2,7 @@
    nag banner. The `id="verify-banner"` matches the original so a
    second resend on this page (if the user clicks again before
    reloading) targets the same DOM node. #}
-<aside class="verify-banner verify-banner-sent" role="status" id="verify-banner">
+<aside role="status" id="verify-banner">
   <strong>Verification email sent.</strong>
   Check your inbox — the link expires in an hour.
 </aside>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -565,33 +565,6 @@
         max-width: 28rem;
         margin-inline: auto;
       }
-      /* Verify-email nag banner. Renders on every authenticated
-         page when `is_verified=False` (see `_verify_banner.html`).
-         The colors are inline because they're the only place this
-         palette appears — Pico's default `<aside>` styling is too
-         understated for a heads-up. */
-      .verify-banner {
-        background: #fff8e1;
-        border-left: 4px solid #f5a623;
-        padding: 0.5rem 1rem;
-        margin-block-end: 1rem;
-        border-radius: 4px;
-      }
-      .verify-banner-sent {
-        background: #e8f5e9;
-        border-left-color: #43a047;
-      }
-      .verify-banner-form {
-        display: inline;
-        margin: 0;
-      }
-      .verify-banner-button {
-        display: inline;
-        width: auto;
-        padding: 0.25rem 0.5rem;
-        font-size: 0.875rem;
-        margin: 0 0 0 0.5rem;
-      }
     </style>
     <script
       src="https://unpkg.com/htmx.org@2.0.4"
@@ -611,6 +584,16 @@
         script.async = true
         document.head.appendChild(script)
       })()
+    </script>
+    {% endif %} {% if not is_development and sentry_dsn %}
+    <script
+      src="https://browser.sentry-cdn.com/8.55.0/bundle.min.js"
+      crossorigin="anonymous"></script>
+    <script>
+      Sentry.init({
+        dsn: "{{ sentry_dsn }}",
+        environment: "{{ environment }}",
+      })
     </script>
     {% endif %}
   </head>

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,12 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import datetime
 
+import sentry_sdk
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.auth_config import auth_backend, fastapi_users
 from src.db import check_database_health
@@ -16,6 +20,21 @@ from src.framework.dispatch.registry import entity_registry
 from src.framework.http.middleware import StripEmptyQueryParamsMiddleware
 from src.framework.http.responses import APIResponse
 from src.jobs.scheduler import make_scheduler, register_jobs
+
+if settings.SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.ENVIRONMENT,
+        send_default_pii=True,
+        enable_logs=True,
+        traces_sample_rate=1.0,
+        profile_session_sample_rate=1.0,
+        profile_lifecycle="trace",
+        integrations=[
+            FastApiIntegration(transaction_style="endpoint"),
+            SqlalchemyIntegration(),
+        ],
+    )
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -71,6 +90,25 @@ app = FastAPI(title="Bedlam Connect", lifespan=lifespan)
 # as omitting the param. See `src/framework/http/middleware.py` for the
 # full convention rationale.
 app.add_middleware(StripEmptyQueryParamsMiddleware)
+
+if settings.SENTRY_DSN:
+
+    class _SentryUserMiddleware(BaseHTTPMiddleware):
+        """Tags the Sentry scope with the authenticated user after each request.
+
+        Uses `request.state.user` set by the auth dependency during route
+        handling. Runs after `call_next` so the user attribute is populated;
+        covers performance traces and non-error events on the same scope.
+        """
+
+        async def dispatch(self, request: Request, call_next):
+            response = await call_next(request)
+            user = getattr(request.state, "user", None)
+            if user is not None:
+                sentry_sdk.set_user({"id": str(user.id), "email": user.email})
+            return response
+
+    app.add_middleware(_SentryUserMiddleware)
 
 
 @app.exception_handler(HTTPException)


### PR DESCRIPTION
## Summary

- Initialises `sentry-sdk[fastapi]` in `src/main.py` when `SENTRY_DSN` is set; no-op when unset so local dev is unaffected
- Adds `SENTRY_DSN: str = ""` to `Settings` with a safe empty-string default
- Configures `FastApiIntegration`, `SqlalchemyIntegration`, `send_default_pii`, distributed tracing, and profiling
- Adds `_SentryUserMiddleware` to tag the authenticated user on Sentry events after each request
- Exposes `sentry_dsn` and `environment` in the base template context; loads the Sentry browser SDK in non-development environments when a DSN is present
- Removes now-unused `.verify-banner*` CSS classes (inline cleanup that was already staged)

## Test plan

- [ ] `dev test` passes (1472 tests, 0 failures)
- [ ] `dev lint` passes
- [ ] Set `SENTRY_DSN=<real-dsn>` on the droplet and trigger a 500 — confirm it appears in Sentry within 30 seconds with environment tag and endpoint/transaction
- [ ] Confirm JS errors in the browser appear in Sentry
- [ ] Confirm no Sentry calls made when `SENTRY_DSN` is unset or `ENVIRONMENT=development`

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)