### PR TITLE
refactor(framework): lift list_owned_by + full_address out of domain

### DIFF
--- a/src/domain/logic/organizations/repository.py
+++ b/src/domain/logic/organizations/repository.py
@@ -16,8 +16,6 @@ read the tree but won't widen the writer surface.
 import uuid
 from typing import Any, Sequence
 
-from sqlalchemy import select
-
 from src.domain.models import Organization
 from src.framework.http.exceptions import NotFoundError
 from src.framework.persistence.base_repository import BaseRepository
@@ -31,12 +29,7 @@ class OrganizationRepository(BaseRepository):
         can only attach Providers to Orgs they own (#524 retro: Org
         ownership is the boundary for who may attach Providers, mirroring
         ``Organization.write_authz``)."""
-        stmt = (
-            select(Organization)
-            .filter(Organization.owner_id == user_id)
-            .order_by(Organization.created_at.desc())
-        )
-        return await self._list(stmt)
+        return await self.list_owned_by(Organization, user_id)
 
     async def _resolve_root_id(
         self, parent_org_id: uuid.UUID | None

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -46,6 +46,7 @@ All three helpers are exposed as Jinja globals by
 from typing import Any
 
 from src.domain.models.enums import CLIENT_AGE_GROUPS_BY_KEY
+from src.framework.rendering.address import full_address
 
 # Gender values that don't fit a "<age> <gender>" phrase. `gender_diverse`
 # is the umbrella token (genderqueer / agender / two-spirit / etc.) —
@@ -119,20 +120,6 @@ def _location_chunk(
     if not any((city, state, zip_code)):
         return None
     return {"city": city, "state": state, "zip": zip_code}
-
-
-def _full_address(
-    city: str | None, state: str | None, zip_code: str | None
-) -> str | None:
-    """Compose ``"City, ST ZIP"`` for the detail page's expanded address
-    row. Returns ``None`` when no parts are present so templates omit
-    the row entirely."""
-    if not any((city, state, zip_code)):
-        return None
-    head = ", ".join(p for p in (city, state) if p)
-    if zip_code:
-        return f"{head} {zip_code}" if head else zip_code
-    return head or None
 
 
 def _referral_or_none(website: str | None, instructions: str | None) -> dict | None:
@@ -277,7 +264,7 @@ def post_card_view(post) -> dict[str, Any]:
             ),
             description=getattr(d, "description", None),
             desired_times=list(getattr(d, "desired_times", None) or []),
-            full_address=_full_address(
+            full_address=full_address(
                 getattr(d, "location_city", None),
                 getattr(d, "location_state", None),
                 getattr(d, "location_zip", None),
@@ -334,7 +321,7 @@ def post_card_view(post) -> dict[str, Any]:
                 else None
             ),
             full_address=(
-                _full_address(
+                full_address(
                     getattr(p, "location_city", None),
                     getattr(p, "location_state", None),
                     getattr(p, "location_zip", None),

--- a/src/domain/logic/programs/repository.py
+++ b/src/domain/logic/programs/repository.py
@@ -1,16 +1,13 @@
 """Repository for the `Program` entity.
 
-Mostly delegates to ``BaseRepository`` for the generic CRUD path the
-framework's mount layer calls. The one custom read — ``list_for_user``
-— mirrors :meth:`OrganizationRepository.list_for_user` /
-:meth:`ProviderRepository.list_for_user` so the same per-user scoping
-pattern works on the ``intake`` post form.
+Delegates to ``BaseRepository`` for the generic CRUD path the
+framework's mount layer calls. ``list_for_user`` is a domain-named
+entry point onto the framework's ``list_owned_by`` helper — same
+"owned rows newest first" shape Organization and Provider use.
 """
 
 import uuid
 from typing import Sequence
-
-from sqlalchemy import select
 
 from src.domain.models import Program
 from src.framework.persistence.base_repository import BaseRepository
@@ -20,18 +17,10 @@ from src.framework.persistence.dependencies import register_repository
 class ProgramRepository(BaseRepository):
     async def list_for_user(self, user_id: uuid.UUID) -> Sequence[Program]:
         """Lists every Program owned by ``user_id``, newest first.
