### PR TITLE
feat(onboarding): T4 — first-opening wizard step + done page

### DIFF
--- a/src/domain/logic/onboarding/README.md
+++ b/src/domain/logic/onboarding/README.md
@@ -14,8 +14,22 @@ it. The signal table:
 | `intent` | `user.onboarding_intent` |
 | `has_clinician` | `user.providers` non-empty (selectin-loaded) |
 | `clinician_verified` | onboarding clinician's latest `Verification.status == 'verified'` |
-| `has_opening` | onboarding clinician owns ≥1 `OpeningDetail` (T4+) |
+| `has_opening` | onboarding clinician owns ≥1 `clinician_opening` Post (T4) |
 | `has_reciprocity_profile` | clinician has non-empty specialties AND modality (T5+) |
+
+### Truth table (current)
+
+| intent | has_clinician | clinician_verified | has_opening | next URL |
+|---|---|---|---|---|
+| any | False | — | — | `/welcome/verify` |
+| any | True | False | — | `/welcome/verify` |
+| `have_openings` | True | True | False | `/welcome/first-opening` |
+| `have_openings` | True | True | True | `/welcome/done` |
+| `refer_now` | True | True | — | `/welcome/coming-soon` (T5) |
+| `building_network` | True | True | — | `/welcome/coming-soon` (T7) |
+| `invited` | True | True | — | `/welcome/coming-soon` (T7) |
+
+**Terminal rule**: Repeat visits to `/welcome/done` re-render the done page — the natural exit is the "Go to the board" CTA. No session flag is used (see `state_machine.py` comment).
 
 ### Onboarding clinician convention
 

--- a/src/domain/logic/onboarding/schema.py
+++ b/src/domain/logic/onboarding/schema.py
@@ -45,7 +45,7 @@ class FirstOpeningForm(BaseModel):
     opening_type: OptionalOpeningType = None
     specialties: SpecialtiesField = []
     population_tags: PopulationTagsField = []
-    languages: Annotated[list[_LANGUAGES], Field(default_factory=list)] = []
+    languages: list[_LANGUAGES] = []
     fee_low: int | None = None
     fee_high: int | None = None
     payment_types: PaymentTypesField = []

--- a/src/domain/logic/onboarding/schema.py
+++ b/src/domain/logic/onboarding/schema.py
@@ -1,11 +1,20 @@
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
-from src.domain.models.enums import LICENSE_TYPES, US_STATES
+from src.domain.logic.posts.schema import (
+    OptionalAvailabilityState,
+    OptionalOpeningType,
+    PaymentTypesField,
+    PopulationTagsField,
+    SpecialtiesField,
+)
+from src.domain.models.enums import LANGUAGES, LICENSE_TYPES, US_STATES
+from src.framework.schema_validators import StrippedOptionalText
 
 _LICENSE_TYPES = Literal[tuple(LICENSE_TYPES)]  # type: ignore[valid-type]
 _US_STATES = Literal[tuple(US_STATES)]  # type: ignore[valid-type]
+_LANGUAGES = Literal[tuple(LANGUAGES)]  # type: ignore[valid-type]
 
 
 class VerifyForm(BaseModel):
@@ -22,3 +31,23 @@ class VerifyForm(BaseModel):
     license_type: _LICENSE_TYPES
     license_number: str
     issuing_state: _US_STATES
+
+
+class FirstOpeningForm(BaseModel):
+    """Wire schema for POST /welcome/first-opening.
+
+    All slot fields are optional — the wizard encourages completion but
+    never blocks on it. Field types mirror the T3 schema aliases on
+    ClinicianOpeningCreate; validation rules (empty→None, scalar→list)
+    are shared via those aliases.
+    """
+
+    opening_type: OptionalOpeningType = None
+    specialties: SpecialtiesField = []
+    population_tags: PopulationTagsField = []
+    languages: Annotated[list[_LANGUAGES], Field(default_factory=list)] = []
+    fee_low: int | None = None
+    fee_high: int | None = None
+    payment_types: PaymentTypesField = []
+    availability_state: OptionalAvailabilityState = None
+    colleague_note: Annotated[StrippedOptionalText, Field(max_length=280)] = None

--- a/src/domain/logic/onboarding/services.py
+++ b/src/domain/logic/onboarding/services.py
@@ -18,12 +18,22 @@ import uuid
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.logic.onboarding.schema import VerifyForm
+from src.domain.logic.onboarding.schema import FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.state_machine import onboarding_clinician
 from src.domain.logic.providers.repository import ProviderRepository
 from src.domain.logic.verifications.handlers import run_provider_verification
 from src.domain.logic.verifications.repository import VerificationRepository
