### PR TITLE
feat(auth): inline error UX + success banner for forgot-password

### DIFF
--- a/src/domain/routes/auth_pages.py
+++ b/src/domain/routes/auth_pages.py
@@ -5,6 +5,7 @@ from fastapi_users import exceptions as fa_users_exceptions
 from fastapi_users import models
 from fastapi_users.authentication import Strategy
 from fastapi_users.manager import BaseUserManager
+from pydantic import BaseModel, EmailStr, ValidationError
 
 from src.auth_config import auth_backend, current_active_user, get_user_manager
 from src.domain.models import User
@@ -179,6 +180,130 @@ async def get_forgot_password_page(request: Request):
     return APIResponse.html_response(
         template_name="auth/forgot_password.html", context={}, request=request
     )
+
+
+class _ForgotPasswordRequest(BaseModel):
+    """Request body for the HTMX-friendly forgot-password wrapper.
+
+    Matches the JSON shape fastapi-users' built-in `POST
+    /auth/forgot-password` expects (`{"email": "..."}`). `EmailStr`
+    handles malformed-email validation so the wrapper can raise a
+    `RequestValidationError` and let the decorator render the inline
+    error on the email input.
+    """
+
+    email: EmailStr
+
+
+class _MalformedForgotPasswordBody(Exception):
+    """Sentinel raised when the JSON body fails `_ForgotPasswordRequest`
+    validation inside the route body (not via FastAPI auto-validation —
+    that fires before the decorator can catch it).
+
+    Carries the Pydantic-style errors list so the registered handler
+    can build a `{field: msg}` dict via `build_form_errors_dict`.
+    """
+
+    def __init__(self, errors: list[dict]):
+        self.errors = errors
+
+
+def _render_validation_errors(exc: _MalformedForgotPasswordBody) -> "FormError":
+    """Convert collected validation errors to a `FormError`.
+
+    Reuses `build_form_errors_dict` (the same helper `mount_create`
+    uses on a Pydantic 422 path) so the loc-to-field mapping is
+    shared.
+    """
+    from src.framework.dispatch.mounts.create import build_form_errors_dict
+    from src.framework.http.form_error_handler import FormError
+
+    return FormError(
+        field_errors=build_form_errors_dict(exc.errors),
+        status_code=422,
+    )
+
+
+@router.post("/forgot-password", name="auth_pages:post_forgot_password")
+@form_error_handler(
+    # Browser-only flow — programmatic clients hit this same path; the
+    # wrapper returns 202 for non-HTMX preserving the documented JSON
+    # contract (pinned by `test_forgot_password_request*`).
+    # `require_htmx=False` so a bare POST with a malformed body also
+    # lands on the rerender path.
+    #
+    # We use a route-private sentinel (`_MalformedForgotPasswordBody`)
+    # instead of FastAPI's `RequestValidationError` because the latter
+    # is raised by FastAPI's framework machinery *before* the route
+    # function runs — outside the decorator's try/except. The route
+    # body parses the request manually and raises the sentinel inside
+    # the decorated function so the decorator catches it.
+    template="auth/_forgot_password_form.html",
+    handlers={_MalformedForgotPasswordBody: _render_validation_errors},
+    require_htmx=False,
+)
+async def post_forgot_password(
+    request: Request,
+    user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+):
+    """HTMX-friendly forgot-password wrapper. Same JSON wire shape as
+    fastapi-users' built-in but returns rendered HTML for HTMX clients.
+
+    Replaces fastapi-users' router-mounted route at this path
+    (registration order in `src/main.py` puts auth_pages first so this
+    wrapper wins). Replicates the original behavior:
+
+      - Look up user by email; if found, call
+        `user_manager.forgot_password(user, request)` which mints a
+        token and triggers `on_after_forgot_password` → send-reset-
+        email. Swallow `UserNotExists` and `UserInactive` silently to
+        avoid revealing which emails are registered.
+      - Return 202 (no body) for non-HTMX clients so the existing
+        JSON contract is preserved.
+      - For HTMX clients, render the form fragment with a success
+        banner ("If an account ..."). Same banner copy whether the
+        email exists or not — anti-enumeration.
+
+    Body parsing is manual (not a FastAPI `body:` param) because the
+    framework's auto-validation raises `RequestValidationError`
+    *before* the route runs — too early for the decorator to catch.
+    Parsing inside the body lets the decorator render the inline
+    error on the email field.
+    """
+    try:
+        raw = await request.json()
+    except Exception:
+        raise _MalformedForgotPasswordBody(
+            [{"loc": ("email",), "msg": "Body must be JSON.", "type": "value_error"}]
+        )
+    try:
+        body = _ForgotPasswordRequest.model_validate(raw)
+    except ValidationError as e:
+        raise _MalformedForgotPasswordBody(e.errors())
+
+    try:
+        user = await user_manager.get_by_email(body.email)
+        await user_manager.forgot_password(user, request)
+    except (fa_users_exceptions.UserNotExists, fa_users_exceptions.UserInactive):
+        # Anti-enumeration — same response either way.
+        pass
+
+    if request.headers.get("HX-Request") == "true":
+        return APIResponse.html_response(
+            template_name="auth/_forgot_password_form.html",
+            context={
+                "form_banner_text": (
+                    "If an account with that email exists, "
+                    "you'll receive a reset link shortly."
+                ),
+                "form_errors": {},
+                "form_values": {"email": body.email},
+                "submitted": True,
+            },
+            request=request,
+        )
+    # Non-HTMX clients keep the documented JSON 202 contract.
+    return Response(status_code=202)
 
 
 @router.get("/reset-password/{token}", name="auth_pages:reset_password")

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -369,6 +369,63 @@ async def test_forgot_password_request_nonexistent_user(test_client: AsyncClient
     assert response.status_code == 202
 
 
+async def test_forgot_password_htmx_success_renders_banner(
+    test_client: AsyncClient, logged_in_user: User
+):
+    """HTMX submit with a valid email → 200 + form fragment with the
+    canonical "if an account ... exists" banner. The banner copy is
+    the same for nonexistent emails (next test) — anti-enumeration
+    contract preserved end-to-end."""
+    response = await test_client.post(
+        "/auth/forgot-password",
+        json={"email": logged_in_user.email},
+        headers={"HX-Request": "true", "Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    body = response.text
+    assert 'class="form-banner"' in body
+    assert "If an account with that email exists" in body
+    # Email is prefilled so the user sees what they submitted.
+    assert f'value="{logged_in_user.email}"' in body
+    # Fragment-only; no page chrome.
+    assert "<!DOCTYPE" not in body
+    assert "<html" not in body
+
+
+async def test_forgot_password_htmx_nonexistent_email_renders_same_banner(
+    test_client: AsyncClient,
+):
+    """Nonexistent email → same 200 + same banner copy as the success
+    case above. Anti-enumeration — an attacker can't tell from the
+    response which emails are registered."""
+    response = await test_client.post(
+        "/auth/forgot-password",
+        json={"email": "nobody@example.com"},
+        headers={"HX-Request": "true", "Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    assert "If an account with that email exists" in response.text
+
+
+async def test_forgot_password_htmx_malformed_email_renders_field_error(
+    test_client: AsyncClient,
+):
+    """Malformed email body → 422 + form fragment with an inline error
+    on the `email` input. The `response-targets` extension swaps the
+    body on the 4xx so the user actually sees the error (vs the
+    pre-wrapper behavior of a silent JSON 422)."""
+    response = await test_client.post(
+        "/auth/forgot-password",
+        json={"email": "not-an-email"},
+        headers={"HX-Request": "true", "Content-Type": "application/json"},
+    )
+    assert response.status_code == 422, response.text
+    body = response.text
+    email_at = body.index('name="email"')
+    window = body[max(0, email_at - 200) : email_at + 200]
+    assert 'aria-invalid="true"' in window, window
+
+
 async def test_reset_password(test_client: AsyncClient, logged_in_user: User):
     request_response = await test_client.post(
         "/auth/forgot-password", json={"email": logged_in_user.email}

--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -70,6 +70,42 @@ async def test_create_organization_happy_path(
     assert rows[0].action == "create_organization"
 
 
+async def test_create_organization_form_error_render_is_wired(
+    authenticated_client: AsyncClient,
+):
+    """Integration smoke for `ORGANIZATION_ENTITY.form_error_render`.
+
+    HX-Request POST with an empty `name` trips the schema's
+    min-length constraint → 422 + HTML fragment with the inline
+    error landed on the `name` input via macro auto-resolution.
+
+    Structural contracts (HX-Request gating, fragment-only response,
+    422 status from PR #5) live in `test_post_families.py` /
+    `test_create.py` — duplicating them here would be alphabet
+    instead of grammar. This smoke just asserts the wiring is on
+    end-to-end for this entity (the spec opt-in, the form's
+    `with context` imports, the fragment file's existence).
+    """
+    response = await authenticated_client.post(
+        "/organizations",
+        data={"name": "", "type": "health_system"},
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 422, response.text
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    # `aria-invalid="true"` on the name input proves the macro layer
+    # picked up `form_errors["name"]` from the rerender context.
+    assert 'name="name"' in body
+    name_at = body.index('name="name"')
+    name_window = body[max(0, name_at - 200) : name_at + 200]
+    assert 'aria-invalid="true"' in name_window, name_window
+    # Fragment-only response — no page chrome leakage.
+    assert "<!DOCTYPE" not in body
+    assert "<html" not in body
+    assert "Bedlam Connect" not in body
+
+
 async def test_create_organization_with_parent_inherits_root(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/routes/test_programs.py
+++ b/src/domain/routes/test_programs.py
@@ -105,6 +105,35 @@ async def test_create_program_happy_path(
     assert rows[0].actor_id == logged_in_user.id
 
 
+async def test_create_program_form_error_render_is_wired(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Integration smoke for `PROGRAM_ENTITY.form_error_render`.
+
+    HX-Request POST with an empty `name` trips the schema's
+    min-length → 422 + HTML fragment with the inline error on the
+    `name` input. Same shape as the organizations smoke; rationale
+    in `test_post_families.py::test_clinician_opening_create_form_error_render_is_wired`.
+    """
+    org_id = await _seed_org(db_test_session_manager, owner_id=logged_in_user.id)
+    response = await authenticated_client.post(
+        "/programs",
+        data=_program_payload(org_id=org_id, name=""),
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 422, response.text
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    name_at = body.index('name="name"')
+    name_window = body[max(0, name_at - 200) : name_at + 200]
+    assert 'aria-invalid="true"' in name_window, name_window
+    assert "<!DOCTYPE" not in body
+    assert "<html" not in body
+    assert "Bedlam Connect" not in body
+
+
 async def test_create_program_with_blank_optional_form_fields_succeeds(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/routes/test_providers.py
+++ b/src/domain/routes/test_providers.py
@@ -145,6 +145,45 @@ async def test_create_provider_happy_path(
     assert rows[0].actor_id == logged_in_user.id
 
 
+async def test_create_provider_form_error_render_is_wired(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Integration smoke for `PROVIDER_ENTITY.form_error_render`.
+
+    HX-Request POST with an invalid `in_person_sessions` value
+    (the field is a Literal over `LOCATION_AVAILABILITY_OPTIONS`)
+    → 422 + HTML fragment with the inline error landed on the
+    `in_person_sessions` input. Same shape as the organizations /
+    programs smokes.
+
+    `first_name` would have been a more obvious trip — but the
+    schema models it as `StrippedOptionalText = None` (matches the
+    rest of the provider model's tolerant defaults), so an empty
+    string passes. Pin the actual Literal field instead.
+    """
+    org_id = await _seed_org(
+        db_test_session_manager, owner_id=logged_in_user.id, name="Acme"
+    )
+    payload = provider_payload(org_id=str(org_id))
+    payload["in_person_sessions"] = "not-a-valid-option"
+    response = await authenticated_client.post(
+        "/clinicians",
+        data=payload,
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 422, response.text
+    assert response.headers["content-type"].startswith("text/html")
+    body = response.text
+    field_at = body.index('name="in_person_sessions"')
+    window = body[max(0, field_at - 200) : field_at + 200]
+    assert 'aria-invalid="true"' in window, window
+    assert "<!DOCTYPE" not in body
+    assert "<html" not in body
+    assert "Bedlam Connect" not in body
+
+
 async def test_create_provider_allows_multiple_per_user(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/specs/organization.py
+++ b/src/domain/specs/organization.py
@@ -52,6 +52,13 @@ ORGANIZATION_ENTITY: Final[EntitySpec] = EntitySpec(
     list_order_by=Organization.created_at.desc(),
     create_redirect=_organization_form_redirect,
     update_redirect=_organization_form_redirect,
+    # Opt into the HX-Request re-render-on-validation-failure path —
+    # see `EntitySpec.form_error_render`. On a Pydantic 422 the
+    # framework re-renders `organizations/_form_new_fragment.html`
+    # with `form_errors` / `form_values` injected; the form-field
+    # macros auto-resolve from those keys (the form template imports
+    # them `with context`).
+    form_error_render=True,
     # The create/edit form's parent-Org picker is scoped per-viewer to
     # the user's owned Organizations (superusers see all). Replaces the
     # free-text UUID input — see issue #581. The framework invokes the

--- a/src/domain/specs/program.py
+++ b/src/domain/specs/program.py
@@ -50,6 +50,11 @@ PROGRAM_ENTITY: Final[EntitySpec] = EntitySpec(
     list_order_by=Program.created_at.desc(),
     create_redirect=_program_form_redirect,
     update_redirect=_program_form_redirect,
+    # Opt into the HX-Request re-render-on-validation-failure path —
+    # see `EntitySpec.form_error_render`. On a Pydantic 422 the
+    # framework re-renders `programs/_form_new_fragment.html` with
+    # `form_errors` / `form_values` injected.
+    form_error_render=True,
     # The create/edit form's Org-picker is scoped per-viewer to the user's
     # owned Organizations. The framework invokes the extras callable on
     # both the create path (target=None) and the edit path (target=<row>)

--- a/src/domain/specs/provider.py
+++ b/src/domain/specs/provider.py
@@ -113,6 +113,11 @@ PROVIDER_ENTITY: Final[EntitySpec] = EntitySpec(
     ),
     create_redirect=_provider_form_redirect,
     update_redirect=_provider_form_redirect,
+    # Opt into the HX-Request re-render-on-validation-failure path —
+    # see `EntitySpec.form_error_render`. On a Pydantic 422 the
+    # framework re-renders `providers/_form_new_fragment.html`
+    # with `form_errors` / `form_values` injected.
+    form_error_render=True,
     # Template paths are pinned explicitly because the directory cluster
     # is still `templates/providers/` (the Python model file lives at
     # `models/providers/provider.py` and the brief kept that filename

--- a/src/domain/templates/auth/_forgot_password_form.html
+++ b/src/domain/templates/auth/_forgot_password_form.html
@@ -1,0 +1,25 @@
+{# Forgot-password form fragment — just the `<form>` and its
+   contents, no page chrome.
+
+   Rendered in two contexts:
+
+   1. As part of `auth/forgot_password.html` (the full GET page).
+   2. Standalone by `post_forgot_password`'s rerender paths:
+        - validation failure on the `email` body → 422 + inline
+          field error.
+        - success / nonexistent-email → 200 + `form_banner_text`
+          with the canonical "if an account ... exists" message
+          (same copy either way — anti-enumeration).
+
+   `with context` lets the form-field macros auto-resolve `error=` /
+   `current=` from the `form_errors` / `form_values` injected by the
+   framework on the rerender (see `_shared/form_fields.html`
+   docstring). The `form_with_errors` wrapper handles the four hx-*
+   attrs + banner placement; `json_enc=True` matches fastapi-users'
+   JSON body contract for the underlying endpoint. #}
+{%- from "_shared/form_fields.html" import text_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{% call form_with_errors(action="/auth/forgot-password", method="post", json_enc=True) %}
+  {{ text_field("email", "Email", type="email", autocomplete="email") }}
+  <button type="submit">Send reset link</button>
+{% endcall %}

--- a/src/domain/templates/auth/forgot_password.html
+++ b/src/domain/templates/auth/forgot_password.html
@@ -5,19 +5,11 @@
       <h1>Reset your password</h1>
       <p>Enter your email and we'll send you a reset link.</p>
     </header>
-    {# fastapi-users' `/auth/forgot-password` expects a JSON body
-     ({"email": "..."}). The htmx `json-enc` extension (loaded
-     globally in `base.html`) encodes the form values as JSON on
-     submit. Plain `<form method="post" action="...">` would send
-     `application/x-www-form-urlencoded` and the endpoint would 422
-     with "email field required". Pattern mirrors `register.html`. #}
-    <form hx-post="/auth/forgot-password" hx-ext="json-enc">
-      <label for="email">
-        Email
-        <input type="email" id="email" name="email" required />
-      </label>
-      <button type="submit">Send reset link</button>
-    </form>
+    {# Form body lives in `_forgot_password_form.html` so the wrapper
+       route (`auth_pages.post_forgot_password`) can re-render *just the
+       form fragment* on validation failure / success — HTMX's
+       `outerHTML` swap replaces just the form in place. #}
+    {% include "auth/_forgot_password_form.html" %}
     <footer>
       <p>
         Remembered it?

--- a/src/domain/templates/organizations/_form_new_fragment.html
+++ b/src/domain/templates/organizations/_form_new_fragment.html
@@ -1,0 +1,44 @@
+{# Organization create-form fragment — just the `<form>` element, no
+   page chrome.
+
+   Rendered in two contexts:
+
+   1. Included by `organizations/form_new.html` when the user has
+      passed `?type=<value>` (the type-picker has been resolved to a
+      specific organization type and the form should appear).
+   2. Standalone by `mount_create._render_form_with_errors` on a
+      validation-failure re-render. The path-derivation convention
+      (`<dir>/_<name>_fragment.html`) requires this file's name.
+
+   `with context` is required so the form-field macros auto-resolve
+   per-field `error=`/`current=` from `form_errors`/`form_values`
+   injected into the render context by `mount_create` — see
+   `_shared/form_fields.html` docstring. The `form_with_errors`
+   wrapper bakes in the four hx-* attrs (`hx-target`, `hx-swap`,
+   `hx-target-4xx`, `hx-swap-4xx`) and the `{{ form_banner() }}`
+   placement, so the template stays focused on field declarations. #}
+{%- from "_shared/form_fields.html" import entity_select_field, select_field, text_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{%- from "_shared/actions.html" import actions -%}
+{%- set selected_type = request.query_params.get('type', '') -%}
+{% call form_with_errors(action=entity_url('organization'), method="post") %}
+  <fieldset>
+    <legend>Organization</legend>
+    <div class="grid">
+      {{ text_field("name", "Name", maxlength=200) }}
+      {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, current=selected_type) }}
+    </div>
+    {# Parent-Org picker — replaces the free-text UUID input from #581.
+       `parent_org_options` is populated by `organization_form_extras`
+       (see `ORGANIZATION_ENTITY.form_extras_path`). Empty value =
+       root organization; blank-string is coerced to None by the
+       schema's `OptionalUuid`. #}
+    {{ entity_select_field("parent_org_id",
+        "Parent organization",
+        parent_org_options,
+        blank_label="(no parent)",
+        required=false,
+        help="Most organizations have no parent. Set one only if this is part of a larger network.",) }}
+  </fieldset>
+  {{ actions(entity_create_label('organization') , cancel_url=entity_url('organization')) }}
+{% endcall %}

--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -7,10 +7,14 @@ set) skips the picker and renders the full create form with that type
 pre-selected in the Type dropdown.
 
 This mirrors the `/openings/form` picker pattern (issue #704).
+
+The actual form lives in `_form_new_fragment.html` so the framework's
+error-rerender path (`mount_create._render_form_with_errors`) can
+re-render just the form fragment on a Pydantic validation failure —
+the path-derivation convention (`<dir>/_<name>_fragment.html`) requires
+a sibling file with that exact name. The full page below includes it.
 #}
 {% extends "views/form_new.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, select_field, text_field -%}
-{%- from "_shared/actions.html" import actions -%}
 {%- from "_shared/_picker.html" import picker -%}
 {% block resource_label %}Organizations{% endblock %}
 {% block content %}
@@ -38,28 +42,6 @@ This mirrors the `/openings/form` picker pattern (issue #704).
     "description": "Doesn't fit the above."},
     ]) }}
   {% else %}
-    {# Form: shown when ?type= is set (either via picker click or deep link).
-   The Type dropdown is pre-selected to the value from the query param. #}
-    <form hx-post="{{ entity_url('organization') }}">
-      <fieldset>
-        <legend>Organization</legend>
-        <div class="grid">
-          {{ text_field("name", "Name", maxlength=200) }}
-          {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, current=selected_type) }}
-        </div>
-        {# Parent-Org picker — replaces the free-text UUID input from #581.
-       `parent_org_options` is populated by `organization_form_extras`
-       (see `ORGANIZATION_ENTITY.form_extras_path`). Empty value =
-       root organization; blank-string is coerced to None by the
-       schema's `OptionalUuid`. #}
-        {{ entity_select_field("parent_org_id",
-                "Parent organization",
-                parent_org_options,
-                blank_label="(no parent)",
-                required=false,
-                help="Most organizations have no parent. Set one only if this is part of a larger network.",) }}
-      </fieldset>
-      {{ actions(entity_create_label('organization') , cancel_url=entity_url('organization')) }}
-    </form>
+    {% include "organizations/_form_new_fragment.html" %}
   {% endif %}
 {% endblock %}

--- a/src/domain/templates/programs/_form_new_fragment.html
+++ b/src/domain/templates/programs/_form_new_fragment.html
@@ -1,0 +1,43 @@
+{# Program create-form fragment — just the `<form>` element, no page
+   chrome.
+
+   Rendered in two contexts:
+
+   1. Included by `programs/form_new.html` (the full GET page).
+   2. Standalone by `mount_create._render_form_with_errors` on a
+      validation-failure re-render. The path-derivation convention
+      (`<dir>/_<name>_fragment.html`) requires this file's name.
+
+   `with context` lets the form-field macros auto-resolve `error=` /
+   `current=` from the `form_errors` / `form_values` injected into
+   the render context by `mount_create` on a 422. #}
+{%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{%- from "_shared/form_copy.html" import org_picker_help -%}
+{%- from "_shared/actions.html" import actions -%}
+{# `org_id` is the FK to the owning Organization. The dropdown is
+   scoped per-viewer by `program_form_extras` (the spec's
+   `form_extras_path`) — it lists only the Orgs the requesting user
+   owns. Superusers see every Org. The "create one first" hint lives
+   in `_shared/form_copy.html::org_picker_help`. #}
+{% call form_with_errors(action=entity_url('program'), method="post") %}
+  <fieldset>
+    <legend>Program</legend>
+    {{ entity_select_field("org_id", "Organization", organizations, help=org_picker_help() ) }}
+    {{ field_for(schema, "name", "Name") }}
+    {{ field_for(schema, "description", "Description", required=false) }}
+  </fieldset>
+  <fieldset>
+    <legend>Where and when</legend>
+    {{ field_for(schema, "state_preference", "State served", required=false) }}
+    <div class="grid">
+      {{ text_field("start_date", "Start date", required=false, type="date") }}
+      {{ text_field("end_date", "End date", required=false, type="date") }}
+    </div>
+  </fieldset>
+  <fieldset>
+    <legend>Intake</legend>
+    {{ radio_bool_field("accepting_referrals", "Accepting referrals?", current=true, required=false) }}
+  </fieldset>
+  {{ actions(entity_create_label('program') , cancel_url=entity_url('program')) }}
+{% endcall %}

--- a/src/domain/templates/programs/form_new.html
+++ b/src/domain/templates/programs/form_new.html
@@ -1,34 +1,9 @@
 {% extends "views/form_new.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field -%}
-{%- from "_shared/form_copy.html" import org_picker_help -%}
-{%- from "_shared/actions.html" import actions -%}
 {% block resource_label %}Programs{% endblock %}
 {% block content %}
   <p>A program is a treatment offering owned by an organization — for example a cohort, IOP, or day program.</p>
-  {# `org_id` is the FK to the owning Organization. The dropdown is
-   scoped per-viewer by `program_form_extras` (the spec's
-   `form_extras_path`) — it lists only the Orgs the requesting user
-   owns. Superusers see every Org. The "create one first" hint lives
-   in `_shared/form_copy.html::org_picker_help`. #}
-  <form hx-post="{{ entity_url('program') }}">
-    <fieldset>
-      <legend>Program</legend>
-      {{ entity_select_field("org_id", "Organization", organizations, help=org_picker_help() ) }}
-      {{ field_for(schema, "name", "Name") }}
-      {{ field_for(schema, "description", "Description", required=false) }}
-    </fieldset>
-    <fieldset>
-      <legend>Where and when</legend>
-      {{ field_for(schema, "state_preference", "State served", required=false) }}
-      <div class="grid">
-        {{ text_field("start_date", "Start date", required=false, type="date") }}
-        {{ text_field("end_date", "End date", required=false, type="date") }}
-      </div>
-    </fieldset>
-    <fieldset>
-      <legend>Intake</legend>
-      {{ radio_bool_field("accepting_referrals", "Accepting referrals?", current=true, required=false) }}
-    </fieldset>
-    {{ actions(entity_create_label('program') , cancel_url=entity_url('program')) }}
-  </form>
+  {# The form body lives in `_form_new_fragment.html` so the framework's
+     error-rerender path (`mount_create._render_form_with_errors`) can
+     re-render just the form fragment on a Pydantic validation failure. #}
+  {% include "programs/_form_new_fragment.html" %}
 {% endblock %}

--- a/src/domain/templates/providers/_form_new_fragment.html
+++ b/src/domain/templates/providers/_form_new_fragment.html
@@ -1,0 +1,76 @@
+{# Clinician (Provider) create-form fragment — just the `<form>`, no
+   page chrome.
+
+   Rendered in two contexts:
+
+   1. Included by `providers/form_new.html` (the full GET page).
+   2. Standalone by `mount_create._render_form_with_errors` on a
+      validation-failure re-render. The path-derivation convention
+      (`<dir>/_<name>_fragment.html`) requires this file's name.
+
+   `with context` lets the form-field macros auto-resolve per-field
+   `error=` / `current=` from the `form_errors` / `form_values`
+   injected by `mount_create` on a 422.
+
+   The underlying model class is still `Provider` — only the
+   user-facing surface flipped in #642 PR 4. #}
+{%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{%- from "_shared/form_copy.html" import cost_help, npi_help, org_picker_help -%}
+{%- from "_shared/actions.html" import actions -%}
+{% call form_with_errors(action=entity_url('clinician'), method="post") %}
+  {# Person-level fields (name, NPI) — these live on the linked
+     `Clinician` row and follow the person across affiliations. Kept in
+     their own fieldset so the form reads "who is this clinician" →
+     "where do they practice" top-to-bottom. #}
+  <fieldset>
+    <legend>Clinician</legend>
+    <div class="grid">
+      {{ field_for(schema, "first_name", "First name") }}
+      {{ field_for(schema, "last_name", "Last name") }}
+    </div>
+    {{ field_for(schema, "npi", "NPI", required=false, help=npi_help() ) }}
+  </fieldset>
+  <fieldset>
+    <legend>Practice</legend>
+    {# Solo-practice toggle (#699): when checked, the create handler
+       auto-creates a solo-practice Org from the clinician's name so
+       the user doesn't have to visit /organizations/form first. The
+       inline script hides/shows the Org picker and marks it
+       required/not-required to match. #}
+    <label class="form-field" for="solo_practice">
+      <span class="form-field-label">Solo practice?</span>
+      <input type="checkbox"
+             id="solo_practice"
+             name="solo_practice"
+             value="true"
+             onchange=" var orgRow = document.getElementById('org-row'); var orgSel = orgRow.querySelector('select'); orgRow.hidden = this.checked; orgSel.required = !this.checked; " />
+    </label>
+    <div id="org-row">{{ entity_select_field("org_id", "Organization", orgs, help=org_picker_help() ) }}</div>
+    <div class="grid">
+      {{ field_for(schema, "location_city", "City") }}
+      {{ field_for(schema, "location_state", "State") }}
+      {{ field_for(schema, "location_zip", "ZIP") }}
+    </div>
+  </fieldset>
+  <fieldset>
+    <legend>Session availability</legend>
+    <div class="grid">
+      {{ field_for(schema, "in_person_sessions", "In-person sessions", current="yes") }}
+      {{ field_for(schema, "virtual_sessions", "Virtual sessions", current="yes") }}
+    </div>
+  </fieldset>
+  {# Insurance & payment. `in_network_carriers` is a multi-select — an
+     empty selection means "no in-network". `accepts_out_of_network` is
+     independent. No cross-field invariant. #}
+  <fieldset>
+    <legend>Insurance &amp; payment</legend>
+    {{ field_for(schema, "in_network_carriers", "In-network carriers") }}
+    <div class="grid">
+      {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", required=false) }}
+      {{ radio_bool_field("sliding_scale", "Sliding scale?", required=false) }}
+    </div>
+    {{ text_field("cost", "Cost", required=false, help=cost_help() ) }}
+  </fieldset>
+  {{ actions(entity_create_label('clinician') , cancel_url=entity_url('clinician')) }}
+{% endcall %}

--- a/src/domain/templates/providers/form_new.html
+++ b/src/domain/templates/providers/form_new.html
@@ -1,72 +1,9 @@
 {% extends "views/form_new.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, field_for, radio_bool_field, text_field -%}
-{%- from "_shared/form_copy.html" import cost_help, npi_help, org_picker_help -%}
-{%- from "_shared/actions.html" import actions -%}
 {% block resource_label %}Clinicians{% endblock %}
 {% block content %}
   <p>Start with the basics. You can add licensures, education, and certifications after the clinician is created.</p>
-  {# `org_id` is the FK to the directory entry's Organization (the
-   practice's display name lives on `org.name`). The dropdown lists
-   every Org in the directory; any user may attach their clinician
-   entry to any Org. To create a new Organization, visit the create
-   form first; the org-picker help (`org_picker_help` in
-   `_shared/form_copy.html`) links there. The underlying model class
-   is still `Provider` — only the user-facing surface flipped in #642
-   PR 4. #}
-  <form hx-post="{{ entity_url('clinician') }}">
-    {# Person-level fields (name, NPI) — these live on the linked
-     `Clinician` row and follow the person across affiliations. Kept in
-     their own fieldset so the form reads "who is this clinician" →
-     "where do they practice" top-to-bottom. #}
-    <fieldset>
-      <legend>Clinician</legend>
-      <div class="grid">
-        {{ field_for(schema, "first_name", "First name") }}
-        {{ field_for(schema, "last_name", "Last name") }}
-      </div>
-      {{ field_for(schema, "npi", "NPI", required=false, help=npi_help() ) }}
-    </fieldset>
-    <fieldset>
-      <legend>Practice</legend>
-      {# Solo-practice toggle (#699): when checked, the create handler
-       auto-creates a solo-practice Org from the clinician's name so
-       the user doesn't have to visit /organizations/form first. The
-       inline script hides/shows the Org picker and marks it
-       required/not-required to match. #}
-      <label class="form-field" for="solo_practice">
-        <span class="form-field-label">Solo practice?</span>
-        <input type="checkbox"
-               id="solo_practice"
-               name="solo_practice"
-               value="true"
-               onchange=" var orgRow = document.getElementById('org-row'); var orgSel = orgRow.querySelector('select'); orgRow.hidden = this.checked; orgSel.required = !this.checked; " />
-      </label>
-      <div id="org-row">{{ entity_select_field("org_id", "Organization", orgs, help=org_picker_help() ) }}</div>
-      <div class="grid">
-        {{ field_for(schema, "location_city", "City") }}
-        {{ field_for(schema, "location_state", "State") }}
-        {{ field_for(schema, "location_zip", "ZIP") }}
-      </div>
-    </fieldset>
-    <fieldset>
-      <legend>Session availability</legend>
-      <div class="grid">
-        {{ field_for(schema, "in_person_sessions", "In-person sessions", current="yes") }}
-        {{ field_for(schema, "virtual_sessions", "Virtual sessions", current="yes") }}
-      </div>
-    </fieldset>
-    {# Insurance & payment. `in_network_carriers` is a multi-select — an
-     empty selection means "no in-network". `accepts_out_of_network` is
-     independent. No cross-field invariant. #}
-    <fieldset>
-      <legend>Insurance &amp; payment</legend>
-      {{ field_for(schema, "in_network_carriers", "In-network carriers") }}
-      <div class="grid">
-        {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", required=false) }}
-        {{ radio_bool_field("sliding_scale", "Sliding scale?", required=false) }}
-      </div>
-      {{ text_field("cost", "Cost", required=false, help=cost_help() ) }}
-    </fieldset>
-    {{ actions(entity_create_label('clinician') , cancel_url=entity_url('clinician')) }}
-  </form>
+  {# The form body lives in `_form_new_fragment.html` so the framework's
+     error-rerender path (`mount_create._render_form_with_errors`) can
+     re-render just the form fragment on a Pydantic validation failure. #}
+  {% include "providers/_form_new_fragment.html" %}
 {% endblock %}

--- a/src/main.py
+++ b/src/main.py
@@ -118,6 +118,13 @@ app.include_router(
     tags=["auth"],
 )
 
+# `auth_pages` is included BEFORE `get_reset_password_router()` because
+# the latter mounts a `POST /auth/forgot-password` at the same path as
+# our HTMX-friendly wrapper. FastAPI matches in registration order, so
+# whichever router is included first wins. The fastapi-users routes
+# remain mounted (for any path the wrapper doesn't intercept) — see
+# `auth_pages.post_forgot_password` for why we wrap.
+app.include_router(auth_pages.auth_pages_api_router)
 app.include_router(
     fastapi_users.get_reset_password_router(),
     prefix="/auth",
@@ -128,7 +135,6 @@ app.include_router(
     prefix="/auth",
     tags=["auth"],
 )
-app.include_router(auth_pages.auth_pages_api_router)
 app.include_router(verifications.verifications_api_router)
 
 # Every entity route file calls `register_entity(SPEC)` at import time


### PR DESCRIPTION
## Summary

Wraps fastapi-users' \`POST /auth/forgot-password\` with an HTMX-friendly handler that renders a success banner inline + per-field errors on malformed input. Preserves the JSON 202 contract for non-HTMX clients.

**Stacked on #849.** Re-target to main as the chain merges.

## Before / After (UX)

Before: user submits, sees nothing change. The 202 has no body and HTMX doesn't update the DOM.

After: form fragment re-renders with a banner — \"If an account with that email exists, you'll receive a reset link shortly.\" Same banner copy whether the email is registered or not (anti-enumeration preserved).

## A subtle gotcha

\`RequestValidationError\` is raised by FastAPI's framework machinery *before* the route function runs — too early for \`@form_error_handler\` to catch via try/except. The wrapper parses the body manually inside the route body and raises a route-private \`_MalformedForgotPasswordBody\` sentinel that carries the Pydantic errors list. Same mental model as \`_LoginBadCredentials\` in PR #842.

\`build_form_errors_dict\` (already in \`mount_create\`) does the loc-to-field collapse — sharing it means the entity-create path and the auth-flow path build their \`{field: msg}\` dicts identically.

## What changed

- \`auth_pages.post_forgot_password\` — new wrapper at the same path.
- \`src/main.py\` — reorder router includes so \`auth_pages\` wins over fastapi-users' reset-password router (FastAPI matches in registration order).
- \`auth/_forgot_password_form.html\` — new fragment, uses the \`form_with_errors\` macro from PR #848.
- 3 new route smokes — HTMX success banner, HTMX nonexistent-email banner (asserts same copy), HTMX malformed-email field error.

## Test plan

- [x] 1812 tests pass; \`dev lint\` clean
- [x] Existing JSON-202 contract preserved (\`test_forgot_password_request*\` still pass)
- [x] Anti-enumeration verified: \`test_forgot_password_htmx_nonexistent_email_renders_same_banner\` asserts the same banner copy as the success case
- [ ] Browser smoke: submit with valid email → see banner; submit with malformed email → see field error

## Up next

- **PR #11** — reset-password (\`InvalidResetPasswordToken\` + \`InvalidPasswordException\` inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)