### PR TITLE
docs: mention `dev merge` in README quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dev up                    # starts the dev server at http://localhost:8000
 dev test                  # runs the test suite
 ```
 
-`dev --help` lists every command. See [`scripts/README.md`](scripts/README.md) for what's there.
+`dev --help` lists every command. See [`scripts/README.md`](scripts/README.md) for what's there, including `dev merge <PR#>` for shepherding a PR through Mergify's queue.
 
 ### Dev auto-login
 


### PR DESCRIPTION
## Summary

- Smoke-tests the two-tier Mergify config from #819.
- Adds a one-line pointer to `dev merge <PR#>` in the README quick-start.

## Why a README-only change

This PR is deliberately the smallest viable change that still exercises both tiers of the new merge-queue plumbing:

- **PR tier (`ci.yml`)**: `linting` should pass; `tests-affected` should resolve to *no affected tests* (rule 6 in `scripts/affected_tests.py` — non-Python files are ignored) and exit 0 without running pytest.
- **Queue tier (`ci-queue.yml`)**: once Mergify admits the PR, the rebased `mergify/merge-queue/**` branch should fire `tests`, `contract-tests`, and `docker-health-check`, satisfying `merge_conditions`.

If both tiers behave as designed, the PR squashes to `main` through the queue without manual intervention.

## Test plan

- [ ] PR-tier checks green: `linting`, `tests-affected`, `queue`.
- [ ] Mergify admits to queue (not "skipping").
- [ ] Queue-tier checks green on the queue branch: `tests`, `contract-tests`, `docker-health-check`.
- [ ] Merges to `main` via Mergify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)