### PR TITLE
chore(dev): disable APScheduler in dev server

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,7 @@ services:
       - DATABASE_URL=${DATABASE_URL:-sqlite+aiosqlite:///./data/bedlam-connect.db}
       - ACCESS_TOKEN_EXPIRE_MINUTES=${ACCESS_TOKEN_EXPIRE_MINUTES:-60}
       - ENVIRONMENT=development # Enable template auto-reload
+      - DISABLE_SCHEDULER=1
     volumes:
       - ./data:/app/data
       - ./src:/app/src


### PR DESCRIPTION
## Summary

- Adds `DISABLE_SCHEDULER=1` to the `environment` block in `docker-compose.dev.yml`
- The flag is already wired in `src/main.py` (same mechanism used by `.env.test`) — this just opts the dev server into it

## Test plan

- [ ] Spin up the dev server (`dev up`) and confirm no scheduler log lines appear on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)