### PR TITLE
feat(onboarding): T2 — license-verify wizard step + state-machine dispatcher

### DIFF
--- a/src/domain/logic/onboarding/README.md
+++ b/src/domain/logic/onboarding/README.md
@@ -1,0 +1,42 @@
+# Onboarding logic cluster
+
+Wizard state machine, service functions, and wire schemas for the `/welcome/*`
+bespoke router (`src/domain/routes/welcome.py`).
+
+## State machine
+
+`state_machine.py:next_step(user, *, db)` is the single source of truth for
+"where does this user go next?" Every wizard route that needs a redirect calls
+it. The signal table:
+
+| Signal | Source |
+|---|---|
+| `intent` | `user.onboarding_intent` |
+| `has_clinician` | `user.providers` non-empty (selectin-loaded) |
+| `clinician_verified` | onboarding clinician's latest `Verification.status == 'verified'` |
+| `has_opening` | onboarding clinician owns ≥1 `OpeningDetail` (T4+) |
+| `has_reciprocity_profile` | clinician has non-empty specialties AND modality (T5+) |
+
+### Onboarding clinician convention
+
+The wizard always operates on the **most-recently-created `Provider`** owned by
+the user: `onboarding_clinician(user) = max(user.providers, key=lambda p: p.created_at)`.
+Every downstream ticket uses this helper — never inline the definition.
+
+## Bespoke-shim pattern
+
+Every wizard write is a function in `services.py` that:
+1. Validates form data via a Pydantic schema in `schema.py`
+2. Delegates to existing domain repo primitives / handlers
+3. Owns the transaction (or delegates to the verification pipeline, which commits)
+4. Returns the primary created/updated model
+
+The route handler calls the service function, then redirects via `next_step()`.
+There is no `return_to` primitive — wizard redirects are always determined by
+the state machine.
+
+## No `return_to` primitive
+
+Wizard redirects are always state-machine-driven. There is no `?return_to=`
+query-string pass-through. If a non-onboarding use case emerges that needs a
+`return_to` primitive, design it then — don't add it speculatively here.

--- a/src/domain/logic/onboarding/schema.py
+++ b/src/domain/logic/onboarding/schema.py
@@ -1,0 +1,24 @@
+from typing import Literal
+
+from pydantic import BaseModel, EmailStr
+
+from src.domain.models.enums import LICENSE_TYPES, US_STATES
+
+_LICENSE_TYPES = Literal[tuple(LICENSE_TYPES)]  # type: ignore[valid-type]
+_US_STATES = Literal[tuple(US_STATES)]  # type: ignore[valid-type]
+
+
+class VerifyForm(BaseModel):
+    """Wire schema for POST /welcome/verify.
+
+    Collects enough data to create a Clinician + ProviderLicensure + run NPPES
+    verification. `issuing_state` is required because `ProviderLicensure.issuing_state`
+    is NOT NULL.
+    """
+
+    first_name: str
+    last_name: str
+    work_email: EmailStr
+    license_type: _LICENSE_TYPES
+    license_number: str
+    issuing_state: _US_STATES