-from src.domain.models import Organization, Provider, ProviderLicensure, User
+from src.domain.models import (
+    OpeningDetail,
+    Organization,
+    Post,
+    Provider,
+    ProviderLicensure,
+    User,
+)
+from src.domain.models.posts.post_kinds import POST_KIND_BY_DETAIL_MODEL
 from src.framework.audit.repository import AuditRepository
+from src.framework.persistence.base_repository import BaseRepository
 
 _HTTP_TIMEOUT_SECONDS = 10.0
 
@@ -119,3 +129,37 @@ async def verify_and_create_clinician(
         )
 
     return provider
+
+
+async def create_first_opening(
+    form_data: FirstOpeningForm,
+    user: User,
+    *,
+    db: AsyncSession,
+) -> Post:
+    """Create the wizard's first clinician_opening Post for the user.
+
+    Delegates to `BaseRepository.create_polymorphic` — the same path the
+    canonical `/openings` create route uses. Returns the created Post.
+    """
+    clinician = onboarding_clinician(user)
+    post = Post(kind="clinician_opening", owner_id=user.id)
+    detail = OpeningDetail(
+        provider_id=clinician.id,
+        opening_type=form_data.opening_type,
+        specialties=form_data.specialties or [],
+        population_tags=form_data.population_tags or [],
+        languages=list(form_data.languages) if form_data.languages else [],
+        fee_low=form_data.fee_low,
+        fee_high=form_data.fee_high,
+        payment_types=form_data.payment_types or [],
+        availability_state=form_data.availability_state,
+        colleague_note=form_data.colleague_note,
+    )
+    kind_spec = POST_KIND_BY_DETAIL_MODEL[OpeningDetail]
+    repo = BaseRepository(db)
+    created = await repo.create_polymorphic(
+        post, detail, detail_relationship=kind_spec.detail_relationship
+    )
+    await db.commit()
+    return created

--- a/src/domain/logic/onboarding/state_machine.py
+++ b/src/domain/logic/onboarding/state_machine.py
@@ -21,7 +21,7 @@ by the user. See `onboarding_clinician()`.
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.models import Provider, User, Verification
+from src.domain.models import OpeningDetail, Post, Provider, User, Verification
 
 # Stub URL for steps not yet implemented — returns a minimal placeholder page
 # until the downstream ticket ships the real page.
@@ -75,8 +75,23 @@ async def next_step(user: User, *, db: AsyncSession) -> str:
         return _NOT_YET_BUILT
 
     if intent == "have_openings":
-        # T4 will replace this stub with /welcome/first-opening
-        return _NOT_YET_BUILT
+        has_opening_result = await db.execute(
+            select(Post)
+            .join(OpeningDetail, OpeningDetail.post_id == Post.id)
+            .filter(
+                Post.kind == "clinician_opening",
+                OpeningDetail.provider_id == clinician.id,
+            )
+            .limit(1)
+        )
+        has_opening = has_opening_result.scalars().first() is not None
+        if not has_opening:
+            return "/welcome/first-opening"
+        # Terminal: user has completed the wizard. Navigating back to /welcome
+        # shows the done page again rather than redirecting to /openings, so
+        # the done page is idempotent — clicking "Go to the board" is the
+        # natural exit. A session flag would add complexity for minimal gain.
+        return "/welcome/done"
 
     if intent == "building_network":
         # T7 will replace this stub with /welcome/start-network

--- a/src/domain/logic/onboarding/test_services.py
+++ b/src/domain/logic/onboarding/test_services.py
@@ -15,10 +15,13 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.logic.onboarding.schema import VerifyForm
-from src.domain.logic.onboarding.services import verify_and_create_clinician
+from src.domain.logic.onboarding.schema import FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.services import (
+    create_first_opening,
+    verify_and_create_clinician,
+)
 from src.domain.logic.verifications import oig as oig_module
-from src.domain.models import Provider, ProviderLicensure, Verification
+from src.domain.models import OpeningDetail, Provider, ProviderLicensure, Verification
 from tests.helpers import create_test_user
 
 pytestmark = pytest.mark.asyncio
@@ -160,6 +163,46 @@ async def test_failed_verification_does_not_rollback_clinician(
         )
         assert verif is not None
         assert verif.status == "failed"
