### PR TITLE
fix(forms): let CSS own the label-to-(optional) gap

### DIFF
--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -78,10 +78,14 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    here so the "(optional)" marker is the *only* way an optional field is
    communicated visually — there is no `help="Optional."` pattern anymore
    (the per-field marker beats a help line both visually and in terms of
-   discoverability). Pinned by ``src/domain/templates/test_copy_conventions.py``.
+   discoverability). The gap between the label and "(optional)" is owned
+   by `.form-field-optional { margin-inline-start }` in `base.html` — do
+   not introduce literal whitespace here (spacing belongs in CSS, not
+   markup). Pinned by ``src/domain/templates/test_copy_conventions.py``
+   (copy) and ``test_form_fields.py`` (no literal-space markup).
 #}
 {% macro _field_label(label, required) -%}
-{{ label }}{% if not required %} <small class="form-field-optional">(optional)</small>{% endif %}
+{{ label }}{% if not required %}<small class="form-field-optional">(optional)</small>{% endif %}
 {%- endmacro %}
 
 {# ---- text-like inputs --------------------------------------------- #}

--- a/src/framework/templates/_shared/test_form_fields.py
+++ b/src/framework/templates/_shared/test_form_fields.py
@@ -282,6 +282,40 @@ def test_entity_select_field_preselects_current() -> None:
     assert selected.attributes.get("value") == "2"
 
 
+# --- optional indicator ---------------------------------------------------
+
+
+def test_optional_marker_has_no_literal_space_before_small() -> None:
+    """Spacing between the label text and the `(optional)` marker is
+    owned by `.form-field-optional { margin-inline-start }` in
+    `base.html` — the macro must not emit a literal space character
+    before `<small class="form-field-optional">`. Whitespace-as-spacing
+    in markup is the anti-pattern this test pins against regression.
+    """
+    html = _render(_make_env(), '{{ text_field("zip", "ZIP", required=false) }}')
+    # The label text and the `<small>` must be flush in the rendered
+    # source — no run of one-or-more whitespace chars between them.
+    assert "ZIP<small" in html, (
+        "Expected label text flush against `<small>` (CSS owns the "
+        f"gap). Rendered HTML: {html!r}"
+    )
+
+
+def test_optional_marker_renders_inside_form_field_label_span() -> None:
+    """Sanity-check the structural contract while we're here: when
+    `required=false`, the `<small class="form-field-optional">` lives
+    inside the `<span class="form-field-label">` next to the label
+    text. This is what lets the CSS rule key off `.form-field-optional`
+    without any additional selector specificity."""
+    html = _render(_make_env(), '{{ text_field("zip", "ZIP", required=false) }}')
+    tree = HTMLParser(html)
+    span = tree.css_first("span.form-field-label")
+    assert span is not None
+    small = span.css_first("small.form-field-optional")
+    assert small is not None
+    assert small.text().strip() == "(optional)"
+
+
 # --- radio_bool_field -----------------------------------------------------
 
 

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -229,11 +229,13 @@
          label so it's visually clear the field can be left blank
          without competing with the label itself. Replaces the previous
          per-form `help="Optional."` pattern (single source of truth in
-         `_field_label` — see `_shared/form_fields.html`). */
+         `_field_label` — see `_shared/form_fields.html`). The
+         label-to-"(optional)" gap is owned here — `_field_label` emits
+         no literal whitespace between the two. */
       .form-field-optional {
         font-weight: 400;
         color: var(--pico-muted-color);
-        margin-inline-start: 0.25em;
+        margin-inline-start: 0.5em;
       }
       .entity-form-page form .form-field > input,
       .entity-form-page form .form-field > select,


### PR DESCRIPTION
## Summary
- Removes the literal space between the field label and the `(optional)` marker in `_field_label` (`src/framework/templates/_shared/form_fields.html:84`); spacing-as-content is an anti-pattern — it belongs in CSS.
- Bumps `.form-field-optional { margin-inline-start }` from `0.25em` → `0.5em` in `base.html` to preserve the previous visual gap (which was literal-space + 0.25em margin).
- Adds two colocated tests in `test_form_fields.py` pinning the contract (no literal whitespace before `<small>`, structural shape of the optional marker inside `.form-field-label`).

A repo-wide audit of `src/**/*.html` for the same anti-pattern (literal whitespace between text/`}}` and an inline tag carrying its own CSS class) found **zero other offenders**, so the fix scope stays narrow.

## Test plan
- [x] `dev test src/framework/templates/_shared/test_form_fields.py` — 25 passed
- [x] `dev test src/domain/templates/test_copy_conventions.py` — passed
- [x] `pytest` (full suite) — 1662 passed, 96 skipped
- [x] `dev lint` — all checks passed
- [ ] Visual spot-check: open any form with an optional field (e.g. provider edit, opening intake) and confirm the gap between the label text and "(optional)" looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)