--- a/src/domain/logic/onboarding/services.py
+++ b/src/domain/logic/onboarding/services.py
@@ -1,0 +1,121 @@
+"""Onboarding wizard service functions.
+
+Each function here is a "thin bespoke shim" called from a wizard POST handler.
+The shim validates form data (via schema.py), delegates to existing domain
+handlers / repos, and owns the transaction boundary (or delegates it to the
+verification pipeline which commits at the end).
+
+Pattern: every wizard write is a function here that:
+  1. Creates / mutates rows via existing repo primitives or model constructors
+  2. Calls the verification pipeline (which commits) or commits explicitly
+  3. Returns the primary created/updated model
+
+No `return_to` primitive — redirects are always determined by `next_step()`.
+"""
+
+import uuid
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.logic.onboarding.schema import VerifyForm
+from src.domain.logic.providers.repository import ProviderRepository
+from src.domain.logic.verifications.handlers import run_provider_verification
+from src.domain.logic.verifications.repository import VerificationRepository
+from src.domain.models import Organization, Provider, ProviderLicensure, User
+from src.framework.audit.repository import AuditRepository
+
+_HTTP_TIMEOUT_SECONDS = 10.0
+
+
+async def verify_and_create_clinician(
+    form_data: VerifyForm,
+    user: User,
+    *,
+    db: AsyncSession,
+) -> Provider:
+    """Create a Clinician (via Provider constructor), Licensure, and run
+    NPPES/OIG verification — all in a single transaction.
+
+    Atomicity: all row creation is flushed (not committed) until
+    `run_provider_verification` commits at the end. If the pipeline raises
+    before committing, none of the flushed rows persist.
+
+    If verification yields status 'failed', the Clinician/Provider/Licensure
+    rows **still exist** — the wizard lets the user see the failure and
+    re-submit. Only an unhandled exception (DB error, network crash during
+    NPPES before the ORM flush) rolls back and leaves no orphans.
+
+    Returns the created Provider (always, even on verification failure).
+    """
+    # 1. Auto-create a solo-practice Organization for this clinician.
+    #    root_org_id is NOT NULL with no server default — set it to the
+    #    org's own id to make this a root org (parent_org_id IS NULL).
+    #    Mirrors OrganizationRepository.create and make_organization_row.
+    name_parts = [p for p in (form_data.first_name, form_data.last_name) if p.strip()]
+    org_name = (
+        " ".join(name_parts) if name_parts else (user.username or "Solo Practice")
+    )
+    org_id = uuid.uuid4()
+    org = Organization(
+        id=org_id,
+        name=org_name,
+        type="solo_practice",
+        owner_id=user.id,
+    )
+    org.root_org_id = org_id
+    db.add(org)
+    await db.flush()
+
+    # 2. Create Provider — the constructor auto-creates a Clinician (from
+    # first_name/last_name) and an Affiliation (from the per-role kwargs).
+    # location_city/zip are required NOT NULL on Affiliation; use empty-string
+    # placeholders — the user fills real values in the profile steps (T5/T7).
+    # location_state is seeded from the license issuing_state (best available
+    # proxy at this point in the wizard).
+    provider = Provider(
+        owner_id=user.id,
+        first_name=form_data.first_name,
+        last_name=form_data.last_name,
+        org_id=org.id,
+        location_city="",
+        location_state=form_data.issuing_state,
+        location_zip="",
+        in_person_sessions="please_contact",
+        virtual_sessions="please_contact",
+    )
+    db.add(provider)
+    await db.flush()
+    await db.refresh(provider)
+
+    # 3. Add the license that was submitted on the verify form.
+    #    FK is to clinicians.id (not providers.id) — #635 PR A moved creds.
+    licensure = ProviderLicensure(
+        clinician_id=provider.clinician.id,
+        license_type=form_data.license_type,
+        license_number=form_data.license_number,
+        issuing_state=form_data.issuing_state,
+    )
+    db.add(licensure)
+    await db.flush()
+    await db.refresh(licensure)
+
+    # 4. Run the NPPES + OIG + scoring pipeline.  `run_provider_verification`
+    # commits the session at the end — all flushed rows above commit with it.
+    # Using `run_provider_verification` (not `handle_create_provider_verification`)
+    # because the latter enforces `is_superuser`; the wizard is a self-service path.
+    provider_repo = ProviderRepository(db)
+    verification_repo = VerificationRepository(db)
+    audit_repo = AuditRepository(db)
+
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as http:
+        await run_provider_verification(
+            provider_id=provider.id,
+            verification_repo=verification_repo,
+            provider_repo=provider_repo,
+            audit_repo=audit_repo,
+            http=http,
+            actor_id=user.id,
+        )
+
+    return provider

