### PR TITLE
feat(auth): drop username field from signup form

### DIFF
--- a/src/domain/logic/auth/handlers.py
+++ b/src/domain/logic/auth/handlers.py
@@ -35,6 +35,8 @@ async def handle_registration(
     user activation/delete) get true atomicity via shared transactions; this
     is the one exception.
     """
+    if request_data.username is None:
+        request_data.username = request_data.email
     created_user = await user_manager.create(request_data, safe=True, request=request)
     await record_audit(
         audit_repo,

--- a/src/domain/logic/users/schema.py
+++ b/src/domain/logic/users/schema.py
@@ -19,7 +19,11 @@ class UserRead(schemas.BaseUser):
 
 
 class UserCreate(schemas.BaseUserCreate):
-    username: str
+    # Optional on the wire: the signup form no longer collects a username.
+    # `handle_registration` fills it from `email` before persisting so the
+    # `users.username` column (UNIQUE, NOT NULL) and `UserAuditSnapshot`
+    # shape remain unchanged.
+    username: str | None = None
 
 
 class UserUpdate(schemas.BaseUserUpdate):

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -26,7 +26,6 @@ async def test_register(
     register_data = {
         "email": email_to_test,
         "password": password_to_test,
-        "username": "testreguser",
     }
     response = await test_client.post("/auth/register", json=register_data)
     assert response.status_code == 201
@@ -35,6 +34,10 @@ async def test_register(
     assert user_info["email"] == email_to_test
     assert user_info["is_active"] is True
     assert user_info["is_superuser"] is False
+    # Signup form no longer collects a username; `handle_registration`
+    # fills the (UNIQUE, NOT NULL) column from `email` so existing
+    # downstream consumers (display, audit snapshot, emails) keep working.
+    assert user_info["username"] == email_to_test
     # `is_verified` restored to the response with the verification
     # rollout (reversing #696). Tests run with `ENVIRONMENT=development`
     # (see `.env.test`), so the dev-mode auto-verify guardrail in
@@ -74,7 +77,6 @@ async def test_register_prod_mode_leaves_user_unverified(
     register_data = {
         "email": "prod-mode-user@example.com",
         "password": "password123",
-        "username": "prodmodeuser",
     }
     response = await test_client.post("/auth/register", json=register_data)
     assert response.status_code == 201
@@ -85,7 +87,6 @@ async def test_register_via_htmx_sets_cookie_and_redirects(test_client: AsyncCli
     """HTMX register should auto-login (cookie) and redirect, not return JSON."""
     payload = {
         "email": "htmx@example.com",
-        "username": "htmxuser",
         "password": "Password123!",
     }
     response = await test_client.post(
@@ -106,7 +107,6 @@ async def test_register_duplicate_email(test_client: AsyncClient, logged_in_user
     register_data = {
         "email": logged_in_user.email,
         "password": "newpassword",
-        "username": "anotheruser",
     }
     response = await test_client.post("/auth/register", json=register_data)
     assert response.status_code == 400
@@ -241,6 +241,10 @@ async def test_get_register_page(test_client: AsyncClient):
     # before any value framing (#694).
     assert "openings, referrals, and intakes" not in response.text
     assert "clinician profile" in response.text
+    # Signup form collects email + password only — username is filled
+    # server-side from email in `handle_registration`. Pin the absence
+    # so the field doesn't sneak back in.
+    assert 'name="username"' not in response.text
 
 
 async def test_get_login_page(test_client: AsyncClient):

--- a/src/domain/templates/auth/register.html
+++ b/src/domain/templates/auth/register.html
@@ -10,10 +10,6 @@
       Email
       <input type="email" id="email" name="email" required />
     </label>
-    <label for="username">
-      Username
-      <input type="text" id="username" name="username" required />
-    </label>
     <label for="password">
       Password
       <input type="password" id="password" name="password" required />

--- a/tests/test_contract/tests/consumer/test_auth_form.py
+++ b/tests/test_contract/tests/consumer/test_auth_form.py
@@ -11,7 +11,6 @@ from tests.test_contract.constants import (
     REGISTER_API_PATH,
     TEST_EMAIL,
     TEST_PASSWORD,
-    TEST_USERNAME,
 )
 from tests.test_contract.tests.shared.helpers import (
     setup_pact,
@@ -36,10 +35,11 @@ async def test_consumer_registration_form_interaction(
     full_mock_url = f"{mock_server_uri}{REGISTER_API_PATH}"
 
     expected_request_headers = {"Content-Type": "application/json"}
+    # Signup form collects email + password only; the provider fills
+    # `username` from `email` server-side in `handle_registration`.
     expected_request_body = {
         "email": Like(TEST_EMAIL),
         "password": Like(TEST_PASSWORD),
-        "username": Like(TEST_USERNAME),
     }
 
     (
@@ -67,7 +67,6 @@ async def test_consumer_registration_form_interaction(
         await page.wait_for_selector("#email")
         await page.locator("#email").fill(TEST_EMAIL)
         await page.locator("#password").fill(TEST_PASSWORD)
-        await page.locator("#username").fill(TEST_USERNAME)
         await page.locator("button[type='submit']").click()
         await page.wait_for_timeout(NETWORK_TIMEOUT_MS)
 


### PR DESCRIPTION
## Summary
- Registration form now collects only email + password — username input is removed.
- `handle_registration` fills `UserCreate.username` from `email` server-side before calling `user_manager.create`, so the `users.username` column (UNIQUE, NOT NULL) and `UserAuditSnapshot` JSON shape stay unchanged.
- `UserCreate.username` is now `Optional[str] = None` on the wire; downstream display, audit, and email-greeting consumers continue to read a non-null `username` off the model.

## Why this shape
Per the contract-surface check in CLAUDE.md, ripping out the username concept would break the persisted `audit_log.before/after` JSON and require a DB migration. This is the smaller, reversible prep PR: the user-facing concept is gone today, and a follow-up can remove the column + `get_user_by_username` once we're confident no internal path depends on the field.

## Test plan
- [x] `pytest src/domain/routes/test_auth_routes.py` — 32 passed, 1 skipped.
- [x] `pytest src/domain/logic/auth/test_emails.py src/domain/logic/users/test_handlers.py src/domain/routes/test_auth_routes.py` — 42 passed.
- [x] `test_get_register_page` pins that `name="username"` is no longer in the rendered form.
- [x] `test_register` asserts `user_info["username"] == email_to_test`.
- [ ] Contract suite (`dev test contract`) — registration consumer test updated to drop the `username` body field; full suite has some pre-existing flakiness on this machine, recommend re-running in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)