-
-        Mirrors :meth:`OrganizationRepository.list_for_user` and
-        :meth:`ProviderRepository.list_for_user`. Drives the
-        ``intake`` post create/edit form's Program-picker
+        Drives the ``intake`` post create/edit form's Program-picker
         dropdown and pairs with the wire-level ownership check in
         ``POST_ENTITY.payload_authz_path``."""
-        stmt = (
-            select(Program)
-            .filter(Program.owner_id == user_id)
-            .order_by(Program.created_at.desc())
-        )
-        return await self._list(stmt)
+        return await self.list_owned_by(Program, user_id)
 
 
 get_program_repository = register_repository(ProgramRepository)

--- a/src/domain/logic/providers/repository.py
+++ b/src/domain/logic/providers/repository.py
@@ -31,13 +31,7 @@ class ProviderRepository(BaseRepository):
         """Lists every provider owned by the given user, newest first.
         `offset`/`limit` come from the pagination layer (the bespoke
         `handle_list_user_providers` handler computes them)."""
-        return await self._list(
-            select(Provider)
-            .filter(Provider.owner_id == user_id)
-            .order_by(Provider.created_at.desc()),
-            offset=offset,
-            limit=limit,
-        )
+        return await self.list_owned_by(Provider, user_id, offset=offset, limit=limit)
 
     async def list_for_verification(self) -> Sequence[Provider]:
         """Return providers eligible for the nightly verification job