--- a/src/domain/logic/onboarding/state_machine.py
+++ b/src/domain/logic/onboarding/state_machine.py
@@ -1,0 +1,89 @@
+"""Onboarding wizard state machine.
+
+`next_step(user, *, db)` is the single source of truth for "where does this
+user go next in the wizard?" Every wizard route that needs to redirect calls
+this function so the truth table lives in one place.
+
+Signal table (read at each dispatch):
+
+| Signal                | Source                                                       |
+|-----------------------|--------------------------------------------------------------|
+| intent                | user.onboarding_intent                                       |
+| has_clinician         | user.providers non-empty (selectin-loaded on User)           |
+| clinician_verified    | onboarding clinician's latest Verification.status=='verified'|
+| has_opening           | onboarding clinician owns ≥1 OpeningDetail (T4+)            |
+| has_reciprocity_profile | clinician has non-empty specialties AND modality (T5+)   |
+
+The "onboarding clinician" is always the most-recently-created Provider owned
+by the user. See `onboarding_clinician()`.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.models import Provider, User, Verification
+
+# Stub URL for steps not yet implemented — returns a minimal placeholder page
+# until the downstream ticket ships the real page.
+_NOT_YET_BUILT = "/welcome/coming-soon"
+
+
+def onboarding_clinician(user: User) -> Provider | None:
+    """Return the most-recently-created Provider owned by `user`, or None.
+
+    All wizard writes target this clinician. Using `created_at` means
+    a user who creates a second clinician later gets the wizard routed to the
+    new one — intentional; new clinicians need verification too.
+    """
+    if not user.providers:
+        return None
+    return max(user.providers, key=lambda p: p.created_at)
+
+
+async def next_step(user: User, *, db: AsyncSession) -> str:
+    """Return the next wizard URL for `user`.
+
+    Pure in the sense that it does not mutate state — it only reads
+    signals and returns a URL string. The DB session is needed to check
+    verification status (Verifications are not eager-loaded on Provider).
+    """
+    if user.onboarding_intent is None:
+        return "/"
+
+    clinician = onboarding_clinician(user)
+    if clinician is None:
+        return "/welcome/verify"
+
+    # Check verification status for the onboarding clinician.
+    result = await db.execute(
+        select(Verification)
+        .filter(Verification.provider_id == clinician.id)
+        .order_by(Verification.created_at.desc())
+        .limit(1)
+    )
+    latest = result.scalars().first()
+    clinician_verified = latest is not None and latest.status == "verified"
+
+    if not clinician_verified:
+        return "/welcome/verify"
+
+    # Clinician exists and is verified — branch by intent.
+    intent = user.onboarding_intent
+
+    if intent == "refer_now":
+        # T5 will replace this stub with /welcome/be-findable
+        return _NOT_YET_BUILT
+
+    if intent == "have_openings":
+        # T4 will replace this stub with /welcome/first-opening
+        return _NOT_YET_BUILT
+
+    if intent == "building_network":
+        # T7 will replace this stub with /welcome/start-network
+        return _NOT_YET_BUILT
+
+    if intent == "invited":
+        # T7 will replace this stub with /welcome/minimal-profile
+        return _NOT_YET_BUILT
+
+    return "/"

--- a/src/domain/logic/onboarding/test_services.py
+++ b/src/domain/logic/onboarding/test_services.py
@@ -1,0 +1,196 @@
+"""Tests for onboarding wizard service functions.
+
+Covers the atomic create path, verification-failure retention, and rollback on
+pipeline exception.
+"""
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.logic.onboarding.schema import VerifyForm
+from src.domain.logic.onboarding.services import verify_and_create_clinician
+from src.domain.logic.verifications import oig as oig_module
+from src.domain.models import Provider, ProviderLicensure, Verification
+from tests.helpers import create_test_user
+
+pytestmark = pytest.mark.asyncio
+
+_LEIE_FIXTURE = (
+    Path(__file__).parents[4]
+    / "tests"
+    / "logic"
+    / "verifications"
+    / "test_data"
+    / "leie_sample.csv"
+)
+
+_VALID_FORM = VerifyForm(
+    first_name="Alice",
+    last_name="Smith",
+    work_email="alice@example.com",
+    license_type="lcsw",
+    license_number="LIC123",
+    issuing_state="CA",
+)
+
+
+@pytest.fixture(autouse=True)
+def _patch_external_apis(monkeypatch):
+    """Point OIG at the local LEIE fixture and stub NPPES to return a
+    matching result so scoring yields 'verified' in the happy path."""
+    monkeypatch.setenv("LEIE_CSV_PATH", str(_LEIE_FIXTURE))
+    oig_module._reset_cache_for_tests()
+
+    from src.domain.logic.verifications import handlers as handlers_mod
+
+    def _payload(npi: str) -> dict[str, Any]:
+        return {"results": [{"basic": {"first_name": "Alice", "last_name": "Smith"}}]}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        npi = request.url.params.get("number") or ""
+        return httpx.Response(200, content=json.dumps(_payload(npi)).encode())
+
+    class _StubAsyncClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(transport=httpx.MockTransport(_handler))
+
+    monkeypatch.setattr(handlers_mod.httpx, "AsyncClient", _StubAsyncClient)
+    yield
+    oig_module._reset_cache_for_tests()
+
+
+async def _seed_user(db_test_session_manager: async_sessionmaker[AsyncSession]):
+    user = create_test_user(username=f"wizard-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+    return user
+
+
+async def test_happy_path_creates_provider_licensure_verification(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """verify_and_create_clinician creates Provider + Licensure + Verification rows."""
+    user = await _seed_user(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        provider = await verify_and_create_clinician(_VALID_FORM, user, db=session)
+
+    assert provider.id is not None
+
+    async with db_test_session_manager() as session:
+        # Provider row exists
+        p = await session.get(Provider, provider.id)
+        assert p is not None
+        assert p.owner_id == user.id
+
+        # Licensure row exists
+        licensures = (
+            (
+                await session.execute(
+                    select(ProviderLicensure).filter(
+                        ProviderLicensure.clinician_id == p.clinician_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(licensures) == 1
+        assert licensures[0].license_type == "lcsw"
+        assert licensures[0].license_number == "LIC123"
+
+        # Verification row exists
+        verifications = (
+            (
+                await session.execute(
+                    select(Verification).filter(Verification.provider_id == p.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(verifications) == 1
+
+
+async def test_failed_verification_does_not_rollback_clinician(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """When verification yields 'failed', the Provider/Licensure rows are kept.
+    The wizard surfaces the failure to the user rather than hiding it.
+    """
+    user = await _seed_user(db_test_session_manager)
+
+    # Override NPPES to return not-found → scoring yields 'failed'
+    from src.domain.logic.verifications import handlers as handlers_mod
+
+    def _not_found_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'{"results": []}')
+
+    class _NotFoundClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            super().__init__(transport=httpx.MockTransport(_not_found_handler))
+
+    with patch.object(handlers_mod.httpx, "AsyncClient", _NotFoundClient):
+        async with db_test_session_manager() as session:
+            provider = await verify_and_create_clinician(_VALID_FORM, user, db=session)
+
+    # Provider still exists
+    async with db_test_session_manager() as session:
+        p = await session.get(Provider, provider.id)
+        assert p is not None
+
+        # Verification exists with failed status
+        verif = (
+            (
+                await session.execute(
+                    select(Verification).filter(Verification.provider_id == p.id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert verif is not None
+        assert verif.status == "failed"
+
+
+async def test_atomicity_on_pipeline_raise(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """If run_provider_verification raises before committing, no Provider or
+    Licensure rows persist — the flushed state is rolled back with the session.
+    """
+    user = await _seed_user(db_test_session_manager)
+
+    from src.domain.logic.onboarding import services as services_mod
+
+    with patch.object(
+        services_mod,
+        "run_provider_verification",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("pipeline exploded"),
+    ):
+        with pytest.raises(RuntimeError, match="pipeline exploded"):
+            async with db_test_session_manager() as session:
+                await verify_and_create_clinician(_VALID_FORM, user, db=session)
+
+    # No Provider rows for this user
+    async with db_test_session_manager() as session:
+        providers = (
+            (
+                await session.execute(
+                    select(Provider).filter(Provider.owner_id == user.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert providers == []

--- a/src/domain/logic/onboarding/test_state_machine.py
+++ b/src/domain/logic/onboarding/test_state_machine.py
@@ -1,0 +1,109 @@
+"""Parametrized truth-table tests for the onboarding state machine.
+
+Each row covers one (intent, has_clinician, clinician_verified) combination
+from the documented signal table in state_machine.py.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.domain.logic.onboarding.state_machine import next_step, onboarding_clinician
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# onboarding_clinician helper
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(created_at_offset: int = 0):
+    """Create a minimal fake Provider with a predictable created_at."""
+    from datetime import datetime, timedelta
+
+    p = MagicMock()
+    p.id = uuid.uuid4()
+    p.created_at = datetime(2024, 1, 1) + timedelta(days=created_at_offset)
+    return p
+
+
+def test_onboarding_clinician_returns_none_for_no_providers():
+    user = MagicMock()
+    user.providers = []
+    assert onboarding_clinician(user) is None
+
+
+def test_onboarding_clinician_returns_most_recent():
+    p1 = _make_provider(0)
+    p2 = _make_provider(5)
+    p3 = _make_provider(3)
+    user = MagicMock()
+    user.providers = [p1, p2, p3]
+    assert onboarding_clinician(user) is p2  # latest by created_at
+
+
+def test_onboarding_clinician_single_provider():
+    p = _make_provider(0)
+    user = MagicMock()
+    user.providers = [p]
+    assert onboarding_clinician(user) is p
+
+
+# ---------------------------------------------------------------------------
+# next_step truth table
+# ---------------------------------------------------------------------------
+
+_NOT_YET_BUILT = "/welcome/coming-soon"
+
+
+@pytest.mark.parametrize(
+    "intent,has_clinician,clinician_verified,expected",
+    [
+        # No intent → landing
+        (None, False, False, "/"),
+        (None, True, True, "/"),
+        # No clinician → verify
+        ("refer_now", False, False, "/welcome/verify"),
+        ("have_openings", False, False, "/welcome/verify"),
+        ("building_network", False, False, "/welcome/verify"),
+        ("invited", False, False, "/welcome/verify"),
+        # Clinician exists but not verified → verify
+        ("refer_now", True, False, "/welcome/verify"),
+        ("have_openings", True, False, "/welcome/verify"),
+        ("building_network", True, False, "/welcome/verify"),
+        ("invited", True, False, "/welcome/verify"),
+        # Clinician exists and verified → intent-specific stub (T4/T5/T7 replace)
+        ("refer_now", True, True, _NOT_YET_BUILT),
+        ("have_openings", True, True, _NOT_YET_BUILT),
+        ("building_network", True, True, _NOT_YET_BUILT),
+        ("invited", True, True, _NOT_YET_BUILT),
+    ],
+)
+async def test_next_step_truth_table(
+    intent, has_clinician, clinician_verified, expected
+):
+    provider = _make_provider()
+    user = MagicMock()
+    user.onboarding_intent = intent
+    user.providers = [provider] if has_clinician else []
+
+    # Build a fake Verification with the requested status, or None.
+    if has_clinician and clinician_verified:
+        fake_verification = MagicMock()
+        fake_verification.status = "verified"
+    elif has_clinician and not clinician_verified:
+        fake_verification = MagicMock()
+        fake_verification.status = "needs_review"
+    else:
+        fake_verification = None
+
+    # Mock db.execute so scalars().first() returns the fake verification.
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = fake_verification
+    mock_db = AsyncMock()
+    mock_db.execute.return_value = mock_result
+
+    result = await next_step(user, db=mock_db)
+    assert result == expected

