### PR TITLE
perf(tests): cut suite from ~115s to ~83s

### DIFF
--- a/scripts/dev/test_seed.py
+++ b/scripts/dev/test_seed.py
@@ -19,6 +19,14 @@ Three things are invariants that future schema changes must not break:
 Structural invariants the runtime relies on (hierarchy + multi-affiliation)
 also have direct assertions — they're not auto-discoverable from
 metadata.
+
+Fixture scope: the schema-create + `seed_all()` runs ONCE per module
+(`seeded_db`). Every test in this file is a read-only assertion on the
+shared seeded DB except `test_idempotent_rerun`, which re-runs
+`seed_all` and asserts row counts haven't grown — re-seeding is a
+no-op by contract, so it doesn't perturb the shared state for
+subsequent tests. Running seed_all() once instead of per-test cuts
+this module from ~38s to ~6s.
 """
 
 from __future__ import annotations
@@ -37,24 +45,30 @@ from src.domain.models import (
 from tests.fixtures import async_test_sessionmaker, test_engine
 
 
-@pytest.fixture(autouse=True)
-def patch_session_maker(monkeypatch):
-    """Point `seed.runner` at the in-memory test DB. The overrides
-    receive their session from the runner so they don't need patching
-    individually."""
+@pytest.fixture(scope="module")
+async def seeded_db():
+    """Create the schema and run `seed_all()` once per module. All
+    tests in this file are read-only assertions on the shared seeded
+    DB except `test_idempotent_rerun`, which exercises re-seeding (a
+    no-op by contract).
+
+    Uses `pytest.MonkeyPatch()` directly because the default
+    `monkeypatch` fixture is function-scoped; the seed runner's
+    `async_session_maker` reference must stay pointed at the test
+    sessionmaker for the whole module's seed + assertion run."""
+    mp = pytest.MonkeyPatch()
     import scripts.dev.seed.runner as runner_mod
 
-    monkeypatch.setattr(runner_mod, "async_session_maker", async_test_sessionmaker)
-
-
-@pytest.fixture(scope="function")
-async def fresh_db():
-    """Create the schema once per test, drop after."""
+    mp.setattr(runner_mod, "async_session_maker", async_test_sessionmaker)
     async with test_engine.begin() as conn:
+        await conn.run_sync(metadata.drop_all)
         await conn.run_sync(metadata.create_all)
+    rc = await seed_all()
+    assert rc == 0, f"seed_all() failed during module setup (rc={rc})"
     yield
     async with test_engine.begin() as conn:
         await conn.run_sync(metadata.drop_all)
+    mp.undo()
 
 
 async def _count_table(table_name: str) -> int:
@@ -85,19 +99,19 @@ async def _count_nulls(table_name: str, column_name: str) -> tuple[int, int]:
         return nulls.scalar_one(), nonnull.scalar_one()
 
 
-async def test_seed_all_smoke(fresh_db):
-    """seed_all() runs to completion on a fresh DB and populates the
-    expected major tables."""
-    rc = await seed_all()
-    assert rc == 0
+async def test_seed_all_smoke(seeded_db):
+    """The shared module seed populated the expected major tables."""
     assert await _count_table("organizations") >= 10
     assert await _count_table("providers") >= 100
     assert await _count_table("affiliations") >= 100
 
 
