### PR TITLE
feat(auth): inline error UX for register; duplicate email shows per-field error

### DIFF
--- a/src/domain/routes/auth_routes.py
+++ b/src/domain/routes/auth_routes.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, Request, status
+from fastapi_users import exceptions as fa_users_exceptions
 from fastapi_users import models
 from fastapi_users.manager import BaseUserManager
 from fastapi_users.router.common import ErrorCode, ErrorModel
@@ -10,6 +11,7 @@ from src.domain.logic.auth.handlers import handle_registration
 from src.domain.logic.users.schema import UserCreate, UserRead
 from src.framework import BaseRouter
 from src.framework.audit.repository import AuditRepository
+from src.framework.http.form_rerender import form_rerender
 from src.framework.persistence.dependencies import get_audit_repository
 
 auth_api_router = APIRouter()
@@ -73,14 +75,49 @@ async def register_request_handler(
     audit_repo: AuditRepository = Depends(get_audit_repository),
 ):
     logger.debug(f"Handling registration for email: {request_data.email}")
-    created_user = await handle_registration(
-        request_data=request_data,
-        request=request,
-        user_manager=user_manager,
-        audit_repo=audit_repo,
-    )
+    is_htmx = request.headers.get("HX-Request") == "true"
+    try:
+        created_user = await handle_registration(
+            request_data=request_data,
+            request=request,
+            user_manager=user_manager,
+            audit_repo=audit_repo,
+        )
+    except fa_users_exceptions.UserAlreadyExists:
+        # HTMX submit: re-render the form fragment in place with a
+        # per-field error pointing at `email` instead of letting the
+        # `handle_route_errors` decorator translate this into a JSON
+        # 400 that HTMX has nowhere to land. Password is *not* echoed
+        # back into form HTML — only the email is prefilled via
+        # `form_values["email"]` (see `_register_form.html`).
+        # Non-HTMX clients preserve the existing JSON 400 contract
+        # (programmatic clients, contract tests) — fall through to
+        # re-raise so the decorator does its translation.
+        if is_htmx:
+            return form_rerender(
+                request=request,
+                template_name="auth/_register_form.html",
+                field_errors={
+                    "email": "An account with this email already exists.",
+                },
+                values={"email": request_data.email},
+            )
+        raise
+    except fa_users_exceptions.InvalidPasswordException as e:
+        # Same rerender pattern for the password-policy failure case.
+        # `e.reason` carries the policy-specific message the password
+        # validator raised (length, char-class, etc.) — surface it
+        # directly so the user knows what to fix.
+        if is_htmx:
+            return form_rerender(
+                request=request,
+                template_name="auth/_register_form.html",
+                field_errors={"password": e.reason},
+                values={"email": request_data.email},
+            )
+        raise
 
