### PR TITLE
refactor(landing): drop hand-padded &middot; in footer

### DIFF
--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -52,5 +52,5 @@
 </section>
 {% endblock %}
 {% block footer %}
-<small>&copy; 2026 Bedlam Health &middot; <a href="mailto:support@bedlamhealth.com">support@bedlamhealth.com</a></small>
+<small class="meta"><span>&copy; 2026 Bedlam Health</span><a href="mailto:support@bedlamhealth.com">support@bedlamhealth.com</a></small>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Audited HTML partials for strings with leading/trailing whitespace being used as visual spacing.
- Only real hit: `landing.html` footer used `' &middot; '` (literal spaces around the entity) to separate the copyright line from the support email.
- Wrapped the two parts in `<span>` / `<a>` under `<small class="meta">` so the existing `.meta > * + *::before { content: " · "; }` rule in `base.html:293` injects the separator with no literal whitespace.

## Test plan
- [x] `dev lint` (passes — pre-commit hooks ran on commit).
- [x] `dev test --affected` (no Python files changed; nothing to run).
- [ ] Visually confirm the landing-page footer still renders as `© 2026 Bedlam Health · support@bedlamhealth.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)