### PR TITLE
feat(onboarding): T5 — Flow A steps (A1 landing fragment + A3 be-findable)

### DIFF
--- a/alembic/versions/a1b9c2d3e4f5_affiliation_specialties.py
+++ b/alembic/versions/a1b9c2d3e4f5_affiliation_specialties.py
@@ -1,7 +1,7 @@
 """affiliation.specialties — JSON list for be-findable wizard step
 
 Revision ID: a1b9c2d3e4f5
-Revises: b5b6057986f2
+Revises: af760f747e18
 Create Date: 2026-05-24 19:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "a1b9c2d3e4f5"
-down_revision: Union[str, None] = "b5b6057986f2"
+down_revision: Union[str, None] = "af760f747e18"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/a1b9c2d3e4f5_affiliation_specialties.py
+++ b/alembic/versions/a1b9c2d3e4f5_affiliation_specialties.py
@@ -1,0 +1,35 @@
+"""affiliation.specialties — JSON list for be-findable wizard step
+
+Revision ID: a1b9c2d3e4f5
+Revises: b5b6057986f2
+Create Date: 2026-05-24 19:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b9c2d3e4f5"
+down_revision: Union[str, None] = "b5b6057986f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("affiliations") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "specialties",
+                sa.JSON(),
+                nullable=False,
+                server_default="'[]'",
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("affiliations") as batch_op:
+        batch_op.drop_column("specialties")

