### PR TITLE
ci: split into PR (lite) and queue (full) tiers via Mergify queue branches

### DIFF
--- a/.github/workflows/ci-queue.yml
+++ b/.github/workflows/ci-queue.yml
@@ -1,0 +1,130 @@
+name: CI - queue tier (full)
+
+# Triggered on push to Mergify's queue branches. Runs the full suite,
+# contract tests, and the docker health check — the real correctness
+# gate before a PR merges to main. `.mergify.yml`'s `merge_conditions`
+# block merging until these checks succeed on the queue branch.
+#
+# Mergify rebases queued PRs onto a synthetic `mergify/merge-queue/<base>/...`
+# branch and pushes it; that push fires this workflow. Batched queues
+# (we use `batch_size: 3`) push one branch per batch — this workflow
+# proves the batch's combined diff is still green before any of the
+# PRs in the batch merge.
+#
+# Job names match the ones the previous single-tier `ci.yml` used so
+# branch-protection "required checks" entries keep working without a
+# repo-settings change.
+
+on:
+  push:
+    branches:
+      # Mergify's queue branch naming. Adjust if Mergify config changes.
+      - 'mergify/merge-queue/**'
+      - 'mergify/batches/**'
+  workflow_dispatch: # Allow manual runs against any ref (debugging).
+
+env:
+  PYTHON_VERSION: '3.11'
+  DATABASE_URL: sqlite+aiosqlite:///./test.db
+  SECRET: test-secret-key-for-ci-only-padded-to-32-bytes
+  ALGORITHM: HS256
+  ACCESS_TOKEN_EXPIRE_MINUTES: 60
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[full]
+
+      - name: Create test database
+        run: alembic -c config/alembic.ini upgrade head
+
+      - name: Run tests
+        run: dev test --tb short -v
+
+  contract-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[full]
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: playwright install --with-deps chromium
+
+      - name: Create test database
+        run: alembic -c config/alembic.ini upgrade head
+
+      - name: Run contract tests
+        run: dev test tests/test_contract --tb short -v
+
+  docker-health-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image for testing
+        run: docker build -f ./deployment/docker/Dockerfile -t test-image .
+
+      - name: Create test data directory
+        run: mkdir -p ./test-data
+
+      - name: Start application with docker-compose
+        run: docker compose -f deployment/docker/docker-compose.test.yml up -d
+        env:
+          SECRET: ${{ env.SECRET }}
+          ACCESS_TOKEN_EXPIRE_MINUTES: ${{ env.ACCESS_TOKEN_EXPIRE_MINUTES }}
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          ALGORITHM: ${{ env.ALGORITHM }}
+
+      - name: Wait for application to be healthy
+        run: |
+          timeout 60 bash -c 'until docker compose -f deployment/docker/docker-compose.test.yml ps | grep -q healthy; do echo "Waiting for health check..."; sleep 2; done'
+
+      - name: Test application endpoints
+        run: |
+          curl -f http://localhost:8000/health || exit 1
+          curl -f http://localhost:8000/docs/ || exit 1
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose -f deployment/docker/docker-compose.test.yml logs
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose -f deployment/docker/docker-compose.test.yml down
+          docker rmi test-image || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,15 @@
-name: CI - Test and lint
+name: CI - PR tier (lite)
+
+# Two-tier CI plan:
+#  - This workflow runs on every `pull_request` push. Lite by design:
+#    `linting` + `tests-affected`. Purpose is author feedback.
+#  - `ci-queue.yml` runs on push to Mergify's `mergify/merge-queue/**`
+#    branches and is the real correctness gate (full suite, contract
+#    tests, docker health check).
+#
+# Mergify's `queue_conditions` gates queue admission on the PR-tier
+# checks; `merge_conditions` gates the actual merge on the queue-tier
+# checks. See `.mergify.yml`.
 
 on:
   pull_request:
@@ -6,8 +17,6 @@ on:
   workflow_dispatch: # Allow manual runs
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   PYTHON_VERSION: '3.11'
   DATABASE_URL: sqlite+aiosqlite:///./test.db
   # Padded to >=32 chars; PyJWT warns on shorter HMAC keys for SHA256.
