### PR TITLE
feat(home): add post buttons to home page

### DIFF
--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Home{% endblock %}
 {% block content %}
-  <div class="grid">
+  <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
     <a href="{{ entity_form_url('referral') }}"
        role="button"
        class="outline">+ Post a referral</a>

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Home{% endblock %}
 {% block content %}
-  <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
+  <div class="grid">
     <a href="{{ entity_form_url('referral') }}"
        role="button"
        class="outline">+ Post a referral</a>

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,3 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Home{% endblock %}
-{% block content %}{% endblock %}
+{% block content %}
+  <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
+    <a href="{{ entity_form_url('referral') }}"
+       role="button"
+       class="outline">+ Post a referral</a>
+    <a href="{{ entity_form_url('opening') }}" role="button" class="outline">+ Post an opening</a>
+  </div>
+{% endblock %}

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -10,8 +10,41 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
+from httpx import AsyncClient
+from selectolax.parser import HTMLParser
 
 from src.main import lifespan
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- GET /home -----------------------------------------------------------
+
+
+async def test_home_page_requires_auth(test_client: AsyncClient):
+    """Unauthenticated browser requests to /home redirect to the login page.
+    The 401→302 rewrite fires only when Accept: text/html is present
+    (see `unauthorized_exception_handler` in main.py)."""
+    response = await test_client.get(
+        "/home",
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers["location"]
+
+
+async def test_home_page_shows_post_buttons(authenticated_client: AsyncClient):
+    """The home page renders both action buttons linking to the correct
+    create-form URLs."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first('a[href="/referrals/form"]') is not None
+    assert tree.css_first('a[href="/openings/form"]') is not None
+
+
+# --- lifespan -----------------------------------------------------------
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Stacks on #884 (adds the home page route + nav link).

- Adds "+ Post a referral" and "+ Post an opening" outline buttons to `GET /home`
- Buttons sit in a flex row (`display: flex; gap: 1rem; flex-wrap: wrap`) — wraps on narrow screens
- No custom CSS beyond the inline flex container

## Test plan

- [ ] Log in and visit `/home` — two outline buttons render side by side
- [ ] Narrow the viewport — buttons wrap to a single column
- [ ] Click each button — lands on the correct create form
- [ ] `dev test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)