--- a/scripts/dev/seed/vocab.py
+++ b/scripts/dev/seed/vocab.py
@@ -671,6 +671,19 @@ PLACEHOLDER_OK: Final[frozenset[str]] = frozenset(
 # JSON-list columns → which enum to subset over. Most JSON columns
 # carry a vocabulary referenced from `enums.py`; the generator can't
 # infer the link from the column itself, so we declare it explicitly.
+_SPECIALTIES: Final[tuple[str, ...]] = (
+    "Trauma/PTSD",
+    "EMDR",
+    "Anxiety",
+    "OCD/ERP",
+    "Depression",
+    "Grief",
+    "Couples",
+    "Adolescents",
+    "ADHD",
+    "Perinatal",
+)
+
 JSON_LIST_SOURCE: Final[dict[str, tuple[str, ...]]] = {
     "age_groups": CLIENT_AGE_GROUPS,
     "languages": LANGUAGES,
@@ -679,20 +692,10 @@ JSON_LIST_SOURCE: Final[dict[str, tuple[str, ...]]] = {
     "desired_times": DESIRED_TIME_SLOTS,
     "genders": GENDERS,
     "in_network_carriers": INSURANCE_CARRIERS,
-    # T3 slot-shape fields. `specialties` and `population_tags` are
-    # free-form (no canonical enum yet); seed them from stable sample
-    # tuples. `payment_types` seeds from a small static list.
-    "specialties": (
-        "trauma",
-        "anxiety",
-        "depression",
-        "grief",
-        "ocd",
-        "emdr",
-        "dbt",
-        "cbt",
-        "relationships",
-    ),
+    # Slot-shape fields. `specialties` uses canonical display labels (shared
+    # between OpeningDetail and Affiliation); `population_tags` and
+    # `payment_types` are free-form (no CHECK constraint).
+    "specialties": _SPECIALTIES,
     "population_tags": (
         "lgbtq",
         "poc",

--- a/src/domain/logic/onboarding/README.md
+++ b/src/domain/logic/onboarding/README.md
@@ -19,17 +19,24 @@ it. The signal table:
 
 ### Truth table (current)
 
-| intent | has_clinician | clinician_verified | has_opening | next URL |
-|---|---|---|---|---|
-| any | False | — | — | `/welcome/verify` |
-| any | True | False | — | `/welcome/verify` |
-| `have_openings` | True | True | False | `/welcome/first-opening` |
-| `have_openings` | True | True | True | `/welcome/done` |
-| `refer_now` | True | True | — | `/welcome/coming-soon` (T5) |
-| `building_network` | True | True | — | `/welcome/coming-soon` (T7) |
-| `invited` | True | True | — | `/welcome/coming-soon` (T7) |
+| intent | has_clinician | clinician_verified | has_opening | has_reciprocity_profile | next URL |
+|---|---|---|---|---|---|
+| any | False | — | — | — | `/welcome/verify` |
+| any | True | False | — | — | `/welcome/verify` |
+| `refer_now` | True | True | — | False | `/welcome/be-findable` |
+| `refer_now` | True | True | — | True | `/openings` (terminal) |
+| `have_openings` | True | True | False | — | `/welcome/first-opening` |
+| `have_openings` | True | True | True | — | `/welcome/done` |
+| `building_network` | True | True | — | — | `/welcome/coming-soon` (T7) |
+| `invited` | True | True | — | — | `/welcome/coming-soon` (T7) |
 
 **Terminal rule**: Repeat visits to `/welcome/done` re-render the done page — the natural exit is the "Go to the board" CTA. No session flag is used (see `state_machine.py` comment).
+
+`has_reciprocity_profile(clinician)` returns True when the clinician's
+`primary_affiliation` has non-empty `specialties` AND at least one modality
+(`in_person_sessions == "yes"` OR `virtual_sessions == "yes"`). AND not OR
+because neither alone is sufficient to be findable. Implemented synchronously
+— Provider loads Affiliations via `lazy="selectin"`.
 
 ### Onboarding clinician convention
 

--- a/src/domain/logic/onboarding/schema.py
+++ b/src/domain/logic/onboarding/schema.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field
 
 from src.domain.logic.posts.schema import (
     OptionalAvailabilityState,
@@ -10,11 +10,13 @@ from src.domain.logic.posts.schema import (
     SpecialtiesField,
 )
 from src.domain.models.enums import LANGUAGES, LICENSE_TYPES, US_STATES
-from src.framework.schema_validators import StrippedOptionalText
+from src.framework.schema_validators import StrippedOptionalText, scalar_to_list
 
 _LICENSE_TYPES = Literal[tuple(LICENSE_TYPES)]  # type: ignore[valid-type]
 _US_STATES = Literal[tuple(US_STATES)]  # type: ignore[valid-type]
 _LANGUAGES = Literal[tuple(LANGUAGES)]  # type: ignore[valid-type]
+
+_SpecialtiesList = Annotated[list[str], BeforeValidator(scalar_to_list)]
 
 
 class VerifyForm(BaseModel):
@@ -51,3 +53,19 @@ class FirstOpeningForm(BaseModel):
     payment_types: PaymentTypesField = []
     availability_state: OptionalAvailabilityState = None
     colleague_note: Annotated[StrippedOptionalText, Field(max_length=280)] = None
+
+
+class BeFindableForm(BaseModel):
+    """Wire schema for POST /welcome/be-findable.
+
+    Collects the clinician's practice specialties and session modality so they
+    appear in referral searches. All fields optional — the wizard encourages
+    completion but never blocks on it (empty submission = no-op write).
+
+    `in_person` / `virtual` are booleans that map to Affiliation's
+    `in_person_sessions` / `virtual_sessions` TEXT columns ("yes" / "no").
+    """
+
+    specialties: _SpecialtiesList = []
+    in_person: bool = False
+    virtual: bool = False

--- a/src/domain/logic/onboarding/services.py
+++ b/src/domain/logic/onboarding/services.py
@@ -18,7 +18,7 @@ import uuid
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.logic.onboarding.schema import FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.schema import BeFindableForm, FirstOpeningForm, VerifyForm
 from src.domain.logic.onboarding.state_machine import onboarding_clinician
 from src.domain.logic.providers.repository import ProviderRepository
 from src.domain.logic.verifications.handlers import run_provider_verification
@@ -163,3 +163,34 @@ async def create_first_opening(
     )
     await db.commit()
     return created
+
+
+async def update_clinician_for_findability(
+    form_data: BeFindableForm,
+    user: User,
+    *,
+    db: AsyncSession,
+) -> None:
+    """Update the onboarding clinician's specialties and session modality.
+
+    Writes to the primary Affiliation of the onboarding clinician (the
+    most-recently-created Provider owned by `user`). Empty submission
+    (no specialties, neither modality box checked) is accepted as a
+    no-op write — the wizard allows "skip for now" by posting empty values.
+
+    `in_person_sessions` / `virtual_sessions` on Affiliation use the
+    string enum ("yes", "no", "please_contact"); we map booleans to
+    "yes"/"no" so the existing CHECK constraint stays satisfied.
+    """
+    clinician = onboarding_clinician(user)
+    if clinician is None:
+        return
+
+    aff = clinician.primary_affiliation
+    if aff is None:
+        return
+
+    aff.specialties = form_data.specialties
+    aff.in_person_sessions = "yes" if form_data.in_person else "no"
+    aff.virtual_sessions = "yes" if form_data.virtual else "no"
+    await db.commit()

--- a/src/domain/logic/onboarding/services.py
+++ b/src/domain/logic/onboarding/services.py
@@ -18,7 +18,11 @@ import uuid
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.logic.onboarding.schema import BeFindableForm, FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.schema import (
+    BeFindableForm,
+    FirstOpeningForm,
+    VerifyForm,
+)
 from src.domain.logic.onboarding.state_machine import onboarding_clinician
 from src.domain.logic.providers.repository import ProviderRepository
 from src.domain.logic.verifications.handlers import run_provider_verification

--- a/src/domain/logic/onboarding/state_machine.py
+++ b/src/domain/logic/onboarding/state_machine.py
@@ -28,6 +28,27 @@ from src.domain.models import OpeningDetail, Post, Provider, User, Verification
 _NOT_YET_BUILT = "/welcome/coming-soon"
 
 
+def has_reciprocity_profile(clinician: Provider) -> bool:
+    """True when the clinician has BOTH non-empty specialties AND at least one
+    modality set to "yes".
+
+    AND (not OR) because a profile with only specialties — or only modality —
+    is too thin to be usefully findable: specialties without modality can't
+    tell a referring clinician how to reach this person, and modality without
+    specialties can't tell them what this clinician treats.
+
+    Called synchronously inside `next_step` because Provider loads its
+    Affiliations via `lazy="selectin"`, so `primary_affiliation` is already
+    populated when `next_step` receives the user's loaded `providers` list.
+    """
+    aff = clinician.primary_affiliation
+    if aff is None:
+        return False
+    has_specialties = bool(aff.specialties)
+    has_modality = aff.in_person_sessions == "yes" or aff.virtual_sessions == "yes"
+    return has_specialties and has_modality
+
+
 def onboarding_clinician(user: User) -> Provider | None:
     """Return the most-recently-created Provider owned by `user`, or None.
 
@@ -71,8 +92,10 @@ async def next_step(user: User, *, db: AsyncSession) -> str:
     intent = user.onboarding_intent
 
     if intent == "refer_now":
-        # T5 will replace this stub with /welcome/be-findable
-        return _NOT_YET_BUILT
+        if not has_reciprocity_profile(clinician):
+            return "/welcome/be-findable"
+        # Terminal — exit the wizard to the canonical openings board.
+        return "/openings"
 
     if intent == "have_openings":
         has_opening_result = await db.execute(

--- a/src/domain/logic/onboarding/test_services.py
+++ b/src/domain/logic/onboarding/test_services.py
@@ -15,7 +15,11 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.logic.onboarding.schema import BeFindableForm, FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.schema import (
+    BeFindableForm,
+    FirstOpeningForm,
+    VerifyForm,
+)
 from src.domain.logic.onboarding.services import (
     create_first_opening,
     update_clinician_for_findability,

--- a/src/domain/logic/onboarding/test_services.py
+++ b/src/domain/logic/onboarding/test_services.py
@@ -15,9 +15,10 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.logic.onboarding.schema import FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.schema import BeFindableForm, FirstOpeningForm, VerifyForm
 from src.domain.logic.onboarding.services import (
     create_first_opening,
+    update_clinician_for_findability,
     verify_and_create_clinician,
 )
 from src.domain.logic.verifications import oig as oig_module
@@ -237,3 +238,69 @@ async def test_atomicity_on_pipeline_raise(
             .all()
         )
         assert providers == []
+
+
+# ---------------------------------------------------------------------------
+# update_clinician_for_findability
+# ---------------------------------------------------------------------------
+
+
+async def test_update_clinician_for_findability_happy_path(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Updating specialties + modality persists to the primary affiliation."""
+    user = await _seed_user(db_test_session_manager)
+
+    # First create a verified clinician via the verify step
+    async with db_test_session_manager() as session:
+        provider = await verify_and_create_clinician(_VALID_FORM, user, db=session)
+
+    # Reload user with providers
+    from src.domain.models import User as UserModel
+
+    async with db_test_session_manager() as session:
+        user = await session.get(UserModel, user.id)
+
+        form = BeFindableForm(
+            specialties=["Trauma/PTSD", "EMDR"],
+            in_person=True,
+            virtual=False,
+        )
+        await update_clinician_for_findability(form, user, db=session)
+
+    # Verify the affiliation was updated
+
+    async with db_test_session_manager() as session:
+        p = await session.get(Provider, provider.id)
+        await session.refresh(p, ["affiliations"])
+        aff = p.primary_affiliation
+        assert aff is not None
+        assert set(aff.specialties) == {"Trauma/PTSD", "EMDR"}
+        assert aff.in_person_sessions == "yes"
+        assert aff.virtual_sessions == "no"
+
+
+async def test_update_clinician_for_findability_empty_submission(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Empty submission (skip-for-now) is accepted without error."""
+    user = await _seed_user(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        provider = await verify_and_create_clinician(_VALID_FORM, user, db=session)
+
+    from src.domain.models import User as UserModel
+
+    async with db_test_session_manager() as session:
+        user = await session.get(UserModel, user.id)
+
+        form = BeFindableForm(specialties=[], in_person=False, virtual=False)
+        await update_clinician_for_findability(form, user, db=session)
+
+    async with db_test_session_manager() as session:
+        p = await session.get(Provider, provider.id)
+        await session.refresh(p, ["affiliations"])
+        aff = p.primary_affiliation
+        assert aff.specialties == []
+        assert aff.in_person_sessions == "no"
+        assert aff.virtual_sessions == "no"

--- a/src/domain/logic/onboarding/test_state_machine.py
+++ b/src/domain/logic/onboarding/test_state_machine.py
@@ -1,7 +1,7 @@
 """Parametrized truth-table tests for the onboarding state machine.
 
-Each row covers one (intent, has_clinician, clinician_verified, has_opening)
-combination from the documented signal table in state_machine.py.
+Each row covers one (intent, has_clinician, clinician_verified, has_opening,
+has_profile) combination from the documented signal table in state_machine.py.
 """
 
 import uuid
@@ -9,9 +9,15 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.domain.logic.onboarding.state_machine import next_step, onboarding_clinician
+from src.domain.logic.onboarding.state_machine import (
+    has_reciprocity_profile,
+    next_step,
+    onboarding_clinician,
+)
 
 pytestmark = pytest.mark.asyncio
+
+_NOT_YET_BUILT = "/welcome/coming-soon"
 
 
 # ---------------------------------------------------------------------------
@@ -19,13 +25,24 @@ pytestmark = pytest.mark.asyncio
 # ---------------------------------------------------------------------------
 
 
-def _make_provider(created_at_offset: int = 0):
+def _make_provider(
+    created_at_offset: int = 0,
+    specialties=None,
+    in_person_sessions="please_contact",
+    virtual_sessions="please_contact",
+):
     """Create a minimal fake Provider with a predictable created_at."""
     from datetime import datetime, timedelta
+
+    aff = MagicMock()
+    aff.specialties = specialties if specialties is not None else []
+    aff.in_person_sessions = in_person_sessions
+    aff.virtual_sessions = virtual_sessions
 
     p = MagicMock()
     p.id = uuid.uuid4()
     p.created_at = datetime(2024, 1, 1) + timedelta(days=created_at_offset)
+    p.primary_affiliation = aff
     return p
 
 
@@ -52,55 +69,120 @@ def test_onboarding_clinician_single_provider():
 
 
 # ---------------------------------------------------------------------------
+# has_reciprocity_profile predicate
+# ---------------------------------------------------------------------------
+
+
+def test_has_reciprocity_profile_false_when_no_affiliation():
+    p = MagicMock()
+    p.primary_affiliation = None
+    assert has_reciprocity_profile(p) is False
+
+
+def test_has_reciprocity_profile_false_when_no_specialties():
+    p = _make_provider(specialties=[], in_person_sessions="yes")
+    assert has_reciprocity_profile(p) is False
+
+
+def test_has_reciprocity_profile_false_when_no_modality():
+    p = _make_provider(
+        specialties=["Trauma/PTSD"], in_person_sessions="no", virtual_sessions="no"
+    )
+    assert has_reciprocity_profile(p) is False
+
+
+def test_has_reciprocity_profile_false_when_only_specialties():
+    p = _make_provider(
+        specialties=["Anxiety"],
+        in_person_sessions="please_contact",
+        virtual_sessions="please_contact",
+    )
+    assert has_reciprocity_profile(p) is False
+
+
+def test_has_reciprocity_profile_true_with_in_person():
+    p = _make_provider(specialties=["Trauma/PTSD"], in_person_sessions="yes")
+    assert has_reciprocity_profile(p) is True
+
+
+def test_has_reciprocity_profile_true_with_virtual():
+    p = _make_provider(specialties=["EMDR"], virtual_sessions="yes")
+    assert has_reciprocity_profile(p) is True
+
+
+def test_has_reciprocity_profile_true_with_both_modalities():
+    p = _make_provider(
+        specialties=["Anxiety", "Depression"],
+        in_person_sessions="yes",
+        virtual_sessions="yes",
+    )
+    assert has_reciprocity_profile(p) is True
+
+
+# ---------------------------------------------------------------------------
 # next_step truth table
 # ---------------------------------------------------------------------------
 
-_NOT_YET_BUILT = "/welcome/coming-soon"
+
+def _make_verified_result():
+    v = MagicMock()
+    v.status = "verified"
+    return v
+
+
+def _make_unverified_result():
+    v = MagicMock()
+    v.status = "needs_review"
+    return v
 
 
 @pytest.mark.parametrize(
-    "intent,has_clinician,clinician_verified,has_opening,expected",
+    "intent,has_clinician,clinician_verified,has_opening,has_profile,expected",
     [
         # No intent → landing
-        (None, False, False, False, "/"),
-        (None, True, True, False, "/"),
+        (None, False, False, False, False, "/"),
+        (None, True, True, False, False, "/"),
         # No clinician → verify
-        ("refer_now", False, False, False, "/welcome/verify"),
-        ("have_openings", False, False, False, "/welcome/verify"),
-        ("building_network", False, False, False, "/welcome/verify"),
-        ("invited", False, False, False, "/welcome/verify"),
+        ("refer_now", False, False, False, False, "/welcome/verify"),
+        ("have_openings", False, False, False, False, "/welcome/verify"),
+        ("building_network", False, False, False, False, "/welcome/verify"),
+        ("invited", False, False, False, False, "/welcome/verify"),
         # Clinician exists but not verified → verify
-        ("refer_now", True, False, False, "/welcome/verify"),
-        ("have_openings", True, False, False, "/welcome/verify"),
-        ("building_network", True, False, False, "/welcome/verify"),
-        ("invited", True, False, False, "/welcome/verify"),
-        # Clinician verified, other intents → stub (T5/T7 will replace)
-        ("refer_now", True, True, False, _NOT_YET_BUILT),
-        ("building_network", True, True, False, _NOT_YET_BUILT),
-        ("invited", True, True, False, _NOT_YET_BUILT),
+        ("refer_now", True, False, False, False, "/welcome/verify"),
+        ("have_openings", True, False, False, False, "/welcome/verify"),
+        ("building_network", True, False, False, False, "/welcome/verify"),
+        ("invited", True, False, False, False, "/welcome/verify"),
+        # refer_now: verified + no reciprocity profile → be-findable
+        ("refer_now", True, True, False, False, "/welcome/be-findable"),
+        # refer_now: verified + has profile → openings (terminal)
+        ("refer_now", True, True, False, True, "/openings"),
         # have_openings, verified, no opening yet → first-opening step
-        ("have_openings", True, True, False, "/welcome/first-opening"),
+        ("have_openings", True, True, False, False, "/welcome/first-opening"),
         # have_openings, verified, has opening → done
-        ("have_openings", True, True, True, "/welcome/done"),
+        ("have_openings", True, True, True, False, "/welcome/done"),
+        # building_network / invited: stub (T7 replaces)
+        ("building_network", True, True, False, False, _NOT_YET_BUILT),
+        ("invited", True, True, False, False, _NOT_YET_BUILT),
     ],
 )
 async def test_next_step_truth_table(
-    intent, has_clinician, clinician_verified, has_opening, expected
+    intent, has_clinician, clinician_verified, has_opening, has_profile, expected
 ):
-    provider = _make_provider()
+    in_person = "yes" if has_profile else "no"
+    specialties = ["Trauma/PTSD"] if has_profile else []
+    provider = _make_provider(
+        specialties=specialties,
+        in_person_sessions=in_person,
+    )
     user = MagicMock()
     user.onboarding_intent = intent
     user.providers = [provider] if has_clinician else []
 
-    # Build a fake Verification with the requested status, or None.
-    if has_clinician and clinician_verified:
-        fake_verification = MagicMock()
-        fake_verification.status = "verified"
-    elif has_clinician and not clinician_verified:
-        fake_verification = MagicMock()
-        fake_verification.status = "needs_review"
-    else:
-        fake_verification = None
+    fake_verification = (
+        _make_verified_result()
+        if (has_clinician and clinician_verified)
+        else (_make_unverified_result() if has_clinician else None)
+    )
 
     # Mock db.execute to return the fake verification first, then simulate
     # the has_opening query. The state machine calls execute once for

--- a/src/domain/models/affiliations/affiliation.py
+++ b/src/domain/models/affiliations/affiliation.py
@@ -102,6 +102,13 @@ class Affiliation(LocationMixin, BaseModel):
         Boolean, nullable=False, server_default=text("0"), default=False
     )
     cost = Column(Text, nullable=True)
+    # Practice-area specialties — JSON list of strings (e.g. ["Trauma/PTSD",
+    # "EMDR"]). Populated by the T5 be-findable wizard step. Nullable so
+    # existing affiliations created before T5 (which set it via the migration
+    # default '[]') keep working without a forced re-submission.
+    specialties = Column(
+        JSON, nullable=False, server_default=text("'[]'"), default=list
+    )
 
 
 @event.listens_for(Affiliation.provider, "set")

--- a/src/domain/models/providers/provider.py
+++ b/src/domain/models/providers/provider.py
@@ -395,6 +395,18 @@ class Provider(BaseModel):
             self.primary_affiliation.cost = value
 
     @property
+    def specialties(self) -> list:
+        aff = self.primary_affiliation
+        if aff is None or aff.specialties is None:
+            return []
+        return aff.specialties
+
+    @specialties.setter
+    def specialties(self, value) -> None:
+        if self.primary_affiliation is not None:
+            self.primary_affiliation.specialties = value
+
+    @property
     def licensures(self):
         """Person-level credential list — proxies through
         `provider.clinician.licensures` after the FK move (#635 PR A).

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -940,3 +940,50 @@ async def test_root_b1_preview_absent_for_other_intents(
     response = await authenticated_client.get("/", follow_redirects=False)
     assert response.status_code == 200
     assert 'data-testid="b1-preview"' not in response.text
+
+
+async def test_root_refer_now_unverified_shows_a1_preview(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """refer_now user without a verified clinician sees the A1 search preview."""
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            from sqlalchemy import select
+
+            from src.domain.models import User
+
+            result = await session.execute(
+                select(User).filter(User.email == "testuser@example.com")
+            )
+            user = result.scalars().first()
+            user.onboarding_intent = "refer_now"
+
+    response = await authenticated_client.get("/", follow_redirects=False)
+    assert response.status_code == 200
+    assert 'data-testid="a1-search-preview"' in response.text
+    assert 'data-testid="a1-card-1"' in response.text
+    assert 'data-testid="a1-card-2"' in response.text
+    assert 'data-testid="a1-verify-cta"' in response.text
+
+
+async def test_root_non_refer_now_user_no_a1_preview(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """have_openings user does not see the A1 preview."""
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            from sqlalchemy import select
+
+            from src.domain.models import User
+
+            result = await session.execute(
+                select(User).filter(User.email == "testuser@example.com")
+            )
+            user = result.scalars().first()
+            user.onboarding_intent = "have_openings"
+
+    response = await authenticated_client.get("/", follow_redirects=False)
+    assert response.status_code == 200
+    assert 'data-testid="a1-search-preview"' not in response.text

--- a/src/domain/routes/test_welcome.py
+++ b/src/domain/routes/test_welcome.py
@@ -424,3 +424,122 @@ async def test_get_coming_soon_renders_200(authenticated_client: AsyncClient):
     )
     assert response.status_code == 200
     assert b"coming soon" in response.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Helpers — setup a verified clinician (reused for be-findable tests)
+# ---------------------------------------------------------------------------
+
+
+async def _setup_verified_clinician(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    user_email: str,
+    intent: str = "refer_now",
+) -> None:
+    await _set_intent(db_test_session_manager, user_email, intent)
+    resp = await authenticated_client.post(
+        "/welcome/verify",
+        json=_VALID_BODY,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# GET /welcome/be-findable
+# ---------------------------------------------------------------------------
+
+
+async def test_get_be_findable_renders_when_clinician_exists(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    await _setup_verified_clinician(
+        authenticated_client, db_test_session_manager, logged_in_user.email
+    )
+    response = await authenticated_client.get(
+        "/welcome/be-findable",
+        headers={"Accept": "text/html"},
+    )
+    assert response.status_code == 200
+    assert b"Be findable" in response.content
+    assert b'data-testid="be-findable-specialties"' in response.content
+    assert b'data-testid="be-findable-modality"' in response.content
+
+
+async def test_get_be_findable_without_clinician_redirects_to_welcome(
+    authenticated_client: AsyncClient,
+):
+    response = await authenticated_client.get(
+        "/welcome/be-findable",
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/welcome"
+
+
+async def test_get_be_findable_anon_redirected(test_client: AsyncClient):
+    response = await test_client.get(
+        "/welcome/be-findable",
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code in {302, 401}
+
+
+# ---------------------------------------------------------------------------
+# POST /welcome/be-findable
+# ---------------------------------------------------------------------------
+
+
+_BE_FINDABLE_BODY = {
+    "specialties": ["Trauma/PTSD", "EMDR"],
+    "in_person": True,
+    "virtual": False,
+}
+
+
+async def test_post_be_findable_happy_path_updates_clinician_and_redirects(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Valid body → specialties + modality updated, 302 to /openings."""
+    await _setup_verified_clinician(
+        authenticated_client, db_test_session_manager, logged_in_user.email
+    )
+
+    response = await authenticated_client.post(
+        "/welcome/be-findable",
+        json=_BE_FINDABLE_BODY,
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    # has_reciprocity_profile → True → terminal /openings
+    assert response.headers["location"] == "/openings"
+
+
+async def test_post_be_findable_empty_submission_accepted(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Empty submission (skip) is accepted; state machine sends back to /welcome/be-findable."""
+    await _setup_verified_clinician(
+        authenticated_client, db_test_session_manager, logged_in_user.email
+    )
+
+    response = await authenticated_client.post(
+        "/welcome/be-findable",
+        json={"specialties": [], "in_person": False, "virtual": False},
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    # No profile → state machine routes back to be-findable
+    assert response.headers["location"] == "/welcome/be-findable"

--- a/src/domain/routes/test_welcome.py
+++ b/src/domain/routes/test_welcome.py
@@ -202,22 +202,6 @@ async def test_post_verify_invalid_body_returns_422_inline(
 # ---------------------------------------------------------------------------
 
 
-async def _setup_verified_clinician(
-    authenticated_client: AsyncClient,
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-    logged_in_user: User,
-) -> None:
-    """Create a verified clinician for the logged-in user by running the verify step."""
-    await _set_intent(db_test_session_manager, logged_in_user.email, "have_openings")
-    response = await authenticated_client.post(
-        "/welcome/verify",
-        json=_VALID_BODY,
-        headers={"Accept": "text/html"},
-        follow_redirects=False,
-    )
-    assert response.status_code == 302, f"Verify failed: {response.status_code}"
-
-
 async def test_get_first_opening_renders_when_clinician_verified(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
@@ -225,7 +209,10 @@ async def test_get_first_opening_renders_when_clinician_verified(
 ):
     """GET /welcome/first-opening renders the form when preconditions met."""
     await _setup_verified_clinician(
-        authenticated_client, db_test_session_manager, logged_in_user
+        authenticated_client,
+        db_test_session_manager,
+        logged_in_user.email,
+        intent="have_openings",
     )
     response = await authenticated_client.get(
         "/welcome/first-opening",
@@ -268,7 +255,10 @@ async def test_post_first_opening_happy_path_creates_opening_and_redirects(
 ):
     """Valid body → Opening created, 302 to /welcome/done."""
     await _setup_verified_clinician(
-        authenticated_client, db_test_session_manager, logged_in_user
+        authenticated_client,
+        db_test_session_manager,
+        logged_in_user.email,
+        intent="have_openings",
     )
 
     response = await authenticated_client.post(
@@ -299,7 +289,10 @@ async def test_post_first_opening_sets_slot_fields(
 ):
     """Slot fields written to OpeningDetail survive a read-back."""
     await _setup_verified_clinician(
-        authenticated_client, db_test_session_manager, logged_in_user
+        authenticated_client,
+        db_test_session_manager,
+        logged_in_user.email,
+        intent="have_openings",
     )
 
     body = {
@@ -337,7 +330,10 @@ async def test_post_first_opening_skip_note_clears_colleague_note(
 ):
     """skip_note=1 in body clears colleague_note before validation."""
     await _setup_verified_clinician(
-        authenticated_client, db_test_session_manager, logged_in_user
+        authenticated_client,
+        db_test_session_manager,
+        logged_in_user.email,
+        intent="have_openings",
     )
 
     body = {
@@ -373,7 +369,10 @@ async def test_post_first_opening_invalid_opening_type_returns_422(
 ):
     """Bad opening_type → form re-rendered with 422 inline errors."""
     await _setup_verified_clinician(
-        authenticated_client, db_test_session_manager, logged_in_user
+        authenticated_client,
+        db_test_session_manager,
+        logged_in_user.email,
+        intent="have_openings",
     )
 
     bad_body = {**_FIRST_OPENING_BODY, "opening_type": "not_a_valid_type"}

--- a/src/domain/routes/welcome.py
+++ b/src/domain/routes/welcome.py
@@ -18,9 +18,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth_config import current_active_user
 from src.db import get_db_session
-from src.domain.logic.onboarding.schema import FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.schema import BeFindableForm, FirstOpeningForm, VerifyForm
 from src.domain.logic.onboarding.services import (
     create_first_opening,
+    update_clinician_for_findability,
     verify_and_create_clinician,
 )
 from src.domain.logic.onboarding.state_machine import next_step, onboarding_clinician
@@ -69,7 +70,23 @@ class _MalformedFirstOpeningBody(Exception):
         self.errors = errors
 
 
+class _MalformedBeFindableBody(Exception):
+    """Validation failed on POST /welcome/be-findable body."""
+
+    def __init__(self, errors: list[dict]):
+        self.errors = errors
+
+
 def _render_first_opening_errors(exc: _MalformedFirstOpeningBody) -> FormError:
+    from src.framework.dispatch.mounts.create import build_form_errors_dict
+
+    return FormError(
+        field_errors=build_form_errors_dict(exc.errors),
+        status_code=422,
+    )
+
+
+def _render_be_findable_errors(exc: _MalformedBeFindableBody) -> FormError:
     from src.framework.dispatch.mounts.create import build_form_errors_dict
 
     return FormError(
@@ -276,7 +293,95 @@ async def get_done(
 
 
 # ---------------------------------------------------------------------------
-# Coming-soon stub (placeholder for T5/T7 steps)
+# Be-findable step (A3) — refer_now flow, Step 2 of 2
+# ---------------------------------------------------------------------------
+
+_BE_FINDABLE_STEP_INFO = "Step 2 of 2"
+_BE_FINDABLE_TEMPLATE = "welcome/be_findable.html"
+
+_SPECIALTIES = [
+    "Trauma/PTSD",
+    "EMDR",
+    "Anxiety",
+    "OCD/ERP",
+    "Depression",
+    "Grief",
+    "Couples",
+    "Adolescents",
+    "ADHD",
+    "Perinatal",
+]
+
+
+def _be_findable_context(clinician=None) -> dict:
+    return {
+        "step_info": _BE_FINDABLE_STEP_INFO,
+        "specialties_choices": _SPECIALTIES,
+        "clinician": clinician,
+    }
+
+
+@router.get("/welcome/be-findable", name="welcome:get_be_findable")
+async def get_be_findable(
+    request: Request,
+    requesting_user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Render the be-findable form (Step 2 of 2 for refer_now flow).
+
+    Redirects to /welcome if preconditions aren't met (no verified clinician).
+    """
+    clinician = onboarding_clinician(requesting_user)
+    if clinician is None:
+        return _redirect(request, "/welcome")
+
+    return APIResponse.html_response(
+        template_name=_BE_FINDABLE_TEMPLATE,
+        context=_be_findable_context(clinician=clinician),
+        request=request,
+    )
+
+
+@router.post("/welcome/be-findable", name="welcome:post_be_findable")
+@form_error_handler(
+    template=_BE_FINDABLE_TEMPLATE,
+    handlers={_MalformedBeFindableBody: _render_be_findable_errors},
+    context_builder=lambda kwargs: _be_findable_context(),
+    require_htmx=False,
+)
+async def post_be_findable(
+    request: Request,
+    body: dict = Body(...),
+    requesting_user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Validate BeFindableForm, update clinician specialties + modality, redirect.
+
+    Uses `body: dict = Body(...)` (raw JSON via hx-ext="json-enc") so the
+    decorator catches `_MalformedBeFindableBody` before FastAPI's
+    auto-validation fires outside the decorator's reach.
+
+    Empty submission (skip-for-now with neither box checked, no specialties)
+    is accepted — `update_clinician_for_findability` treats it as a no-op
+    write that still commits, leaving `has_reciprocity_profile` False and
+    routing back here on next visit. The user exits by selecting at least
+    one specialty AND one modality, or by navigating directly to /openings.
+    """
+    try:
+        form_data = BeFindableForm.model_validate(body)
+    except ValidationError as e:
+        raise _MalformedBeFindableBody(e.errors())
+
+    await update_clinician_for_findability(form_data, requesting_user, db=db)
+
+    await db.refresh(requesting_user)
+
+    next_url = await next_step(requesting_user, db=db)
+    return _redirect(request, next_url)
+
+
+# ---------------------------------------------------------------------------
+# Coming-soon stub (placeholder for T7 steps)
 # ---------------------------------------------------------------------------
 
 

--- a/src/domain/routes/welcome.py
+++ b/src/domain/routes/welcome.py
@@ -18,7 +18,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth_config import current_active_user
 from src.db import get_db_session
-from src.domain.logic.onboarding.schema import BeFindableForm, FirstOpeningForm, VerifyForm
+from src.domain.logic.onboarding.schema import (
+    BeFindableForm,
+    FirstOpeningForm,
+    VerifyForm,
+)
 from src.domain.logic.onboarding.services import (
     create_first_opening,
     update_clinician_for_findability,

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -9,6 +9,9 @@
   {% if user and user.onboarding_intent == 'have_openings' and not user.providers %}
     {% include "landing/_b1_preview.html" %}
   {% endif %}
+  {% if user and user.onboarding_intent == 'refer_now' and not user_has_verified_clinician %}
+    {% include "landing/_a1_search_preview.html" %}
+  {% endif %}
   {# Onboarding intent picker — 4 cards, one per intent value.
    Click behaviour differs by auth state:
    - Authenticated: HTMX PUT /users/me/onboarding-intent; on success

--- a/src/domain/templates/landing/_a1_search_preview.html
+++ b/src/domain/templates/landing/_a1_search_preview.html
@@ -1,0 +1,46 @@
+{# A1 landing fragment — shown to refer_now users before license verification.
+   Illustrates what the board looks like; cards 2 and 3 are locked to create
+   a "verify to unlock" moment. All data is hardcoded — not a real query.
+   See src/domain/templates/welcome/README.md for the wizard context. #}
+<section data-testid="a1-search-preview">
+  <hgroup>
+    <h2>Find a clinician for your client</h2>
+    <p>Verify your license to see full profiles and send referrals.</p>
+  </hgroup>
+  <input type="text"
+         value="EMDR trauma Spanish-speaking adults SF"
+         disabled
+         aria-label="Search preview (disabled)">
+  <div>
+    <article data-testid="a1-card-1">
+      <header>
+        {# title-case-ignore #}
+        <strong>Elena Reyes, LCSW</strong>
+        <small>EMDR · Trauma/PTSD · Spanish</small>
+      </header>
+      {# title-case-ignore #}
+      <p>$140–180 · Virtual · In-person · San Francisco, CA</p>
+      <footer>
+        <small>Confirmed 3 days ago</small>
+      </footer>
+    </article>
+    <article data-testid="a1-card-2" aria-label="Locked profile">
+      <header>
+        <strong>Locked — verify to view</strong>
+      </header>
+      <p>— · — · —</p>
+    </article>
+    <article data-testid="a1-card-3" aria-label="Locked profile">
+      <header>
+        <strong>Locked — verify to view</strong>
+      </header>
+      <p>— · — · —</p>
+    </article>
+  </div>
+  <p>
+    <a href="/welcome/verify" role="button" data-testid="a1-verify-cta">Verify your license to continue →</a>
+  </p>
+  <p>
+    <a href="{{ entity_url('opening') }}" data-testid="a1-browse-link">I'm just browsing for now</a>
+  </p>
+</section>

--- a/src/domain/templates/posts/_shared/_item.html
+++ b/src/domain/templates/posts/_shared/_item.html
@@ -71,6 +71,13 @@ family (e.g. `/referrals/{id}` for referrals' list). #}
        rel="noopener noreferrer"
        role="button"
        class="secondary outline">Email</a>
+    {% if entity_name == 'opening' %}
+      {# Refer CTA — links to /welcome/refer/{id} (T6). 404 until T6 ships. #}
+      <a href="/welcome/refer/{{ post.id }}"
+         role="button"
+         class="outline"
+         data-testid="refer-cta">Refer</a>
+    {% endif %}
   </footer>
 {%- endcall %}
 {%- endmacro %}

--- a/src/domain/templates/welcome/README.md
+++ b/src/domain/templates/welcome/README.md
@@ -17,13 +17,14 @@ Each step template extends `_layout.html` and fills `wizard_content`.
 | `verify.html` | `GET /welcome/verify` | License-verification form (Step 1 of 1 for all flows) |
 | `first_opening.html` | `GET /welcome/first-opening` | First opening form (Step 2 of 2 for `have_openings` flow) |
 | `done.html` | `GET /welcome/done` | Terminal "You're on the board" page (`have_openings` flow) |
-| `coming_soon.html` | `GET /welcome/coming-soon` | Placeholder while T5/T7 steps ship |
+| `be_findable.html` | `GET /welcome/be-findable` | Specialties + modality form (Step 2 of 2 for `refer_now` flow) |
+| `coming_soon.html` | `GET /welcome/coming-soon` | Placeholder while T7 steps ship |
 
 ## Steps (downstream)
 
-T5/T6/T7 add `be_findable.html`, `refer.html`, `start_network.html`,
-`minimal_profile.html`. Each follows the same pattern: extend `_layout.html`,
-fill `wizard_content`, form via `form_with_errors` macro.
+T6/T7 add `refer.html`, `start_network.html`, `minimal_profile.html`. Each
+follows the same pattern: extend `_layout.html`, fill `wizard_content`, form
+via `form_with_errors` macro.
 
 ## Styling note
 

--- a/src/domain/templates/welcome/be_findable.html
+++ b/src/domain/templates/welcome/be_findable.html
@@ -1,0 +1,42 @@
+{% extends "welcome/_layout.html" %}
+{%- from "_shared/form_fields.html" import text_field, select_field with context -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{% block wizard_content %}
+  {% if clinician %}
+    <span class="bc-verified" data-testid="verified-badge">License verified · {{ clinician.clinician.first_name }} {{ clinician.clinician.last_name }}</span>
+  {% endif %}
+  <hgroup>
+    <h1>Be findable to other clinicians</h1>
+    <p>
+      Your search results are unlocked. Before you go — clinicians can't find you yet. Takes 2 minutes if you want to be reachable.
+    </p>
+  </hgroup>
+  {% call form_with_errors(action="/welcome/be-findable", method="post", json_enc=true) %}
+    <fieldset data-testid="be-findable-specialties">
+      <legend>Specialties</legend>
+      {% for label in specialties_choices %}
+        <label>
+          <input type="checkbox" name="specialties" value="{{ label }}">
+          {{ label }}
+        </label>
+      {% endfor %}
+    </fieldset>
+    <fieldset data-testid="be-findable-modality">
+      <legend>Session format</legend>
+      <label>
+        <input type="checkbox" name="in_person" value="true">
+        In-person
+      </label>
+      <label>
+        <input type="checkbox" name="virtual" value="true">
+        Virtual
+      </label>
+    </fieldset>
+    <button type="submit" data-testid="be-findable-submit">Save and go to results →</button>
+    <button type="submit"
+            name="skip"
+            value="1"
+            class="secondary outline"
+            data-testid="be-findable-skip">Skip for now</button>
+  {% endcall %}
+{% endblock %}

--- a/src/main.py
+++ b/src/main.py
@@ -121,6 +121,8 @@ async def read_root(
     here. Anonymous visitors see the picker and are routed to register
     after picking.
     """
+    user_has_verified_clinician = False
+
     if user is not None and user.onboarding_intent is not None:
         from src.domain.logic.providers.repository import ProviderRepository
         from src.domain.logic.verifications.repository import VerificationRepository
@@ -132,11 +134,15 @@ async def read_root(
             for provider in providers:
                 latest = await verif_repo.latest_for_provider(provider.id)
                 if latest and latest.status == "verified":
+                    user_has_verified_clinician = True
                     return RedirectResponse(url="/openings", status_code=302)
 
     return APIResponse.html_response(
         template_name="landing.html",
-        context={"user": user},
+        context={
+            "user": user,
+            "user_has_verified_clinician": user_has_verified_clinician,
+        },
         request=request,
     )
 


### PR DESCRIPTION
## Summary
- Adds A1 landing search-preview fragment for `refer_now` users who haven't verified yet (3 hardcoded cards, 2 locked)
- Adds `/welcome/be-findable` wizard step (A3) — specialties checkboxes + in-person/virtual modality, persisted to `Affiliation`
- Adds `has_reciprocity_profile()` predicate to state machine; gates `refer_now` users at A3 before sending to `/openings`
- Adds `Affiliation.specialties` JSON column + Alembic migration
- Adds `update_clinician_for_findability()` service + `BeFindableForm` schema
- Adds Refer CTA to opening card footer
- Refactors `read_root` to use `Depends(get_db_session)` for test-session override compatibility

## Test plan
- [ ] `dev test` passes (all 1880+ tests green)
- [ ] `dev lint` passes
- [ ] GET `/welcome/be-findable` renders specialties + modality checkboxes for a verified clinician
- [ ] POST `/welcome/be-findable` with data → persists + redirects to `/openings`
- [ ] POST `/welcome/be-findable` empty (skip) → redirects back to `/welcome/be-findable`
- [ ] A1 preview fragment appears on `/` for `refer_now` users without a verified clinician
- [ ] A1 preview absent for other intent users or anonymous visitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)