@@ -16,89 +25,6 @@ env:
   ACCESS_TOKEN_EXPIRE_MINUTES: 60
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[full]
-
-      - name: Create test database
-        run: |
-          alembic -c config/alembic.ini upgrade head
-
-      - name: Show database setup help on failure
-        if: failure()
-        run: |
-          echo "❌ Database setup failed!"
-          echo "💡 To reproduce this locally, run: alembic -c config/alembic.ini upgrade head"
-          echo "   Or use the development CLI: dev migrate up"
-
-      - name: Run tests
-        run: dev test --tb short -v
-
-      - name: Show test failure help
-        if: failure()
-        run: |
-          echo "❌ Tests failed!"
-          echo "💡 To reproduce this locally, run: dev test --tb short -v"
-          echo "   This runs the full default test suite (excludes contract tests; those run in the contract-tests job)."
-
-  contract-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[full]
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Install Playwright browsers
-        run: |
-          playwright install --with-deps chromium
-
-      - name: Create test database
-        run: |
-          alembic -c config/alembic.ini upgrade head
-
-      - name: Run contract tests
-        run: dev test tests/test_contract --tb short -v
-
-      - name: Show contract test failure help
-        if: failure()
-        run: |
-          echo "❌ Contract tests failed!"
-          echo "💡 To reproduce this locally:"
-          echo "     pip install -e .[full]"
-          echo "     playwright install chromium"
-          echo "     dev test tests/test_contract --tb short -v"
-          echo "   Contract tests are excluded from default 'dev test' runs;"
-          echo "   they must be invoked with the explicit path above."
-
   linting:
     runs-on: ubuntu-latest
     steps:
@@ -106,9 +32,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -123,59 +51,61 @@ jobs:
         run: |
           echo "❌ Linting checks failed!"
           echo "💡 To reproduce this locally, run: dev lint"
-          echo "   This runs black, isort, and title case checks"
           echo "   To fix formatting issues, you can run:"
           echo "     black .           # Fix code formatting"
           echo "     isort .           # Fix import ordering"
 
-  docker-health-check:
+  tests-affected:
     runs-on: ubuntu-latest
     steps:
+      # `fetch-depth: 0` is required so `git diff origin/main...HEAD`
+      # works inside `dev test --affected` — the default shallow clone
+      # only has `HEAD`, no merge-base computable.
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Build Docker image for testing
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
         run: |
-          docker build -f ./deployment/docker/Dockerfile -t test-image .
+          python -m pip install --upgrade pip
+          pip install -e .[full]
 
-      - name: Create test data directory
-        run: |
-          mkdir -p ./test-data
+      - name: Create test database
+        run: alembic -c config/alembic.ini upgrade head
 
-      - name: Start application with docker-compose
-        run: |
-          docker compose -f deployment/docker/docker-compose.test.yml up -d
-        env:
-          SECRET: ${{ env.SECRET }}
-          ACCESS_TOKEN_EXPIRE_MINUTES: ${{ env.ACCESS_TOKEN_EXPIRE_MINUTES }}
-          DATABASE_URL: ${{ env.DATABASE_URL }}
-          ALGORITHM: ${{ env.ALGORITHM }}
+      - name: Run affected tests
+        # `--skip-lint` because the `linting` job above already runs
+        # the lint suite; running it again here would just double the
+        # walltime. The selector escalates to the full default suite
+        # when a blast-radius file changed — see
+        # `scripts/affected_tests.py` for the list.
+        run: dev test --affected --base origin/main --skip-lint --tb short -v
 
-      - name: Wait for application to be healthy
-        run: |
-          timeout 60 bash -c 'until docker compose -f deployment/docker/docker-compose.test.yml ps | grep -q healthy; do echo "Waiting for health check..."; sleep 2; done'
-
-      - name: Test application endpoints
-        run: |
-          # Test the health endpoint
-          curl -f http://localhost:8000/health || exit 1
-          # Test the docs endpoint
-          curl -f http://localhost:8000/docs/ || exit 1
-
-      - name: Show container logs on failure
+      - name: Show test failure help
         if: failure()
         run: |
-          docker compose -f deployment/docker/docker-compose.test.yml logs
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker compose -f deployment/docker/docker-compose.test.yml down
-          docker rmi test-image || true
+          echo "❌ Affected tests failed!"
+          echo "💡 To reproduce locally:"
+          echo "     dev test --affected --base origin/main --skip-lint --tb short -v"
+          echo "   To see which files the selector picked up:"
+          echo "     git diff --name-only origin/main...HEAD"
+          echo "   Then map each path to its colocated test_*.py per"
+          echo "   scripts/affected_tests.py."
+          echo ""
+          echo "ℹ️  The full suite + contract tests + docker health check"
+          echo "    run again in the merge-queue tier — see ci-queue.yml."
 
   queue:
     runs-on: ubuntu-latest