+
+
+async def test_create_first_opening_happy_path(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """create_first_opening creates a Post + OpeningDetail with slot fields."""
+    user = await _seed_user(db_test_session_manager)
+
+    # Must have a verified clinician first (verify_and_create_clinician commits)
+    async with db_test_session_manager() as session:
+        provider = await verify_and_create_clinician(_VALID_FORM, user, db=session)
+
+    # Reload user to have providers eager-loaded (selectin) in a new session
+    async with db_test_session_manager() as session:
+        from src.domain.models import User as UserModel
+
+        fresh_user = await session.get(UserModel, user.id)
+        assert fresh_user is not None
+
+        form = FirstOpeningForm(
+            opening_type="individual",
+            specialties=["Trauma/PTSD", "Anxiety"],
+            availability_state="taking_now",
+            colleague_note="Taking adult clients now.",
+        )
+        created_post = await create_first_opening(form, fresh_user, db=session)
+
+    assert created_post.id is not None
+    assert created_post.kind == "clinician_opening"
+    assert created_post.owner_id == user.id
+
+    # Verify OpeningDetail has the slot fields
+    async with db_test_session_manager() as session:
+        detail = await session.get(OpeningDetail, created_post.id)
+        assert detail is not None
+        assert detail.provider_id == provider.id
+        assert detail.opening_type == "individual"
+        assert detail.availability_state == "taking_now"
+        assert detail.colleague_note == "Taking adult clients now."
+        assert "Trauma/PTSD" in detail.specialties
 
 
 async def test_atomicity_on_pipeline_raise(

--- a/src/domain/logic/onboarding/test_state_machine.py
+++ b/src/domain/logic/onboarding/test_state_machine.py
@@ -1,7 +1,7 @@
 """Parametrized truth-table tests for the onboarding state machine.
 
-Each row covers one (intent, has_clinician, clinician_verified) combination
-from the documented signal table in state_machine.py.
+Each row covers one (intent, has_clinician, clinician_verified, has_opening)
+combination from the documented signal table in state_machine.py.
 """
 
 import uuid
@@ -59,30 +59,33 @@ _NOT_YET_BUILT = "/welcome/coming-soon"
 
 
 @pytest.mark.parametrize(
-    "intent,has_clinician,clinician_verified,expected",
+    "intent,has_clinician,clinician_verified,has_opening,expected",
     [
         # No intent → landing
-        (None, False, False, "/"),
-        (None, True, True, "/"),
+        (None, False, False, False, "/"),
+        (None, True, True, False, "/"),
         # No clinician → verify
-        ("refer_now", False, False, "/welcome/verify"),
-        ("have_openings", False, False, "/welcome/verify"),
-        ("building_network", False, False, "/welcome/verify"),
-        ("invited", False, False, "/welcome/verify"),
+        ("refer_now", False, False, False, "/welcome/verify"),
+        ("have_openings", False, False, False, "/welcome/verify"),
+        ("building_network", False, False, False, "/welcome/verify"),
+        ("invited", False, False, False, "/welcome/verify"),
         # Clinician exists but not verified → verify
-        ("refer_now", True, False, "/welcome/verify"),
-        ("have_openings", True, False, "/welcome/verify"),
-        ("building_network", True, False, "/welcome/verify"),
-        ("invited", True, False, "/welcome/verify"),
-        # Clinician exists and verified → intent-specific stub (T4/T5/T7 replace)
-        ("refer_now", True, True, _NOT_YET_BUILT),
-        ("have_openings", True, True, _NOT_YET_BUILT),
-        ("building_network", True, True, _NOT_YET_BUILT),
-        ("invited", True, True, _NOT_YET_BUILT),
+        ("refer_now", True, False, False, "/welcome/verify"),
+        ("have_openings", True, False, False, "/welcome/verify"),
+        ("building_network", True, False, False, "/welcome/verify"),
+        ("invited", True, False, False, "/welcome/verify"),
+        # Clinician verified, other intents → stub (T5/T7 will replace)
+        ("refer_now", True, True, False, _NOT_YET_BUILT),
+        ("building_network", True, True, False, _NOT_YET_BUILT),
+        ("invited", True, True, False, _NOT_YET_BUILT),
+        # have_openings, verified, no opening yet → first-opening step
+        ("have_openings", True, True, False, "/welcome/first-opening"),
+        # have_openings, verified, has opening → done
+        ("have_openings", True, True, True, "/welcome/done"),
     ],
 )
 async def test_next_step_truth_table(
-    intent, has_clinician, clinician_verified, expected
+    intent, has_clinician, clinician_verified, has_opening, expected
 ):
     provider = _make_provider()
     user = MagicMock()
@@ -99,11 +102,25 @@ async def test_next_step_truth_table(
     else:
         fake_verification = None
 
-    # Mock db.execute so scalars().first() returns the fake verification.
-    mock_result = MagicMock()
-    mock_result.scalars.return_value.first.return_value = fake_verification
+    # Mock db.execute to return the fake verification first, then simulate
+    # the has_opening query. The state machine calls execute once for
+    # verification, and (for have_openings+verified) once for openings.
+    fake_post = MagicMock() if has_opening else None
+
+    call_count = 0
+
+    def _side_effect(stmt):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.scalars.return_value.first.return_value = fake_verification
+        else:
+            result.scalars.return_value.first.return_value = fake_post
+        return result
+
     mock_db = AsyncMock()
-    mock_db.execute.return_value = mock_result
+    mock_db.execute.side_effect = _side_effect
 
     result = await next_step(user, db=mock_db)
     assert result == expected

--- a/src/domain/routes/test_welcome.py
+++ b/src/domain/routes/test_welcome.py
@@ -5,6 +5,12 @@ Covers:
 - GET /welcome/verify renders with 200 and the step header
 - POST /welcome/verify happy path: creates Provider+Licensure, runs verification, redirects
 - POST /welcome/verify validation error: re-renders form with 422 inline errors
+- GET /welcome/first-opening renders when preconditions met
+- GET /welcome/first-opening redirects to /welcome when no clinician
+- POST /welcome/first-opening happy path: Opening created, redirects to /welcome/done
+- POST /welcome/first-opening validation error: re-renders form with errors
+- POST /welcome/first-opening skip-note: colleague_note is None
+- GET /welcome/done renders static peer cards
 - GET /welcome/coming-soon renders placeholder
 - Unauthenticated access redirects to login
 
@@ -19,7 +25,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.logic.verifications import oig as oig_module
-from src.domain.models import Provider, User
+from src.domain.models import OpeningDetail, Provider, User
+from src.domain.models.posts.post import Post
 
 pytestmark = pytest.mark.asyncio
 
@@ -188,6 +195,221 @@ async def test_post_verify_invalid_body_returns_422_inline(
     assert response.status_code == 422
     # Form is re-rendered — heading still present
     assert b"Verify your license" in response.content
+
+
+# ---------------------------------------------------------------------------
+# GET /welcome/first-opening
+# ---------------------------------------------------------------------------
+
+
+async def _setup_verified_clinician(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+) -> None:
+    """Create a verified clinician for the logged-in user by running the verify step."""
+    await _set_intent(db_test_session_manager, logged_in_user.email, "have_openings")
+    response = await authenticated_client.post(
+        "/welcome/verify",
+        json=_VALID_BODY,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302, f"Verify failed: {response.status_code}"
+
+
+async def test_get_first_opening_renders_when_clinician_verified(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """GET /welcome/first-opening renders the form when preconditions met."""
+    await _setup_verified_clinician(
+        authenticated_client, db_test_session_manager, logged_in_user
+    )
+    response = await authenticated_client.get(
+        "/welcome/first-opening",
+        headers={"Accept": "text/html"},
+    )
+    assert response.status_code == 200
+    assert b"Describe one opening" in response.content
+    assert b'data-testid="first-opening-type"' in response.content
+    assert b'data-testid="welcome-step-header"' in response.content
+
+
+async def test_get_first_opening_without_clinician_redirects_to_welcome(
+    authenticated_client: AsyncClient,
+):
+    """GET /welcome/first-opening with no clinician → redirect to /welcome."""
+    response = await authenticated_client.get(
+        "/welcome/first-opening",
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/welcome"
+
+
+# ---------------------------------------------------------------------------
+# POST /welcome/first-opening
+# ---------------------------------------------------------------------------
+
+_FIRST_OPENING_BODY = {
+    "opening_type": "individual",
+    "specialties": ["Trauma/PTSD", "Anxiety"],
+    "availability_state": "taking_now",
+}
+
+
+async def test_post_first_opening_happy_path_creates_opening_and_redirects(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Valid body → Opening created, 302 to /welcome/done."""
+    await _setup_verified_clinician(
+        authenticated_client, db_test_session_manager, logged_in_user
+    )
+
+    response = await authenticated_client.post(
+        "/welcome/first-opening",
+        json=_FIRST_OPENING_BODY,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/welcome/done"
+
+    # Verify a Post + OpeningDetail row was created
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(Post).filter(
+                Post.owner_id == logged_in_user.id,
+                Post.kind == "clinician_opening",
+            )
+        )
+        posts = result.scalars().all()
+    assert len(posts) == 1
+
+
+async def test_post_first_opening_sets_slot_fields(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Slot fields written to OpeningDetail survive a read-back."""
+    await _setup_verified_clinician(
+        authenticated_client, db_test_session_manager, logged_in_user
+    )
+
+    body = {
+        **_FIRST_OPENING_BODY,
+        "colleague_note": "Looking for adults with anxiety.",
+    }
+    response = await authenticated_client.post(
+        "/welcome/first-opening",
+        json=body,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(OpeningDetail)
+            .join(Post, Post.id == OpeningDetail.post_id)
+            .filter(
+                Post.owner_id == logged_in_user.id,
+                Post.kind == "clinician_opening",
+            )
+        )
+        detail = result.scalars().first()
+    assert detail is not None
+    assert detail.opening_type == "individual"
+    assert detail.availability_state == "taking_now"
+    assert detail.colleague_note == "Looking for adults with anxiety."
+
+
+async def test_post_first_opening_skip_note_clears_colleague_note(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """skip_note=1 in body clears colleague_note before validation."""
+    await _setup_verified_clinician(
+        authenticated_client, db_test_session_manager, logged_in_user
+    )
+
+    body = {
+        **_FIRST_OPENING_BODY,
+        "colleague_note": "This should be stripped",
+        "skip_note": "1",
+    }
+    response = await authenticated_client.post(
+        "/welcome/first-opening",
+        json=body,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(OpeningDetail)
+            .join(Post, Post.id == OpeningDetail.post_id)
+            .filter(
+                Post.owner_id == logged_in_user.id,
+            )
+        )
+        detail = result.scalars().first()
+    assert detail is not None
+    assert detail.colleague_note is None
+
+
+async def test_post_first_opening_invalid_opening_type_returns_422(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Bad opening_type → form re-rendered with 422 inline errors."""
+    await _setup_verified_clinician(
+        authenticated_client, db_test_session_manager, logged_in_user
+    )
+
+    bad_body = {**_FIRST_OPENING_BODY, "opening_type": "not_a_valid_type"}
+    response = await authenticated_client.post(
+        "/welcome/first-opening",
+        json=bad_body,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 422
+    assert b"Describe one opening" in response.content
+
+
+# ---------------------------------------------------------------------------
+# GET /welcome/done
+# ---------------------------------------------------------------------------
+
+
+async def test_get_done_renders_200(authenticated_client: AsyncClient):
+    """GET /welcome/done always renders 200 with peer cards."""
+    response = await authenticated_client.get(
+        "/welcome/done",
+        headers={"Accept": "text/html"},
+    )
+    assert response.status_code == 200
+    assert b"You're on the board" in response.content
+    assert b'data-testid="likely-referral-sources"' in response.content
+
+
+async def test_get_done_anon_redirected(test_client: AsyncClient):
+    response = await test_client.get(
+        "/welcome/done",
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code in {302, 401}
 
 
 # ---------------------------------------------------------------------------

--- a/src/domain/routes/welcome.py
+++ b/src/domain/routes/welcome.py
@@ -18,11 +18,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth_config import current_active_user
 from src.db import get_db_session
-from src.domain.logic.onboarding.schema import VerifyForm
-from src.domain.logic.onboarding.services import verify_and_create_clinician
-from src.domain.logic.onboarding.state_machine import next_step
+from src.domain.logic.onboarding.schema import FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.services import (
+    create_first_opening,
+    verify_and_create_clinician,
+)
+from src.domain.logic.onboarding.state_machine import next_step, onboarding_clinician
 from src.domain.models import User
-from src.domain.models.enums import LICENSE_TYPES, LICENSE_TYPES_LABELS
+from src.domain.models.enums import (
+    AVAILABILITY_STATES,
+    AVAILABILITY_STATES_LABELS,
+    LICENSE_TYPES,
+    LICENSE_TYPES_LABELS,
+    OPENING_TYPES,
+    OPENING_TYPES_LABELS,
+)
 from src.framework import BaseRouter
 from src.framework.http.form_error_handler import FormError, form_error_handler
 from src.framework.http.responses import APIResponse
@@ -44,6 +54,22 @@ class _MalformedVerifyBody(Exception):
 
 
 def _render_verify_errors(exc: _MalformedVerifyBody) -> FormError:
+    from src.framework.dispatch.mounts.create import build_form_errors_dict
+
+    return FormError(
+        field_errors=build_form_errors_dict(exc.errors),
+        status_code=422,
+    )
+
+
+class _MalformedFirstOpeningBody(Exception):
+    """Validation failed on POST /welcome/first-opening body."""
+
+    def __init__(self, errors: list[dict]):
+        self.errors = errors
+
+
+def _render_first_opening_errors(exc: _MalformedFirstOpeningBody) -> FormError:
     from src.framework.dispatch.mounts.create import build_form_errors_dict
 
     return FormError(
@@ -147,7 +173,110 @@ async def post_verify(
 
 
 # ---------------------------------------------------------------------------
-# Coming-soon stub (placeholder for T4/T5/T7 steps)
+# First-opening step (B3)
+# ---------------------------------------------------------------------------
+
+_FIRST_OPENING_STEP_INFO = "Step 2 of 2"
+_FIRST_OPENING_TEMPLATE = "welcome/first_opening.html"
+
+_FIRST_OPENING_CONTEXT = {
+    "step_info": _FIRST_OPENING_STEP_INFO,
+    "opening_types": OPENING_TYPES,
+    "opening_types_labels": OPENING_TYPES_LABELS,
+    "availability_states": AVAILABILITY_STATES,
+    "availability_states_labels": AVAILABILITY_STATES_LABELS,
+}
+
+
+@router.get("/welcome/first-opening", name="welcome:get_first_opening")
+async def get_first_opening(
+    request: Request,
+    requesting_user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Render the first-opening form (Step 2 of 2 for have_openings flow).
+
+    Redirects to /welcome if preconditions aren't met (no verified clinician).
+    """
+    clinician = onboarding_clinician(requesting_user)
+    if clinician is None:
+        return _redirect(request, "/welcome")
+
+    return APIResponse.html_response(
+        template_name=_FIRST_OPENING_TEMPLATE,
+        context=_FIRST_OPENING_CONTEXT,
+        request=request,
+    )
+
+
+@router.post("/welcome/first-opening", name="welcome:post_first_opening")
+@form_error_handler(
+    template=_FIRST_OPENING_TEMPLATE,
+    handlers={_MalformedFirstOpeningBody: _render_first_opening_errors},
+    context_builder=lambda kwargs: _FIRST_OPENING_CONTEXT,
+    require_htmx=False,
+)
+async def post_first_opening(
+    request: Request,
+    body: dict = Body(...),
+    requesting_user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Validate FirstOpeningForm, create the clinician_opening Post, redirect.
+
+    Uses `body: dict = Body(...)` (raw JSON via hx-ext="json-enc") so the
+    decorator catches `_MalformedFirstOpeningBody` before FastAPI's
+    auto-validation fires outside the decorator's reach.
+
+    The "skip note" button sends `{"skip_note": "1", ...}` — we strip
+    `colleague_note` before validation when present.
+    """
+    if body.pop("skip_note", None):
+        body.pop("colleague_note", None)
+
+    try:
+        form_data = FirstOpeningForm.model_validate(body)
+    except Exception as e:
+        from pydantic import ValidationError
+
+        if isinstance(e, ValidationError):
+            raise _MalformedFirstOpeningBody(e.errors())
+        raise
+
+    await create_first_opening(form_data, requesting_user, db=db)
+
+    await db.refresh(requesting_user)
+
+    next_url = await next_step(requesting_user, db=db)
+    return _redirect(request, next_url)
+
+
+# ---------------------------------------------------------------------------
+# Done page (B4)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/welcome/done", name="welcome:done")
+async def get_done(
+    request: Request,
+    requesting_user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Terminal step of the have_openings wizard flow.
+
+    Always 200 — no redirect on re-visit. The natural exit is the
+    'Go to the board' CTA (→ /openings). See state_machine.py for
+    why we don't use a session flag to redirect repeat visitors.
+    """
+    return APIResponse.html_response(
+        template_name="welcome/done.html",
+        context={"user": requesting_user},
+        request=request,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coming-soon stub (placeholder for T5/T7 steps)
 # ---------------------------------------------------------------------------
 
 

--- a/src/domain/templates/welcome/README.md
+++ b/src/domain/templates/welcome/README.md
@@ -10,19 +10,20 @@ Templates for the `/welcome/*` bespoke router (`src/domain/routes/welcome.py`).
 
 Each step template extends `_layout.html` and fills `wizard_content`.
 
-## Steps (this ticket)
+## Steps
 
 | File | URL | Description |
 |---|---|---|
-| `verify.html` | `GET /welcome/verify` | License-verification form |
-| `coming_soon.html` | `GET /welcome/coming-soon` | Placeholder while downstream steps ship |
+| `verify.html` | `GET /welcome/verify` | License-verification form (Step 1 of 1 for all flows) |
+| `first_opening.html` | `GET /welcome/first-opening` | First opening form (Step 2 of 2 for `have_openings` flow) |
+| `done.html` | `GET /welcome/done` | Terminal "You're on the board" page (`have_openings` flow) |
+| `coming_soon.html` | `GET /welcome/coming-soon` | Placeholder while T5/T7 steps ship |
 
 ## Steps (downstream)
 
-T4/T5/T6/T7 add `first_opening.html`, `done.html`, `be_findable.html`,
-`refer.html`, `start_network.html`, `minimal_profile.html`. Each follows the
-same pattern: extend `_layout.html`, fill `wizard_content`, form via
-`form_with_errors` macro.
+T5/T6/T7 add `be_findable.html`, `refer.html`, `start_network.html`,
+`minimal_profile.html`. Each follows the same pattern: extend `_layout.html`,
+fill `wizard_content`, form via `form_with_errors` macro.
 
 ## Styling note
 

--- a/src/domain/templates/welcome/done.html
+++ b/src/domain/templates/welcome/done.html
@@ -1,0 +1,45 @@
+{% extends "welcome/_layout.html" %}
+{% block wizard_content %}
+  <span aria-hidden="true" style="font-size:3rem;">✓</span>
+  <hgroup>
+    <h1>You're on the board.</h1>
+    {% if user and user.onboarding_intent == 'have_openings' %}
+      <p>
+        Clinicians searching for your specialties can find you now. You'll only hear from us when someone actually reaches out.
+      </p>
+    {% else %}
+      <p>You're set up. Browse the board whenever you're ready.</p>
+    {% endif %}
+  </hgroup>
+  <section data-testid="likely-referral-sources">
+    <h2>Clinicians likely to refer to you</h2>
+    <article>
+      <header>
+        {# title-case-ignore #}
+        <strong>Sarah Kim, LCSW</strong>
+      </header>
+      {# title-case-ignore #}
+      <p>Anxiety/OCD — OCD clients often need trauma work after symptom stabilization.</p>
+    </article>
+    <article>
+      <header>
+        {# title-case-ignore #}
+        <strong>Marcus Webb, LPC</strong>
+      </header>
+      {# title-case-ignore #}
+      <p>Grief/loss — clients in complicated grief often benefit from deeper trauma processing.</p>
+    </article>
+    <article>
+      <header>
+        {# title-case-ignore #}
+        <strong>Priya Nair, LMFT</strong>
+      </header>
+      {# title-case-ignore #}
+      <p>Couples — partners frequently need individual trauma work alongside couples therapy.</p>
+    </article>
+  </section>
+  <p>
+    <a href="{{ entity_form_url('opening') }}" class="secondary">Want to add another opening? Takes 30 seconds.</a>
+  </p>
+  <a href="{{ entity_url('opening') }}" role="button">Go to the board</a>
+{% endblock %}

--- a/src/domain/templates/welcome/first_opening.html
+++ b/src/domain/templates/welcome/first_opening.html
@@ -1,0 +1,88 @@
+{% extends "welcome/_layout.html" %}
+{%- from "_shared/form_fields.html" import text_field, select_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{% block wizard_content %}
+  <hgroup>
+    <h1>Describe one opening</h1>
+    <p>You can add as many as you need after you're live.</p>
+  </hgroup>
+  {% call form_with_errors(action="/welcome/first-opening", method="post", json_enc=true) %}
+    <fieldset data-testid="first-opening-type">
+      <legend>Session type</legend>
+      {% for t in opening_types %}
+        <label>
+          <input type="radio" name="opening_type" value="{{ t }}">
+          {{ opening_types_labels[t] }}
+        </label>
+      {% endfor %}
+    </fieldset>
+    <fieldset data-testid="first-opening-specialties">
+      <legend>Specialties</legend>
+      {% for label in ["Trauma/PTSD", "EMDR", "Anxiety", "OCD/ERP", "Depression", "Grief", "Couples", "Adolescents", "ADHD", "Perinatal"] %}
+        <label>
+          <input type="checkbox" name="specialties" value="{{ label }}">
+          {{ label }}
+        </label>
+      {% endfor %}
+    </fieldset>
+    <fieldset data-testid="first-opening-population-tags">
+      <legend>Who you work with</legend>
+      {% for label in ["Adults", "Adolescents", "Children", "Couples", "Older adults"] %}
+        <label>
+          <input type="checkbox" name="population_tags" value="{{ label }}">
+          {{ label }}
+        </label>
+      {% endfor %}
+    </fieldset>
+    <fieldset data-testid="first-opening-languages">
+      <legend>Languages (besides English)</legend>
+      {% for lang_value, lang_label in [("es", "Spanish"), ("zh", "Mandarin"), ("vi", "Vietnamese"), ("ar", "Arabic"), ("tl", "Tagalog"), ("pt", "Portuguese"), ("fr", "French"), ("yue", "Cantonese")] %}
+        <label>
+          <input type="checkbox" name="languages" value="{{ lang_value }}">
+          {{ lang_label }}
+        </label>
+      {% endfor %}
+    </fieldset>
+    <fieldset data-testid="first-opening-fee">
+      <legend>Fee range (optional)</legend>
+      <div class="grid">
+        <label>
+          Low ($)
+          <input type="number" name="fee_low" min="0" placeholder="e.g. 100">
+        </label>
+        <label>
+          High ($)
+          <input type="number" name="fee_high" min="0" placeholder="e.g. 200">
+        </label>
+      </div>
+    </fieldset>
+    <fieldset data-testid="first-opening-payment-types">
+      <legend>Payment</legend>
+      {% for pt_value, pt_label in [("sliding_scale", "Sliding scale"), ("superbill", "Superbill"), ("insurance_panels", "Insurance panels"), ("self_pay", "Self-pay only")] %}
+        <label>
+          <input type="checkbox" name="payment_types" value="{{ pt_value }}">
+          {{ pt_label }}
+        </label>
+      {% endfor %}
+    </fieldset>
+    <fieldset data-testid="first-opening-availability">
+      <legend>Availability</legend>
+      {% for state in availability_states %}
+        <label>
+          <input type="radio" name="availability_state" value="{{ state }}">
+          {{ availability_states_labels[state] }}
+        </label>
+      {% endfor %}
+    </fieldset>
+    <fieldset data-testid="first-opening-note">
+      <label for="colleague_note">Note for clinicians (optional)</label>
+      <textarea id="colleague_note"
+                name="colleague_note"
+                rows="3"
+                placeholder="What makes a good referral here? Write it like you'd say it to a clinician."></textarea>
+      <small>Disappears after 4 weeks unless renewed. Never shown to clients.</small>
+    </fieldset>
+    <button type="submit">Go live →</button>
+    <button type="submit" name="skip_note" value="1" class="secondary outline">Skip note</button>
+  {% endcall %}
+{% endblock %}


### PR DESCRIPTION
## Summary

- Adds `GET /welcome/first-opening` + `POST /welcome/first-opening` — the second wizard step for the `have_openings` flow, collecting opening type, specialties, population tags, languages, fee range, payment types, availability state, and an optional colleague note
- Extends `next_step()` state machine: routes `have_openings` users to `/welcome/first-opening` when no `clinician_opening` Post exists yet, then to `/welcome/done` once one is created
- Adds `GET /welcome/done` — terminal confirmation page that always renders (no session flag redirect)
- New `FirstOpeningForm` Pydantic schema + `create_first_opening` service function using `BaseRepository.create_polymorphic`

## Test plan
- [ ] `dev test` passes (1885 tests)
- [ ] `dev lint` passes
- [ ] Verify GET /welcome/first-opening renders for verified clinician
- [ ] Verify POST /welcome/first-opening creates `clinician_opening` Post and redirects to `/welcome/done`
- [ ] Verify "Skip note" button strips `colleague_note` before creation
- [ ] Verify state machine routes `have_openings` users correctly through the two-step flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)