--- a/src/domain/logic/verifications/README.md
+++ b/src/domain/logic/verifications/README.md
@@ -11,10 +11,11 @@ Persistence + pure-function primitives for the provider verification pipeline. T
 - `scoring.py` — `score_verification(...)` table-driven rules over `(NppesResult, OigResult, provider name)` → `Score(status, flags, name_match_score)`. No I/O.
 - `handlers.py` — `run_provider_verification(...)` orchestrator + `handle_create_provider_verification(...)` admin-only retrigger. Composes the primitives with persistence + audit + an `httpx.AsyncClient`. The bespoke route lives at [`../../routes/verifications.py`](../../routes/verifications.py) and is wired into `src/main.py` next to the other hand-rolled routers.
 
-The orchestrator has two callers:
+The orchestrator has three callers:
 
 1. **`handle_create_provider_verification`** in this file (admin retrigger; `actor_id=requesting_user.id`).
 2. **`run_nightly_verification`** in [`../../../jobs/nightly_verification.py`](../../../jobs/nightly_verification.py) (daily APScheduler job; `actor_id=None`).
+3. **`verify_and_create_clinician`** in [`../../logic/onboarding/services.py`](../onboarding/services.py) (self-service wizard path; `actor_id=user.id`).
 
 (`__init__.py` is intentionally empty — these are imported directly via `src.domain.logic.verifications.nppes`/`.oig`/`.scoring`/`.repository`/`.schema`/`.handlers`.)
 
@@ -43,6 +44,10 @@ The orchestrator writes one `Verification` row plus one matching audit row in a 
 ### Why `record_audit_for` + explicit commit (not `mutate`)
 
 The `mutate(...)` context manager is a snapshot-before / mutate / record_audit / commit ritual built around a pre-existing target — it snapshots `before` from the row that's already in the DB. Verification rows are *created* each run, so there's no pre-existing target. `record_audit_for` plus an explicit commit matches the favorites cluster's edge-add/remove pattern (`src/domain/logic/favorites/handlers.py`), which has the same shape (no pre-existing target on add).
