### PR TITLE
refactor(framework): lift scalar_to_list + use existing assert_fk_ownership

### DIFF
--- a/src/domain/logic/affiliations/schema.py
+++ b/src/domain/logic/affiliations/schema.py
@@ -38,22 +38,11 @@ from src.framework.schema_validators import (
     ReadProjection,
     StrippedOptionalText,
     WirePayload,
+    scalar_to_list,
 )
 
-
-def _scalar_to_list(v):
-    """Wrap a single string in a one-element list. HTML form posts
-    collapse a 1-checkbox-checked group to a scalar (htmx's `json-enc`
-    only emits an array when the same name appears 2+ times); this
-    normalizes that 1-element case before the `Literal[*TUPLE]` member
-    check fires. Mirrors the helper in `providers/schema.py`."""
-    if isinstance(v, str):
-        return [v]
-    return v
-
-
 InNetworkCarriersField = Annotated[
-    list[Literal[*INSURANCE_CARRIERS]], BeforeValidator(_scalar_to_list)
+    list[Literal[*INSURANCE_CARRIERS]], BeforeValidator(scalar_to_list)
 ]
 
 

--- a/src/domain/logic/posts/handlers.py
+++ b/src/domain/logic/posts/handlers.py
@@ -32,9 +32,20 @@ from pydantic import BaseModel
 from src.domain.logic.programs.repository import ProgramRepository
 from src.domain.logic.providers.repository import ProviderRepository
 from src.domain.models import Program, Provider, User
-from src.framework.http.exceptions import ForbiddenError, NotFoundError
+from src.framework.authz import assert_fk_ownership
 
 logger = logging.getLogger(__name__)
