### PR TITLE
feat: add Home page and nav link

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -25,10 +25,10 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     logged_in_user: User,
 ):
     """Authenticated pages render the primary nav as a single `<ul>`
-    with the brand on the left and four inline links pushed to the
-    right via `margin-left: auto` on the first link: Referrals (= "find
-    new clients"), Openings (= "refer out a client"), Profile, and
-    Sign out. Other URL families — `/intakes`, `/clinicians`,
+    with the brand on the left and five inline links pushed to the
+    right via `margin-left: auto` on the first link: Home, Referrals
+    (= "find new clients"), Openings (= "refer out a client"), Profile,
+    and Sign out. Other URL families — `/intakes`, `/clinicians`,
     `/organizations`, `/programs`, `/users` — stay live and reachable
     by URL/bookmark, but are no longer chrome-promoted.
 
@@ -41,15 +41,16 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     # "Create clinician" button no longer lives in the nav (#697).
     cta_items = tree.css("#primary-nav > li > a[href='/clinicians/form']")
     assert len(cta_items) == 0, "Create-clinician CTA should be removed from nav (#697)"
-    # Profile link is one of the four inline nav links.
+    # Profile link is one of the five inline nav links.
     assert tree.css_first('#primary-nav a[href="/users/me"]') is not None
-    # All four authed-chrome destinations render in this exact order
+    # All five authed-chrome destinations render in this exact order
     # inside #primary-nav. Sign-out is the `#` placeholder href on the
     # `<a hx-post>` that drives the HTMX POST.
     nav_items = tree.css("#primary-nav > li > a")
     nav_hrefs = [a.attributes.get("href") for a in nav_items]
     assert nav_hrefs == [
         "/",
+        "/home",
         "/referrals",
         "/openings",
         "/users/me",

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,0 +1,3 @@
+{% extends "base.html" %}
+{% block title %}Home{% endblock %}
+{% block content %}{% endblock %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -668,7 +668,7 @@
   <body hx-ext="response-targets">
     {# Primary nav renders on every screen so the chrome stays
        consistent between authenticated app pages and the public auth
-       flow. Authed users get the four inline links (Referrals,
+       flow. Authed users get the five inline links (Home, Referrals,
        Openings, Profile, Sign out); anonymous visitors get only the
        brand. The brand link goes to `/`, which redirects authed users
        to `/referrals` (the "find new clients" journey home — see
@@ -687,6 +687,7 @@
        Active-state rule is the same path-prefix shape used everywhere
        else: the tab lights on the family's list page and any subpath
        (`/referrals/42`, `/referrals/42/form`). #}
+    {%- set _on_home = is_authenticated and request.url.path == '/home' -%}
     {%- set _referrals_path = entity_url('referral') -%}
     {%- set _on_referrals = is_authenticated and (request.url.path == _referrals_path or request.url.path.startswith(_referrals_path + '/')) -%}
     {%- set _openings_path = entity_url('opening') -%}
@@ -698,7 +699,7 @@
             <a href="/"><strong>Bedlam Connect</strong></a>
           </li>
           {% if is_authenticated %}
-            {# Flat nav: brand on the left, four links pushed right via
+            {# Flat nav: brand on the left, five links pushed right via
              `margin-left: auto` on the first item. Sign-out uses
              `hx-post` because the route returns `HX-Redirect`; HTMX
              handles the full-page navigation to `/auth/login`.
@@ -706,6 +707,9 @@
              now the row may wrap or scroll horizontally on small
              screens. #}
             <li style="margin-left: auto;">
+              <a href="/home" {% if _on_home %}aria-current="page"{% endif %}>Home</a>
+            </li>
+            <li>
               <a href="{{ entity_url('referral') }}"
                  {% if _on_referrals %}aria-current="page"{% endif %}>Referrals</a>
             </li>

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,12 @@ from datetime import datetime
 from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
 
-from src.auth_config import auth_backend, current_optional_user, fastapi_users
+from src.auth_config import (
+    auth_backend,
+    current_active_user,
+    current_optional_user,
+    fastapi_users,
+)
 from src.db import check_database_health
 from src.domain import routes  # noqa: F401  # populates entity_registry
 from src.domain import template_globals  # noqa: F401  # populates Jinja env globals
@@ -91,6 +96,15 @@ async def unauthorized_exception_handler(request: Request, exc: HTTPException):
             )
 
     return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+
+@app.get("/home")
+async def read_home(request: Request, _user=Depends(current_active_user)):
+    return APIResponse.html_response(
+        template_name="home.html",
+        context={},
+        request=request,
+    )
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary

- Adds `GET /home` route (authenticated-only, redirects to login if not authed)
- Creates empty `home.html` template extending `base.html`
- Inserts a **Home** link as the first item in the authenticated primary nav (before Referrals)

## Test plan

- [ ] Log in and confirm "Home" appears first in the nav bar
- [ ] Visit `/home` directly — should render an empty page with full chrome
- [ ] Visit `/home` while logged out — should redirect to `/auth/login`
- [ ] Confirm Referrals, Openings, Profile, Sign out still present and in order
- [ ] `dev test` passes (nav-order assertion updated in `test_users.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)