### PR TITLE
fix(dev): skip APScheduler subsystem entirely when DISABLE_SCHEDULER=1

### DIFF
--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -33,7 +33,7 @@ The `JOB_RUN_STARTED` action is bespoke (no spec home) — see [`../framework/au
 
 ## Disabling the scheduler
 
-Set `DISABLE_SCHEDULER=1` to skip `scheduler.start()` in [`../main.py`](../main.py). `register_jobs` still runs so the job table is introspectable; the scheduler simply never fires. The test environment sets this in `.env.test`.
+Set `DISABLE_SCHEDULER=1` to skip the subsystem entirely in [`../main.py`](../main.py) — no `make_scheduler()`, no `register_jobs`, no `.start()`. Registration is still pinned by [`test_scheduler.py`](test_scheduler.py), so a registration-time bug fails fast in CI rather than at dev startup. The test environment sets this in `.env.test`; `docker-compose.dev.yml` sets it for `dev up`.
 
 ## APScheduler vs system cron
 

--- a/src/main.py
+++ b/src/main.py
@@ -66,20 +66,20 @@ async def lifespan(app: FastAPI):
 
     # APScheduler runs inside the app process so jobs share the real
     # async_session_maker and audit repository (see src/jobs/README.md).
-    # DISABLE_SCHEDULER=1 keeps the scheduler idle under pytest while
-    # still letting tests inspect register_jobs(make_scheduler()).
-    scheduler = make_scheduler()
-    register_jobs(scheduler)
-    scheduler_running = False
-    if os.getenv("DISABLE_SCHEDULER") != "1":
+    # DISABLE_SCHEDULER=1 skips the subsystem entirely (dev + pytest); job
+    # registration is exercised by src/jobs/test_scheduler.py instead.
+    if os.getenv("DISABLE_SCHEDULER") == "1":
+        scheduler = None
+    else:
+        scheduler = make_scheduler()
+        register_jobs(scheduler)
         scheduler.start()
-        scheduler_running = True
         logger.info("APScheduler started")
 
     try:
         yield
     finally:
-        if scheduler_running:
+        if scheduler is not None:
             scheduler.shutdown(wait=False)
 
 

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -1,0 +1,49 @@
+"""Pins the `lifespan` scheduler-gating contract: DISABLE_SCHEDULER=1 skips
+the subsystem entirely (no construction, no registration, no start), while
+the default path constructs + registers + starts. The contract matters
+because APScheduler's `add_job` logs "Adding job tentatively…" whenever a
+job is registered against a not-yet-started scheduler — calling
+`register_jobs` on a disabled scheduler is observable noise.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+from src.main import lifespan
+
+
+@pytest.mark.asyncio
+async def test_lifespan_skips_scheduler_entirely_when_disabled(monkeypatch):
+    monkeypatch.setenv("DISABLE_SCHEDULER", "1")
+
+    with (
+        patch("src.main.check_database_health", new=AsyncMock()),
+        patch("src.main.make_scheduler") as mk,
+        patch("src.main.register_jobs") as reg,
+    ):
+        async with lifespan(FastAPI()):
+            pass
+
+        mk.assert_not_called()
+        reg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_scheduler_when_enabled(monkeypatch):
+    monkeypatch.delenv("DISABLE_SCHEDULER", raising=False)
+    scheduler = MagicMock()
+
+    with (
+        patch("src.main.check_database_health", new=AsyncMock()),
+        patch("src.main.make_scheduler", return_value=scheduler) as mk,
+        patch("src.main.register_jobs") as reg,
+    ):
+        async with lifespan(FastAPI()):
+            pass
+
+        mk.assert_called_once()
+        reg.assert_called_once_with(scheduler)
+        scheduler.start.assert_called_once()
+        scheduler.shutdown.assert_called_once_with(wait=False)


### PR DESCRIPTION
## Summary

- #801 wired `DISABLE_SCHEDULER=1` into `docker-compose.dev.yml`, but the gate in `src/main.py` only skipped `scheduler.start()`. `register_jobs(scheduler)` still ran, and APScheduler's `add_job` logs `"Adding job tentatively -- it will be properly scheduled when the scheduler starts"` against a not-yet-started scheduler — which is exactly the noise that was still appearing on `dev up`.
- Move `make_scheduler()` + `register_jobs()` inside the gate so the subsystem is fully off when disabled. Registration is already pinned by `src/jobs/test_scheduler.py`, so we don't lose the "registration works" validation property.
- Add `src/test_main.py` pinning both branches of the gate.
- Update `src/jobs/README.md` to reflect the new behavior (was claiming `register_jobs` still runs under `DISABLE_SCHEDULER=1`).

## Test plan

- [ ] `dev up` — no `Adding job tentatively…` or `APScheduler started` log lines on startup
- [ ] `dev up` with `DISABLE_SCHEDULER` unset locally — scheduler logs return, hello-world job fires on its interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)