+
+# Per-kind mapping for the FK-ownership check. Each entry says: when the
+# payload's `kind` matches, validate that the named attribute points at a
+# row of `model` (loaded via `repo`) that the requesting user owns.
+# `referral` is intentionally absent — it has no target FK; the dispatch
+# below no-ops for any kind not in this map.
+_KIND_FK_TARGETS: tuple[tuple[str, str, str, type], ...] = (
+    # (kind, attr, parent_noun, parent_model)
+    ("clinician_opening", "provider_id", "Provider", Provider),
+    ("program_intake", "program_id", "Program", Program),
+)
 
 
 async def _assert_post_payload_target_ownership(
@@ -48,45 +59,36 @@ async def _assert_post_payload_target_ownership(
     create/update whose per-kind FK points at a row the requesting user
     doesn't own (superusers bypass).
 
-    Dispatches on ``payload.kind``:
+    Dispatches on ``payload.kind`` via :data:`_KIND_FK_TARGETS`:
 
     * ``clinician_opening`` — checks ``payload.provider_id`` against
       ``Provider.owner_id``.
     * ``program_intake`` — checks ``payload.program_id`` against
       ``Program.owner_id``.
-    * ``referral`` — no target FK; no-op.
+    * ``referral`` (and any future kind without a target FK) — no-op.
 
     404 when the target row doesn't exist (no info leak about other
     users' ids); 403 when it exists but belongs to someone else. PATCH
     payloads where the FK field is None (the PATCH doesn't touch the
     FK) are a no-op — only flow through the ownership check when the
-    payload is actually trying to set a new target.
+    payload is actually trying to set a new target. Both branches share
+    the generic :func:`~src.framework.authz.assert_fk_ownership` helper.
 
     See module docstring for why the dispatcher lives here rather than
     on :class:`PostKindSpec` per-kind."""
     kind = getattr(payload, "kind", None)
-    if kind == "clinician_opening":
-        provider_id = getattr(payload, "provider_id", None)
-        if provider_id is None:
-            return
-        provider = await provider_repo._get_by_id(Provider, provider_id)
-        if provider is None:
-            raise NotFoundError(detail=f"Provider {provider_id} not found")
-        if not requesting_user.is_superuser and provider.owner_id != requesting_user.id:
-            raise ForbiddenError(
-                detail="You may only post availability for a Provider you own"
-            )
-        return
-    if kind == "program_intake":
-        program_id = getattr(payload, "program_id", None)
-        if program_id is None:
-            return
-        program = await program_repo._get_by_id(Program, program_id)
-        if program is None:
-            raise NotFoundError(detail=f"Program {program_id} not found")
-        if not requesting_user.is_superuser and program.owner_id != requesting_user.id:
-            raise ForbiddenError(
-                detail="You may only post availability for a Program you own"
-            )
+    repos = {"provider_id": provider_repo, "program_id": program_repo}
+    for target_kind, attr, parent_noun, parent_model in _KIND_FK_TARGETS:
+        if kind != target_kind:
+            continue
+        await assert_fk_ownership(
+            payload=payload,
+            attr=attr,
+            requesting_user=requesting_user,
+            parent_repo=repos[attr],
+            parent_model=parent_model,
+            parent_noun=parent_noun,
+            child_noun="post",
+        )
         return
     # referral and any future kind without a target FK: no-op.

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -71,6 +71,7 @@ from src.framework.schema_validators import (
     StrippedOptionalText,
     StrippedText,
     WirePayload,
+    scalar_to_list,
 )
 
 # `description` and `referral_instructions` on `opening` are
@@ -84,19 +85,6 @@ TextareaOptional = Annotated[StrippedOptionalText, HtmlTextarea()]
 # `<input type=url>`. Schema-side validation stays the same; browser
 # gates submission on URL syntax client-side.
 UrlOptional = Annotated[StrippedOptionalText, HtmlUrl()]
-
-
-def _scalar_to_list(v):
-    """Wrap a single string in a one-element list. HTML form posts collapse
-    a 1-checkbox-checked group to a scalar (htmx's `json-enc` only emits
-    an array when the same name appears 2+ times); this normalizes that
-    1-element case before the `Literal[*TUPLE]` member check fires. The
-    0-element case is handled by the field default `[]`; the 2+ case
-    already arrives as a list. Reused by every multi-checkbox field
-    (`desired_times`, `services`, and the upcoming `settings`)."""
-    if isinstance(v, str):
-        return [v]
-    return v
 
 
 def _empty_to_none(v):
@@ -119,12 +107,12 @@ OptionalInsuranceCarrier = Annotated[
 
 # Annotated aliases for the multi-checkbox fields. The `BeforeValidator`
 # runs first and normalizes a scalar string to a single-element list
-# (see `_scalar_to_list`); `Literal[*TUPLE]` then validates each member.
+# (see `scalar_to_list` in `framework/schema_validators.py`); `Literal[*TUPLE]` then validates each member.
 DesiredTimesField = Annotated[
-    list[Literal[*DESIRED_TIME_SLOTS]], BeforeValidator(_scalar_to_list)
+    list[Literal[*DESIRED_TIME_SLOTS]], BeforeValidator(scalar_to_list)
 ]
 ServicesField = Annotated[
-    list[Literal[*REFERRAL_SERVICES]], BeforeValidator(_scalar_to_list)
+    list[Literal[*REFERRAL_SERVICES]], BeforeValidator(scalar_to_list)
 ]
 # `opening.services` is required-min-1 on the wire; layer
 # the constraint over the shared alias so the scalar-coercion still runs
@@ -133,18 +121,18 @@ ServicesField = Annotated[
 # (Update — `None` means "leave unchanged"; an empty list 422s).
 RequiredServicesField = Annotated[ServicesField, Field(min_length=1)]
 SettingsField = Annotated[
-    list[Literal[*TREATMENT_SETTINGS]], BeforeValidator(_scalar_to_list)
+    list[Literal[*TREATMENT_SETTINGS]], BeforeValidator(scalar_to_list)
 ]
 # `opening.settings` is required-min-1 on the wire; same
 # pattern as services.
 RequiredSettingsField = Annotated[SettingsField, Field(min_length=1)]
-LanguagesField = Annotated[list[Literal[*LANGUAGES]], BeforeValidator(_scalar_to_list)]
+LanguagesField = Annotated[list[Literal[*LANGUAGES]], BeforeValidator(scalar_to_list)]
 # `opening.languages` is required-min-1 on the wire — every
 # practice speaks at least one language, and the unfilterable "no
 # languages" state is meaningless. Mirrors services / settings.
 RequiredLanguagesField = Annotated[LanguagesField, Field(min_length=1)]
 AgeGroupsField = Annotated[
-    list[Literal[*CLIENT_AGE_GROUPS]], BeforeValidator(_scalar_to_list)
+    list[Literal[*CLIENT_AGE_GROUPS]], BeforeValidator(scalar_to_list)
 ]
 # `opening.age_groups` is required-min-1 on the wire — every
 # practice serves at least one age bucket.
@@ -152,7 +140,7 @@ RequiredAgeGroupsField = Annotated[AgeGroupsField, Field(min_length=1)]
 # `opening.genders` is a multi-checkbox on the wire, same
 # normalization shape as services/settings/age_groups. Empty list is
 # allowed — "no restriction stated" / serves any gender.
-GendersField = Annotated[list[Literal[*GENDERS]], BeforeValidator(_scalar_to_list)]
+GendersField = Annotated[list[Literal[*GENDERS]], BeforeValidator(scalar_to_list)]
 
 
 # --- Shared flatten helper ----------------------------------------------

--- a/src/domain/logic/programs/handlers.py
+++ b/src/domain/logic/programs/handlers.py
@@ -85,7 +85,9 @@ async def program_form_extras(
     if target is not None:
         org_ids = {o.id for o in orgs}
         if target.org_id not in org_ids:
-            attached = await organization_repo._get_by_id(Organization, target.org_id)
+            attached = await organization_repo.get_by_model_id(
+                Organization, target.org_id
+            )
             if attached is not None:
                 orgs = [*orgs, attached]
     return {"organizations": orgs}

--- a/src/domain/logic/providers/schema.py
+++ b/src/domain/logic/providers/schema.py
@@ -59,6 +59,7 @@ from src.framework.schema_validators import (
     StrippedOptionalText,
     StrippedText,
     WirePayload,
+    scalar_to_list,
 )
 
 _NPI_RE = re.compile(r"^[0-9]{10}$")
@@ -91,21 +92,10 @@ NpiText = Annotated[
 ]
 
 
-def _scalar_to_list(v):
-    """Wrap a single string in a one-element list. HTML form posts collapse
-    a 1-checkbox-checked group to a scalar (htmx's `json-enc` only emits an
-    array when the same name appears 2+ times); this normalizes that
-    1-element case before the `Literal[*TUPLE]` member check fires. Mirrors
-    the helper in `src/domain/logic/posts/schema.py`."""
-    if isinstance(v, str):
-        return [v]
-    return v
-
-
 # `in_network_carriers` is a multi-checkbox group; scalar→singleton coercion
 # matches the pattern shared with PA/CR multi-select fields.
 InNetworkCarriersField = Annotated[
-    list[Literal[*INSURANCE_CARRIERS]], BeforeValidator(_scalar_to_list)
+    list[Literal[*INSURANCE_CARRIERS]], BeforeValidator(scalar_to_list)
 ]
 
 

--- a/src/framework/authz.py
+++ b/src/framework/authz.py
@@ -136,7 +136,7 @@ async def assert_fk_ownership(
     fk_id = getattr(payload, attr, None)
     if fk_id is None:
         return
-    parent = await parent_repo._get_by_id(parent_model, fk_id)
+    parent = await parent_repo.get_by_model_id(parent_model, fk_id)
     if parent is None:
         from src.framework.http.exceptions import NotFoundError
 

--- a/src/framework/schema_validators.py
+++ b/src/framework/schema_validators.py
@@ -62,6 +62,30 @@ def _strip_optional(v: str | None) -> str | None:
     return v or None
 
 
+def scalar_to_list(v):
+    """Wrap a single string in a one-element list.
+
+    HTML form posts collapse a 1-checkbox-checked group to a scalar
+    (htmx's `json-enc` only emits an array when the same name appears
+    2+ times); this `BeforeValidator` normalizes that 1-element case
+    before the `Literal[*TUPLE]` member check fires. The 0-element
+    case is handled by the field default `[]`; the 2+ case already
+    arrives as a list.
+
+    Used by every multi-checkbox field across domain schemas
+    (posts, providers, affiliations, ...). Each schema layers its own
+    `Literal[*TUPLE]` over the shared coercion:
+
+        MyField = Annotated[
+            list[Literal[*MY_TUPLE]],
+            BeforeValidator(scalar_to_list),
+        ]
+    """
+    if isinstance(v, str):
+        return [v]
+    return v
+
+
 # --- Annotated field types ----------------------------------------------
 #
 # Attach the cleaning rule to the field's type, not to a per-class

--- a/src/framework/test_schema_validators.py
+++ b/src/framework/test_schema_validators.py
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 from typing import Annotated, ClassVar, Literal
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, BeforeValidator, ValidationError
 
 from src.framework.schema_validators import (
     PartialUpdate,
@@ -22,6 +22,7 @@ from src.framework.schema_validators import (
     StrippedOptionalText,
     StrippedText,
     WirePayload,
+    scalar_to_list,
 )
 
 
@@ -242,3 +243,41 @@ def test_coercion_applies_through_partial_update():
     instance = _Update(fk="", name="")
     assert instance.fk is None
     assert instance.name == ""
+
+
+def test_scalar_to_list_wraps_lone_string_in_list():
+    """An HTML form with one checkbox checked posts a scalar; the
+    coercion lifts it to a one-element list before `Literal` member
+    validation runs."""
+
+    class _Checkboxes(WirePayload):
+        choices: Annotated[
+            list[Literal["a", "b", "c"]], BeforeValidator(scalar_to_list)
+        ] = []
+
+    assert _Checkboxes(choices="a").choices == ["a"]
+
+
+def test_scalar_to_list_passes_lists_through_unchanged():
+    """2+ checkboxes arrive as a list already; the coercion is a no-op."""
+
+    class _Checkboxes(WirePayload):
+        choices: Annotated[
+            list[Literal["a", "b", "c"]], BeforeValidator(scalar_to_list)
+        ] = []
+
+    assert _Checkboxes(choices=["a", "b"]).choices == ["a", "b"]
+
+
+def test_scalar_to_list_rejects_invalid_member_after_lifting():
+    """Coercion runs before the `Literal[...]` member check, so an
+    invalid scalar still 422s — the helper doesn't bypass validation,
+    it just normalizes the wire shape."""
+
+    class _Checkboxes(WirePayload):
+        choices: Annotated[
+            list[Literal["a", "b", "c"]], BeforeValidator(scalar_to_list)
+        ] = []
+
+    with pytest.raises(ValidationError):
+        _Checkboxes(choices="z")


### PR DESCRIPTION
## Summary

Three small dedup wins that consolidate domain code around helpers the framework already provides (or now provides):

- **`scalar_to_list` lifts to `framework/schema_validators.py`.** The HTML-form-checkbox `scalar → [scalar]` coercion was defined verbatim in `posts/schema.py`, `providers/schema.py`, and `affiliations/schema.py` — docstrings literally cross-referenced each other. The validators module already documents \"trigger to add: a primitive used by 2+ schema modules,\" so this is the textbook home.
- **Post payload-authz delegates to the existing `assert_fk_ownership`.** The post handler had two near-identical 11-line `if kind == ...` blocks differing only in (attr, model, repo, noun). The framework's `assert_fk_ownership` already handles this shape (providers and programs already use it); posts was the outlier. Replacing the if-elif chain with a `(kind, attr, noun, model)` table + one helper call shrinks the function to a single loop.
- **Two cross-cluster `_get_by_id` violations → `get_by_model_id`** (`framework/authz.py:139`, `programs/handlers.py:88`). The convention in `base_repository.py` reserves the underscored form for intra-cluster use; these were the only remaining violations.

## Behavior change

Post payload-authz error-message wording shifts from \"You may only post availability for a {parent} you own\" to the generic \"You may only attach a post to a {parent} you own\" — no tests pinned the old wording, and the new phrasing matches the provider/program payload-authz messages.

## Test plan

- [x] `dev test` — 1653 passed (3 new `scalar_to_list` tests), 96 skipped
- [x] `dev lint` — all checks pass
- [x] `dev test contract` — 40 passed
- [x] Audited every remaining `_get_by_id` call site to confirm only intra-cluster uses remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)