-    needs: [tests, contract-tests, linting, docker-health-check]
+    needs: [linting, tests-affected]
     if: success() && github.event_name == 'pull_request'
     permissions:
       pull-requests: write

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,15 +7,17 @@ commands_restrictions:
 
 queue_rules:
   - name: default
+    # Two-tier CI: `queue_conditions` gate queue admission on the lite
+    # PR-tier checks (linting + tests-affected from `ci.yml`).
+    # `merge_conditions` gate the actual merge on the full queue-tier
+    # checks run by `ci-queue.yml` against the rebased queue branch.
+    # See the workflow files for what each check actually does.
     queue_conditions:
-      - check-success = tests
-      - check-success = contract-tests
       - check-success = linting
-      - check-success = docker-health-check
+      - check-success = tests-affected
     merge_conditions:
       - check-success = tests
       - check-success = contract-tests
-      - check-success = linting
       - check-success = docker-health-check
     merge_method: squash
     batch_size: 3


### PR DESCRIPTION
## Summary

Final PR in the CI-speedup series. Stack: #817 (composite actions) → #819 (\`dev test --affected\`) → this PR. **Must merge in that order.**

- `.github/workflows/ci.yml` is now the **PR tier**: only `linting` + `tests-affected` (the selector from #819) on every \`pull_request\`. Author sees green/red on the lite checks; the queue job still comments \`@mergifyio queue\` once both pass.
- `.github/workflows/ci-queue.yml` is the new **queue tier**: triggered by \`push\` to \`mergify/merge-queue/**\` (and \`mergify/batches/**\` as a safety glob). Runs the existing \`tests\` + \`contract-tests\` + \`docker-health-check\` against the rebased queue branch. Job names match the previous single-tier names so branch-protection entries keep resolving.
- `.mergify.yml`: \`queue_conditions\` now lists the lite checks (\`linting\`, \`tests-affected\`); \`merge_conditions\` lists the full checks (\`tests\`, \`contract-tests\`, \`docker-health-check\`).

## Expected effect

A typical single-file source PR now hits ~30-60s of pre-queue CI (lint + a handful of colocated tests) instead of ~5+ minutes (full suite + Playwright + Docker build). Author iteration loop drops from \"push and go get coffee\" to \"push and watch.\" The merge-queue tier still runs the full correctness gate against the rebased commit, so we don't trade safety for speed.

When a blast-radius file changes (\`pyproject.toml\`, \`alembic/\`, \`src/framework/config.py\`, anything in \`.github/\`), the selector escalates to the full default suite on the PR — see \`scripts/affected_tests.py\` for the full list.

## ⚠️ Before merging

1. **Branch protection on \`main\`.** The current \"required status checks\" likely names \`tests\`, \`contract-tests\`, \`docker-health-check\`. After this PR, those jobs only run on \`mergify/merge-queue/**\` branches — never on PR heads. Two options:
   - Leave the required-checks list alone. Mergify carries the queue-branch SHA into main via the squash merge; GitHub treats the squashed commit's checks as inherited. This *should* work because Mergify uses the GitHub merge API. **Test on a throwaway PR before relying on it.**
   - Update the required-checks list to include the new \`tests-affected\` and \`linting\` names instead. Loses the safety of "main can't accept a commit without the full suite" — depends on Mergify exclusively. Less defensive.
2. **Queue-branch name pattern.** I included both \`mergify/merge-queue/**\` and \`mergify/batches/**\` in \`ci-queue.yml\`'s trigger as a safety glob. If Mergify is configured to use a different pattern, the queue-tier workflow won't fire and \`merge_conditions\` will block merges. **Verify on the first PR through the new flow** — if the queue tier doesn't trigger, adjust \`ci-queue.yml\` and \`.mergify.yml\` accordingly.

## Test plan

- [ ] Merge in order: #817, #819, this PR.
- [ ] Open a throwaway one-file PR and verify only \`linting\` + \`tests-affected\` run. Confirm \`@mergifyio queue\` still gets commented.
- [ ] After Mergify rebases onto its queue branch, confirm \`ci-queue.yml\` fires and the full \`tests\`/\`contract-tests\`/\`docker-health-check\` succeed.
- [ ] Confirm Mergify merges to \`main\` once queue checks pass. If branch protection blocks, see the warning above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)