+
+### Dev/test fallback (`BEDLAM_VERIFY_DEV_FALLBACK`)
+
+Set `BEDLAM_VERIFY_DEV_FALLBACK=1` to skip the real NPPES network call and synthesize an NPPES hit that matches the provider's own names (name-similarity = 1.0 → `verified`). Only for local dev and integration tests; never set in production. The OIG check still runs (using the configured CSV path).
 
 ### Name fields gap (followup tracking)
 

--- a/src/domain/logic/verifications/handlers.py
+++ b/src/domain/logic/verifications/handlers.py
@@ -17,6 +17,7 @@ should leave this alone.
 """
 
 import logging
+import os
 from uuid import UUID
 
 import httpx
@@ -113,7 +114,14 @@ async def run_provider_verification(
     first_name, last_name = _clinician_names(provider, owner)
 
     extra_flags: list[str] = []
-    if provider.npi:
+    if os.getenv("BEDLAM_VERIFY_DEV_FALLBACK") == "1":
+        # Dev/test shortcut: synthesize an NPPES hit matching the provider's
+        # own names so scoring yields `verified` without hitting the public
+        # CMS registry. Never set in production.
+        nppes_result = NppesResult(
+            found=True, first_name=first_name, last_name=last_name, raw=None
+        )
+    elif provider.npi:
         nppes_result = await nppes_lookup(provider.npi, http=http)
     else:
         nppes_result = _SKIPPED_NPPES

--- a/src/domain/routes/README.md
+++ b/src/domain/routes/README.md
@@ -35,6 +35,7 @@ The grammar fits resource-shaped CRUD. These stay hand-written:
 | `GET /auth/{register,login,forgot-password,reset-password/{token}}` | `auth_pages.py` | Pure form rendering. |
 | `GET /users/me`, `GET /users/me/clinicians` | `users.py` | Singleton aliases — mounted via `singleton_alias=` on the existing `mount_detail` / `mount_related_list`. |
 | `POST/DELETE/GET /users/me/favorites[/{provider_id}]` | `favorites.py` | M:N edge add/remove — no `mount_*` helper for edge mutations. |
+| `GET /welcome`, `GET/POST /welcome/verify`, `GET /welcome/coming-soon` | `welcome.py` | Onboarding wizard — multi-step flow with state-machine dispatch; see `src/domain/logic/onboarding/README.md`. |
 | `GET /`, `GET /health` | `../../main.py` | Utility endpoints. |
 
 ## Tests

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -1120,7 +1120,8 @@ async def test_put_onboarding_intent_accepts_each_valid_value(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
     """Each of the 4 enum values is accepted and persisted.
