### PR TITLE
refactor(observability): provider-agnostic abstraction + fix user tagging

### DIFF
--- a/src/auth_config.py
+++ b/src/auth_config.py
@@ -13,6 +13,7 @@ from fastapi_users.db import SQLAlchemyUserDatabase
 from src.db import get_user_db
 from src.domain.models import User
 from src.framework.config import settings
+from src.framework.observability import observability
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
@@ -120,5 +121,30 @@ auth_backend = AuthenticationBackend(
 
 fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
 
-current_active_user = fastapi_users.current_user(active=True)
-current_admin_user = fastapi_users.current_user(active=True, superuser=True)
+# Raw fastapi-users deps. We wrap them below so every successful resolve
+# tags the observability scope — see `src/framework/observability/` for
+# why we tag here (inside the request) rather than in middleware (which
+# runs after `call_next` and so misses exceptions raised in the handler).
+_current_active_user = fastapi_users.current_user(active=True)
+_current_admin_user = fastapi_users.current_user(active=True, superuser=True)
+_current_optional_user = fastapi_users.current_user(optional=True)
+
+
+async def current_active_user(user: User = Depends(_current_active_user)) -> User:
+    observability.set_user(str(user.id), user.email)
+    return user
+
+
+async def current_admin_user(user: User = Depends(_current_admin_user)) -> User:
+    observability.set_user(str(user.id), user.email)
+    return user
+
+
+async def current_optional_user(
+    user: Optional[User] = Depends(_current_optional_user),
+) -> Optional[User]:
+    """Anonymous-allowed variant. Tags the scope only when a user is
+    present so anonymous traffic doesn't carry stale identities."""
+    if user is not None:
+        observability.set_user(str(user.id), user.email)
+    return user

--- a/src/framework/README.md
+++ b/src/framework/README.md
@@ -9,6 +9,7 @@ The framework groups its code by concern:
 - **[`audit/`](audit/README.md)** — the audit framework. `AuditLog` model, `AuditRepository`, the `record_audit` / `record_audit_for` helpers, the `mutate(...)` context manager, the `AuditedResource` / `EdgeAudit` bindings.
 - **[`http/`](http/README.md)** — cross-cutting HTTP plumbing. `APIException` subclasses, response helpers, form parsing, decorators, ASGI middleware.
 - **[`rendering/`](rendering/README.md)** — Jinja + form rendering. Templating env, view projections, the schema-driven form-field markers.
+- **[`observability/`](observability/README.md)** — provider-agnostic error tracking + tracing. `ObservabilityBackend` Protocol with Sentry + Noop implementations; the only place a provider SDK is imported.
 
 Plus three flat-at-root single-file modules used by everything:
 

--- a/src/framework/config.py
+++ b/src/framework/config.py
@@ -32,10 +32,24 @@ class Settings(BaseSettings):
     APP_BASE_URL: str = "http://localhost:8000"
     RESEND_API_KEY: str | None = None
 
-    # Error tracking. Empty string disables Sentry entirely — app starts
-    # normally without it. Set in production via the `.env` file on the
-    # droplet or as a CI/CD secret.
+    # Error tracking + tracing. Read by `src/framework/observability/`,
+    # which picks a backend (Sentry or Noop) based on `SENTRY_DSN`. Set
+    # in production via the `.env` file on the droplet or as a CI/CD
+    # secret. Empty DSN → the app runs with no provider at all.
     SENTRY_DSN: str = ""
+    # Sample rates default to 10% so a traffic spike doesn't tank the
+    # Sentry quota. Override per-environment if you need fuller traces.
+    SENTRY_TRACES_SAMPLE_RATE: float = 0.1
+    SENTRY_PROFILES_SAMPLE_RATE: float = 0.1
+    # Session Replay is opt-in (paid feature, larger payload). `0.0`
+    # disables; bump the on-error rate to e.g. `1.0` to record replays
+    # only when something throws.
+    SENTRY_REPLAY_SAMPLE_RATE: float = 0.0
+    SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE: float = 0.0
+    # Release tag (typically the deploy's git SHA) used by both the
+    # backend SDK and the browser SDK. Provider-agnostic name so a
+    # future swap doesn't churn the deploy pipeline. Empty → no tag.
+    APP_RELEASE: str = ""
 
     model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/src/framework/observability/README.md
+++ b/src/framework/observability/README.md
@@ -1,0 +1,39 @@
+# Observability: provider-agnostic error tracking + tracing
+
+A thin abstraction over whatever error-tracking / APM SaaS the app is wired to. The only file that imports a provider SDK is the matching `*_backend.py` — every other call site goes through `observability` from this package.
+
+## Files
+
+- `backend.py` — the `ObservabilityBackend` `Protocol`. Three methods: `init_app(app)`, `set_user(user_id, email)`, `frontend_context()`.
+- `sentry_backend.py` — the Sentry implementation. Reads sample rates, release tag, and PII flags from `settings`.
+- `noop_backend.py` — selected when no DSN is set. Lets call sites drop the `if settings.X` guard.
+- `__init__.py` — exposes `observability`, the module-level singleton chosen by `_select_backend()` from settings.
+
+## Call sites
+
+- **Init** — `src/main.py` calls `observability.init_app(app)` once during FastAPI construction.
+- **User tagging** — the wrapping deps `current_active_user` / `current_admin_user` / `current_optional_user` in `src/auth_config.py` call `observability.set_user(...)` during request handling. Tagging from middleware after `call_next` is too late — exceptions raised inside the handler are already captured by then.
+- **Browser SDK** — `src/framework/rendering/templating.py:get_template_context` puts `observability.frontend_context()` into every render as `observability_frontend`; `src/framework/templates/base.html` branches on `observability_frontend.provider` and renders the right `<script>` block.
+
+## Adding a new provider
+
+1. Add `<name>_backend.py` with a class that satisfies `ObservabilityBackend`.
+2. Add a branch in `_select_backend()` in `__init__.py` keyed off a new (or existing) setting.
+3. Add a `{% elif observability_frontend.provider == "<name>" %}` block in `base.html` with that provider's browser SDK init.
+4. Add tests in `test_<name>_backend.py`.
+
+No other file should need to change. If a call site needs something the contract doesn't expose, extend `backend.py` first (and update every existing backend) — never special-case a provider at a call site.
+
+## Settings
+
+All provider knobs live in `src/framework/config.py` with sensible production defaults:
+
+- `SENTRY_DSN` — empty disables the provider entirely (Noop backend selected).
+- `SENTRY_TRACES_SAMPLE_RATE` (default `0.1`).
+- `SENTRY_PROFILES_SAMPLE_RATE` (default `0.1`).
+- `SENTRY_REPLAY_SAMPLE_RATE`, `SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE` (default `0.0` / `0.0` — Replay opt-in).
+- `APP_RELEASE` — git SHA injected at deploy time. Provider-agnostic name; consumed by every backend that supports a release tag.
+
+## Tests
+
+`test_backend.py`, `test_sentry_backend.py`, `test_noop_backend.py` — one per module. The Sentry test patches `sentry_sdk` rather than calling the real SDK.

--- a/src/framework/observability/__init__.py
+++ b/src/framework/observability/__init__.py
@@ -1,0 +1,41 @@
+"""Provider-agnostic error tracking + performance tracing.
+
+Public surface:
+  - `observability.init_app(app)` — install integrations. Called once
+    from `src/main.py` at app construction.
+  - `observability.set_user(user_id, email)` — tag the active request
+    scope. Called from the wrapping auth dependencies in
+    `src/auth_config.py` so errors raised inside the handler carry the
+    user (the older middleware-after-`call_next` pattern was a no-op for
+    exceptions).
+  - `observability.frontend_context()` — dict (or `None`) consumed by
+    `base.html` to init the browser SDK.
+
+Swapping providers is a code change in this directory only:
+  1. Add `*_backend.py` implementing `ObservabilityBackend`.
+  2. Branch in `_select_backend()` below.
+  3. Add the provider's init snippet in `base.html` next to the existing
+     Sentry branch and key it off `observability_frontend.provider`.
+"""
+
+from src.framework.config import settings
+from src.framework.observability.backend import ObservabilityBackend
+from src.framework.observability.noop_backend import NoopBackend
+from src.framework.observability.sentry_backend import SentryBackend
+
+
+def _select_backend() -> ObservabilityBackend:
+    """Pick a backend from settings.
+
+    Empty DSN → `NoopBackend` so the app runs locally without any
+    provider credentials. Add new providers as additional branches.
+    """
+    if settings.SENTRY_DSN:
+        return SentryBackend()
+    return NoopBackend()
+
+
+observability: ObservabilityBackend = _select_backend()
+
+
+__all__ = ["ObservabilityBackend", "observability"]

--- a/src/framework/observability/backend.py
+++ b/src/framework/observability/backend.py
@@ -1,0 +1,50 @@
+"""The provider-agnostic observability contract.
+
+Every backend in this package implements this Protocol. The rest of the
+codebase imports `observability` from `__init__.py` (an `ObservabilityBackend`
+instance) and never imports a provider SDK directly — that's the seam that
+lets us swap Sentry out without touching the call sites.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from fastapi import FastAPI
+
+
+@runtime_checkable
+class ObservabilityBackend(Protocol):
+    """Error tracking + performance tracing contract.
+
+    Kept deliberately small: anything bigger ties the abstraction to a
+    specific provider's feature set. Provider-specific knobs (sample
+    rates, replay, etc.) belong in settings and the backend reads them
+    directly — they don't surface here.
+    """
+
+    def init_app(self, app: FastAPI) -> None:
+        """Install integrations + initialize the provider SDK.
+
+        Called once from `src/main.py` during app construction. Idempotent
+        backends are allowed but not required; callers must not call this
+        twice.
+        """
+        ...
+
+    def set_user(self, user_id: str, email: str | None = None) -> None:
+        """Attach a user identity to the active request scope.
+
+        Called from the auth dependencies in `src/auth_config.py` so that
+        any error raised inside the handler carries the user. Tagging from
+        middleware after `call_next` is too late — the exception has
+        already been captured by then.
+        """
+        ...
+
+    def frontend_context(self) -> dict | None:
+        """Return the dict consumed by `base.html` to init the browser SDK.
+
+        `None` means "no browser SDK loaded" (e.g. provider disabled, or
+        a server-only backend). Concrete shape is provider-specific; the
+        template branches on `provider`.
+        """
+        ...

--- a/src/framework/observability/noop_backend.py
+++ b/src/framework/observability/noop_backend.py
@@ -1,0 +1,20 @@
+"""No-op backend used when no provider is configured.
+
+Lets every call site invoke `observability.set_user(...)` etc.
+unconditionally without paying a `if settings.SENTRY_DSN` guard at each
+site. Selected by `_select_backend()` in `__init__.py` when the
+provider's DSN/key is empty.
+"""
+
+from fastapi import FastAPI
+
+
+class NoopBackend:
+    def init_app(self, app: FastAPI) -> None:
+        return
+
+    def set_user(self, user_id: str, email: str | None = None) -> None:
+        return
+
+    def frontend_context(self) -> dict | None:
+        return None

--- a/src/framework/observability/sentry_backend.py
+++ b/src/framework/observability/sentry_backend.py
@@ -1,0 +1,52 @@
+"""Sentry implementation of the observability contract.
+
+Reads all knobs from `settings` so swapping in another provider is a
+matter of adding a sibling backend file and changing `_select_backend()`
+in `__init__.py`. No other file in the codebase imports `sentry_sdk`
+directly — this is the only place.
+"""
+
+import sentry_sdk
+from fastapi import FastAPI
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
+from src.framework.config import settings
+
+
+class SentryBackend:
+    def init_app(self, app: FastAPI) -> None:
+        # `release=None` (rather than empty string) tells Sentry "no
+        # release tag" — important so events from un-tagged builds don't
+        # cluster into a synthetic "" release.
+        sentry_sdk.init(
+            dsn=settings.SENTRY_DSN,
+            environment=settings.ENVIRONMENT,
+            release=settings.APP_RELEASE or None,
+            send_default_pii=True,
+            enable_logs=True,
+            traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+            profile_session_sample_rate=settings.SENTRY_PROFILES_SAMPLE_RATE,
+            profile_lifecycle="trace",
+            integrations=[
+                FastApiIntegration(transaction_style="endpoint"),
+                SqlalchemyIntegration(),
+            ],
+        )
+
+    def set_user(self, user_id: str, email: str | None = None) -> None:
+        payload: dict[str, str] = {"id": user_id}
+        if email is not None:
+            payload["email"] = email
+        sentry_sdk.set_user(payload)
+
+    def frontend_context(self) -> dict:
+        return {
+            "provider": "sentry",
+            "dsn": settings.SENTRY_DSN,
+            "environment": settings.ENVIRONMENT,
+            "release": settings.APP_RELEASE,
+            "traces_sample_rate": settings.SENTRY_TRACES_SAMPLE_RATE,
+            "replays_session_sample_rate": settings.SENTRY_REPLAY_SAMPLE_RATE,
+            "replays_on_error_sample_rate": settings.SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE,
+        }

--- a/src/framework/observability/test_backend.py
+++ b/src/framework/observability/test_backend.py
@@ -1,0 +1,43 @@
+"""Tests for the backend factory in `src/framework/observability/__init__.py`.
+
+The factory's job is just "pick the right backend from settings." We
+test that here so a regression — e.g. silently falling through to Noop
+when a DSN is set — surfaces immediately.
+"""
+
+from unittest.mock import patch
+
+from .backend import ObservabilityBackend
+from .noop_backend import NoopBackend
+from .sentry_backend import SentryBackend
+
+
+def _import_factory():
+    """Pull `_select_backend` lazily so each test sees the patched settings."""
+    from . import _select_backend
+
+    return _select_backend
+
+
+def test_select_backend_returns_sentry_when_dsn_set():
+    with patch("src.framework.observability.settings") as mock_settings:
+        mock_settings.SENTRY_DSN = "https://abc@sentry.io/1"
+        backend = _import_factory()()
+    assert isinstance(backend, SentryBackend)
+
+
+def test_select_backend_returns_noop_when_dsn_empty():
+    with patch("src.framework.observability.settings") as mock_settings:
+        mock_settings.SENTRY_DSN = ""
+        backend = _import_factory()()
+    assert isinstance(backend, NoopBackend)
+
+
+def test_concrete_backends_satisfy_protocol():
+    """Both backends must structurally satisfy `ObservabilityBackend` so
+    call sites typed against the Protocol never need a provider-specific
+    branch."""
+    assert isinstance(NoopBackend(), ObservabilityBackend)
+    # SentryBackend doesn't init the SDK at construction, only on
+    # `init_app`, so it's cheap to instantiate here.
+    assert isinstance(SentryBackend(), ObservabilityBackend)

--- a/src/framework/observability/test_noop_backend.py
+++ b/src/framework/observability/test_noop_backend.py
@@ -1,0 +1,28 @@
+"""Tests for `noop_backend.py`.
+
+The Noop backend's contract is "doesn't crash, returns the sentinel
+shape" — that's exactly what we verify here.
+"""
+
+from fastapi import FastAPI
+
+from .noop_backend import NoopBackend
+
+
+def test_init_app_is_noop():
+    backend = NoopBackend()
+    # Must not raise on a real FastAPI instance — call sites pass `app`
+    # unconditionally and the Noop branch has to absorb it.
+    backend.init_app(FastAPI())
+
+
+def test_set_user_is_noop():
+    backend = NoopBackend()
+    backend.set_user("abc", "user@example.com")
+    backend.set_user("abc", None)
+
+
+def test_frontend_context_returns_none():
+    """`None` is the signal `base.html` reads to skip the browser SDK
+    `<script>` block entirely."""
+    assert NoopBackend().frontend_context() is None

--- a/src/framework/observability/test_sentry_backend.py
+++ b/src/framework/observability/test_sentry_backend.py
@@ -1,0 +1,97 @@
+"""Tests for `sentry_backend.py`.
+
+We patch `sentry_sdk` rather than touching the real SDK so the test
+process doesn't open a network connection or carry state between tests.
+The contract under test is "settings → SDK init kwargs", "user payload
+shape", "frontend_context dict shape" — not the SDK's internals.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+
+from .sentry_backend import SentryBackend
+
+
+def test_init_app_calls_sentry_init_with_settings():
+    with (
+        patch("src.framework.observability.sentry_backend.sentry_sdk") as mock_sdk,
+        patch("src.framework.observability.sentry_backend.settings") as mock_settings,
+    ):
+        mock_settings.SENTRY_DSN = "https://abc@sentry.io/1"
+        mock_settings.ENVIRONMENT = "production"
+        mock_settings.APP_RELEASE = "deadbeef"
+        mock_settings.SENTRY_TRACES_SAMPLE_RATE = 0.25
+        mock_settings.SENTRY_PROFILES_SAMPLE_RATE = 0.5
+
+        SentryBackend().init_app(FastAPI())
+
+        mock_sdk.init.assert_called_once()
+        kwargs = mock_sdk.init.call_args.kwargs
+        assert kwargs["dsn"] == "https://abc@sentry.io/1"
+        assert kwargs["environment"] == "production"
+        assert kwargs["release"] == "deadbeef"
+        assert kwargs["traces_sample_rate"] == 0.25
+        assert kwargs["profile_session_sample_rate"] == 0.5
+        assert kwargs["send_default_pii"] is True
+
+
+def test_init_app_passes_release_as_none_when_unset():
+    """Empty `APP_RELEASE` must become `release=None` so events from
+    un-tagged builds don't cluster under a synthetic empty-string
+    release in the Sentry UI."""
+    with (
+        patch("src.framework.observability.sentry_backend.sentry_sdk") as mock_sdk,
+        patch("src.framework.observability.sentry_backend.settings") as mock_settings,
+    ):
+        mock_settings.SENTRY_DSN = "https://abc@sentry.io/1"
+        mock_settings.ENVIRONMENT = "production"
+        mock_settings.APP_RELEASE = ""
+        mock_settings.SENTRY_TRACES_SAMPLE_RATE = 0.1
+        mock_settings.SENTRY_PROFILES_SAMPLE_RATE = 0.1
+
+        SentryBackend().init_app(FastAPI())
+
+        assert mock_sdk.init.call_args.kwargs["release"] is None
+
+
+def test_set_user_includes_email_when_provided():
+    with patch("src.framework.observability.sentry_backend.sentry_sdk") as mock_sdk:
+        mock_sdk.set_user = MagicMock()
+        SentryBackend().set_user("uid-1", "u@example.com")
+        mock_sdk.set_user.assert_called_once_with(
+            {"id": "uid-1", "email": "u@example.com"}
+        )
+
+
+def test_set_user_omits_email_when_none():
+    """Passing `email=None` shouldn't ship a literal `None` to Sentry —
+    drop the key so the UI doesn't render a blank email field."""
+    with patch("src.framework.observability.sentry_backend.sentry_sdk") as mock_sdk:
+        mock_sdk.set_user = MagicMock()
+        SentryBackend().set_user("uid-1", None)
+        mock_sdk.set_user.assert_called_once_with({"id": "uid-1"})
+
+
+def test_frontend_context_shape():
+    """The dict that lands in `base.html`. Keys checked exhaustively so
+    a rename here forces a template + test update."""
+    with patch("src.framework.observability.sentry_backend.settings") as mock_settings:
+        mock_settings.SENTRY_DSN = "https://abc@sentry.io/1"
+        mock_settings.ENVIRONMENT = "production"
+        mock_settings.APP_RELEASE = "deadbeef"
+        mock_settings.SENTRY_TRACES_SAMPLE_RATE = 0.1
+        mock_settings.SENTRY_REPLAY_SAMPLE_RATE = 0.0
+        mock_settings.SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE = 0.0
+
+        ctx = SentryBackend().frontend_context()
+
+    assert ctx == {
+        "provider": "sentry",
+        "dsn": "https://abc@sentry.io/1",
+        "environment": "production",
+        "release": "deadbeef",
+        "traces_sample_rate": 0.1,
+        "replays_session_sample_rate": 0.0,
+        "replays_on_error_sample_rate": 0.0,
+    }

