### PR TITLE
fix(landing,auth): site footer + login centering + landing CTA cluster

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -596,6 +596,17 @@ async def test_root_anonymous_returns_landing_page(test_client: AsyncClient):
     assert "/auth/login" in response.text
     assert "Sign in" in response.text
     assert "Sign up" in response.text
+    # CTA buttons live in `.cta-cluster`, NOT Pico's `.grid` — `.grid`
+    # would stretch them to the full hero width on tablet+. The
+    # `.cta-cluster` CSS in `landing.html` overrides Pico's
+    # `<a role="button">` full-width default at ≥768px so the buttons
+    # render at natural width, but keeps the full-width treatment on
+    # phones where stacked tappable bars read better.
+    assert "cta-cluster" in response.text
+    # The footer slot is shared across every page (default block in
+    # `base.html`), so the brand/contact line is present on the
+    # landing page too.
+    assert "support@bedlamhealth.com" in response.text
 
 
 async def test_root_authenticated_redirects_to_referrals(

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -1,42 +1,37 @@
 {% extends "base.html" %}
 {% block content %}
-{# Two-column `.grid` so the login box sits in the left half of the
-   container on tablet+ and stacks to full-width on phones. Pico's
-   `.grid` switches between `grid-template-columns: repeat(N, 1fr)`
-   and a single stacked column at its 768px breakpoint; the empty
-   trailing `<div>` reserves the right cell so the auth section
-   occupies exactly half the row. #}
-<div class="grid">
-  <section class="auth-page">
-    <header>
-      <h1>Log in</h1>
-      {% if just_registered %}<p>Account created — log in to continue.</p>{% else %}<p>Sign in to your Bedlam Connect account.</p>{% endif %}
-    </header>
-    <!-- FastAPI Users JWT login endpoint expects 'username' (which is email) and 'password' as form data. -->
-    <form
-      method="post"
-      action="/auth/jwt/login{% if next_url %}?next={{ next_url }}{% endif %}">
-      <label for="username">
-        Email
-        <input type="email" id="username" name="username" required />
-      </label>
-      <label for="password">
-        Password
-        <input type="password" id="password" name="password" required />
-      </label>
-      <button type="submit">Log in</button>
-    </form>
-    <footer>
-      <p>
-        Forgot your password?
-        <a href="/auth/forgot-password">Reset it.</a>
-      </p>
-      <p>
-        New here?
-        <a href="/auth/register">Create an account.</a>
-      </p>
-    </footer>
-  </section>
-  <div></div>
-</div>
+{# Login form sits in a `<section class="auth-page">` — the rule in
+   `base.html` caps the section at 28rem and centers it horizontally
+   via `margin-inline: auto`, matching every other auth page
+   (register, forgot-password, reset-password, verify). #}
+<section class="auth-page">
+  <header>
+    <h1>Log in</h1>
+    {% if just_registered %}<p>Account created — log in to continue.</p>{% else %}<p>Sign in to your Bedlam Connect account.</p>{% endif %}
+  </header>
+  <!-- FastAPI Users JWT login endpoint expects 'username' (which is email) and 'password' as form data. -->
+  <form
+    method="post"
+    action="/auth/jwt/login{% if next_url %}?next={{ next_url }}{% endif %}">
+    <label for="username">
+      Email
+      <input type="email" id="username" name="username" required />
+    </label>
+    <label for="password">
+      Password
+      <input type="password" id="password" name="password" required />
+    </label>
+    <button type="submit">Log in</button>
+  </form>
+  <footer>
+    <p>
+      Forgot your password?
+      <a href="/auth/forgot-password">Reset it.</a>
+    </p>
+    <p>
+      New here?
+      <a href="/auth/register">Create an account.</a>
+    </p>
+  </footer>
+</section>
 {% endblock %}

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -1,33 +1,31 @@
 {% extends "base.html" %}
 {% block head %}
-{# Landing-only layout. Scoped to `body:has(.landing-hero)` so these
-   rules don't leak to any other page — every other template extends
-   `base.html` without rendering a `.landing-hero`. On tablet+ the
-   page is exactly one viewport tall: header at top, hero vertically
-   centered in the main row, footer pinned to the bottom. On phones
-   the natural document flow is preferred (the dvh trick reads as
-   awkward at narrow widths where the hero already fills the screen).
-
-   The `<footer>` is rendered by `base.html` *outside* `<main>` (via
-   the `{% raw %}{% block footer %}{% endraw %}` slot), so the body grid carries three rows
-   (header, main, footer) and the main row alone holds the hero. #}
+{# Landing-only layout. The sticky-footer body grid (auto 1fr auto)
+   lives in `base.html` and already grows the `<main>` row to fill the
+   viewport. This block adds the landing-specific extras: vertically
+   center the hero within `<main>` and switch the CTA cluster to a
+   natural-width inline row, both at tablet+. Mobile relies on Pico
+   defaults — `<a role="button">` is block-level full-width, which is
+   exactly what we want for stacked tappable bars. Scoped to
+   `body:has(.landing-hero)` and `.landing-hero` so the rules don't
+   leak to any other page. #}
 <style>
   @media (min-width: 768px) {
-    body:has(.landing-hero) {
-      min-height: 100dvh;
-      display: grid;
-      grid-template-rows: auto 1fr auto;
-    }
     body:has(.landing-hero) main.container {
       display: grid;
       padding-block: 2rem;
     }
     .landing-hero { align-self: center; }
+    .landing-hero .cta-cluster {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+    .landing-hero .cta-cluster > [role="button"] {
+      width: auto;
+      margin: 0;
+    }
   }
-  /* CTA cluster — Pico styles `<a role="button">` as block-level
-     100%-wide; inside a `.grid` utility we want them sitting in
-     their cells, not stretching the row. */
-  .landing-hero .grid > [role="button"] { margin: 0; }
 </style>
 {% endblock %}
 {% block content %}
@@ -45,12 +43,9 @@
     <p>Connecting providers, helping patients.</p>
   </hgroup>
   <p>Post referrals, find referrals, and maintain a network of professional contacts.</p>
-  <div class="grid">
+  <div class="cta-cluster">
     <a href="/auth/login" role="button">Sign in</a>
     <a href="/auth/register" role="button" class="secondary">Sign up</a>
   </div>
 </section>
-{% endblock %}
-{% block footer %}
-<small>&copy; 2026 Bedlam Health &middot; <a href="mailto:support@bedlamhealth.com">support@bedlamhealth.com</a></small>
 {% endblock %}

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -67,8 +67,14 @@ Every page extending `base.html` lands the same three-strip chrome above its con
 │ toolbar / action bar         [filters left]    [actions ▶] │  ← `{% block toolbar %}`
 ├───────────────────────────────────────────────────────────┤
 │ page content                                              │  ← `{% block content %}`
+├───────────────────────────────────────────────────────────┤
+│ <footer> site chrome           &copy; … · support@ …      │  ← `{% block footer %}` (default body in `base.html`)
 └───────────────────────────────────────────────────────────┘
 ```
+
+**Body layout.** `<header>`, `<main>`, and `<footer>` are direct siblings of `<body>`, and `<body>` is a three-row CSS grid (`grid-template-rows: auto 1fr auto`) sized to `min-height: 100dvh`. Short pages pin the footer to the viewport bottom instead of leaving it floating; tall pages flow normally and push the footer below. The landing page reuses this scaffold to vertically center its hero inside the `<main>` row (see [`../../domain/templates/landing.html`](../../domain/templates/landing.html)).
+
+**Site footer** (`{% block footer %}`) renders on every page from the default body in `base.html` — a centered `<small>` with the copyright line and a `mailto:` to support. Pages can override the block to swap or extend the line; today none do.
 
 **Primary nav** lives in `base.html` and renders on every screen (authed *and* anonymous) as a single `<ul id="primary-nav">`. The brand sits on the left; when authed, four inline links push to the right via `margin-left: auto` on the first link: Referrals (`/referrals`), Openings (`/openings`), Profile (`/users/me`), and Sign out (an `<a hx-post="/auth/sign-out">` — the route returns `HX-Redirect`). Anonymous visitors see only the brand; the chrome carries no Login shortcut (visitors enter the auth flow from the landing page CTA). Active state is matched against `request.url.path`. Pages don't extend it.
 

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -555,6 +555,21 @@
         max-width: 28rem;
         margin-inline: auto;
       }
+      /* Page footer (`<footer class="container">` in base.html — sibling
+         of `<header>` and `<main>`). Centered chrome line, present on
+         every page via the default `{% raw %}{% block footer %}{% endraw %}` body. */
+      footer.container { text-align: center; }
+      /* Sticky-footer layout. The body is a three-row grid
+         (`<header>` / `<main>` / `<footer>`) sized to the viewport, so
+         short pages pin the footer at the bottom instead of leaving it
+         floating mid-screen. The landing page reuses this row scaffold
+         to vertically center its hero (see `landing.html`); regular
+         content pages just benefit from the pinned footer. */
+      body {
+        min-height: 100dvh;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+      }
     </style>
     <script
       src="https://unpkg.com/htmx.org@2.0.4"
@@ -682,7 +697,13 @@
        document's `<footer>` (semantic site-level role) rather than a
        child of the main content. Wrapped in Pico's `.container` so
        footer content picks up the same max-width centering as the
-       header/main bands. Empty on pages that don't fill the block. #}
-    <footer class="container">{% block footer %}{% endblock %}</footer>
+       header/main bands. The default body is a site-wide copyright /
+       contact line shown on every page; pages can override by
+       redefining `{% raw %}{% block footer %}{% endraw %}`. #}
+    <footer class="container">
+      {% block footer %}
+      <small>&copy; 2026 Bedlam Health &middot; <a href="mailto:support@bedlamhealth.com">support@bedlamhealth.com</a></small>
+      {% endblock %}
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Move the site footer (copyright + `support@bedlamhealth.com` mailto) into `base.html` as the default `{% block footer %}` body, and add a sticky-footer body grid (`auto 1fr auto` over 100dvh) so it pins to the viewport on short pages instead of floating.
- Drop the two-column `.grid` wrapper on `/auth/login`. The existing `.auth-page` cap (28rem, `margin-inline: auto`) already centers the form, matching every other auth page.
- Replace the landing CTA `.grid` wrapper with a `.cta-cluster` that renders as a natural-width inline row at ≥768px and stacks full-width on phones via Pico defaults.
- Update `src/framework/templates/README.md` and `test_root_anonymous_returns_landing_page` to pin the new contracts.

## Test plan
- [ ] `dev test` passes
- [ ] `/` (anonymous) shows hero with inline CTAs at tablet+ and stacked full-width CTAs on phone, footer pinned to bottom
- [ ] `/auth/login` form is centered (not jammed to the left half) and matches `/auth/register` width

🤖 Generated with [Claude Code](https://claude.com/claude-code)