-    The response is a 302 redirect to /openings."""
+    The response is a 302 redirect to /welcome (dispatcher sends user to their next step).
+    """
     for intent in ("refer_now", "have_openings", "invited", "building_network"):
         response = await authenticated_client.put(
             "/users/me/onboarding-intent",
@@ -1130,7 +1131,7 @@ async def test_put_onboarding_intent_accepts_each_valid_value(
         assert (
             response.status_code == 302
         ), f"intent={intent!r} got {response.status_code}"
-        assert response.headers["location"] == "/openings"
+        assert response.headers["location"] == "/welcome"
 
         async with db_test_session_manager() as session:
             result = await session.execute(

--- a/src/domain/routes/test_welcome.py
+++ b/src/domain/routes/test_welcome.py
@@ -1,0 +1,204 @@
+"""Route-level tests for the /welcome onboarding wizard.
+
+Covers:
+- GET /welcome dispatches to next_step (redirect to / for no intent, /welcome/verify for no clinician)
+- GET /welcome/verify renders with 200 and the step header
+- POST /welcome/verify happy path: creates Provider+Licensure, runs verification, redirects
+- POST /welcome/verify validation error: re-renders form with 422 inline errors
+- GET /welcome/coming-soon renders placeholder
+- Unauthenticated access redirects to login
+
+NPPES is stubbed via `BEDLAM_VERIFY_DEV_FALLBACK=1`; OIG uses the local LEIE fixture.
+"""
+
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.logic.verifications import oig as oig_module
+from src.domain.models import Provider, User
+
+pytestmark = pytest.mark.asyncio
+
+_LEIE_FIXTURE = (
+    Path(__file__).parent.parent
+    / "logic"
+    / "verifications"
+    / "test_data"
+    / "leie_sample.csv"
+)
+
+_VALID_BODY = {
+    "first_name": "Jane",
+    "last_name": "Smith",
+    "work_email": "jane@clinic.example",
+    "license_type": "lcsw",
+    "license_number": "L-99999",
+    "issuing_state": "IL",
+}
+
+
+@pytest.fixture(autouse=True)
+def _stub_external(monkeypatch):
+    """Point OIG at the local fixture; enable dev-mode NPPES fallback."""
+    monkeypatch.setenv("LEIE_CSV_PATH", str(_LEIE_FIXTURE))
+    monkeypatch.setenv("BEDLAM_VERIFY_DEV_FALLBACK", "1")
+    oig_module._reset_cache_for_tests()
+    yield
+    oig_module._reset_cache_for_tests()
+
+
+async def _set_intent(
+    session_maker: async_sessionmaker[AsyncSession],
+    user_email: str,
+    intent: str,
+) -> None:
+    async with session_maker() as session:
+        async with session.begin():
+            result = await session.execute(
+                select(User).filter(User.email == user_email)
+            )
+            user = result.scalars().first()
+            assert user is not None
+            user.onboarding_intent = intent
+
+
+# ---------------------------------------------------------------------------
+# GET /welcome
+# ---------------------------------------------------------------------------
+
+
+async def test_welcome_no_intent_redirects_to_root(
+    authenticated_client: AsyncClient,
+):
+    """User with no intent → dispatched to /."""
+    response = await authenticated_client.get("/welcome", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+
+
+async def test_welcome_with_intent_no_clinician_redirects_to_verify(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """User with intent but no clinician → dispatched to /welcome/verify."""
+    await _set_intent(db_test_session_manager, "testuser@example.com", "have_openings")
+    response = await authenticated_client.get("/welcome", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/welcome/verify"
+
+
+async def test_welcome_anon_redirects_to_login(test_client: AsyncClient):
+    response = await test_client.get("/welcome", follow_redirects=False)
+    assert response.status_code in {302, 401}
+
+
+# ---------------------------------------------------------------------------
+# GET /welcome/verify
+# ---------------------------------------------------------------------------
+
+
+async def test_get_verify_renders_200(authenticated_client: AsyncClient):
+    response = await authenticated_client.get(
+        "/welcome/verify",
+        headers={"Accept": "text/html"},
+    )
+    assert response.status_code == 200
+    assert b"Verify your license" in response.content
+    assert b'data-testid="verify-license-heading"' in response.content
+    assert b'data-testid="welcome-step-header"' in response.content
+
+
+async def test_get_verify_anon_redirected(test_client: AsyncClient):
+    response = await test_client.get(
+        "/welcome/verify",
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code in {302, 401}
+
+
+# ---------------------------------------------------------------------------
+# POST /welcome/verify
+# ---------------------------------------------------------------------------
+
+
+async def test_post_verify_happy_path_creates_provider_and_redirects(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Valid body → Provider + Licensure created, verification run, 302 to next step."""
+    await _set_intent(db_test_session_manager, logged_in_user.email, "have_openings")
+
+    response = await authenticated_client.post(
+        "/welcome/verify",
+        json=_VALID_BODY,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    # Plain non-HTMX request → 302
+    assert response.status_code == 302
+
+    # Provider row created for this user
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(Provider).filter(Provider.owner_id == logged_in_user.id)
+        )
+        providers = result.scalars().all()
+    assert len(providers) == 1
+
+
+async def test_post_verify_htmx_happy_path_returns_hx_redirect(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """HTMX request → 204 + HX-Redirect header instead of 302."""
+    await _set_intent(db_test_session_manager, logged_in_user.email, "refer_now")
+
+    response = await authenticated_client.post(
+        "/welcome/verify",
+        json=_VALID_BODY,
+        headers={"Accept": "text/html", "HX-Request": "true"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 204
+    assert "HX-Redirect" in response.headers
+
+
+async def test_post_verify_invalid_body_returns_422_inline(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Bad body (missing required field) → form re-rendered with inline errors."""
+    await _set_intent(db_test_session_manager, logged_in_user.email, "have_openings")
+
+    bad_body = {**_VALID_BODY, "license_type": "not_a_valid_type"}
+    response = await authenticated_client.post(
+        "/welcome/verify",
+        json=bad_body,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 422
+    # Form is re-rendered — heading still present
+    assert b"Verify your license" in response.content
+
+
+# ---------------------------------------------------------------------------
+# GET /welcome/coming-soon
+# ---------------------------------------------------------------------------
+
+
+async def test_get_coming_soon_renders_200(authenticated_client: AsyncClient):
+    response = await authenticated_client.get(
+        "/welcome/coming-soon",
+        headers={"Accept": "text/html"},
+    )
+    assert response.status_code == 200
+    assert b"coming soon" in response.content.lower()

--- a/src/domain/routes/users.py
+++ b/src/domain/routes/users.py
@@ -43,7 +43,7 @@ async def put_onboarding_intent(
 
     Self-only: always operates on the authenticated user. Writes an
     audit row with action `UPDATE_USER_ONBOARDING_INTENT`. On success,
-    redirects to `/openings` (placeholder; T2 will change to `/welcome`).
+    redirects to `/welcome` (wizard dispatcher routes to the next step).
 
     This is a field-cluster subresource (RESOURCE_GRAMMAR.md §2) — a
     single-value PUT because `onboarding_intent` has different rules
@@ -55,4 +55,4 @@ async def put_onboarding_intent(
         audit_repo=audit_repo,
         requesting_user=requesting_user,
     )
-    return RedirectResponse(url="/openings", status_code=302)
+    return RedirectResponse(url="/welcome", status_code=302)

--- a/src/domain/routes/welcome.py
+++ b/src/domain/routes/welcome.py
@@ -1,0 +1,166 @@
+"""Bespoke router for the /welcome onboarding wizard.
+
+Pattern: every step is a `GET /welcome/<step>` page + `POST /welcome/<step>`
+shim. The shim validates → calls a service function → redirects via
+`next_step()`. On validation error the form fragment is re-rendered with
+errors inline.
+
+This router is intentionally thin — all business logic lives in
+`src/domain/logic/onboarding/`.
+
+Modeled on `src/domain/routes/auth_pages.py`.
+"""
+
+from fastapi import APIRouter, Body, Depends, Request
+from fastapi.responses import RedirectResponse, Response
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.auth_config import current_active_user
+from src.db import get_db_session
+from src.domain.logic.onboarding.schema import VerifyForm
+from src.domain.logic.onboarding.services import verify_and_create_clinician
+from src.domain.logic.onboarding.state_machine import next_step
+from src.domain.models import User
+from src.domain.models.enums import LICENSE_TYPES, LICENSE_TYPES_LABELS
+from src.framework import BaseRouter
+from src.framework.http.form_error_handler import FormError, form_error_handler
+from src.framework.http.responses import APIResponse
+
+welcome_api_router = APIRouter(tags=["Welcome Wizard"])
+router = BaseRouter(router=welcome_api_router, default_tags=["Welcome Wizard"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MalformedVerifyBody(Exception):
+    """Validation failed on POST /welcome/verify body."""
+
+    def __init__(self, errors: list[dict]):
+        self.errors = errors
+
+
+def _render_verify_errors(exc: _MalformedVerifyBody) -> FormError:
+    from src.framework.dispatch.mounts.create import build_form_errors_dict
+
+    return FormError(
+        field_errors=build_form_errors_dict(exc.errors),
+        status_code=422,
+    )
+
+
+def _redirect(request: Request, url: str) -> Response:
+    """Return HX-Redirect for HTMX requests; plain 302 otherwise."""
+    if request.headers.get("HX-Request") == "true":
+        response = Response(status_code=204)
+        response.headers["HX-Redirect"] = url
+        return response
+    return RedirectResponse(url=url, status_code=302)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+@router.get("/welcome", name="welcome:index")
+async def get_welcome(
+    request: Request,
+    requesting_user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Wizard dispatcher — calls next_step and redirects.
+
+    Authed users who land here are sent to their next wizard step.
+    Anonymous users are sent to /auth/login (via the 401 handler in main.py).
+    """
+    next_url = await next_step(requesting_user, db=db)
+    return _redirect(request, next_url)
+
+
+# ---------------------------------------------------------------------------
+# Verify step
+# ---------------------------------------------------------------------------
+
+_VERIFY_STEP_INFO = "Step 1 of 1"
+_VERIFY_TEMPLATE = "welcome/verify.html"
+
+
+_VERIFY_CONTEXT = {
+    "step_info": _VERIFY_STEP_INFO,
+    "license_types": LICENSE_TYPES,
+    "license_types_labels": LICENSE_TYPES_LABELS,
+}
+
+
+@router.get("/welcome/verify", name="welcome:get_verify")
+async def get_verify(
+    request: Request,
+    requesting_user: User = Depends(current_active_user),
+):
+    """Render the license-verification form."""
+    return APIResponse.html_response(
+        template_name=_VERIFY_TEMPLATE,
+        context=_VERIFY_CONTEXT,
+        request=request,
+    )
+
+
+@router.post("/welcome/verify", name="welcome:post_verify")
+@form_error_handler(
+    template=_VERIFY_TEMPLATE,
+    handlers={_MalformedVerifyBody: _render_verify_errors},
+    context_builder=lambda kwargs: _VERIFY_CONTEXT,
+    # Browser-only form — no JSON contract to preserve, so re-render on
+    # every client (not just HTMX).
+    require_htmx=False,
+)
+async def post_verify(
+    request: Request,
+    body: dict = Body(...),
+    requesting_user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Validate VerifyForm, create Clinician + Licensure, run verification,
+    redirect to next_step.
+
+    Uses `body: dict = Body(...)` (raw JSON via hx-ext="json-enc") so the
+    decorator can catch `_MalformedVerifyBody` before FastAPI's auto-validation
+    would raise outside the decorator's reach.
+    """
+    try:
+        form_data = VerifyForm.model_validate(body)
+    except ValidationError as e:
+        raise _MalformedVerifyBody(e.errors())
+
+    await verify_and_create_clinician(form_data, requesting_user, db=db)
+
+    # After the service commits, reload the user's providers relationship so
+    # next_step sees the newly created Provider.
+    await db.refresh(requesting_user)
+
+    next_url = await next_step(requesting_user, db=db)
+    return _redirect(request, next_url)
+
+
+# ---------------------------------------------------------------------------
+# Coming-soon stub (placeholder for T4/T5/T7 steps)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/welcome/coming-soon", name="welcome:coming_soon")
+async def get_coming_soon(
+    request: Request,
+    requesting_user: User = Depends(current_active_user),
+):
+    """Placeholder rendered for verified users while downstream steps are not
+    yet built. T4/T5/T7 will replace the real pages; this page disappears
+    from the state machine once all stubs are filled in."""
+    return APIResponse.html_response(
+        template_name="welcome/coming_soon.html",
+        context={},
+        request=request,
+    )

--- a/src/domain/templates/welcome/README.md
+++ b/src/domain/templates/welcome/README.md
@@ -1,0 +1,30 @@
+# Welcome wizard templates
+
+Templates for the `/welcome/*` bespoke router (`src/domain/routes/welcome.py`).
+
+## Layout
+
+`_layout.html` extends `base.html` and provides the wizard page chrome:
+- Optional step header (via `step_info` context variable, e.g. `"Step 1 of 1"`)
+- `{% block wizard_content %}{% endblock %}` for each step's body
+
+Each step template extends `_layout.html` and fills `wizard_content`.
+
+## Steps (this ticket)
+
+| File | URL | Description |
+|---|---|---|
+| `verify.html` | `GET /welcome/verify` | License-verification form |
+| `coming_soon.html` | `GET /welcome/coming-soon` | Placeholder while downstream steps ship |
+
+## Steps (downstream)
+
+T4/T5/T6/T7 add `first_opening.html`, `done.html`, `be_findable.html`,
+`refer.html`, `start_network.html`, `minimal_profile.html`. Each follows the
+same pattern: extend `_layout.html`, fill `wizard_content`, form via
+`form_with_errors` macro.
+
+## Styling note
+
+Deliberately minimal — no custom CSS, no chip components, no color tokens.
+A basecoat.ui migration will style wizard pages after the epic is complete.

--- a/src/domain/templates/welcome/_layout.html
+++ b/src/domain/templates/welcome/_layout.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}
+  <section>
+    {% if step_info %}<p data-testid="welcome-step-header">{{ step_info }}</p>{% endif %}
+    {% block wizard_content %}{% endblock %}
+  </section>
+{% endblock %}

--- a/src/domain/templates/welcome/coming_soon.html
+++ b/src/domain/templates/welcome/coming_soon.html
@@ -1,0 +1,8 @@
+{% extends "welcome/_layout.html" %}
+{% block wizard_content %}
+  <hgroup>
+    <h1>This step is coming soon</h1>
+    <p>The next part of your onboarding is still being built.</p>
+  </hgroup>
+  <a href="{{ entity_url('opening') }}" role="button" class="secondary">Browse the board</a>
+{% endblock %}

--- a/src/domain/templates/welcome/verify.html
+++ b/src/domain/templates/welcome/verify.html
@@ -1,0 +1,22 @@
+{% extends "welcome/_layout.html" %}
+{%- from "_shared/form_fields.html" import text_field, select_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{% block wizard_content %}
+  <hgroup>
+    <h1 data-testid="verify-license-heading">Verify your license</h1>
+    <p>This keeps the board trustworthy for everyone.</p>
+  </hgroup>
+  <blockquote>
+    <small>Your license number is used only for verification — never shown on your profile.</small>
+  </blockquote>
+  {% call form_with_errors(action="/welcome/verify", method="post", json_enc=true) %}
+    {{ text_field("first_name", "First name", autocomplete="given-name") }}
+    {{ text_field("last_name", "Last name", autocomplete="family-name") }}
+    {{ text_field("work_email", "Work email", type="email", autocomplete="email") }}
+    {{ select_field("license_type", "License type", options=license_types, labels=license_types_labels, placeholder=True) }}
+    {{ text_field('license_number', 'License number') }}
+    {{ select_field("issuing_state", "Issuing state", options=us_states, placeholder=True) }}
+    <small>Checked against state board databases. Usually instant.</small>
+    <button type="submit" data-testid="verify-submit">Verify →</button>
+  {% endcall %}
+{% endblock %}

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from src.domain import routes  # noqa: F401  # populates entity_registry
 from src.domain import template_globals  # noqa: F401  # populates Jinja env globals
 from src.domain.logic.users.schema import UserRead
 from src.domain.models.enums import ONBOARDING_INTENTS
-from src.domain.routes import auth_pages, auth_routes, dev_auth, verifications
+from src.domain.routes import auth_pages, auth_routes, dev_auth, verifications, welcome
 from src.framework.config import settings
 from src.framework.dispatch.registry import entity_registry
 from src.framework.http.middleware import StripEmptyQueryParamsMiddleware
@@ -188,6 +188,7 @@ app.include_router(
     tags=["auth"],
 )
 app.include_router(verifications.verifications_api_router)
+app.include_router(welcome.welcome_api_router)
 
 # Every entity route file calls `register_entity(SPEC)` at import time
 # (see `src/framework/dispatch/registry.py`). The package import above


### PR DESCRIPTION
## Summary

- Adds `GET /welcome`, `GET/POST /welcome/verify`, `GET /welcome/coming-soon` bespoke wizard routes (`src/domain/routes/welcome.py`)
- `next_step()` state machine in `src/domain/logic/onboarding/state_machine.py` routes each user to their correct next step based on intent, clinician existence, and verification status
- `verify_and_create_clinician()` in `services.py` atomically creates Org + Provider (Clinician + Affiliation) + ProviderLicensure, then runs the NPPES/OIG pipeline
- Adds `BEDLAM_VERIFY_DEV_FALLBACK=1` env var to skip real NPPES calls in dev/test environments
- Changes `PUT /me/onboarding-intent` redirect from `/openings` → `/welcome` so the wizard flow begins immediately after intent capture

**Depends on:** fix/onboarding-t1

## Test plan

- [ ] `dev test` passes (1861 tests)
- [ ] `dev lint` passes
- [ ] `GET /welcome/verify` renders the license form with step header
- [ ] `POST /welcome/verify` with valid data creates Provider + Verification and redirects to coming-soon
- [ ] `POST /welcome/verify` with invalid data re-renders form with inline errors
- [ ] Unauthenticated access to `/welcome/*` redirects to `/auth/login`
- [ ] Setting onboarding intent on landing page redirects to `/welcome` (not `/openings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)