### PR TITLE
feat(forms): inline error UX for organizations, programs, providers

### DIFF
--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -70,6 +70,42 @@ async def test_create_organization_happy_path(
     assert rows[0].action == "create_organization"
 
 
+async def test_create_organization_form_error_render_is_wired(
+    authenticated_client: AsyncClient,
+):
+    """Integration smoke for `ORGANIZATION_ENTITY.form_error_render`.
+
+    HX-Request POST with an empty `name` trips the schema's
+    min-length constraint → 422 + HTML fragment with the inline
+    error landed on the `name` input via macro auto-resolution.
+
+    Structural contracts (HX-Request gating, fragment-only response,
+    422 status from PR #5) live in `test_post_families.py` /
+    `test_create.py` — duplicating them here would be alphabet
+    instead of grammar. This smoke just asserts the wiring is on
+    end-to-end for this entity (the spec opt-in, the form's
+    `with context` imports, the fragment file's existence).
+    """
+    response = await authenticated_client.post(
+        "/organizations",
+        data={"name": "", "type": "health_system"},
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 422, response.text
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    # `aria-invalid="true"` on the name input proves the macro layer
+    # picked up `form_errors["name"]` from the rerender context.
+    assert 'name="name"' in body
+    name_at = body.index('name="name"')
+    name_window = body[max(0, name_at - 200) : name_at + 200]
+    assert 'aria-invalid="true"' in name_window, name_window
+    # Fragment-only response — no page chrome leakage.
+    assert "<!DOCTYPE" not in body
+    assert "<html" not in body
+    assert "Bedlam Connect" not in body
+
+
 async def test_create_organization_with_parent_inherits_root(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/routes/test_programs.py
+++ b/src/domain/routes/test_programs.py
@@ -105,6 +105,35 @@ async def test_create_program_happy_path(
     assert rows[0].actor_id == logged_in_user.id
 
 
+async def test_create_program_form_error_render_is_wired(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Integration smoke for `PROGRAM_ENTITY.form_error_render`.
+
+    HX-Request POST with an empty `name` trips the schema's
+    min-length → 422 + HTML fragment with the inline error on the
+    `name` input. Same shape as the organizations smoke; rationale
+    in `test_post_families.py::test_clinician_opening_create_form_error_render_is_wired`.
+    """
+    org_id = await _seed_org(db_test_session_manager, owner_id=logged_in_user.id)
+    response = await authenticated_client.post(
+        "/programs",
+        data=_program_payload(org_id=org_id, name=""),
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 422, response.text
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    name_at = body.index('name="name"')
+    name_window = body[max(0, name_at - 200) : name_at + 200]
+    assert 'aria-invalid="true"' in name_window, name_window
+    assert "<!DOCTYPE" not in body
+    assert "<html" not in body
+    assert "Bedlam Connect" not in body
+
+
 async def test_create_program_with_blank_optional_form_fields_succeeds(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -145,6 +145,45 @@ async def test_create_provider_happy_path(
     assert rows[0].actor_id == logged_in_user.id
 
 
+async def test_create_provider_form_error_render_is_wired(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Integration smoke for `PROVIDER_ENTITY.form_error_render`.
+
+    HX-Request POST with an invalid `in_person_sessions` value
+    (the field is a Literal over `LOCATION_AVAILABILITY_OPTIONS`)
+    → 422 + HTML fragment with the inline error landed on the
+    `in_person_sessions` input. Same shape as the organizations /
+    programs smokes.
+
+    `first_name` would have been a more obvious trip — but the
+    schema models it as `StrippedOptionalText = None` (matches the
+    rest of the provider model's tolerant defaults), so an empty
+    string passes. Pin the actual Literal field instead.
+    """
+    org_id = await _seed_org(
+        db_test_session_manager, owner_id=logged_in_user.id, name="Acme"
+    )
+    payload = provider_payload(org_id=str(org_id))
+    payload["in_person_sessions"] = "not-a-valid-option"
+    response = await authenticated_client.post(
+        "/clinicians",
+        data=payload,
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 422, response.text
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    field_at = body.index('name="in_person_sessions"')
+    window = body[max(0, field_at - 200) : field_at + 200]
+    assert 'aria-invalid="true"' in window, window
+    assert "<!DOCTYPE" not in body
+    assert "<html" not in body
+    assert "Bedlam Connect" not in body
+
+
 async def test_create_provider_allows_multiple_per_user(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/specs/organization.py
+++ b/src/domain/specs/organization.py
@@ -52,6 +52,13 @@ ORGANIZATION_ENTITY: Final[EntitySpec] = EntitySpec(
     list_order_by=Organization.created_at.desc(),
     create_redirect=_organization_form_redirect,
     update_redirect=_organization_form_redirect,
+    # Opt into the HX-Request re-render-on-validation-failure path —
+    # see `EntitySpec.form_error_render`. On a Pydantic 422 the
+    # framework re-renders `organizations/_form_new_fragment.html`
+    # with `form_errors` / `form_values` injected; the form-field
+    # macros auto-resolve from those keys (the form template imports
+    # them `with context`).
+    form_error_render=True,
     # The create/edit form's parent-Org picker is scoped per-viewer to
     # the user's owned Organizations (superusers see all). Replaces the
     # free-text UUID input — see issue #581. The framework invokes the

--- a/src/domain/specs/program.py
+++ b/src/domain/specs/program.py
@@ -50,6 +50,11 @@ PROGRAM_ENTITY: Final[EntitySpec] = EntitySpec(
     list_order_by=Program.created_at.desc(),
     create_redirect=_program_form_redirect,
     update_redirect=_program_form_redirect,
+    # Opt into the HX-Request re-render-on-validation-failure path —
+    # see `EntitySpec.form_error_render`. On a Pydantic 422 the
+    # framework re-renders `programs/_form_new_fragment.html` with
+    # `form_errors` / `form_values` injected.
+    form_error_render=True,
     # The create/edit form's Org-picker is scoped per-viewer to the user's
     # owned Organizations. The framework invokes the extras callable on
     # both the create path (target=None) and the edit path (target=<row>)

--- a/src/domain/specs/provider.py
+++ b/src/domain/specs/provider.py
@@ -113,6 +113,11 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     ),
     create_redirect=_provider_form_redirect,
     update_redirect=_provider_form_redirect,
+    # Opt into the HX-Request re-render-on-validation-failure path —
+    # see `EntitySpec.form_error_render`. On a Pydantic 422 the
+    # framework re-renders `providers/_form_new_fragment.html`
+    # with `form_errors` / `form_values` injected.
+    form_error_render=True,
     # Template paths are pinned explicitly because the directory cluster
     # is still `templates/providers/` (the Python model file lives at
     # `models/providers/provider.py` and the brief kept that filename

--- a/src/domain/templates/organizations/_form_new_fragment.html
+++ b/src/domain/templates/organizations/_form_new_fragment.html
@@ -1,0 +1,44 @@
+{# Organization create-form fragment — just the `<form>` element, no
+   page chrome.
+
+   Rendered in two contexts:
+
+   1. Included by `organizations/form_new.html` when the user has
+      passed `?type=<value>` (the type-picker has been resolved to a
+      specific organization type and the form should appear).
+   2. Standalone by `mount_create._render_form_with_errors` on a
+      validation-failure re-render. The path-derivation convention
+      (`<dir>/_<name>_fragment.html`) requires this file's name.
+
+   `with context` is required so the form-field macros auto-resolve
+   per-field `error=`/`current=` from `form_errors`/`form_values`
+   injected into the render context by `mount_create` — see
+   `_shared/form_fields.html` docstring. The `form_with_errors`
+   wrapper bakes in the four hx-* attrs (`hx-target`, `hx-swap`,
+   `hx-target-4xx`, `hx-swap-4xx`) and the `{{ form_banner() }}`
+   placement, so the template stays focused on field declarations. #}
+{%- from "_shared/form_fields.html" import entity_select_field, select_field, text_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{%- from "_shared/actions.html" import actions -%}
+{%- set selected_type = request.query_params.get('type', '') -%}
+{% call form_with_errors(action=entity_url('organization'), method="post") %}
+  <fieldset>
+    <legend>Organization</legend>
+    <div class="grid">
+      {{ text_field("name", "Name", maxlength=200) }}
+      {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, current=selected_type) }}
+    </div>
+    {# Parent-Org picker — replaces the free-text UUID input from #581.
+       `parent_org_options` is populated by `organization_form_extras`
+       (see `ORGANIZATION_ENTITY.form_extras_path`). Empty value =
+       root organization; blank-string is coerced to None by the
+       schema's `OptionalUuid`. #}
+    {{ entity_select_field("parent_org_id",
+        "Parent organization",
+        parent_org_options,
+        blank_label="(no parent)",
+        required=false,
+        help="Most organizations have no parent. Set one only if this is part of a larger network.",) }}
+  </fieldset>
+  {{ actions(entity_create_label('organization') , cancel_url=entity_url('organization')) }}
+{% endcall %}

--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -7,10 +7,14 @@ set) skips the picker and renders the full create form with that type
 pre-selected in the Type dropdown.
 
 This mirrors the `/openings/form` picker pattern (issue #704).
+
+The actual form lives in `_form_new_fragment.html` so the framework's
+error-rerender path (`mount_create._render_form_with_errors`) can
+re-render just the form fragment on a Pydantic validation failure —
+the path-derivation convention (`<dir>/_<name>_fragment.html`) requires
+a sibling file with that exact name. The full page below includes it.
 #}
 {% extends "views/form_new.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, select_field, text_field -%}
-{%- from "_shared/actions.html" import actions -%}
 {%- from "_shared/_picker.html" import picker -%}
 {% block resource_label %}Organizations{% endblock %}
 {% block content %}
@@ -38,28 +42,6 @@ This mirrors the `/openings/form` picker pattern (issue #704).
     "description": "Doesn't fit the above."},
     ]) }}
   {% else %}
-    {# Form: shown when ?type= is set (either via picker click or deep link).
-   The Type dropdown is pre-selected to the value from the query param. #}
-    <form hx-post="{{ entity_url('organization') }}">
-      <fieldset>
-        <legend>Organization</legend>
-        <div class="grid">
-          {{ text_field("name", "Name", maxlength=200) }}
-          {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, current=selected_type) }}
-        </div>
-        {# Parent-Org picker — replaces the free-text UUID input from #581.
-       `parent_org_options` is populated by `organization_form_extras`
-       (see `ORGANIZATION_ENTITY.form_extras_path`). Empty value =
-       root organization; blank-string is coerced to None by the
-       schema's `OptionalUuid`. #}
-        {{ entity_select_field("parent_org_id",
-                "Parent organization",
-                parent_org_options,
-                blank_label="(no parent)",
-                required=false,
-                help="Most organizations have no parent. Set one only if this is part of a larger network.",) }}
-      </fieldset>
-      {{ actions(entity_create_label('organization') , cancel_url=entity_url('organization')) }}
-    </form>
+    {% include "organizations/_form_new_fragment.html" %}
   {% endif %}
 {% endblock %}

--- a/src/domain/templates/programs/_form_new_fragment.html
+++ b/src/domain/templates/programs/_form_new_fragment.html
@@ -1,0 +1,43 @@
+{# Program create-form fragment — just the `<form>` element, no page
+   chrome.
+
+   Rendered in two contexts:
+
+   1. Included by `programs/form_new.html` (the full GET page).
+   2. Standalone by `mount_create._render_form_with_errors` on a
+      validation-failure re-render. The path-derivation convention
+      (`<dir>/_<name>_fragment.html`) requires this file's name.
+
+   `with context` lets the form-field macros auto-resolve `error=` /
+   `current=` from the `form_errors` / `form_values` injected into
+   the render context by `mount_create` on a 422. #}
+{%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{%- from "_shared/form_copy.html" import org_picker_help -%}
+{%- from "_shared/actions.html" import actions -%}
+{# `org_id` is the FK to the owning Organization. The dropdown is
+   scoped per-viewer by `program_form_extras` (the spec's
+   `form_extras_path`) — it lists only the Orgs the requesting user
+   owns. Superusers see every Org. The "create one first" hint lives
+   in `_shared/form_copy.html::org_picker_help`. #}
+{% call form_with_errors(action=entity_url('program'), method="post") %}
+  <fieldset>
+    <legend>Program</legend>
+    {{ entity_select_field("org_id", "Organization", organizations, help=org_picker_help() ) }}
+    {{ field_for(schema, "name", "Name") }}
+    {{ field_for(schema, "description", "Description", required=false) }}
+  </fieldset>
+  <fieldset>
+    <legend>Where and when</legend>
+    {{ field_for(schema, "state_preference", "State served", required=false) }}
+    <div class="grid">
+      {{ text_field("start_date", "Start date", required=false, type="date") }}
+      {{ text_field("end_date", "End date", required=false, type="date") }}
+    </div>
+  </fieldset>
+  <fieldset>
+    <legend>Intake</legend>
+    {{ radio_bool_field("accepting_referrals", "Accepting referrals?", current=true, required=false) }}
+  </fieldset>
+  {{ actions(entity_create_label('program') , cancel_url=entity_url('program')) }}
+{% endcall %}

--- a/src/domain/templates/programs/form_new.html
+++ b/src/domain/templates/programs/form_new.html
@@ -1,34 +1,9 @@
 {% extends "views/form_new.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field -%}
-{%- from "_shared/form_copy.html" import org_picker_help -%}
-{%- from "_shared/actions.html" import actions -%}
 {% block resource_label %}Programs{% endblock %}
 {% block content %}
   <p>A program is a treatment offering owned by an organization — for example a cohort, IOP, or day program.</p>
-  {# `org_id` is the FK to the owning Organization. The dropdown is
-   scoped per-viewer by `program_form_extras` (the spec's
-   `form_extras_path`) — it lists only the Orgs the requesting user
-   owns. Superusers see every Org. The "create one first" hint lives
-   in `_shared/form_copy.html::org_picker_help`. #}
-  <form hx-post="{{ entity_url('program') }}">
-    <fieldset>
-      <legend>Program</legend>
-      {{ entity_select_field("org_id", "Organization", organizations, help=org_picker_help() ) }}
-      {{ field_for(schema, "name", "Name") }}
-      {{ field_for(schema, "description", "Description", required=false) }}
-    </fieldset>
-    <fieldset>
-      <legend>Where and when</legend>
-      {{ field_for(schema, "state_preference", "State served", required=false) }}
-      <div class="grid">
-        {{ text_field("start_date", "Start date", required=false, type="date") }}
-        {{ text_field("end_date", "End date", required=false, type="date") }}
-      </div>
-    </fieldset>
-    <fieldset>
-      <legend>Intake</legend>
-      {{ radio_bool_field("accepting_referrals", "Accepting referrals?", current=true, required=false) }}
-    </fieldset>
-    {{ actions(entity_create_label('program') , cancel_url=entity_url('program')) }}
-  </form>
+  {# The form body lives in `_form_new_fragment.html` so the framework's
+     error-rerender path (`mount_create._render_form_with_errors`) can
+     re-render just the form fragment on a Pydantic validation failure. #}
+  {% include "programs/_form_new_fragment.html" %}
 {% endblock %}

--- a/src/domain/templates/providers/_form_new_fragment.html
+++ b/src/domain/templates/providers/_form_new_fragment.html
@@ -1,0 +1,76 @@
+{# Clinician (Provider) create-form fragment — just the `<form>`, no
+   page chrome.
+
+   Rendered in two contexts:
+
+   1. Included by `providers/form_new.html` (the full GET page).
+   2. Standalone by `mount_create._render_form_with_errors` on a
+      validation-failure re-render. The path-derivation convention
+      (`<dir>/_<name>_fragment.html`) requires this file's name.
+
+   `with context` lets the form-field macros auto-resolve per-field
+   `error=` / `current=` from the `form_errors` / `form_values`
+   injected by `mount_create` on a 422.
+
+   The underlying model class is still `Provider` — only the
+   user-facing surface flipped in #642 PR 4. #}
+{%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{%- from "_shared/form_copy.html" import cost_help, npi_help, org_picker_help -%}
+{%- from "_shared/actions.html" import actions -%}
+{% call form_with_errors(action=entity_url('clinician'), method="post") %}
+  {# Person-level fields (name, NPI) — these live on the linked
+     `Clinician` row and follow the person across affiliations. Kept in
+     their own fieldset so the form reads "who is this clinician" →
+     "where do they practice" top-to-bottom. #}
+  <fieldset>
+    <legend>Clinician</legend>
+    <div class="grid">
+      {{ field_for(schema, "first_name", "First name") }}
+      {{ field_for(schema, "last_name", "Last name") }}
+    </div>
+    {{ field_for(schema, "npi", "NPI", required=false, help=npi_help() ) }}
+  </fieldset>
+  <fieldset>
+    <legend>Practice</legend>
+    {# Solo-practice toggle (#699): when checked, the create handler
+       auto-creates a solo-practice Org from the clinician's name so
+       the user doesn't have to visit /organizations/form first. The
+       inline script hides/shows the Org picker and marks it
+       required/not-required to match. #}
+    <label class="form-field" for="solo_practice">
+      <span class="form-field-label">Solo practice?</span>
+      <input type="checkbox"
+             id="solo_practice"
+             name="solo_practice"
+             value="true"
+             onchange=" var orgRow = document.getElementById('org-row'); var orgSel = orgRow.querySelector('select'); orgRow.hidden = this.checked; orgSel.required = !this.checked; " />
+    </label>
+    <div id="org-row">{{ entity_select_field("org_id", "Organization", orgs, help=org_picker_help() ) }}</div>
+    <div class="grid">
+      {{ field_for(schema, "location_city", "City") }}
+      {{ field_for(schema, "location_state", "State") }}
+      {{ field_for(schema, "location_zip", "ZIP") }}
+    </div>
+  </fieldset>
+  <fieldset>
+    <legend>Session availability</legend>
+    <div class="grid">
+      {{ field_for(schema, "in_person_sessions", "In-person sessions", current="yes") }}
+      {{ field_for(schema, "virtual_sessions", "Virtual sessions", current="yes") }}
+    </div>
+  </fieldset>
+  {# Insurance & payment. `in_network_carriers` is a multi-select — an
+     empty selection means "no in-network". `accepts_out_of_network` is
+     independent. No cross-field invariant. #}
+  <fieldset>
+    <legend>Insurance &amp; payment</legend>
+    {{ field_for(schema, "in_network_carriers", "In-network carriers") }}
+    <div class="grid">
+      {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", required=false) }}
+      {{ radio_bool_field("sliding_scale", "Sliding scale?", required=false) }}
+    </div>
+    {{ text_field("cost", "Cost", required=false, help=cost_help() ) }}
+  </fieldset>
+  {{ actions(entity_create_label('clinician') , cancel_url=entity_url('clinician')) }}
+{% endcall %}

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -1,72 +1,9 @@
 {% extends "views/form_new.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field -%}
-{%- from "_shared/form_copy.html" import cost_help, npi_help, org_picker_help -%}
-{%- from "_shared/actions.html" import actions -%}
 {% block resource_label %}Clinicians{% endblock %}
 {% block content %}
   <p>Start with the basics. You can add licensures, education, and certifications after the clinician is created.</p>
-  {# `org_id` is the FK to the directory entry's Organization (the
-   practice's display name lives on `org.name`). The dropdown lists
-   every Org in the directory; any user may attach their clinician
-   entry to any Org. To create a new Organization, visit the create
-   form first; the org-picker help (`org_picker_help` in
-   `_shared/form_copy.html`) links there. The underlying model class
-   is still `Provider` — only the user-facing surface flipped in #642
-   PR 4. #}
-  <form hx-post="{{ entity_url('clinician') }}">
-    {# Person-level fields (name, NPI) — these live on the linked
-     `Clinician` row and follow the person across affiliations. Kept in
-     their own fieldset so the form reads "who is this clinician" →
-     "where do they practice" top-to-bottom. #}
-    <fieldset>
-      <legend>Clinician</legend>
-      <div class="grid">
-        {{ field_for(schema, "first_name", "First name") }}
-        {{ field_for(schema, "last_name", "Last name") }}
-      </div>
-      {{ field_for(schema, "npi", "NPI", required=false, help=npi_help() ) }}
-    </fieldset>
-    <fieldset>
-      <legend>Practice</legend>
-      {# Solo-practice toggle (#699): when checked, the create handler
-       auto-creates a solo-practice Org from the clinician's name so
-       the user doesn't have to visit /organizations/form first. The
-       inline script hides/shows the Org picker and marks it
-       required/not-required to match. #}
-      <label class="form-field" for="solo_practice">
-        <span class="form-field-label">Solo practice?</span>
-        <input type="checkbox"
-               id="solo_practice"
-               name="solo_practice"
-               value="true"
-               onchange=" var orgRow = document.getElementById('org-row'); var orgSel = orgRow.querySelector('select'); orgRow.hidden = this.checked; orgSel.required = !this.checked; " />
-      </label>
-      <div id="org-row">{{ entity_select_field("org_id", "Organization", orgs, help=org_picker_help() ) }}</div>
-      <div class="grid">
-        {{ field_for(schema, "location_city", "City") }}
-        {{ field_for(schema, "location_state", "State") }}
-        {{ field_for(schema, "location_zip", "ZIP") }}
-      </div>
-    </fieldset>
-    <fieldset>
-      <legend>Session availability</legend>
-      <div class="grid">
-        {{ field_for(schema, "in_person_sessions", "In-person sessions", current="yes") }}
-        {{ field_for(schema, "virtual_sessions", "Virtual sessions", current="yes") }}
-      </div>
-    </fieldset>
-    {# Insurance & payment. `in_network_carriers` is a multi-select — an
-     empty selection means "no in-network". `accepts_out_of_network` is
-     independent. No cross-field invariant. #}
-    <fieldset>
-      <legend>Insurance &amp; payment</legend>
-      {{ field_for(schema, "in_network_carriers", "In-network carriers") }}
-      <div class="grid">
-        {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", required=false) }}
-        {{ radio_bool_field("sliding_scale", "Sliding scale?", required=false) }}
-      </div>
-      {{ text_field("cost", "Cost", required=false, help=cost_help() ) }}
-    </fieldset>
-    {{ actions(entity_create_label('clinician') , cancel_url=entity_url('clinician')) }}
-  </form>
+  {# The form body lives in `_form_new_fragment.html` so the framework's
+     error-rerender path (`mount_create._render_form_with_errors`) can
+     re-render just the form fragment on a Pydantic validation failure. #}
+  {% include "providers/_form_new_fragment.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary

Opts the three remaining create-form entities into the same \`form_error_render\` path the posts faces already use. Pydantic 422s now re-render the form fragment inline with \`aria-invalid\` + per-field error messages instead of leaving HTMX with a JSON 422 it can't display.

**Stacked on #848.** Re-target to main as the chain merges.

## What changed (per entity)

| Entity | Status | What it took |
|---|---|---|
| Organizations | ✅ | spec flag + fragment + with-context import + macro switch |
| Programs | ✅ | same |
| Providers (Clinicians) | ✅ | same |

The migration is the same four-step recipe at each callsite:

1. \`EntitySpec.form_error_render=True\`.
2. Extract \`form_new.html\` body into sibling \`_form_new_fragment.html\` (path convention required by \`mount_create._render_form_with_errors\`).
3. Import form-field macros \`with context\` so auto-resolution works.
4. Switch \`<form>\` to \`{% call form_with_errors(...) %}\` from PR #848 — bakes in the four hx-* attrs + banner placement.

After this PR, every form in the codebase that posts to a \`mount_create\` route renders inline errors.

## Worth flagging

- **Organizations** uses a type-picker chrome (\`?type=<value>\` query param). The picker stays in the page; only the form body moved to the fragment. The fragment never renders without \`?type=\` set because the rerender path lands on \`/organizations\` (POST), which never serves the picker.
- **Providers** uses \`first_name: StrippedOptionalText = None\` — empty string passes. The smoke test trips the Literal field \`in_person_sessions\` instead.

## Test plan

- [x] 1807 tests pass; \`dev lint\` clean
- [x] 3 new integration smokes — one per entity — pin the 422 + aria-invalid + no-chrome-leakage contract
- [ ] Browser smoke each form (empty required field, watch the form rerender inline with the right field highlighted)

## What's left in the form migration

- **\`/auth/forgot-password\`** — needs a route wrapper (PR #10).
- **\`/auth/reset-password\`** — needs a route wrapper (PR #11).

Both wrap fastapi-users endpoints that currently return raw JSON 4xx — same shape as the original register/login problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)