--- a/src/framework/rendering/templating.py
+++ b/src/framework/rendering/templating.py
@@ -5,6 +5,7 @@ from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from src.framework.config import settings
+from src.framework.observability import observability
 from src.framework.rendering.form_fields import field_spec
 from src.framework.rendering.labels import (
     entity_create_label,
@@ -85,10 +86,16 @@ templates = Jinja2Templates(env=_env)
 
 # Add global template variables for development features
 def get_template_context():
-    """Get global template context with environment information."""
+    """Get global template context.
+
+    `observability_frontend` is the provider-agnostic dict consumed by
+    `base.html` to render the browser SDK init block — `None` when no
+    provider is configured (no script tag rendered). See
+    `src/framework/observability/` for the contract and how to add a new
+    provider.
+    """
     return {
         "is_development": settings.ENVIRONMENT == "development",
         "livereload_port": "35729",
-        "sentry_dsn": settings.SENTRY_DSN,
-        "environment": settings.ENVIRONMENT,
+        "observability_frontend": observability.frontend_context(),
     }

--- a/src/framework/rendering/test_templating.py
+++ b/src/framework/rendering/test_templating.py
@@ -44,24 +44,25 @@ def test_livereload_loaded_in_development():
         assert context["is_development"] is True
 
 
-def test_sentry_dsn_and_environment_exposed_in_template_context():
-    """Both `sentry_dsn` and `environment` must appear in the template
-    context so `base.html` can conditionally load the browser SDK and
-    tag events with the correct environment."""
-    with patch("src.framework.rendering.templating.settings") as mock_settings:
-        mock_settings.ENVIRONMENT = "production"
-        mock_settings.SENTRY_DSN = "https://abc@sentry.io/1"
+def test_observability_frontend_exposed_in_template_context():
+    """`observability_frontend` is the dict `base.html` reads to render
+    the browser SDK init block. The framework asks the abstraction for
+    it; provider-specific shape is the backend's concern."""
+    sentinel = {"provider": "sentry", "dsn": "https://abc@sentry.io/1"}
+    with patch(
+        "src.framework.rendering.templating.observability"
+    ) as mock_observability:
+        mock_observability.frontend_context.return_value = sentinel
         context = get_template_context()
-        assert context["sentry_dsn"] == "https://abc@sentry.io/1"
-        assert context["environment"] == "production"
+    assert context["observability_frontend"] is sentinel
 
 
-def test_sentry_dsn_empty_string_when_unset():
-    """An unset `SENTRY_DSN` (empty string) is forwarded as-is so the
-    `{% if sentry_dsn %}` guard in `base.html` evaluates to falsy and
-    the browser SDK is not loaded."""
-    with patch("src.framework.rendering.templating.settings") as mock_settings:
-        mock_settings.ENVIRONMENT = "production"
-        mock_settings.SENTRY_DSN = ""
+def test_observability_frontend_none_when_disabled():
+    """`None` from the backend → `None` in the context. `base.html`
+    treats `None` as "skip the browser SDK script tag entirely"."""
+    with patch(
+        "src.framework.rendering.templating.observability"
+    ) as mock_observability:
+        mock_observability.frontend_context.return_value = None
         context = get_template_context()
-        assert context["sentry_dsn"] == ""
+    assert context["observability_frontend"] is None

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -575,17 +575,33 @@
         document.head.appendChild(script)
       })()
     </script>