--- a/src/domain/logic/providers/test_view.py
+++ b/src/domain/logic/providers/test_view.py
@@ -3,7 +3,6 @@
 from types import SimpleNamespace
 
 from src.domain.logic.providers.view import (
-    _full_address,
     _insurance_summary,
     affiliation_card_view,
     provider_card_view,
@@ -74,24 +73,10 @@ def _stub_provider(**overrides):
     return SimpleNamespace(**defaults)
 
 
-# --- _full_address -----------------------------------------------------
-
-
-def test_full_address_composes_all_three_parts():
-    assert _full_address("Brooklyn", "NY", "11201") == "Brooklyn, NY 11201"
-
-
-def test_full_address_handles_missing_zip():
-    assert _full_address("Brooklyn", "NY", None) == "Brooklyn, NY"
-
-
-def test_full_address_handles_missing_city():
-    assert _full_address(None, "NY", "11201") == "NY 11201"
-
-
-def test_full_address_returns_none_when_all_empty():
-    assert _full_address(None, None, None) is None
-    assert _full_address("", "", "") is None
+# Address composition lives in `src/framework/rendering/address.py`;
+# its full unit-test matrix is `src/framework/rendering/test_address.py`.
+# `provider_card_view`'s integration with that helper is exercised by
+# the card-view tests below.
 
 
 # --- _insurance_summary ------------------------------------------------

--- a/src/domain/logic/providers/view.py
+++ b/src/domain/logic/providers/view.py
@@ -12,23 +12,7 @@ Exposed as a Jinja global via `src/domain/template_globals.py`.
 
 from typing import Any
 
-
-def _full_address(
-    city: str | None, state: str | None, zip_code: str | None
-) -> str | None:
-    """Compose ``"City, ST ZIP"`` from the three location columns.
-
-    Returns ``None`` when every part is empty so templates can ``{% if
-    view.full_address %}`` rather than render a blank row. Mirrors
-    :func:`src.domain.logic.posts.view._full_address` — kept separate
-    because the providers logic module should not import from the posts
-    logic module (cross-cluster boundary)."""
-    if not any((city, state, zip_code)):
-        return None
-    head = ", ".join(p for p in (city, state) if p)
-    if zip_code:
-        return f"{head} {zip_code}" if head else zip_code
-    return head or None
+from src.framework.rendering.address import full_address
 
 
 def _role_attr(provider, attr, default=None):
@@ -179,7 +163,7 @@ def affiliation_card_view(affiliation, org=None) -> dict[str, Any]:
         "org_id": org_id,
         "org_name": (getattr(org, "name", None) if org else None),
         "org_url": (f"/organizations/{org_id}" if org_id is not None else None),
-        "full_address": _full_address(
+        "full_address": full_address(
             getattr(affiliation, "location_city", None),
             getattr(affiliation, "location_state", None),
             getattr(affiliation, "location_zip", None),
@@ -264,7 +248,7 @@ def provider_card_view(provider) -> dict[str, Any]:
     return {
         "practice_name": (getattr(org, "name", None) if org else None),
         "practice_url": (f"/organizations/{org_id}" if org_id is not None else None),
-        "full_address": _full_address(
+        "full_address": full_address(
             _role_attr(provider, "location_city"),
             _role_attr(provider, "location_state"),
             _role_attr(provider, "location_zip"),

--- a/src/framework/persistence/base_repository.py
+++ b/src/framework/persistence/base_repository.py
@@ -190,6 +190,35 @@ class BaseRepository:
         stmt = stmt.order_by(order_by)
         return await self._list(stmt, offset=offset, limit=limit)
 
+    async def list_owned_by(
+        self,
+        model: type[M],
+        user_id: UUID,
+        *,
+        owner_attr: str = "owner_id",
+        offset: int = 0,
+        limit: int | None = None,
+    ) -> Sequence[M]:
+        """Framework helper for the "rows owned by a user, newest first"
+        listing shape — `select(model).filter(<owner_attr> == user_id)
+        .order_by(model.created_at.desc())`. Per-entity
+        `list_for_user`-style methods delegate here so the query
+        construction lives in one place; the per-entity wrapper keeps
+        the domain-named entry point and its docstring describing
+        *why* the listing exists.
+
+        `owner_attr` defaults to ``"owner_id"`` (the column every
+        owned entity uses today). Threaded as a kwarg so a future
+        renamed-FK entity can opt in without altering this method or
+        its callers.
+        """
+        stmt = (
+            select(model)
+            .filter(getattr(model, owner_attr) == user_id)
+            .order_by(model.created_at.desc())
+        )
+        return await self._list(stmt, offset=offset, limit=limit)
+
     async def create_polymorphic(
         self, parent: Any, detail: Any, *, detail_relationship: str
     ) -> Any:

--- a/src/framework/persistence/test_base_repository.py
+++ b/src/framework/persistence/test_base_repository.py
@@ -268,3 +268,103 @@ async def test_list_default_none_exclude_self_returns_everyone(
         rows = await repo.list_default(User, order_by=User.username)
 
     assert len(rows) == 2
+
+
+# --- list_owned_by --------------------------------------------------------
+
+
+async def test_list_owned_by_returns_only_rows_owned_by_user(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`list_owned_by` filters by `owner_id` — rows owned by a
+    different user are excluded."""
+    owner = await _seed_users(db_test_session_manager, ["owner"])
+    other = await _seed_users(db_test_session_manager, ["other"])
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(make_provider_with_org(owner_id=owner[0].id))
+            session.add(make_provider_with_org(owner_id=other[0].id))
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo.list_owned_by(Provider, owner[0].id)
+
+    assert len(rows) == 1
+    assert rows[0].owner_id == owner[0].id
+
+
+async def test_list_owned_by_orders_newest_first(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`list_owned_by` orders by `created_at` descending. Set
+    `created_at` explicitly to force a deterministic ordering — SQLite's
+    server-default `CURRENT_TIMESTAMP` is second-precision and rows
+    inserted in the same second would tie."""
+    from datetime import datetime, timedelta, timezone
+
+    owner = await _seed_users(db_test_session_manager, ["owner"])
+    earlier = datetime.now(timezone.utc)
+    later = earlier + timedelta(seconds=1)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                make_provider_with_org(
+                    owner_id=owner[0].id,
+                    practice_name="First",
+                    created_at=earlier,
+                )
+            )
+            session.add(
+                make_provider_with_org(
+                    owner_id=owner[0].id,
+                    practice_name="Second",
+                    created_at=later,
+                )
+            )
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo.list_owned_by(Provider, owner[0].id)
+
+    assert [p.org.name for p in rows] == ["Second", "First"]
+
+
+async def test_list_owned_by_honors_offset_and_limit(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`offset` and `limit` flow through to `_list`."""
+    from datetime import datetime, timedelta, timezone
+
+    owner = await _seed_users(db_test_session_manager, ["owner"])
+    base = datetime.now(timezone.utc)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            for i, name in enumerate(["A", "B", "C", "D"]):
+                session.add(
+                    make_provider_with_org(
+                        owner_id=owner[0].id,
+                        practice_name=name,
+                        created_at=base + timedelta(seconds=i),
+                    )
+                )
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo.list_owned_by(Provider, owner[0].id, offset=1, limit=2)
+
+    # Newest first: D, C, B, A — offset=1 limit=2 → C, B.
+    assert [p.org.name for p in rows] == ["C", "B"]
+
+
+async def test_list_owned_by_empty_when_user_owns_nothing(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    owner = await _seed_users(db_test_session_manager, ["owner"])
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        rows = await repo.list_owned_by(Provider, owner[0].id)
+
+    assert list(rows) == []

--- a/src/framework/rendering/address.py
+++ b/src/framework/rendering/address.py
@@ -1,0 +1,30 @@
+"""Address composition helpers — domain-agnostic text formatters.
+
+Templates that render an address row (`provider.full_address`,
+`post.full_address`) read a pre-composed string instead of re-checking
+each location field. The composition logic was previously duplicated in
+`src/domain/logic/posts/view.py` and `src/domain/logic/providers/view.py`
+because cross-cluster imports between domain logic modules aren't
+allowed — the framework is the right home for the shared shape.
+"""
+
+from __future__ import annotations
+
+
+def full_address(
+    city: str | None, state: str | None, zip_code: str | None
+) -> str | None:
+    """Compose ``"City, ST ZIP"`` from three optional location parts.
+
+    Returns ``None`` when every part is empty so templates can write
+    ``{% if view.full_address %}`` and skip the row entirely. The
+    comma joins city + state; the ZIP appends with a space. Partial
+    inputs degrade naturally — only the parts that are present
+    appear, and the punctuation between them adjusts.
+    """
+    if not any((city, state, zip_code)):
+        return None
+    head = ", ".join(p for p in (city, state) if p)
+    if zip_code:
+        return f"{head} {zip_code}" if head else zip_code
+    return head or None

--- a/src/framework/rendering/test_address.py
+++ b/src/framework/rendering/test_address.py
@@ -1,0 +1,42 @@
+"""Tests for `src/framework/rendering/address.py`."""
+
+from src.framework.rendering.address import full_address
+
+
+def test_full_address_with_all_parts():
+    assert full_address("San Francisco", "CA", "94110") == "San Francisco, CA 94110"
+
+
+def test_full_address_with_no_parts_returns_none():
+    assert full_address(None, None, None) is None
+    assert full_address("", "", "") is None
+
+
+def test_full_address_city_only():
+    assert full_address("San Francisco", None, None) == "San Francisco"
+
+
+def test_full_address_state_only():
+    assert full_address(None, "CA", None) == "CA"
+
+
+def test_full_address_zip_only():
+    assert full_address(None, None, "94110") == "94110"
+
+
+def test_full_address_city_and_state_no_zip():
+    assert full_address("San Francisco", "CA", None) == "San Francisco, CA"
+
+
+def test_full_address_city_and_zip_no_state():
+    """City + ZIP joins with a single space (no leading comma)."""
+    assert full_address("San Francisco", None, "94110") == "San Francisco 94110"
+
+
+def test_full_address_state_and_zip_no_city():
+    assert full_address(None, "CA", "94110") == "CA 94110"
+
+
+def test_full_address_empty_string_treated_as_missing():
+    """Empty strings count as absent — `any(("", "", ""))` is falsey."""
+    assert full_address("", "CA", "94110") == "CA 94110"


### PR DESCRIPTION
## Summary

Two patterns that lived in \`src/domain/\` were domain-agnostic and duplicated across entities; both belong in \`src/framework/\`. Both were flagged by the earlier extraction audit (PR #816 took the first two; this PR closes out the remaining two).

### \`BaseRepository.list_owned_by(model, user_id, *, owner_attr, offset, limit)\`

The "rows owned by a user, newest first" shape was hand-rolled in three repos (organizations, programs, providers) with identical query construction. Programs's docstring already said *\"Mirrors OrganizationRepository.list_for_user and ProviderRepository.list_for_user\"* — as explicit a "lift me" signal as you get.

The framework now owns the query. Each per-entity \`list_for_user\` collapses to a one-line delegation whose docstring keeps the domain "why" (which form dropdown it powers, what authz boundary it pairs with).

### \`framework.rendering.address.full_address(city, state, zip_code)\`

The same \`\"City, ST ZIP\"\` composer existed in \`posts/view.py\` and \`providers/view.py\`. The providers copy's docstring even called out the constraint: *\"kept separate because the providers logic module should not import from the posts logic module (cross-cluster boundary)\"* — the framework is exactly the right home for shared shape blocked by cross-cluster rules.

## Test reorganization
- \`test_base_repository.py\` adds 4 \`list_owned_by\` tests (owner filter, newest-first ordering with explicit \`created_at\` to dodge SQLite's second-precision tie, offset+limit, empty result).
- \`test_address.py\` is the framework unit-test home for the address composer (9 cases — every combination of present/absent parts).
- \`providers/test_view.py\` drops its 4 redundant \`_full_address\` tests with a comment pointing at the framework test file. Integration through \`provider_card_view\` is still exercised by the card-view tests.

## Test plan
- [x] \`dev test\` passes (1678 passed, 96 skipped — same as main + new framework tests)
- [x] \`dev lint\` passes
- [x] No README references to renamed symbols (only \`programs/README.md\` mentions \`list_for_user\`, which still exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)