-async def test_idempotent_rerun(fresh_db):
-    """Re-running seed_all is a no-op — row counts don't grow."""
-    await seed_all()
+async def test_idempotent_rerun(seeded_db):
+    """Re-running seed_all is a no-op — row counts don't grow. The
+    module fixture has already seeded once; this test runs a second
+    seed_all and asserts the row counts before/after are equal. The
+    no-op property is what lets the shared `seeded_db` fixture work
+    safely across tests in this module."""
     counts_first = {
         table.name: await _count_table(table.name)
         for table in metadata.sorted_tables
@@ -112,7 +126,7 @@ async def test_idempotent_rerun(fresh_db):
     assert counts_first == counts_second
 
 
-async def test_enum_coverage_for_every_check_constraint(fresh_db):
+async def test_enum_coverage_for_every_check_constraint(seeded_db):
     """For every CHECK-bound column, every allowed value appears in at
     least one row — IF the table has enough rows to cover the enum's
     cardinality. (Programs has 12 rows; the `state_preference` enum
@@ -120,7 +134,6 @@ async def test_enum_coverage_for_every_check_constraint(fresh_db):
     isn't a meaningful test signal.) Auto-discovered from
     `CHECK_VALUES` — adding a new CHECK value automatically widens
     the assertion where it's feasible."""
-    await seed_all()
     misses: list[str] = []
     for (table_name, column_name), allowed in CHECK_VALUES.items():
         if table_name not in metadata.tables:
@@ -139,12 +152,11 @@ async def test_enum_coverage_for_every_check_constraint(fresh_db):
     assert not misses, "Enum coverage gaps:\n" + "\n".join(misses)
 
 
-async def test_nullable_columns_have_both_null_and_populated(fresh_db):
+async def test_nullable_columns_have_both_null_and_populated(seeded_db):
     """For every nullable column (excluding PKs / FKs / system cols),
     at least one row is NULL and at least one row is populated.
     Auto-discovered — adding a nullable column auto-covers it.
     `deleted_at` is always-null by design — exempted globally."""
-    await seed_all()
     system = {"id", "created_at", "updated_at", "deleted_at"}
     misses: list[str] = []
     for table in metadata.tables.values():
@@ -175,10 +187,9 @@ async def test_nullable_columns_have_both_null_and_populated(fresh_db):
     assert not misses, "Nullable-coverage gaps:\n" + "\n".join(misses)
 
 
-async def test_organization_hierarchy_present(fresh_db):
+async def test_organization_hierarchy_present(seeded_db):
     """At least 2 orgs are child rows (parent_org_id IS NOT NULL),
     exercising the self-referential tree."""
-    await seed_all()
     async with async_test_sessionmaker() as session:
         result = await session.execute(
             select(func.count())
@@ -189,10 +200,9 @@ async def test_organization_hierarchy_present(fresh_db):
     assert child_count >= 2, f"Expected ≥2 child organizations, got {child_count}"
 
 
-async def test_multi_affiliation_provider_present(fresh_db):
+async def test_multi_affiliation_provider_present(seeded_db):
     """At least one provider has 2+ affiliations — exercises the
     `Provider.affiliations` 1:N edge."""
-    await seed_all()
     async with async_test_sessionmaker() as session:
         subq = (
             select(Affiliation.provider_id, func.count().label("n"))

--- a/src/domain/logic/favorites/test_repository.py
+++ b/src/domain/logic/favorites/test_repository.py
@@ -7,8 +7,8 @@ test file pins the listing's newest-first ordering and the `is_favorited`
 truth table.
 """
 
-import asyncio
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import select
@@ -137,23 +137,27 @@ async def test_delete_favorite_removes_edge(
 async def test_list_favorited_providers_newest_first(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
-    """Ordering is by `UserFavorite.created_at DESC`. We add two edges
-    with a short sleep between to force a different timestamp on SQLite."""
+    """Ordering is by `UserFavorite.created_at DESC`. SQLite's
+    server-default `CURRENT_TIMESTAMP` is second-precision, so two
+    inserts in the same second tie on ordering. The test bypasses
+    `add_favorite` (which doesn't accept `created_at`) and inserts
+    `UserFavorite` rows directly with explicit timestamps to force a
+    deterministic ordering without `asyncio.sleep`. The repo
+    listing's `created_at DESC` is what's under test, not the writer."""
     user = await _seed_user(db_test_session_manager)
     first = await _seed_provider(db_test_session_manager, practice_name="First")
     second = await _seed_provider(db_test_session_manager, practice_name="Second")
+    earlier = datetime.now(timezone.utc)
+    later = earlier + timedelta(seconds=1)
 
     async with db_test_session_manager() as session:
-        repo = UserFavoriteRepository(session)
-        await repo.add_favorite(user_id=user.id, provider_id=first.id)
-        await session.commit()
-
-    await asyncio.sleep(1.1)
-
-    async with db_test_session_manager() as session:
-        repo = UserFavoriteRepository(session)
-        await repo.add_favorite(user_id=user.id, provider_id=second.id)
-        await session.commit()
+        async with session.begin():
+            session.add(
+                UserFavorite(user_id=user.id, provider_id=first.id, created_at=earlier)
+            )
+            session.add(
+                UserFavorite(user_id=user.id, provider_id=second.id, created_at=later)
+            )
 
     async with db_test_session_manager() as session:
         repo = UserFavoriteRepository(session)

--- a/src/domain/logic/verifications/test_repository.py
+++ b/src/domain/logic/verifications/test_repository.py
@@ -7,7 +7,7 @@ tested in A4; here we only exercise the persistence shape and the
 ordering / pagination contract.
 """
 
-import asyncio
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -57,18 +57,27 @@ async def test_latest_for_provider_returns_most_recent(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
     """`latest_for_provider` orders by `created_at` desc and returns
-    the top row. SQLite's `CURRENT_TIMESTAMP` is second-precision, so
-    we sleep ≥1.0s between inserts to force a different timestamp —
-    same pattern as `test_list_favorited_providers_newest_first`."""
+    the top row. SQLite's server-default `CURRENT_TIMESTAMP` is
+    second-precision, so two inserts in the same second tie on
+    ordering. Pass `created_at` explicitly on the model constructor
+    to force a deterministic ordering without burning real wall-clock
+    on `asyncio.sleep(1.0+)`."""
     provider = await _seed_provider(db_test_session_manager)
+    earlier = datetime.now(timezone.utc)
+    later = earlier + timedelta(seconds=1)
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            session.add(Verification(provider_id=provider.id, status="failed"))
-    await asyncio.sleep(1.1)
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(Verification(provider_id=provider.id, status="verified"))
+            session.add(
+                Verification(
+                    provider_id=provider.id, status="failed", created_at=earlier
+                )
+            )
+            session.add(
+                Verification(
+                    provider_id=provider.id, status="verified", created_at=later
+                )
+            )
 
     async with db_test_session_manager() as session:
         repo = VerificationRepository(session)
@@ -89,16 +98,23 @@ async def test_latest_for_provider_returns_none_when_no_history(
 async def test_list_for_provider_orders_newest_first(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
-    """SQLite second-precision `created_at` — sleep ≥1.0s between
-    inserts to force a distinct timestamp."""
+    """Same SQLite-tie problem as `test_latest_for_provider_returns_most_recent`
+    — pass `created_at` explicitly to avoid a second-precision tie."""
     provider = await _seed_provider(db_test_session_manager)
+    earlier = datetime.now(timezone.utc)
+    later = earlier + timedelta(seconds=1)
     async with db_test_session_manager() as session:
         async with session.begin():
-            session.add(Verification(provider_id=provider.id, status="failed"))
-    await asyncio.sleep(1.1)
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(Verification(provider_id=provider.id, status="verified"))
+            session.add(
+                Verification(
+                    provider_id=provider.id, status="failed", created_at=earlier
+                )
+            )
+            session.add(
+                Verification(
+                    provider_id=provider.id, status="verified", created_at=later
+                )
+            )
 
     async with db_test_session_manager() as session:
         repo = VerificationRepository(session)
@@ -110,16 +126,22 @@ async def test_list_for_provider_honors_limit_and_offset(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
     """Two-row pagination sanity: offset=1 limit=1 returns the second
-    row from the newest-first listing. Only two distinct timestamps
-    needed → one sleep call, not three."""
+    row from the newest-first listing."""
     provider = await _seed_provider(db_test_session_manager)
+    earlier = datetime.now(timezone.utc)
+    later = earlier + timedelta(seconds=1)
     async with db_test_session_manager() as session:
         async with session.begin():
-            session.add(Verification(provider_id=provider.id, status="failed"))
-    await asyncio.sleep(1.1)
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(Verification(provider_id=provider.id, status="verified"))
+            session.add(
+                Verification(
+                    provider_id=provider.id, status="failed", created_at=earlier
+                )
+            )
+            session.add(
+                Verification(
+                    provider_id=provider.id, status="verified", created_at=later
+                )
+            )
 
     async with db_test_session_manager() as session:
         repo = VerificationRepository(session)


### PR DESCRIPTION
## Summary
- `scripts/dev/test_seed.py`: switch `fresh_db` from `scope=\"function\"` to a `scope=\"module\"` `seeded_db` fixture. Six of the seven tests in this module are read-only assertions on a fully-seeded DB, so paying the ~5s `seed_all()` cost per test was pure waste. `test_idempotent_rerun` exercises re-seeding — its no-op property is exactly what makes the shared fixture safe.
- `src/domain/logic/{verifications,favorites}/test_repository.py`: four tests used `await asyncio.sleep(1.1)` to force a distinct `created_at` past SQLite's second-precision `CURRENT_TIMESTAMP`. Pass `created_at` explicitly on the model constructor instead — same invariant, no wall-clock burn.

## Measurements
| Suite | Before | After |
|---|---|---|
| Full pytest (`--durations=20`) | 114.81s | **83.01s** (~-28%) |
| `scripts/dev/test_seed.py` module | ~38s | **~8.7s** |
| 4 sleep-based repo tests | ~4.5s | **~0.4s** |

The seed module dropped from 7 of the top-30 slowest tests to 2. The verification repo tests dropped out of the top-20 entirely. Migrate tests are now the dominant cost (~28s across 10 tests) — those spawn `alembic` subprocesses and exercise distinct migration states, so they're inherently hard to cache and out of scope for this PR.

A follow-up PR could add `pytest-xdist` to parallelize the remaining long-tail (~30–40s further savings) — left out here because it touches CI config and the seed/migrate tests need `xdist_group` marks to stay correct under parallelism.

## Test plan
- [x] `dev test` passes (1654 passed, 96 skipped, same counts as before)
- [x] `dev lint` passes
- [x] `pytest scripts/dev/test_seed.py` passes — module fixture seeds once, tests share state, idempotent re-seed doesn't perturb other tests
- [x] `pytest src/domain/logic/verifications/test_repository.py src/domain/logic/favorites/test_repository.py` passes — explicit timestamps preserve newest-first ordering invariant

🤖 Generated with [Claude Code](https://claude.com/claude-code)