-    if request.headers.get("HX-Request") == "true":
+    if is_htmx:
         # HTMX submit: auto-login and redirect instead of returning raw JSON.
         # Mirrors the pattern in src/domain/routes/dev_auth.py.
         login_response = await auth_backend.login(get_strategy(), created_user)

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -112,6 +112,44 @@ async def test_register_duplicate_email(test_client: AsyncClient, logged_in_user
     assert response.status_code == 400
 
 
+async def test_register_htmx_duplicate_email_rerenders_form_with_field_error(
+    test_client: AsyncClient, logged_in_user: User
+):
+    """HTMX register + duplicate email → 200 + HTML form fragment with
+    a per-field error on the email input and the email prefilled via
+    `form_values`. Password is *not* echoed back (never echo a
+    password into form HTML). Mirrors the login bad-creds re-render
+    path — same `form_rerender` plumbing on the framework side.
+
+    Non-HTMX clients still get the JSON 400 contract (pinned by
+    `test_register_duplicate_email` above) — the rerender branch is
+    gated on `HX-Request: true`."""
+    response = await test_client.post(
+        "/auth/register",
+        json={"email": logged_in_user.email, "password": "newpassword"},
+        headers={"HX-Request": "true", "Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    # Per-field error sits in the email input's `<small>` slot via the
+    # form-fields macro's `error=` auto-resolution.
+    assert "An account with this email already exists." in body
+    # Email is preserved so the user doesn't have to retype it.
+    assert f'value="{logged_in_user.email}"' in body
+    # Password is NOT echoed — same defense as the login re-render.
+    assert "newpassword" not in body
+    # Fragment-only response: the re-render returns just the `<form>`,
+    # not the full `auth/register.html` page. HTMX swaps the form
+    # element in place via `hx-target="this" hx-swap="outerHTML"`;
+    # feeding it the full page here would nest the entire page chrome
+    # inside the form slot.
+    assert "<!DOCTYPE" not in body
+    assert "<html" not in body
+    assert "Bedlam Connect" not in body
+    assert "<h1>Create an account</h1>" not in body
+
+
 async def test_login_success(test_client: AsyncClient, logged_in_user: User):
     login_data = {
         "username": logged_in_user.email,

--- a/src/domain/templates/auth/_register_form.html
+++ b/src/domain/templates/auth/_register_form.html
@@ -1,0 +1,38 @@
+{# Register form fragment — just the `<form>` and its contents, no page
+   chrome.
+
+   Rendered in two contexts:
+
+   1. As part of `auth/register.html` (the full GET page) via
+      `{% include "auth/_register_form.html" %}`. The chrome (header,
+      footer link to login) wraps it.
+   2. Standalone by `register_request_handler`'s error-rerender path
+      (see `src/domain/routes/auth_routes.py` → `form_rerender`) when
+      registration fails (duplicate email, invalid password). HTMX's
+      `outerHTML` swap replaces just the `<form>` in place; rendering
+      the full page here would nest the entire page chrome inside the
+      form slot.
+
+   `with context` is required so the form_fields / form_banner macros
+   auto-resolve from `form_errors` / `form_values` / `form_banner_text`
+   (see the docstring at the top of `_shared/form_fields.html`). #}
+{%- from "_shared/form_fields.html" import text_field with context -%}
+{%- from "_shared/form_banner.html" import form_banner with context -%}
+{# `hx-ext="json-enc"` matches `UserCreate`'s JSON body contract on
+   `POST /auth/register`. `hx-target="this" hx-swap="outerHTML"` lets
+   the error-rerender path swap the form fragment in place. #}
+<form hx-post="/auth/register"
+      hx-ext="json-enc"
+      hx-target="this"
+      hx-swap="outerHTML">
+  {{ form_banner() }}
+  {# Email is preserved on re-render via `form_values["email"]` so the
+     user only retypes the password. Password is intentionally not
+     echoed back — never echo a password into form HTML. #}
+  {{ text_field("email", "Email", type="email", autocomplete="email") }}
+  {{ text_field("password",
+    "Password",
+    type="password",
+    autocomplete="new-password") }}
+  <button type="submit">Create account</button>
+</form>

--- a/src/domain/templates/auth/register.html
+++ b/src/domain/templates/auth/register.html
@@ -5,17 +5,13 @@
       <h1>Create an account</h1>
       <p>Create your clinician profile and start sharing available openings with referrers in your network.</p>
     </header>
-    <form hx-post="/auth/register" hx-ext="json-enc">
-      <label for="email">
-        Email
-        <input type="email" id="email" name="email" required />
-      </label>
-      <label for="password">
-        Password
-        <input type="password" id="password" name="password" required />
-      </label>
-      <button type="submit">Create account</button>
-    </form>
+    {# The form lives in `_register_form.html` so the error-rerender
+       path can re-render *just the form fragment* (`hx-target="this"
+       hx-swap="outerHTML"` would otherwise nest the entire page
+       chrome inside the form slot). See the partial's docstring +
+       `register_request_handler`'s `form_rerender` call for the
+       wiring. #}
+    {% include "auth/_register_form.html" %}
     <footer>
       <p>
         Already have an account?


### PR DESCRIPTION
## Summary

Extends the form-error rerender pattern (#834 referrals, #837 login) to the third inbound auth form — registration. Duplicate-email and invalid-password no longer leave HTMX with a JSON 400 it can't display; they re-render the form fragment in place with a per-field error and the email prefilled.

## What changed

- **Template** — extract `auth/_register_form.html` fragment (mirrors `auth/_login_form.html`); page chrome stays in `register.html`. Macros imported \`with context\` so the framework auto-resolves \`form_errors\` / \`form_values\` on re-render.
- **Route** — \`register_request_handler\` now catches \`UserAlreadyExists\` and \`InvalidPasswordException\`. On \`HX-Request: true\`, returns 200 + the form fragment via \`form_rerender\` with \`field_errors={"email": "..."}\` (or \`{"password": e.reason}\` for the password-policy case). Non-HTMX clients still get the JSON 400 contract (\`test_register_duplicate_email\` still pins it).
- **Security** — password is never echoed back into form HTML.

## Why 200 (not 400) on the rerender

Same reasoning as the login wrapper (see \`src/framework/http/form_rerender.py\` docstring): HTMX only swaps on 2xx, so the wire-level error signal moves from the status code into the rendered HTML (\`aria-invalid="true"\` + per-field \`<small>\`). The 400 contract is preserved for non-HTMX callers.

## Follow-up (separate PRs)

This PR adds a third hand-rolled \`try/except\` block parallel to the login wrapper. Next PRs in this series:

1. Extract \`@with_form_rerender\` decorator (lift the exception → rerender plumbing out of route handlers).
2. \`FormErrorPolicy\` registry — unify the Pydantic 422 path (\`mount_create\`) and the auth exception path under one declarative shape.
3. Contract pinning between leakable exceptions and form templates.

## Test plan

- [x] 1765 unit + contract tests pass; \`dev lint\` clean
- [x] New test: \`test_register_htmx_duplicate_email_rerenders_form_with_field_error\` pins the rerender contract (200, fragment-only body, per-field error text, email prefill, no password echo, no page chrome leakage)
- [x] Existing \`test_register_duplicate_email\` still passes — non-HTMX 400 contract preserved
- [ ] Restart dev server on this branch, navigate to \`/auth/register\`
- [ ] Submit an email that already has an account → form re-renders in place with red field-level error on email; email preserved; password field empty
- [ ] Submit a brand-new email + valid password → 200 + \`HX-Redirect: /users/me\`, cookie set
- [ ] Submit via \`curl\` (no \`HX-Request\`) with a duplicate email → still 400 + JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)