-    {% endif %} {% if not is_development and sentry_dsn %}
+    {% endif %} {% if not is_development and observability_frontend %} {#
+      Browser SDK init. Dict shape and `provider` key come from
+      `src/framework/observability/<provider>_backend.py:frontend_context`.
+      Add a new `{% elif %}` branch here when adding a provider. #}
+    {% if observability_frontend.provider == "sentry" %} {% set _replay_enabled
+    = (observability_frontend.replays_session_sample_rate or 0) > 0 or
+    (observability_frontend.replays_on_error_sample_rate or 0) > 0 %}
     <script
-      src="https://browser.sentry-cdn.com/8.55.0/bundle.min.js"
+      src="https://browser.sentry-cdn.com/8.55.0/{% if _replay_enabled %}bundle.tracing.replay.min.js{% else %}bundle.tracing.min.js{% endif %}"
       crossorigin="anonymous"></script>
     <script>
       Sentry.init({
-        dsn: "{{ sentry_dsn }}",
-        environment: "{{ environment }}",
+        dsn: "{{ observability_frontend.dsn }}",
+        environment: "{{ observability_frontend.environment }}",
+        {% if observability_frontend.release %}release: "{{ observability_frontend.release }}",{% endif %}
+        tracesSampleRate: {{ observability_frontend.traces_sample_rate }},
+        integrations: [
+          Sentry.browserTracingIntegration(),
+          {% if _replay_enabled %}Sentry.replayIntegration(),{% endif %}
+        ],
+        {% if _replay_enabled %}
+        replaysSessionSampleRate: {{ observability_frontend.replays_session_sample_rate }},
+        replaysOnErrorSampleRate: {{ observability_frontend.replays_on_error_sample_rate }},
+        {% endif %}
       })
     </script>
-    {% endif %}
+    {% endif %} {% endif %}
   </head>
   <body>
     {# Primary nav renders on every screen so the chrome stays

--- a/src/framework/test_config.py
+++ b/src/framework/test_config.py
@@ -26,3 +26,17 @@ def test_environment_can_be_set_to_development():
             ENVIRONMENT="development",
         )
         assert settings.ENVIRONMENT == "development"
+
+
+def test_observability_defaults_are_quota_safe():
+    """Sample-rate defaults are pinned because a regression to `1.0`
+    (the SDK's default) would silently 10× the Sentry bill on prod
+    traffic. Replay defaults to off — it's a paid add-on."""
+    with patch.dict(os.environ, {}, clear=True):
+        settings = Settings(SECRET="test", DATABASE_URL="postgresql://test")
+        assert settings.SENTRY_DSN == ""
+        assert settings.SENTRY_TRACES_SAMPLE_RATE == 0.1
+        assert settings.SENTRY_PROFILES_SAMPLE_RATE == 0.1
+        assert settings.SENTRY_REPLAY_SAMPLE_RATE == 0.0
+        assert settings.SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE == 0.0
+        assert settings.APP_RELEASE == ""

--- a/src/main.py
+++ b/src/main.py
@@ -2,14 +2,10 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import datetime
 
-import sentry_sdk
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
-from sentry_sdk.integrations.fastapi import FastApiIntegration
-from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
-from starlette.middleware.base import BaseHTTPMiddleware
 
-from src.auth_config import auth_backend, fastapi_users
+from src.auth_config import auth_backend, current_optional_user, fastapi_users
 from src.db import check_database_health
 from src.domain import routes  # noqa: F401  # populates entity_registry
 from src.domain import template_globals  # noqa: F401  # populates Jinja env globals
@@ -19,22 +15,8 @@ from src.framework.config import settings
 from src.framework.dispatch.registry import entity_registry
 from src.framework.http.middleware import StripEmptyQueryParamsMiddleware
 from src.framework.http.responses import APIResponse
+from src.framework.observability import observability
 from src.jobs.scheduler import make_scheduler, register_jobs
-
-if settings.SENTRY_DSN:
-    sentry_sdk.init(
-        dsn=settings.SENTRY_DSN,
-        environment=settings.ENVIRONMENT,
-        send_default_pii=True,
-        enable_logs=True,
-        traces_sample_rate=1.0,
-        profile_session_sample_rate=1.0,
-        profile_lifecycle="trace",
-        integrations=[
-            FastApiIntegration(transaction_style="endpoint"),
-            SqlalchemyIntegration(),
-        ],
-    )
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -85,30 +67,16 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Bedlam Connect", lifespan=lifespan)
 
+# Initialize the error tracking / tracing provider. No-op when no DSN
+# is configured — see `src/framework/observability/` for the contract
+# and how to swap providers.
+observability.init_app(app)
+
 # Strip empty query-string pairs at request entry so HTML-form
 # submissions ("Apply" with no filter selected → `?x=`) behave the same
 # as omitting the param. See `src/framework/http/middleware.py` for the
 # full convention rationale.
 app.add_middleware(StripEmptyQueryParamsMiddleware)
-
-if settings.SENTRY_DSN:
-
-    class _SentryUserMiddleware(BaseHTTPMiddleware):
-        """Tags the Sentry scope with the authenticated user after each request.
-
-        Uses `request.state.user` set by the auth dependency during route
-        handling. Runs after `call_next` so the user attribute is populated;
-        covers performance traces and non-error events on the same scope.
-        """
-
-        async def dispatch(self, request: Request, call_next):
-            response = await call_next(request)
-            user = getattr(request.state, "user", None)
-            if user is not None:
-                sentry_sdk.set_user({"id": str(user.id), "email": user.email})
-            return response
-
-    app.add_middleware(_SentryUserMiddleware)
 
 
 @app.exception_handler(HTTPException)
@@ -125,11 +93,8 @@ async def unauthorized_exception_handler(request: Request, exc: HTTPException):
     return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
 
-_optional_current_user = fastapi_users.current_user(optional=True)
-
-
 @app.get("/")
-async def read_root(request: Request, user=Depends(_optional_current_user)):
+async def read_root(request: Request, user=Depends(current_optional_user)):
     # Authenticated users land on `/referrals` — the "find new clients"
     # home (see `src/auth_config.py:on_after_login` for the same bias).
     # Anonymous visitors see the public landing page instead of being

--- a/src/test_auth_config.py
+++ b/src/test_auth_config.py
@@ -1,0 +1,55 @@
+"""Tests for the observability-tagging wrappers around fastapi-users deps.
+
+The wrappers in `src/auth_config.py` are the only place we tag the
+observability scope with a user. If a refactor accidentally drops the
+`observability.set_user(...)` call, every error in prod loses its user
+context — pin that here.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from . import auth_config
+
+
+@pytest.mark.asyncio
+async def test_current_active_user_tags_observability():
+    user = SimpleNamespace(id="uid-1", email="u@example.com")
+    with patch.object(auth_config, "observability") as mock_obs:
+        mock_obs.set_user = MagicMock()
+        result = await auth_config.current_active_user(user=user)
+    assert result is user
+    mock_obs.set_user.assert_called_once_with("uid-1", "u@example.com")
+
+
+@pytest.mark.asyncio
+async def test_current_admin_user_tags_observability():
+    user = SimpleNamespace(id="uid-2", email="admin@example.com")
+    with patch.object(auth_config, "observability") as mock_obs:
+        mock_obs.set_user = MagicMock()
+        result = await auth_config.current_admin_user(user=user)
+    assert result is user
+    mock_obs.set_user.assert_called_once_with("uid-2", "admin@example.com")
+
+
+@pytest.mark.asyncio
+async def test_current_optional_user_tags_only_when_present():
+    """Anonymous requests must not inherit a stale identity. When the
+    optional dep returns `None`, `set_user` must not be called."""
+    with patch.object(auth_config, "observability") as mock_obs:
+        mock_obs.set_user = MagicMock()
+        result = await auth_config.current_optional_user(user=None)
+    assert result is None
+    mock_obs.set_user.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_current_optional_user_tags_when_present():
+    user = SimpleNamespace(id="uid-3", email="opt@example.com")
+    with patch.object(auth_config, "observability") as mock_obs:
+        mock_obs.set_user = MagicMock()
+        result = await auth_config.current_optional_user(user=user)
+    assert result is user
+    mock_obs.set_user.assert_called_once_with("uid-3", "opt@example.com")


### PR DESCRIPTION
## Summary

- New `src/framework/observability/` package — `ObservabilityBackend` Protocol with `SentryBackend` + `NoopBackend` implementations. `sentry_sdk` is now imported from exactly one file in the codebase; swapping providers is a 3-step recipe documented in the package README.
- **Bug fix:** the previous `_SentryUserMiddleware` in `main.py` read `request.state.user`, which was never set anywhere in the codebase, so every error in prod arrived with no user attached. User tagging now lives in the auth deps (`current_active_user` / `current_admin_user` / new `current_optional_user`), running inside the request — exceptions raised by the handler carry the user.
- **Cost guard:** `traces_sample_rate` + `profile_session_sample_rate` were hard-coded to `1.0`. Now both are driven by `SENTRY_*_SAMPLE_RATE` settings defaulting to `0.1`. Replay sample rates added (default `0.0`, opt-in).
- **Releases:** new `APP_RELEASE` setting (provider-agnostic name) plumbed into both the backend SDK and the browser SDK so stack traces source-map and "first seen in" works.
- **Frontend:** `base.html` now uses `bundle.tracing.min.js` (or `bundle.tracing.replay.min.js` when replay is enabled), wires `browserTracingIntegration` (and `replayIntegration` conditionally), and sends `release` + `tracesSampleRate`. Template context exposes `observability_frontend` (dict|None); `sentry_dsn`/`environment` keys removed.

## Files

- `src/framework/observability/` — new package: `backend.py`, `sentry_backend.py`, `noop_backend.py`, `__init__.py`, `README.md`, 3 test files.
- `src/auth_config.py` — wrap fastapi-users deps so each resolve tags the observability scope.
- `src/framework/config.py` — `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PROFILES_SAMPLE_RATE`, `SENTRY_REPLAY_SAMPLE_RATE`, `SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE`, `APP_RELEASE`.
- `src/main.py` — direct `sentry_sdk.init` + broken middleware replaced with one `observability.init_app(app)` call.
- `src/framework/rendering/templating.py` + `base.html` — template-context key + provider-aware browser SDK init.
- `src/test_auth_config.py` — new; pins the user-tagging contract on all three wrapped deps.

## Test plan

- [x] `dev lint` — all checks pass.
- [x] Targeted suite (observability + auth + templating + config): 24/24 pass.
- [x] `dev test` — 1664 passed, 2 failed. The two failures are `scripts/dev/test_migrate.py::test_down_one_step_then_up` and `::test_post_write_hooks_format_generated_revision` — alembic-tooling tests with no overlap with this change, verified pre-existing on `main`.
- [ ] After merge: set `APP_RELEASE` in the deploy pipeline (git SHA) so prod gets release-tagged events. Optional: bump `SENTRY_REPLAY_ON_ERROR_SAMPLE_RATE` from `0.0` to `1.0` if Replay seats are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)