### PR TITLE
feat(forms): inline error UX for clinician_opening age_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,13 +80,26 @@ all = [
 dev = "scripts.dev_cli:main"
 
 # Tool configurations
+#
+# Each formatter excludes `.claude/` regardless of how it's invoked
+# (`black .`, `isort .`, pre-commit, `dev lint`). The directory hosts
+# per-task git worktrees (see `scripts/dev/preflight_worktree_check.py`)
+# whose Python trees would otherwise multiply every project-root walk
+# by the number of in-flight worktrees — `isort --check-only .` hung
+# in `dev lint` until this exclusion landed.
 [tool.black]
 line-length = 88
 target-version = ['py311']
+extend-exclude = '''
+/(
+    \.claude
+)/
+'''
 
 [tool.isort]
 profile = "black"
 line_length = 88
+extend_skip = [".claude"]
 
 [tool.djlint]
 profile = "jinja"

--- a/src/domain/routes/test_post_families.py
+++ b/src/domain/routes/test_post_families.py
@@ -413,21 +413,26 @@ async def test_admin_can_patch_anyone(
 # --- Form-error re-render (form_error_render opt-in) ---------------------
 
 
-async def test_clinician_opening_create_rerenders_form_with_age_groups_error_on_htmx(
+async def test_clinician_opening_create_form_error_render_is_wired(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """`POST /openings` (`kind=clinician_opening`) on an HX-Request with
-    an empty `age_groups` returns the form re-rendered with an inline
-    error on the `age_groups` `<select>` — not a JSON 422. This is the
-    first callsite of the `form_error_render` opt-in on `EntitySpec`
-    (see `OPENING_ENTITY` and `mount_create`'s `_render_form_with_errors`).
+    """Integration smoke for the `OPENING_ENTITY.form_error_render`
+    opt-in. Asserts only that the wiring is hooked up end-to-end —
+    HX-Request POST with invalid `age_groups` returns 200 + HTML and
+    the response mentions the failing field somewhere.
 
-    The user owns one Provider so the form template's
-    `current_user.providers` gate passes; the wire-valid `opening_payload`
-    is sent with `age_groups=[]` to trip the schema's `min_length=1`
-    constraint without dragging in unrelated validation noise.
+    Structural contracts live in their owning layers, not here:
+
+      - HX-Request vs not, 200 vs 422, `form_errors` dict shape,
+        kind-prefix stripping → `src/framework/dispatch/mounts/test_create.py`.
+      - Pico-canonical `aria-invalid` + helper-slot rendering →
+        `src/framework/templates/_shared/test_form_fields.py`.
+
+    Adding a second entity that opts into `form_error_render` only
+    needs a copy of this smoke for that entity's form — neither layer
+    above re-runs per entity.
     """
     provider = make_provider_with_org(owner_id=logged_in_user.id)
     async with db_test_session_manager() as session:
@@ -442,55 +447,6 @@ async def test_clinician_opening_create_rerenders_form_with_age_groups_error_on_
         data=payload,
         headers={"HX-Request": "true"},
     )
-    # Status is 200 (not 422 or 201) so HTMX swaps the response body
-    # via the form's `hx-target="this" hx-swap="outerHTML"`. The JSON
-    # 422 contract is preserved for non-HTMX clients (a separate test
-    # below pins that branch).
     assert response.status_code == 200, response.text
     assert response.headers["content-type"].startswith("text/html")
-
-    tree = HTMLParser(response.text)
-    age_select = tree.css_first('select[name="age_groups"]')
-    assert age_select is not None, "age_groups select missing from re-rendered form"
-    assert (
-        age_select.attributes.get("aria-invalid") == "true"
-    ), "age_groups select must carry aria-invalid='true' so Pico colors it red"
-    # Pico's canonical one-small-per-field slot: the helper id stays
-    # `<name>-helper` whether the small carries help text or the error
-    # message. With `error=` set, the small contains the error message.
-    error_small = tree.css_first("small#age_groups-helper")
-    assert error_small is not None, "age_groups error small missing"
-    # The small carries whatever Pydantic emits for the failure mode —
-    # `httpx` drops empty-list form keys so the wire payload omits
-    # `age_groups` entirely and Pydantic returns "Field required"; if a
-    # client submits a single empty value `min_length=1` fires with
-    # "at least 1 item". We only assert *some* message survives the
-    # `loc`-stripping + dict-collapse path, not its exact wording.
-    assert error_small.text().strip(), "age_groups error small is empty"
-
-
-async def test_clinician_opening_create_returns_json_422_without_htmx(
-    authenticated_client: AsyncClient,
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-    logged_in_user,
-):
-    """The same POST without `HX-Request` falls through to the existing
-    JSON 422 contract — `form_error_render` is HTMX-only by design so
-    non-HTMX API clients keep their machine-readable error list."""
-    provider = make_provider_with_org(owner_id=logged_in_user.id)
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(provider)
-
-    payload = opening_payload(provider_id=str(provider.id))
-    payload["age_groups"] = []
-
-    response = await authenticated_client.post("/openings", data=payload)
-    assert response.status_code == 422
-    body = response.json()
-    # The discriminated-union adapter prefixes `loc` with the kind for
-    # nested errors; `age_groups` lives under `clinician_opening`. We
-    # only assert the JSON-422 contract preserves the field name
-    # somewhere in `loc`, not the exact tuple shape.
-    locs = [tuple(err["loc"]) for err in body["detail"]]
-    assert any("age_groups" in loc for loc in locs), body
+    assert "age_groups" in response.text

--- a/src/domain/routes/test_post_families.py
+++ b/src/domain/routes/test_post_families.py
@@ -38,6 +38,7 @@ from tests.helpers import (
     make_program,
     make_provider_with_org,
     make_referral_detail,
+    opening_payload,
     promote_to_admin,
 )
 
@@ -407,3 +408,89 @@ async def test_admin_can_patch_anyone(
     # important assertion is "not 403". A 400 / 422 on body shape is
     # acceptable; a 403 would be the regression we want to catch.
     assert response.status_code != 403
+
+
+# --- Form-error re-render (form_error_render opt-in) ---------------------
+
+
+async def test_clinician_opening_create_rerenders_form_with_age_groups_error_on_htmx(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """`POST /openings` (`kind=clinician_opening`) on an HX-Request with
+    an empty `age_groups` returns the form re-rendered with an inline
+    error on the `age_groups` `<select>` — not a JSON 422. This is the
+    first callsite of the `form_error_render` opt-in on `EntitySpec`
+    (see `OPENING_ENTITY` and `mount_create`'s `_render_form_with_errors`).
+
+    The user owns one Provider so the form template's
+    `current_user.providers` gate passes; the wire-valid `opening_payload`
+    is sent with `age_groups=[]` to trip the schema's `min_length=1`
+    constraint without dragging in unrelated validation noise.
+    """
+    provider = make_provider_with_org(owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(provider)
+
+    payload = opening_payload(provider_id=str(provider.id))
+    payload["age_groups"] = []
+
+    response = await authenticated_client.post(
+        "/openings",
+        data=payload,
+        headers={"HX-Request": "true"},
+    )
+    # Status is 200 (not 422 or 201) so HTMX swaps the response body
+    # via the form's `hx-target="this" hx-swap="outerHTML"`. The JSON
+    # 422 contract is preserved for non-HTMX clients (a separate test
+    # below pins that branch).
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].startswith("text/html")
+
+    tree = HTMLParser(response.text)
+    age_select = tree.css_first('select[name="age_groups"]')
+    assert age_select is not None, "age_groups select missing from re-rendered form"
+    assert (
+        age_select.attributes.get("aria-invalid") == "true"
+    ), "age_groups select must carry aria-invalid='true' so Pico colors it red"
+    # Pico's canonical one-small-per-field slot: the helper id stays
+    # `<name>-helper` whether the small carries help text or the error
+    # message. With `error=` set, the small contains the error message.
+    error_small = tree.css_first("small#age_groups-helper")
+    assert error_small is not None, "age_groups error small missing"
+    # The small carries whatever Pydantic emits for the failure mode —
+    # `httpx` drops empty-list form keys so the wire payload omits
+    # `age_groups` entirely and Pydantic returns "Field required"; if a
+    # client submits a single empty value `min_length=1` fires with
+    # "at least 1 item". We only assert *some* message survives the
+    # `loc`-stripping + dict-collapse path, not its exact wording.
+    assert error_small.text().strip(), "age_groups error small is empty"
+
+
+async def test_clinician_opening_create_returns_json_422_without_htmx(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The same POST without `HX-Request` falls through to the existing
+    JSON 422 contract — `form_error_render` is HTMX-only by design so
+    non-HTMX API clients keep their machine-readable error list."""
+    provider = make_provider_with_org(owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(provider)
+
+    payload = opening_payload(provider_id=str(provider.id))
+    payload["age_groups"] = []
+
+    response = await authenticated_client.post("/openings", data=payload)
+    assert response.status_code == 422
+    body = response.json()
+    # The discriminated-union adapter prefixes `loc` with the kind for
+    # nested errors; `age_groups` lives under `clinician_opening`. We
+    # only assert the JSON-422 contract preserves the field name
+    # somewhere in `loc`, not the exact tuple shape.
+    locs = [tuple(err["loc"]) for err in body["detail"]]
+    assert any("age_groups" in loc for loc in locs), body

--- a/src/domain/specs/posts/_base.py
+++ b/src/domain/specs/posts/_base.py
@@ -123,6 +123,7 @@ def _post_face(
     kinds: tuple[str, ...] | None = None,
     create_adapter: type,
     update_adapter: type,
+    form_error_render: bool = False,
 ) -> EntitySpec:
     """Construct a post face — kind-locked leaf or subset-supertype.
 
@@ -215,4 +216,5 @@ def _post_face(
         discriminator=POST_KINDS,
         discriminator_value=kind,
         discriminator_values=kinds,
+        form_error_render=form_error_render,
     )

--- a/src/domain/specs/posts/opening.py
+++ b/src/domain/specs/posts/opening.py
@@ -19,10 +19,17 @@ from src.framework.dispatch.entity_spec import EntitySpec
 
 from ._base import _post_face
 
+# `form_error_render=True` opts this face into the HX-Request
+# re-render-on-validation-failure path (see `EntitySpec.form_error_render`
+# and `mount_create`). First-pass scope: the clinician_opening form's
+# `age_groups` field surfaces an inline error instead of silently
+# 422-ing. The form templates in `domain/templates/posts/openings/` are
+# wired to consume `form_errors` and `form_values` from the context.
 OPENING_ENTITY: Final[EntitySpec] = _post_face(
     name="opening",
     url_collection="openings",
     kinds=("clinician_opening", "program_intake"),
     create_adapter=openings_create_adapter,
     update_adapter=openings_update_adapter,
+    form_error_render=True,
 )

--- a/src/domain/templates/posts/openings/_form_clinician_opening.html
+++ b/src/domain/templates/posts/openings/_form_clinician_opening.html
@@ -21,9 +21,23 @@ with at least one provider available.
 {%- from "_shared/form_fields.html" import entity_select_field, text_field, textarea_field, select_field, time_grid_field, multi_select_field, field_for -%}
 {%- from "_shared/form_copy.html" import modality_help, schedule_notes_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
-{%- macro opening_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
+{%- macro opening_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None, errors=None, values=None) -%}
   {%- set d = post.opening_detail if post else None -%}
-  <form hx-{{ hx_method }}="{{ action }}">
+  {%- set errors = errors or {} -%}
+  {%- set values = values or {} -%}
+  {# `values` overlays the per-field default when the form is re-rendered
+     after a validation failure (see `form_error_render` in OPENING_ENTITY's
+     spec and `mount_create`). On a normal GET both `errors` and `values`
+     are empty and fields prefill from `post` (edit) or nothing (create).
+     The form's `hx-target="this" hx-swap="outerHTML"` lets the
+     error-rerender path replace the whole `<form>` in place; the success
+     path is unaffected because `mount_create` emits `HX-Redirect`. #}
+  {# `hx-{{ hx_method }}` is a templated attribute *name*; djlint
+     mis-wraps the form tag when the line exceeds its budget, so the
+     extra hx-target / hx-swap pair is read from the `_hx_attrs` set
+     below instead of being inlined as raw attrs. #}
+  {%- set _hx_attrs = "hx-target=\"this\" hx-swap=\"outerHTML\"" -%}
+  <form hx-{{ hx_method }}="{{ action }}" {{ _hx_attrs|safe }}>
     <input type="hidden" name="kind" value="clinician_opening" />
     {# Practice picker. After #642 PR 1 a Provider may carry multiple
      Affiliations (clinician × org practice-role rows); the dropdown
@@ -69,7 +83,7 @@ with at least one provider available.
         {{ multi_select_field("settings", "Treatment settings", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
       </div>
       {{ text_field("treatment_modality", "Treatment modality", current=d.treatment_modality if d else None, required=false, help=modality_help() ) }}
-      {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help() ) }}
+      {{ field_for(schema, "age_groups", "Age groups", current=values.get("age_groups", d.age_groups if d else None) , error=errors.get("age_groups"), help=select_all_help() ) }}
       <div class="grid">
         {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
         {{ multi_select_field("genders", "Genders served", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None) }}

--- a/src/domain/templates/posts/openings/new_clinician_opening.html
+++ b/src/domain/templates/posts/openings/new_clinician_opening.html
@@ -7,6 +7,6 @@
       Set up your clinician profile first — every opening is tied to one. <a href="{{ entity_form_url('clinician') }}">Create your clinician profile.</a>
     </p>
   {% else %}
-    {{ opening_form("post", entity_url('opening') , entity_create_label('opening', kind='clinician_opening'), schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('opening')) }}
+    {{ opening_form("post", entity_url('opening') , entity_create_label('opening', kind='clinician_opening'), schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('opening'), errors=form_errors|default({}), values=form_values|default({})) }}
   {% endif %}
 {% endblock %}

--- a/src/framework/dispatch/entity_spec.py
+++ b/src/framework/dispatch/entity_spec.py
@@ -412,6 +412,28 @@ class EntitySpec:
     # Templates ----------------------------------------------------------
     templates: Templates = field(default_factory=Templates)
 
+    # Form-error re-render opt-in ---------------------------------------
+    # When True, the framework's `mount_create` catches 422 validation
+    # errors from `parse_and_validate_form` on HX-Request POSTs and
+    # re-renders the spec's form_new template with `form_errors` (dict
+    # of field-name → first error message) and `form_values` (the raw
+    # submitted payload) injected into the context. Default False keeps
+    # the existing JSON-422 contract for entities that haven't migrated
+    # their form templates to consume `form_errors`/`form_values`.
+    #
+    # Forms that opt in must:
+    #   - render `_shared/form_fields.html` macros with `error=` wired
+    #     to `errors.get(field_name)` (the macro auto-sets
+    #     `aria-invalid="true"` and emits inline error text);
+    #   - prefill controls from `values.get(field_name, <fallback>)` so
+    #     the user's typed values survive the re-render;
+    #   - set `hx-target="this" hx-swap="outerHTML"` on the `<form>` so
+    #     the returned partial replaces the form in place.
+    #
+    # Today only OPENING_ENTITY's `clinician_opening` create form opts
+    # in (see `src/domain/specs/posts/_base.py`).
+    form_error_render: bool = False
+
     # Route-prefix override --------------------------------------------
     # Default route prefix is ``f"/{url_collection}"`` (e.g. ``/users``).
     # Favorites is the only entity whose URL doesn't fit the convention
@@ -989,6 +1011,8 @@ class EntitySpec:
             private_fields=self.private_fields,
             private_field_predicate=self.private_field_predicate,
             parent=parent_rs,
+            form_error_render=self.form_error_render,
+            entity_spec=self,
         )
 
     def state_axis(self, name: str) -> StateAxis:

--- a/src/framework/dispatch/mounts/_spec.py
+++ b/src/framework/dispatch/mounts/_spec.py
@@ -135,6 +135,23 @@ class ResourceSpec:
 
     parent: "ResourceSpec | None" = None
 
+    # Form-error re-render opt-in. When True, `mount_create` catches the
+    # 422 from `parse_and_validate_form` on HX-Request POSTs and
+    # re-renders the spec's form_new template with field-level errors
+    # and the raw submitted values, instead of letting the JSON 422
+    # bubble up. Mirrors the same-named field on `EntitySpec`; copied
+    # over in `EntitySpec.to_resource_spec()`. See `EntitySpec.form_error_render`
+    # for the full contract.
+    form_error_render: bool = False
+    # Back-reference to the originating `EntitySpec`, populated by
+    # `EntitySpec.to_resource_spec()`. `mount_create`'s
+    # `_render_form_with_errors` reads this to reach the discriminator
+    # registry + the polymorphic template-dispatch logic in
+    # `handle_get_new_form`. `None` for synthetic ResourceSpecs built
+    # outside the `EntitySpec` path (e.g. test specs). Typed `Any` to
+    # avoid the circular import EntitySpec→ResourceSpec→EntitySpec.
+    entity_spec: Any = None
+
     def __post_init__(self) -> None:
         # Field-level visibility metadata: `private_fields` names the
         # attributes gated by `private_field_predicate(actor, target)`.

--- a/src/framework/dispatch/mounts/create.py
+++ b/src/framework/dispatch/mounts/create.py
@@ -111,6 +111,42 @@ def mount_create(
     router.post(path, status_code=status.HTTP_201_CREATED)(route_fn)
 
 
+def build_form_errors_dict(errors: Any, *, kind: str | None = None) -> dict[str, str]:
+    """Collapse a 422 detail list into a `{field_name: first_message}` dict.
+
+    Input shape matches `validate_or_422`'s output:
+    `[{loc: tuple, msg: str, type: str}, ...]`. For discriminated-union
+    adapters Pydantic prefixes `loc` with the kind discriminator (e.g.
+    `("clinician_opening", "age_groups")`); when `kind` is supplied and
+    matches the first `loc` segment, the prefix is stripped so the dict
+    keys land at the field name the form macros look up.
+
+    The first message wins per field — repeated nested errors on the
+    same field don't clobber render order. Malformed entries (no `loc`,
+    no `msg`, prefix-only locs) are skipped silently rather than raising,
+    so a future Pydantic shape change degrades to "no inline error"
+    instead of 500.
+    """
+    out: dict[str, str] = {}
+    if not isinstance(errors, list):
+        return out
+    for err in errors:
+        if not isinstance(err, dict):
+            continue
+        loc = err.get("loc")
+        msg = err.get("msg")
+        if not loc or not msg:
+            continue
+        loc_seq = list(loc) if isinstance(loc, (tuple, list)) else [loc]
+        if kind is not None and loc_seq and loc_seq[0] == kind:
+            loc_seq = loc_seq[1:]
+        if not loc_seq:
+            continue
+        field = loc_seq[0]
+        out.setdefault(str(field), str(msg))
+    return out
+
+
 async def _render_form_with_errors(
     *,
     spec: ResourceSpec,
@@ -168,28 +204,7 @@ async def _render_form_with_errors(
         requesting_user=requesting_user,
         kind=kind,
     )
-    # `form_errors` is a per-field dict for the macro `error=` param.
-    # The detail list is `[{loc: tuple, msg: str, type: str}, ...]`.
-    # For discriminated-union adapters Pydantic prefixes `loc` with the
-    # kind (e.g. `("clinician_opening", "age_groups")`), so strip a
-    # leading segment that matches the submitted kind before reducing
-    # to the field name. Keep the first message per field so repeated
-    # nested errors on the same field don't clobber render order.
-    form_errors: dict[str, str] = {}
-    if isinstance(errors, list):
-        for err in errors:
-            loc = err.get("loc") if isinstance(err, dict) else None
-            msg = err.get("msg") if isinstance(err, dict) else None
-            if not loc or not msg:
-                continue
-            loc_seq = list(loc) if isinstance(loc, (tuple, list)) else [loc]
-            if kind is not None and loc_seq and loc_seq[0] == kind:
-                loc_seq = loc_seq[1:]
-            if not loc_seq:
-                continue
-            field = loc_seq[0]
-            form_errors.setdefault(str(field), str(msg))
-    context["form_errors"] = form_errors
+    context["form_errors"] = build_form_errors_dict(errors, kind=kind)
     context["form_values"] = payload_dict
     template_name = context.pop("template_name", None) or entity_spec.templates.form_new
     if template_name is None:

--- a/src/framework/dispatch/mounts/create.py
+++ b/src/framework/dispatch/mounts/create.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Awaitable, Callable
 
-from fastapi import Request, status
+from fastapi import HTTPException, Request, status
 
 from src.framework.dispatch.mounts._common import (
     call_handler_with,
@@ -12,8 +12,8 @@ from src.framework.dispatch.mounts._common import (
 )
 from src.framework.dispatch.mounts._spec import ResourceSpec
 from src.framework.dispatch.mounts._synth import SynthOptions, synthesize_route_fn
-from src.framework.http.forms import parse_and_validate_form
-from src.framework.http.responses import created_response
+from src.framework.http.forms import parse_form_to_payload, validate_or_422
+from src.framework.http.responses import APIResponse, created_response
 
 
 def mount_create(
@@ -58,7 +58,27 @@ def mount_create(
 
     async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
-        kwargs["payload"] = await parse_and_validate_form(request, create_adapter)
+        # Parse + validate split so the raw payload survives validation
+        # failure: when `spec.form_error_render` opts in, an HX-Request
+        # client gets the form template re-rendered with the typed values
+        # still in place rather than a JSON 422 with nowhere to land.
+        payload_dict = await parse_form_to_payload(request)
+        try:
+            kwargs["payload"] = validate_or_422(create_adapter, payload_dict)
+        except HTTPException as exc:
+            if (
+                exc.status_code == 422
+                and spec.form_error_render
+                and request.headers.get("HX-Request") == "true"
+            ):
+                return await _render_form_with_errors(
+                    spec=spec,
+                    request=request,
+                    requesting_user=kwargs.get("requesting_user"),
+                    payload_dict=payload_dict,
+                    errors=exc.detail,
+                )
+            raise
         created = await call_handler_with(handler, handler_kwarg_names, kwargs)
         path_kwargs = {name: kwargs[name] for name in parent_id_names}
         # Default Location is the canonical resource URL — for a top-level
@@ -89,3 +109,98 @@ def mount_create(
         response_builder=response_builder,
     )
     router.post(path, status_code=status.HTTP_201_CREATED)(route_fn)
+
+
+async def _render_form_with_errors(
+    *,
+    spec: ResourceSpec,
+    request: Request,
+    requesting_user: Any,
+    payload_dict: dict,
+    errors: Any,
+) -> Any:
+    """Re-render the spec's form_new template with field-level errors.
+
+    Called by `mount_create` on a 422 from `validate_or_422` when the
+    spec has opted in via `form_error_render=True` and the request is
+    an HX-Request. The form template receives:
+
+      - `form_errors`: a `{field_name: first_error_message}` dict built
+        from the 422 detail list. Discriminated-union locs (`("<kind>",
+        "<field>")`) are stripped of the kind prefix so the dict keys
+        match the form field names; the macro layer reads
+        `error=errors.get(name)` and auto-emits `aria-invalid="true"`
+        + the inline message.
+      - `form_values`: the raw submitted payload dict, so controls
+        prefill from what the user typed instead of resetting.
+
+    The originating `EntitySpec` (carried as `spec.entity_spec` by
+    `to_resource_spec()`) drives the kind-aware template lookup via
+    `handle_get_new_form` — same template-resolution path the form_new
+    GET handler uses, so the re-render is structurally indistinguishable
+    from a fresh GET aside from the injected `form_errors`/`form_values`.
+
+    Returns a 200-OK HTML response; the form's
+    `hx-target="this" hx-swap="outerHTML"` swaps it in place. Status is
+    200 (not 422) because the default HTMX response-handling table only
+    swaps 2xx — non-HTMX clients and the JSON-422 contract are
+    untouched (this branch is gated on `HX-Request: true`).
+    """
+    from src.framework.dispatch.handlers import handle_get_new_form
+
+    entity_spec = spec.entity_spec
+    if entity_spec is None:
+        # `form_error_render=True` without a back-reference to the
+        # EntitySpec means a synthetic ResourceSpec opted in but didn't
+        # populate `entity_spec`. Bail to the original 422 rather than
+        # 500 on a template lookup.
+        raise HTTPException(status_code=422, detail=errors)
+
+    kind = payload_dict.get("kind") if entity_spec.discriminator is not None else None
+    # `handle_get_new_form` builds the same context the form_new GET
+    # handler would assemble — current_user, schema, create_heading,
+    # resource_url, and (for subset-supertype/whole-supertype) the
+    # kind-specific template_name. Reusing it keeps the re-render
+    # context identical to a fresh GET so child templates can't drift.
+    context = await handle_get_new_form(
+        spec=entity_spec,
+        request=request,
+        requesting_user=requesting_user,
+        kind=kind,
+    )
+    # `form_errors` is a per-field dict for the macro `error=` param.
+    # The detail list is `[{loc: tuple, msg: str, type: str}, ...]`.
+    # For discriminated-union adapters Pydantic prefixes `loc` with the
+    # kind (e.g. `("clinician_opening", "age_groups")`), so strip a
+    # leading segment that matches the submitted kind before reducing
+    # to the field name. Keep the first message per field so repeated
+    # nested errors on the same field don't clobber render order.
+    form_errors: dict[str, str] = {}
+    if isinstance(errors, list):
+        for err in errors:
+            loc = err.get("loc") if isinstance(err, dict) else None
+            msg = err.get("msg") if isinstance(err, dict) else None
+            if not loc or not msg:
+                continue
+            loc_seq = list(loc) if isinstance(loc, (tuple, list)) else [loc]
+            if kind is not None and loc_seq and loc_seq[0] == kind:
+                loc_seq = loc_seq[1:]
+            if not loc_seq:
+                continue
+            field = loc_seq[0]
+            form_errors.setdefault(str(field), str(msg))
+    context["form_errors"] = form_errors
+    context["form_values"] = payload_dict
+    template_name = context.pop("template_name", None) or entity_spec.templates.form_new
+    if template_name is None:
+        # Defensive: a spec that opted into `form_error_render` without
+        # a resolvable form_new template would silently 500 — better to
+        # fall through to the original 422 so the caller sees the
+        # validation failure rather than a template error.
+        raise HTTPException(status_code=422, detail=errors)
+    return APIResponse.html_response(
+        template_name=template_name,
+        context=context,
+        request=request,
+        current_user=requesting_user,
+    )

--- a/src/framework/dispatch/mounts/test_create.py
+++ b/src/framework/dispatch/mounts/test_create.py
@@ -1,0 +1,301 @@
+"""Tests for `mount_create` — focus on the form-error-rerender branching.
+
+`mount_create`'s default path (parse → validate → call handler → 201) is
+covered by every entity's route-level tests; the tests here pin the
+*pattern* that's new with `form_error_render`:
+
+  - **`build_form_errors_dict`** is the pure helper that collapses a
+    422 detail list into the per-field dict the form macros consume.
+    Tests cover the kind-prefix-stripping rule, repeated-field
+    collision policy, and malformed-input degradation. Pure function
+    → table-driven test.
+  - **The dispatch branching** (HX-Request vs not, form_error_render
+    on vs off) goes through a synthetic FastAPI app: the renderer is
+    monkeypatched so the test runs without real templating, and the
+    test asserts what `mount_create` *did* (raised 422 vs. invoked the
+    renderer) rather than what the renderer produced.
+
+Per-entity HTML-shape assertions (e.g. "the age_groups select carries
+`aria-invalid='true'`") belong at the macro layer
+(`src/framework/templates/_shared/test_form_fields.py`); per-entity
+integration smokes ("POST returns 200 + HTML that mentions the failing
+field") belong at the route layer. This file owns the *framework
+contract*: any entity opting into `form_error_render` gets these
+semantics regardless of what its form template looks like.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi import APIRouter, FastAPI, Response
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, TypeAdapter
+
+from src.framework.dispatch.mounts._spec import ResourceSpec
+from src.framework.dispatch.mounts.create import build_form_errors_dict, mount_create
+
+# --- build_form_errors_dict (pure helper) --------------------------------
+
+
+class TestBuildFormErrorsDict:
+    """Pure unit tests for the 422-detail → `{field: msg}` collapse.
+
+    Table-driven because the function's only contract is the
+    loc-shape-to-dict mapping rule; integration of this function with
+    the rest of the rerender path is covered by the dispatch tests
+    below."""
+
+    def test_top_level_loc_maps_to_field_key(self) -> None:
+        errors = [
+            {"loc": ("age_groups",), "msg": "field required", "type": "missing"},
+        ]
+        assert build_form_errors_dict(errors) == {"age_groups": "field required"}
+
+    def test_discriminated_union_prefix_stripped_when_kind_matches(self) -> None:
+        """Pydantic prefixes `loc` with the kind discriminator on a
+        tagged union; the form template looks up by bare field name,
+        so the prefix has to be stripped when `kind` is supplied."""
+        errors = [
+            {
+                "loc": ("clinician_opening", "age_groups"),
+                "msg": "field required",
+                "type": "missing",
+            },
+        ]
+        out = build_form_errors_dict(errors, kind="clinician_opening")
+        assert out == {"age_groups": "field required"}
+
+    def test_prefix_not_stripped_when_kind_mismatch(self) -> None:
+        """Kind mismatch (the first loc segment isn't the supplied
+        kind) leaves the loc alone — we read the first segment as the
+        field name. Defends against silently swallowing errors when a
+        future discriminator naming changes."""
+        errors = [
+            {
+                "loc": ("other_kind", "age_groups"),
+                "msg": "bad",
+                "type": "x",
+            },
+        ]
+        out = build_form_errors_dict(errors, kind="clinician_opening")
+        assert out == {"other_kind": "bad"}
+
+    def test_first_message_wins_per_field(self) -> None:
+        """Repeated errors on the same field — pick the first so the
+        user sees a stable message instead of one that re-orders across
+        Pydantic versions."""
+        errors = [
+            {"loc": ("x",), "msg": "first", "type": "a"},
+            {"loc": ("x",), "msg": "second", "type": "b"},
+        ]
+        assert build_form_errors_dict(errors) == {"x": "first"}
+
+    def test_malformed_entries_skipped_silently(self) -> None:
+        """Missing `loc` / missing `msg` / non-dict entry / non-list
+        input all degrade to "no entry" rather than raising. The
+        rerender path is on the failure side of a request — raising
+        here would 500 instead of just dropping the inline message."""
+        errors = [
+            {"msg": "no loc"},
+            {"loc": ("ok",)},
+            "not a dict",
+            {"loc": (), "msg": "empty loc"},
+        ]
+        assert build_form_errors_dict(errors) == {}
+        assert build_form_errors_dict(None) == {}  # type: ignore[arg-type]
+        assert build_form_errors_dict("not a list") == {}  # type: ignore[arg-type]
+
+    def test_prefix_only_loc_is_skipped(self) -> None:
+        """A loc that's just `(kind,)` with nothing after collapses to
+        empty and is skipped — no field name to attach to."""
+        errors = [
+            {"loc": ("clinician_opening",), "msg": "x", "type": "y"},
+        ]
+        assert build_form_errors_dict(errors, kind="clinician_opening") == {}
+
+
+# --- mount_create dispatch branching -------------------------------------
+
+
+class _Body(BaseModel):
+    """Minimal schema: `x` is required, so an empty POST body always
+    produces a single-field 422 the dispatch tests can rely on."""
+
+    x: str
+
+
+def _build_app(
+    *,
+    form_error_render: bool,
+    entity_spec: Any = None,
+) -> FastAPI:
+    """Synthetic FastAPI app with one `POST /widgets` route mounted via
+    `mount_create`. Stub deps return predictable sentinels so handler
+    invocation can be observed without a real DB / audit layer.
+    """
+    sentinel_user = SimpleNamespace(id=uuid4(), is_superuser=True)
+    spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: sentinel_user,
+        create_adapter=TypeAdapter(_Body),
+        form_error_render=form_error_render,
+        entity_spec=entity_spec,
+    )
+
+    async def handler(payload, repo, requesting_user, request):  # noqa: ARG001
+        # Sentinel "created" object; the success path serializes its id.
+        return SimpleNamespace(id=uuid4())
+
+    app = FastAPI()
+    router = APIRouter(prefix="/widgets")
+    mount_create(router, spec, handler=handler)
+    app.include_router(router)
+    return app
+
+
+def _stub_renderer_returning(html: str) -> Any:
+    """Build a stub for `APIResponse.html_response` that returns a real
+    `Response` carrying `html`, and records the call so the test can
+    assert on the context that landed."""
+    calls: list[dict] = []
+
+    def stub(template_name, context, request, *, current_user=None):
+        calls.append(
+            {
+                "template_name": template_name,
+                "context": context,
+                "current_user": current_user,
+            }
+        )
+        return Response(content=html, media_type="text/html", status_code=200)
+
+    stub.calls = calls  # type: ignore[attr-defined]
+    return stub
+
+
+def _fake_entity_spec(
+    *, discriminator: Any = None, form_new_template: str | None = "widgets/new.html"
+) -> SimpleNamespace:
+    """Minimal stand-in for the `EntitySpec` back-ref. Only the
+    attributes `_render_form_with_errors` reads need to be present —
+    `discriminator` for the kind branch, `templates.form_new` for the
+    fallback template. `handle_get_new_form` is patched out in the
+    tests that exercise the renderer, so its richer demands aren't
+    needed here."""
+    return SimpleNamespace(
+        discriminator=discriminator,
+        templates=SimpleNamespace(form_new=form_new_template),
+    )
+
+
+def test_mount_create_with_hx_request_and_form_error_render_invokes_renderer() -> None:
+    """The headline path: HX-Request + opted-in spec + validation
+    failure → renderer is called (returns 200), no 422 surfaces."""
+    app = _build_app(form_error_render=True, entity_spec=_fake_entity_spec())
+    renderer = _stub_renderer_returning("<form>rendered</form>")
+    with (
+        patch(
+            "src.framework.dispatch.mounts.create.APIResponse.html_response",
+            new=renderer,
+        ),
+        patch(
+            "src.framework.dispatch.handlers.handle_get_new_form",
+            new=_fake_handle_get_new_form,
+        ),
+    ):
+        client = TestClient(app)
+        # POST with no `x` → 422 from validation; HX-Request opts into
+        # the rerender branch.
+        resp = client.post("/widgets", data={}, headers={"HX-Request": "true"})
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert resp.text == "<form>rendered</form>"
+    assert len(renderer.calls) == 1
+    ctx = renderer.calls[0]["context"]
+    # The renderer received the framework-built `form_errors` /
+    # `form_values` keys — the per-form template's only job is to read
+    # them.
+    assert ctx["form_errors"] == {"x": "Field required"}
+    assert ctx["form_values"] == {}
+
+
+def test_mount_create_without_hx_request_falls_through_to_json_422() -> None:
+    """No `HX-Request` header → JSON 422, even when the spec opted in.
+    Preserves the API contract for non-HTMX callers."""
+    app = _build_app(form_error_render=True, entity_spec=_fake_entity_spec())
+    renderer = _stub_renderer_returning("<form>should not be called</form>")
+    with patch(
+        "src.framework.dispatch.mounts.create.APIResponse.html_response",
+        new=renderer,
+    ):
+        client = TestClient(app)
+        resp = client.post("/widgets", data={})
+
+    assert resp.status_code == 422
+    assert resp.headers["content-type"].startswith("application/json")
+    assert renderer.calls == []
+
+
+def test_mount_create_with_hx_request_but_no_opt_in_falls_through_to_json_422() -> None:
+    """Spec without `form_error_render` → JSON 422 even on HX-Request.
+    Default behavior is unchanged; the opt-in is the *only* trigger."""
+    app = _build_app(form_error_render=False)
+    renderer = _stub_renderer_returning("<form>should not be called</form>")
+    with patch(
+        "src.framework.dispatch.mounts.create.APIResponse.html_response",
+        new=renderer,
+    ):
+        client = TestClient(app)
+        resp = client.post("/widgets", data={}, headers={"HX-Request": "true"})
+
+    assert resp.status_code == 422
+    assert renderer.calls == []
+
+
+def test_mount_create_opted_in_but_missing_entity_spec_falls_back_to_422() -> None:
+    """Defensive: a ResourceSpec built outside `EntitySpec.to_resource_spec()`
+    can carry `form_error_render=True` without an `entity_spec` back-ref.
+    Rather than 500 on a None-deref, the rerender path bails to the
+    original 422 so the caller sees the validation failure."""
+    app = _build_app(form_error_render=True, entity_spec=None)
+    client = TestClient(app)
+    resp = client.post("/widgets", data={}, headers={"HX-Request": "true"})
+
+    assert resp.status_code == 422
+
+
+def test_mount_create_successful_post_still_returns_201_with_hx_redirect() -> None:
+    """Sanity check: the rerender branch must not interfere with the
+    happy path. A valid POST still flows through to the handler and
+    returns the standard 201 + HX-Redirect response."""
+    app = _build_app(form_error_render=True, entity_spec=_fake_entity_spec())
+    client = TestClient(app)
+    resp = client.post("/widgets", data={"x": "hello"})
+
+    assert resp.status_code == 201
+    assert "HX-Redirect" in resp.headers
+    assert resp.headers["Location"].startswith("/widgets/")
+
+
+# --- helpers --------------------------------------------------------------
+
+
+async def _fake_handle_get_new_form(
+    *, spec, request, requesting_user, kind=None, **_kwargs
+):
+    """Stand-in for `handle_get_new_form` that returns a minimal
+    context dict — enough for `_render_form_with_errors` to layer
+    `form_errors` / `form_values` on top without needing a real
+    EntitySpec (audit, repos, discriminator registry, …)."""
+    return {
+        "request": request,
+        "current_user": requesting_user,
+        "kind": kind,
+    }

--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -37,9 +37,27 @@ test_no_orphan_small_siblings_in_form_templates`.
 
 `invalid` is a tri-state — `None` (default, no aria), `True` (sets
 `aria-invalid="true"`, Pico colors the field + small red), `False`
-(`aria-invalid="false"`, Pico colors green). Currently unused at
-callsites but plumbed through so an error-rendering pass can land
-without touching every macro again.
+(`aria-invalid="false"`, Pico colors green). Callsites typically set
+this implicitly via the `error=` parameter below.
+
+## Inline error text (`error=None`)
+
+`error` is a string. When set, the macro follows Pico's canonical
+invalid-form pattern (https://picocss.com/docs/forms/input):
+
+  - the `<small id="<name>-helper">` slot carries the error text
+    instead of the helper text (one small per field, single id),
+  - the input keeps `aria-describedby="<name>-helper"` so screen
+    readers announce the error,
+  - the input auto-sets `aria-invalid="true"` — Pico colors both the
+    input and the sibling `<small>` red via its
+    `[aria-invalid="true"] ~ small` rule (callers don't pass
+    `invalid=` redundantly alongside `error=`).
+
+If both `help=` and `error=` are set, the error wins — the helper text
+is suppressed for that render so the visible message is the actionable
+one. Used by the form-error-rerender path on validation failure — see
+the `form_error_render` opt-in on `EntitySpec` and `mount_create`.
 
 ## Schema dispatch (`field_for`)
 
@@ -65,8 +83,16 @@ Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
    `aria-invalid` only when `invalid is not none`. Macros call this
    inline rather than via macro-call to avoid double-whitespace in the
 emitted attribute string. #}
-{% macro _help_small(name, help) -%}
-  {%- if help %}<small id="{{ name }}-helper">{{ help|safe }}</small>{%- endif %}
+{# Pico's canonical "one small per field" slot: when `error` is set the
+   small carries the error text; otherwise (and when `help` is set) it
+   carries the helper text. The id stays `<name>-helper` either way so
+   the input's `aria-describedby="<name>-helper"` stays valid in both
+   states without re-wiring. Pico's `[aria-invalid="true"] ~ small`
+   selector colors the small red automatically when the input has
+   `aria-invalid="true"`. #}
+{% macro _help_small(name, help, error=None) -%}
+  {%- if error %}<small id="{{ name }}-helper">{{ error }}</small>
+  {%- elif help %}<small id="{{ name }}-helper">{{ help|safe }}</small>{%- endif %}
 {%- endmacro %}
 {# Field label + optional indicator. Every macro funnels its label through
    here so the "(optional)" marker is the *only* way an optional field is
@@ -82,7 +108,8 @@ emitted attribute string. #}
   {{ label }}{%- if not required -%}<small class="form-field-optional">(optional)</small>{%- endif -%}
 {%- endmacro %}
 {# ---- text-like inputs --------------------------------------------- #}
-{% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None, help=None, invalid=None, type="text", autocomplete=None) -%}
+{% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None, help=None, invalid=None, error=None, type="text", autocomplete=None) -%}
+  {%- set aria_invalid = true if error else invalid -%}
   <label class="form-field" for="{{ name }}">
     <span class="form-field-label">{{ _field_label(label, required) }}</span>
     <input type="{{ type }}"
@@ -93,43 +120,45 @@ emitted attribute string. #}
            {% if maxlength %}maxlength="{{ maxlength }}"{% endif %}
            {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
            {% if required %}required{% endif %}
-           {% if help %}aria-describedby="{{ name }}-helper"{% endif %}
-           {% if invalid is not none %}aria-invalid="{{ 'true' if invalid else 'false' }}"{% endif %} />
-    {{- _help_small(name, help) }}
+           {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
+           {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %} />
+    {{- _help_small(name, help, error) }}
   </label>
 {%- endmacro %}
-{% macro textarea_field(name, label, current=None, required=True, help=None, invalid=None) -%}
+{% macro textarea_field(name, label, current=None, required=True, help=None, invalid=None, error=None) -%}
+  {%- set aria_invalid = true if error else invalid -%}
   <label class="form-field" for="{{ name }}">
     <span class="form-field-label">{{ _field_label(label, required) }}</span>
     <textarea id="{{ name }}"
               name="{{ name }}"
               {% if required %}required{% endif %}
-              {% if help %}aria-describedby="{{ name }}-helper"{% endif %}
-              {% if invalid is not none %}aria-invalid="{{ 'true' if invalid else 'false' }}"{% endif %}>{{ current or "" }}</textarea>
-    {{- _help_small(name, help) }}
+              {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
+              {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>{{ current or "" }}</textarea>
+    {{- _help_small(name, help, error) }}
   </label>
 {%- endmacro %}
 {# `url_field` is `text_field(type="url")` with a more readable callsite.
    Browsers validate the URL on submit; the Pydantic schema's
    `HttpUrl`/`HtmlUrl` re-validates server-side. #}
-{% macro url_field(name, label, current=None, required=True, help=None, invalid=None) -%}
-  {{ text_field(name, label, current=current, required=required, help=help, invalid=invalid, type="url") }}
+{% macro url_field(name, label, current=None, required=True, help=None, invalid=None, error=None) -%}
+  {{ text_field(name, label, current=current, required=required, help=help, invalid=invalid, error=error, type="url") }}
 {%- endmacro %}
 {# ---- selects ------------------------------------------------------- #}
-{% macro select_field(name, label, options, labels=None, current=None, required=True, placeholder=False, help=None, invalid=None) -%}
+{% macro select_field(name, label, options, labels=None, current=None, required=True, placeholder=False, help=None, invalid=None, error=None) -%}
+  {%- set aria_invalid = true if error else invalid -%}
   <label class="form-field" for="{{ name }}">
     <span class="form-field-label">{{ _field_label(label, required) }}</span>
     <select id="{{ name }}"
             name="{{ name }}"
             {% if required %}required{% endif %}
-            {% if help %}aria-describedby="{{ name }}-helper"{% endif %}
-            {% if invalid is not none %}aria-invalid="{{ 'true' if invalid else 'false' }}"{% endif %}>
+            {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
+            {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>
       {%- if placeholder and not current %}<option value="" disabled selected>--</option>{%- endif %}
       {%- for v in options %}
         <option value="{{ v }}"{% if current == v %} selected{% endif %}>{{ labels[v] if labels else v }}</option>
       {%- endfor %}
     </select>
-    {{- _help_small(name, help) }}
+    {{- _help_small(name, help, error) }}
   </label>
 {%- endmacro %}
 {# `<select multiple>` driven by a controlled-vocabulary tuple. One
@@ -145,21 +174,22 @@ emitted attribute string. #}
    semantic is "any subset, including the empty set" (no in-network
    carriers, no featured services). Callers can pass `required=True`
    to force at least one selection. #}
-{% macro multi_select_field(name, label, options, labels=None, current=None, required=False, help=None, invalid=None) -%}
+{% macro multi_select_field(name, label, options, labels=None, current=None, required=False, help=None, invalid=None, error=None) -%}
   {%- set selected = current or [] -%}
+  {%- set aria_invalid = true if error else invalid -%}
   <label class="form-field" for="{{ name }}">
     <span class="form-field-label">{{ _field_label(label, required) }}</span>
     <select id="{{ name }}"
             name="{{ name }}"
             multiple
             size="{{ [options|length, 8]|min }}"
-            {% if help %}aria-describedby="{{ name }}-helper"{% endif %}
-            {% if invalid is not none %}aria-invalid="{{ 'true' if invalid else 'false' }}"{% endif %}>
+            {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
+            {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>
       {%- for v in options %}
         <option value="{{ v }}"{% if v in selected %} selected{% endif %}>{{ labels[v] if labels else v }}</option>
       {%- endfor %}
     </select>
-    {{- _help_small(name, help) }}
+    {{- _help_small(name, help, error) }}
   </label>
 {%- endmacro %}
 {# `<select>` populated from a list of entity rows — the canonical
@@ -181,15 +211,16 @@ emitted attribute string. #}
    value on edit). String/UUID equality is handled by stringifying both
    sides — the option `value` attribute is stringified by the browser
    anyway, so callers don't need to coerce. #}
-{% macro entity_select_field(name, label, entities, current=None, required=True, blank_label=None, help=None, invalid=None, value_attr="id", label_attr="name") -%}
+{% macro entity_select_field(name, label, entities, current=None, required=True, blank_label=None, help=None, invalid=None, error=None, value_attr="id", label_attr="name") -%}
   {%- set current_s = current|string if current is not none else "" -%}
+  {%- set aria_invalid = true if error else invalid -%}
   <label class="form-field" for="{{ name }}">
     <span class="form-field-label">{{ _field_label(label, required) }}</span>
     <select id="{{ name }}"
             name="{{ name }}"
             {% if required %}required{% endif %}
-            {% if help %}aria-describedby="{{ name }}-helper"{% endif %}
-            {% if invalid is not none %}aria-invalid="{{ 'true' if invalid else 'false' }}"{% endif %}>
+            {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
+            {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>
       {%- if blank_label is not none %}
         <option value=""{% if current_s == "" %} selected{% endif %}>{{ blank_label }}</option>
       {%- elif required and not current %}
@@ -201,7 +232,7 @@ emitted attribute string. #}
         <option value="{{ ev }}"{% if current_s == ev|string %} selected{% endif %}>{{ el }}</option>
       {%- endfor %}
     </select>
-    {{- _help_small(name, help) }}
+    {{- _help_small(name, help, error) }}
   </label>
 {%- endmacro %}
 {# ---- radio groups ------------------------------------------------- #}
@@ -240,19 +271,19 @@ emitted attribute string. #}
    macro. `current`, `required`, `help`, `invalid` pass through. Pass
    `required=false` to override the schema-derived default (e.g. an
    optional filter on a field that's required for create). #}
-{% macro field_for(schema, name, label, current=None, required=None, help=None, invalid=None) -%}
+{% macro field_for(schema, name, label, current=None, required=None, help=None, invalid=None, error=None) -%}
   {%- set spec = field_spec(schema, name) -%}
   {%- set is_required = spec.required if required is none else required -%}
   {%- if spec.kind == "select" -%}
-    {{ select_field(name, label, spec.choices, labels=spec.labels, current=current, required=is_required, placeholder=true, help=help, invalid=invalid) }}
+    {{ select_field(name, label, spec.choices, labels=spec.labels, current=current, required=is_required, placeholder=true, help=help, invalid=invalid, error=error) }}
   {%- elif spec.kind == "multi_select" -%}
-    {{ multi_select_field(name, label, spec.choices, labels=spec.labels, current=current, help=help, invalid=invalid) }}
+    {{ multi_select_field(name, label, spec.choices, labels=spec.labels, current=current, help=help, invalid=invalid, error=error) }}
   {%- elif spec.kind == "textarea" -%}
-    {{ textarea_field(name, label, current=current, required=is_required, help=help, invalid=invalid) }}
+    {{ textarea_field(name, label, current=current, required=is_required, help=help, invalid=invalid, error=error) }}
   {%- elif spec.kind == "url" -%}
-    {{ url_field(name, label, current=current, required=is_required, help=help, invalid=invalid) }}
+    {{ url_field(name, label, current=current, required=is_required, help=help, invalid=invalid, error=error) }}
   {%- elif spec.kind == "text" -%}
-    {{ text_field(name, label, current=current, required=is_required, pattern=spec.pattern, maxlength=spec.maxlength, help=help, invalid=invalid) }}
+    {{ text_field(name, label, current=current, required=is_required, pattern=spec.pattern, maxlength=spec.maxlength, help=help, invalid=invalid, error=error) }}
   {%- endif -%}
 {%- endmacro %}
 {# ---- specialized widgets ------------------------------------------ #}

--- a/src/framework/templates/_shared/test_form_fields.py
+++ b/src/framework/templates/_shared/test_form_fields.py
@@ -121,6 +121,54 @@ def test_text_field_invalid_true_sets_aria_invalid_true() -> None:
     assert "aria-invalid" not in HTMLParser(html_none).css_first("input").attributes
 
 
+def test_text_field_error_sets_aria_invalid_and_replaces_helper_with_error_text() -> (
+    None
+):
+    """`error="..."` follows Pico's canonical invalid-form pattern:
+    the input gets `aria-invalid="true"` and `aria-describedby` points
+    at the `<name>-helper` small, but the small carries the error
+    message instead of the helper text — one small per field, one id
+    in both states. Pico's `[aria-invalid="true"] ~ small` rule colors
+    it red automatically."""
+    html = _render(
+        _make_env(),
+        '{{ text_field("age_groups", "Age groups", error="Pick at least one.") }}',
+    )
+    tree = HTMLParser(html)
+    inp = tree.css_first("input")
+    assert inp.attributes.get("aria-invalid") == "true"
+    assert inp.attributes.get("aria-describedby") == "age_groups-helper"
+    small = tree.css_first("small#age_groups-helper")
+    assert small is not None
+    assert "Pick at least one." in small.text()
+
+
+def test_text_field_error_wins_over_help_text() -> None:
+    """When both `help=` and `error=` are set, the visible small is the
+    actionable error — helper text is suppressed for that render so the
+    user sees the failure, not the hint. The id stays `<name>-helper`
+    either way."""
+    html = _render(
+        _make_env(),
+        '{{ text_field("zip", "ZIP", help="5 digits.", error="Required.") }}',
+    )
+    tree = HTMLParser(html)
+    small = tree.css_first("small#zip-helper")
+    assert small is not None
+    assert "Required." in small.text()
+    assert "5 digits." not in small.text()
+
+
+def test_text_field_no_error_no_help_omits_describedby_and_small() -> None:
+    """Default state: no `aria-describedby`, no small. Pinned so a
+    future regression that always emits `<name>-helper` is caught."""
+    html = _render(_make_env(), '{{ text_field("x", "X") }}')
+    tree = HTMLParser(html)
+    inp = tree.css_first("input")
+    assert "aria-describedby" not in inp.attributes
+    assert tree.css_first("small") is None
+
+
 def test_text_field_type_parameter_overrides_default() -> None:
     """`type=` defaults to `text` and threads through (`date`, `url`,
     etc.). Pico styles all standard HTML5 input types out of the box."""
@@ -206,6 +254,25 @@ def test_multi_select_field_with_help_links_each_via_aria() -> None:
     sel = tree.css_first('select[name="tags"][multiple]')
     assert sel.attributes.get("aria-describedby") == "tags-helper"
     assert tree.css_first("small#tags-helper") is not None
+
+
+def test_multi_select_field_error_sets_aria_invalid_and_carries_message() -> None:
+    """Same Pico-canonical error pattern on `<select multiple>` as on
+    text fields — the age_groups multi-select is the first form-error
+    callsite in the codebase (see `OPENING_ENTITY` /
+    `_form_clinician_opening.html`)."""
+    html = _render(
+        _make_env(),
+        '{{ multi_select_field("age_groups", "Age groups", ("a", "b"),'
+        ' error="Select at least one age group.") }}',
+    )
+    tree = HTMLParser(html)
+    sel = tree.css_first('select[name="age_groups"]')
+    assert sel.attributes.get("aria-invalid") == "true"
+    assert sel.attributes.get("aria-describedby") == "age_groups-helper"
+    small = tree.css_first("small#age_groups-helper")
+    assert small is not None
+    assert "Select at least one age group." in small.text()
 
 
 # --- entity_select_field --------------------------------------------------

--- a/src/framework/templates/_shared/test_form_fields.py
+++ b/src/framework/templates/_shared/test_form_fields.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from jinja2 import ChoiceLoader, DictLoader, Environment, FileSystemLoader
@@ -121,54 +122,6 @@ def test_text_field_invalid_true_sets_aria_invalid_true() -> None:
     assert "aria-invalid" not in HTMLParser(html_none).css_first("input").attributes
 
 
-def test_text_field_error_sets_aria_invalid_and_replaces_helper_with_error_text() -> (
-    None
-):
-    """`error="..."` follows Pico's canonical invalid-form pattern:
-    the input gets `aria-invalid="true"` and `aria-describedby` points
-    at the `<name>-helper` small, but the small carries the error
-    message instead of the helper text — one small per field, one id
-    in both states. Pico's `[aria-invalid="true"] ~ small` rule colors
-    it red automatically."""
-    html = _render(
-        _make_env(),
-        '{{ text_field("age_groups", "Age groups", error="Pick at least one.") }}',
-    )
-    tree = HTMLParser(html)
-    inp = tree.css_first("input")
-    assert inp.attributes.get("aria-invalid") == "true"
-    assert inp.attributes.get("aria-describedby") == "age_groups-helper"
-    small = tree.css_first("small#age_groups-helper")
-    assert small is not None
-    assert "Pick at least one." in small.text()
-
-
-def test_text_field_error_wins_over_help_text() -> None:
-    """When both `help=` and `error=` are set, the visible small is the
-    actionable error — helper text is suppressed for that render so the
-    user sees the failure, not the hint. The id stays `<name>-helper`
-    either way."""
-    html = _render(
-        _make_env(),
-        '{{ text_field("zip", "ZIP", help="5 digits.", error="Required.") }}',
-    )
-    tree = HTMLParser(html)
-    small = tree.css_first("small#zip-helper")
-    assert small is not None
-    assert "Required." in small.text()
-    assert "5 digits." not in small.text()
-
-
-def test_text_field_no_error_no_help_omits_describedby_and_small() -> None:
-    """Default state: no `aria-describedby`, no small. Pinned so a
-    future regression that always emits `<name>-helper` is caught."""
-    html = _render(_make_env(), '{{ text_field("x", "X") }}')
-    tree = HTMLParser(html)
-    inp = tree.css_first("input")
-    assert "aria-describedby" not in inp.attributes
-    assert tree.css_first("small") is None
-
-
 def test_text_field_type_parameter_overrides_default() -> None:
     """`type=` defaults to `text` and threads through (`date`, `url`,
     etc.). Pico styles all standard HTML5 input types out of the box."""
@@ -254,25 +207,6 @@ def test_multi_select_field_with_help_links_each_via_aria() -> None:
     sel = tree.css_first('select[name="tags"][multiple]')
     assert sel.attributes.get("aria-describedby") == "tags-helper"
     assert tree.css_first("small#tags-helper") is not None
-
-
-def test_multi_select_field_error_sets_aria_invalid_and_carries_message() -> None:
-    """Same Pico-canonical error pattern on `<select multiple>` as on
-    text fields — the age_groups multi-select is the first form-error
-    callsite in the codebase (see `OPENING_ENTITY` /
-    `_form_clinician_opening.html`)."""
-    html = _render(
-        _make_env(),
-        '{{ multi_select_field("age_groups", "Age groups", ("a", "b"),'
-        ' error="Select at least one age group.") }}',
-    )
-    tree = HTMLParser(html)
-    sel = tree.css_first('select[name="age_groups"]')
-    assert sel.attributes.get("aria-invalid") == "true"
-    assert sel.attributes.get("aria-describedby") == "age_groups-helper"
-    small = tree.css_first("small#age_groups-helper")
-    assert small is not None
-    assert "Select at least one age group." in small.text()
 
 
 # --- entity_select_field --------------------------------------------------
@@ -403,6 +337,199 @@ def test_radio_bool_field_with_help_emits_small_inside_fieldset() -> None:
     for r in radios:
         assert r.attributes.get("aria-describedby") == "ok-helper"
     assert fs.css_first("small#ok-helper") is not None
+
+
+# --- error-state contract (pattern, parametrized over every macro) -------
+#
+# Each input macro exposed by `form_fields.html` must render the same
+# Pico-canonical error pattern when `error=` is set:
+#
+#   1. the control (`<input>`/`<select>`/`<textarea>`) carries
+#      `aria-invalid="true"` (so Pico colors it red),
+#   2. it points `aria-describedby="<name>-helper"` at the small,
+#   3. the `<small id="<name>-helper">` slot holds the error message
+#      (replacing any helper text — one small per field, single id in
+#      both valid/invalid states).
+#
+# These are the *contract* tests — one parametrized run pins the
+# pattern across every input macro, so adding a new input macro to
+# `form_fields.html` only needs one new entry below. Per-form
+# implementations (e.g. the clinician_opening age_groups callsite) are
+# smoke-tested at the route layer; they don't re-verify the pattern
+# this owns.
+
+
+def _render_macro(macro_call: str) -> "HTMLParser":
+    """Render an inline macro call against the form-fields macro file
+    and return a parsed HTML tree. Stub `entities` global lets the
+    `entity_select_field` parametrize entry render without extra fixtures."""
+    env = _make_env()
+    env.globals["entities"] = [_Stub("1", "Alpha")]
+    template = (
+        '{%- from "_shared/form_fields.html" import text_field, textarea_field,'
+        " url_field, select_field, multi_select_field, entity_select_field,"
+        " field_for -%}\n"
+        f"{macro_call}"
+    )
+    return HTMLParser(env.from_string(template).render())
+
+
+# (macro_call, control_selector) — `control_selector` is the css
+# selector for the focusable element the `aria-invalid`/`aria-describedby`
+# attrs land on (one of `<input>`, `<select>`, `<textarea>`). Each macro
+# gets one row; field_for has a row per dispatch kind (covered by the
+# field_for test below).
+_INPUT_MACROS = [
+    ("text_field", '{{ text_field("x", "X", error="bad") }}', "input"),
+    ("textarea_field", '{{ textarea_field("x", "X", error="bad") }}', "textarea"),
+    ("url_field", '{{ url_field("x", "X", error="bad") }}', "input"),
+    (
+        "select_field",
+        '{{ select_field("x", "X", ("a", "b"), error="bad") }}',
+        "select",
+    ),
+    (
+        "multi_select_field",
+        '{{ multi_select_field("x", "X", ("a", "b"), error="bad") }}',
+        "select",
+    ),
+    (
+        "entity_select_field",
+        '{{ entity_select_field("x", "X", entities, error="bad") }}',
+        "select",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "macro_name,macro_call,control_selector",
+    _INPUT_MACROS,
+    ids=[m[0] for m in _INPUT_MACROS],
+)
+def test_input_macro_with_error_emits_pico_canonical_invalid_pattern(
+    macro_name: str, macro_call: str, control_selector: str
+) -> None:
+    """All input macros emit the same `aria-invalid="true"` +
+    `aria-describedby="<name>-helper"` + `<small id="<name>-helper">`
+    structure when `error=` is set."""
+    tree = _render_macro(macro_call)
+    control = tree.css_first(control_selector)
+    assert control is not None, f"{macro_name}: missing {control_selector!r}"
+    assert (
+        control.attributes.get("aria-invalid") == "true"
+    ), f"{macro_name}: aria-invalid should be 'true' when error= is set"
+    assert (
+        control.attributes.get("aria-describedby") == "x-helper"
+    ), f"{macro_name}: aria-describedby must point at the helper slot"
+    small = tree.css_first("small#x-helper")
+    assert small is not None, f"{macro_name}: missing <small id='x-helper'>"
+    assert (
+        "bad" in small.text()
+    ), f"{macro_name}: error message did not land in the helper slot"
+
+
+@pytest.mark.parametrize(
+    "macro_name,macro_call,control_selector",
+    _INPUT_MACROS,
+    ids=[m[0] for m in _INPUT_MACROS],
+)
+def test_input_macro_error_wins_over_help_text(
+    macro_name: str, macro_call: str, control_selector: str
+) -> None:
+    """When both `help=` and `error=` are set, the small carries the
+    error — helper text is suppressed for that render. Same single-id
+    slot in both states."""
+    with_both = macro_call.replace(', error="bad"', ', help="hint", error="bad"')
+    tree = _render_macro(with_both)
+    small = tree.css_first("small#x-helper")
+    assert small is not None
+    assert "bad" in small.text(), f"{macro_name}: error must replace helper"
+    assert (
+        "hint" not in small.text()
+    ), f"{macro_name}: helper text must not co-render with error"
+
+
+@pytest.mark.parametrize(
+    "macro_name,macro_call,control_selector",
+    _INPUT_MACROS,
+    ids=[m[0] for m in _INPUT_MACROS],
+)
+def test_input_macro_no_error_no_help_omits_describedby_and_small(
+    macro_name: str, macro_call: str, control_selector: str
+) -> None:
+    """Default state: no `aria-describedby`, no small. Pins the
+    "absent unless asked" half of the contract so a regression that
+    always emits `<name>-helper` is caught for every macro."""
+    bare = macro_call.replace(', error="bad"', "")
+    tree = _render_macro(bare)
+    control = tree.css_first(control_selector)
+    assert (
+        "aria-describedby" not in control.attributes
+    ), f"{macro_name}: aria-describedby must be absent without help/error"
+    # `<small id="x-helper">` is the helper/error slot; the macros also
+    # emit a sibling `<small class="form-field-optional">(optional)</small>`
+    # inside the label when `required=False` (so multi_select_field +
+    # any other defaulted-optional field carries one). Only the helper
+    # slot must be absent.
+    assert (
+        tree.css_first("small#x-helper") is None
+    ), f"{macro_name}: <small id='x-helper'> must be absent without help/error"
+
+
+# `field_for` is the schema-driven dispatcher; it must thread `error=`
+# through to every kind it routes to. One row per `spec.kind` branch in
+# the macro. Uses a minimal stub schema so we don't have to import a
+# real Pydantic model — the test asserts the dispatch contract, not
+# the upstream schema-introspection logic (which has its own tests).
+_FIELD_FOR_KINDS = [
+    ("text", {"kind": "text", "required": True, "pattern": None, "maxlength": None}),
+    ("textarea", {"kind": "textarea", "required": True}),
+    ("url", {"kind": "url", "required": True}),
+    (
+        "select",
+        {"kind": "select", "required": True, "choices": ("a", "b"), "labels": None},
+    ),
+    (
+        "multi_select",
+        {
+            "kind": "multi_select",
+            "required": False,
+            "choices": ("a", "b"),
+            "labels": None,
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "kind,spec_dict", _FIELD_FOR_KINDS, ids=[k[0] for k in _FIELD_FOR_KINDS]
+)
+def test_field_for_threads_error_through_every_dispatched_kind(
+    kind: str, spec_dict: dict
+) -> None:
+    """`field_for(..., error=...)` must pass `error=` to whichever
+    underlying macro it dispatches to. One row per `spec.kind`
+    branch — adding a new kind to the dispatcher must add a row here."""
+    env = _make_env()
+
+    def fake_field_spec(_schema, _name):
+        return SimpleNamespace(**spec_dict)
+
+    env.globals["field_spec"] = fake_field_spec
+    tree = HTMLParser(
+        env.from_string(
+            '{%- from "_shared/form_fields.html" import field_for -%}'
+            '{{ field_for(None, "x", "X", error="bad") }}'
+        ).render()
+    )
+    # Whichever macro field_for picked, the error must land in the
+    # `<small id="x-helper">` slot and the control must carry
+    # `aria-invalid="true"` — same contract as direct macro calls.
+    small = tree.css_first("small#x-helper")
+    assert small is not None, f"kind={kind}: small not emitted"
+    assert "bad" in small.text(), f"kind={kind}: error did not thread through"
+    invalid_controls = tree.css('[aria-invalid="true"]')
+    assert invalid_controls, f"kind={kind}: no control carries aria-invalid=true"
 
 
 # --- repository-level guard ------------------------------------------------

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -243,6 +243,17 @@
         margin: 0;
         color: var(--pico-muted-color);
       }
+      /* Error state: when an input/select/textarea inside a `.form-field`
+         row carries `aria-invalid="true"` (set by the macros' `error=`
+         param), the sibling `<small id="<name>-helper">` carries the
+         error text instead of the helper text (Pico's canonical
+         one-small-per-field pattern). The selector mirrors the muted
+         rule above's specificity and adds an attribute selector so it
+         wins; Pico's own `~ small` rule for invalid forms is overridden
+         by the rule above, so we restate it here at matching depth. */
+      .entity-form-page form .form-field > [aria-invalid="true"] ~ small {
+        color: var(--pico-del-color);
+      }
       /* Inline form-fields nested inside a Pico `.grid` utility (a
          responsive 2-up row) fall back to a self-contained grid since
          their parent (the `.grid` div) isn't the subgrid source. */


### PR DESCRIPTION
## Summary

First pass on form-error UX. When a user submits the clinician_opening form without selecting an age group, the response now re-renders the form inline with the error attached to the age_groups select — instead of silently dropping a JSON 422 that HTMX has nowhere to land. Designed as an opt-in pattern any other form can adopt next.

- **Macro layer** (`form_fields.html`): every input macro gains an `error=` param using Pico's canonical one-`<small id="<name>-helper">`-per-field pattern. When `error=` is set, the input auto-carries `aria-invalid="true"` and the helper slot holds the error message instead of the helper text. Pico's `[aria-invalid="true"] ~ small` rule handles the red coloring.
- **Framework layer** (`mount_create.py`): new `form_error_render` spec flag. When True + `HX-Request: true` + Pydantic validation fails, the form template is re-rendered with `form_errors` (per-field dict) + `form_values` (the raw payload, so controls prefill from what the user typed) and returned as 200 + HTML so HTMX swaps it in place. Non-HTMX clients still get the JSON 422.
- **Spec**: `OPENING_ENTITY` opts in; everything else unchanged.
- **Template**: `_form_clinician_opening.html` accepts `errors`/`values`, wires age_groups, sets `hx-target="this" hx-swap="outerHTML"` on the form.

Test layering (per the in-PR discussion about scalability across N forms × M field types):

- Pico-canonical pattern: parametrized macro test runs over all 6 input macros + `field_for` dispatch — adding a new input macro to `form_fields.html` only needs one new entry.
- Framework branching (`form_error_render` on/off, HX-Request on/off, kind-prefix stripping, malformed-input degradation): pure-unit tests in `src/framework/dispatch/mounts/test_create.py` using a synthetic FastAPI app with a mocked renderer — no real templating, runs in 0.09s.
- Per-form integration: `test_post_families.py` shrunk to a single smoke that just asserts "POST returns 200 + HTML mentioning the failing field." Future opt-ins only need a copy of this smoke for their form.

Drive-by: `dev lint` was hanging because `isort --check-only .` and `black --check .` were walking `.claude/worktrees/` (~100 per-task worktrees with full source trees inside). `extend_skip = [".claude"]` (isort) + matching `extend-exclude` (black) drops both checks to under 1s.

## Test plan

- [ ] `dev lint` completes in a reasonable time and passes
- [ ] `dev test` passes (1728 passed locally)
- [ ] `dev up` from this branch; log in, go to the clinician_opening create form, submit without selecting any age groups
  - Expect: form re-renders in place with the age_groups select outlined red and the error message under it
  - Other fields keep their submitted values (no reset)
- [ ] Same submit with a valid age_group: 201 + redirect to detail (success path unchanged)
- [ ] Try a different form (e.g. organization create) with an invalid submission: still 422 + JSON (non-opted-in entities unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)