### PR TITLE
feat: home page My active posts section with compact row layout

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -7,6 +7,7 @@ import pytest
 from src.domain.logic.posts.view import (
     insurance_posture_for_post,
     post_card_view,
+    post_row_summary,
     referral_headline,
 )
 
@@ -537,3 +538,143 @@ def test_view_returns_dict_for_jinja_attribute_access():
     v = post_card_view(_make_cr_post())
     assert isinstance(v, dict)
     assert v["kind"] == "referral"
+
+
+# --- post_row_summary ---------------------------------------------------
+
+
+def test_row_summary_referral_description_carrier_city():
+    """Primary path: description + carrier label + city joined with ' · '."""
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            description="Complex PTSD, seeking weekly EMDR",
+            insurance_carrier="aetna",
+            location_city="Berkeley",
+            age_groups=["adults_25_64"],
+            gender="female",
+        ),
+    )
+    assert (
+        post_row_summary(post) == "Complex PTSD, seeking weekly EMDR · Aetna · Berkeley"
+    )
+
+
+def test_row_summary_referral_no_carrier_no_city():
+    """When carrier and city are absent only the description is returned."""
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            description="Needs a therapist",
+            insurance_carrier=None,
+            location_city=None,
+            age_groups=["adults_25_64"],
+            gender="male",
+        ),
+    )
+    assert post_row_summary(post) == "Needs a therapist"
+
+
+def test_row_summary_referral_no_description_falls_back_to_headline():
+    """When description is absent the age+gender headline is used."""
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            description=None,
+            insurance_carrier=None,
+            location_city=None,
+            age_groups=["adults_25_64"],
+            gender="male",
+        ),
+    )
+    assert post_row_summary(post) == "Adult male (25–64)"
+
+
+def test_row_summary_referral_truncates_long_description():
+    """Descriptions longer than 100 chars are truncated so rows stay readable."""
+    long_desc = "x" * 150
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            description=long_desc,
+            insurance_carrier=None,
+            location_city=None,
+            age_groups=["adults_25_64"],
+            gender=None,
+        ),
+    )
+    summary = post_row_summary(post)
+    assert len(summary) == 100
+    assert summary == "x" * 100
+
+
+def test_row_summary_referral_missing_detail():
+    post = SimpleNamespace(kind="referral", referral_detail=None)
+    assert post_row_summary(post) == "Referral"
+
+
+def test_row_summary_opening_with_description_and_settings():
+    """Opening with description + first settings label + sliding scale."""
+    post = SimpleNamespace(
+        kind="clinician_opening",
+        opening_detail=SimpleNamespace(
+            description="2 slots open",
+            settings=["outpatient"],
+            age_groups=[],
+            services=[],
+            provider=SimpleNamespace(sliding_scale=True),
+        ),
+    )
+    assert post_row_summary(post) == "2 slots open · Outpatient · sliding scale"
+
+
+def test_row_summary_opening_no_description_builds_from_fields():
+    """When opening has no description, age + service labels are used."""
+    post = SimpleNamespace(
+        kind="clinician_opening",
+        opening_detail=SimpleNamespace(
+            description=None,
+            settings=[],
+            age_groups=["adults_25_64"],
+            services=["psychotherapy"],
+            provider=SimpleNamespace(sliding_scale=False),
+        ),
+    )
+    summary = post_row_summary(post)
+    assert "Adult (25–64)" in summary
+    assert "Psychotherapy" in summary
+
+
+def test_row_summary_opening_no_sliding_scale():
+    post = SimpleNamespace(
+        kind="clinician_opening",
+        opening_detail=SimpleNamespace(
+            description="Accepting new clients",
+            settings=[],
+            age_groups=[],
+            services=[],
+            provider=SimpleNamespace(sliding_scale=False),
+        ),
+    )
+    assert post_row_summary(post) == "Accepting new clients"
+
+
+def test_row_summary_opening_missing_detail():
+    post = SimpleNamespace(kind="clinician_opening", opening_detail=None)
+    assert post_row_summary(post) == "Opening"
+
+
+def test_row_summary_program_name_and_description():
+    post = SimpleNamespace(
+        kind="program_intake",
+        intake_detail=SimpleNamespace(
+            program=SimpleNamespace(name="RISE IOP"),
+            description="Cohort starts June 1",
+        ),
+    )
+    assert post_row_summary(post) == "RISE IOP · Cohort starts June 1"
+
+
+def test_row_summary_unknown_kind_returns_empty_string():
+    post = SimpleNamespace(kind="mystery")
+    assert post_row_summary(post) == ""

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -45,7 +45,13 @@ All three helpers are exposed as Jinja globals by
 
 from typing import Any
 
-from src.domain.models.enums import CLIENT_AGE_GROUPS_BY_KEY
+from src.domain.models.enums import (
+    CLIENT_AGE_GROUP_LABELS_SINGULAR,
+    CLIENT_AGE_GROUPS_BY_KEY,
+    INSURANCE_CARRIER_LABELS,
+    REFERRAL_SERVICE_LABELS,
+    TREATMENT_SETTINGS_LABELS,
+)
 from src.framework.rendering.address import full_address
 
 # Gender values that don't fit a "<age> <gender>" phrase. `gender_diverse`
@@ -409,3 +415,77 @@ def referral_headline(detail) -> str:
     if gender_word:
         return f"{age.singular} {gender_word} ({age.range})"
     return f"{age.singular} ({age.range})"
+
+
+def post_row_summary(post) -> str:
+    """Build the compact mid-dot summary line for the row layout.
+
+    Used by the home-page "My active posts" widget and the list-page row
+    view. Returns a " · "-joined string of the post's key facts: the
+    free-text description plus the one or two most differentiating
+    metadata signals (insurance carrier + city for referrals; settings +
+    sliding-scale flag for openings).
+
+    Truncates description to 100 chars so rows stay single-line on typical
+    screens; metadata appended after the truncation so the separators
+    always appear regardless of description length.
+    """
+    kind = getattr(post, "kind", None)
+
+    if kind == "referral":
+        d = getattr(post, "referral_detail", None)
+        if d is None:
+            return "Referral"
+        parts: list[str] = []
+        desc = getattr(d, "description", None)
+        if desc:
+            parts.append(desc[:100])
+        else:
+            parts.append(referral_headline(d))
+        carrier = getattr(d, "insurance_carrier", None)
+        if carrier:
+            parts.append(INSURANCE_CARRIER_LABELS.get(carrier, carrier))
+        city = getattr(d, "location_city", None)
+        if city:
+            parts.append(city)
+        return " · ".join(parts)
+
+    if kind == "clinician_opening":
+        d = getattr(post, "opening_detail", None)
+        if d is None:
+            return "Opening"
+        p = getattr(d, "provider", None)
+        parts = []
+        desc = getattr(d, "description", None)
+        if desc:
+            parts.append(desc[:100])
+        else:
+            ages = list(getattr(d, "age_groups", None) or [])
+            services = list(getattr(d, "services", None) or [])
+            age_labels = [CLIENT_AGE_GROUP_LABELS_SINGULAR.get(a, a) for a in ages[:2]]
+            svc_labels = [REFERRAL_SERVICE_LABELS.get(s, s) for s in services[:2]]
+            combined = age_labels + svc_labels
+            if combined:
+                parts.append(", ".join(combined))
+        settings = list(getattr(d, "settings", None) or [])
+        if settings:
+            parts.append(TREATMENT_SETTINGS_LABELS.get(settings[0], settings[0]))
+        if p and getattr(p, "sliding_scale", None):
+            parts.append("sliding scale")
+        return " · ".join(parts) if parts else "Opening"
+
+    if kind == "program_intake":
+        d = getattr(post, "intake_detail", None)
+        if d is None:
+            return "Program"
+        prog = getattr(d, "program", None)
+        name = getattr(prog, "name", None) if prog else None
+        desc = getattr(d, "description", None)
+        parts = []
+        if name:
+            parts.append(name)
+        if desc:
+            parts.append(desc[:80])
+        return " · ".join(parts) if parts else "Program"
+
+    return ""

--- a/src/domain/routes/test_post_families.py
+++ b/src/domain/routes/test_post_families.py
@@ -266,7 +266,7 @@ async def test_list_only_includes_own_kind(
     response = await authenticated_client.get(f"/{collection}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    cards = tree.css(f"#{collection}-list > article")
+    cards = tree.css(f"#{collection}-list > tbody > tr")
     kinds = {c.attributes.get("data-kind") for c in cards}
     assert kinds == {kind}, f"/{collection} leaked a non-{kind} row: {kinds!r}"
 
@@ -299,7 +299,7 @@ async def test_list_kind_query_param_does_not_override_lock(
     response = await authenticated_client.get(f"/{collection}?kind={other_kind}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    cards = tree.css(f"#{collection}-list > article")
+    cards = tree.css(f"#{collection}-list > tbody > tr")
     kinds_in_page = {c.attributes.get("data-kind") for c in cards}
     # Foreign-kind row never leaks in; for the subset face this means
     # the wrong-kind value was clamped out of the intersection. The
@@ -337,7 +337,7 @@ async def test_openings_kind_filter_narrows_to_one_subkind(
     assert response.status_code == 200
     kinds_unfiltered = {
         c.attributes.get("data-kind")
-        for c in HTMLParser(response.text).css("#openings-list > article")
+        for c in HTMLParser(response.text).css("#openings-list > tbody > tr")
     }
     assert {"clinician_opening", "program_intake"} <= kinds_unfiltered
 
@@ -346,7 +346,7 @@ async def test_openings_kind_filter_narrows_to_one_subkind(
     assert response.status_code == 200
     kinds_filtered = {
         c.attributes.get("data-kind")
-        for c in HTMLParser(response.text).css("#openings-list > article")
+        for c in HTMLParser(response.text).css("#openings-list > tbody > tr")
     }
     assert kinds_filtered == {
         "clinician_opening"

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -23,6 +23,7 @@ from src.domain.logic.posts.schema import (
 from src.domain.logic.posts.view import (
     insurance_posture_for_post,
     post_card_view,
+    post_row_summary,
     referral_headline,
 )
 from src.domain.logic.providers.view import provider_card_view
@@ -103,6 +104,9 @@ register_template_globals(
     # card (`posts/_item.html`) and the detail page (`posts/detail.html`)
     # read from — see its docstring in `src.domain.logic.posts.view`.
     post_card_view=post_card_view,
+    # `post_row_summary(post)` — compact mid-dot summary line for the row
+    # layout used by the home-page widget and list-page compact view.
+    post_row_summary=post_row_summary,
     # `provider_card_view(provider)` is the unified view-model
     # `providers/detail.html` reads from — see its docstring in
     # `src.domain.logic.providers.view`.

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,10 +1,30 @@
 {% extends "base.html" %}
+{%- from "posts/_shared/_row.html" import post_row with context -%}
 {% block title %}Home{% endblock %}
 {% block content %}
+  <p>Welcome back, {{ display_name }}.</p>
   <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
     <a href="{{ entity_form_url('referral') }}"
        role="button"
        class="outline">+ Post a referral</a>
     <a href="{{ entity_form_url('opening') }}" role="button" class="outline">+ Post an opening</a>
   </div>
+  {% if my_posts %}
+    <section>
+      <header style="display: flex;
+                     justify-content: space-between;
+                     align-items: baseline">
+        <h2>My active posts</h2>
+        <a href="{{ entity_url('referral') }}">See all</a>
+      </header>
+      <table class="post-rows">
+        <tbody>
+          {%- for post in my_posts -%}
+            {%- set ename = "referral" if post.kind == "referral" else "opening" -%}
+            {{ post_row(post, ename) }}
+          {%- endfor -%}
+        </tbody>
+      </table>
+    </section>
+  {% endif %}
 {% endblock %}

--- a/src/domain/templates/posts/_shared/_row.html
+++ b/src/domain/templates/posts/_shared/_row.html
@@ -1,0 +1,32 @@
+{# Compact row macro — emits a single <tr> for use inside
+   `<table class="post-rows"><tbody>…</tbody></table>`.
+
+Layout per row (four <td> cells):
+  1. Kind badge  — "REFERRAL" / "OPENING" / "INTAKE"; uppercase small
+                   text via `table.post-rows td:first-child` in base.html.
+  2. Summary     — mid-dot compact text linked to the detail page;
+                   Pico makes the link underline on hover for free.
+  3. Interest    — "No interest yet" (muted via td:nth-last-child(2)).
+                   No interest model yet — always renders this placeholder.
+  4. Age         — compact relative age via the `days_ago` filter;
+                   muted via td:last-child in base.html.
+
+`entity_name` is the URL family ("referral", "opening", "intake"). #}
+{% macro post_row(post, entity_name) -%}
+  {%- set summary = post_row_summary(post) -%}
+  {%- if post.kind == "referral" -%}
+    {%- set kind_label = "referral" -%}
+  {%- elif post.kind == "clinician_opening" -%}
+    {%- set kind_label = "opening" -%}
+  {%- else -%}
+    {%- set kind_label = "intake" -%}
+  {%- endif -%}
+  <tr data-kind="{{ post.kind }}">
+    <td>{{ kind_label }}</td>
+    <td>
+      <a href="{{ entity_url(entity_name, id=post.id) }}">{{ summary }}</a>
+    </td>
+    <td>No interest yet</td>
+    <td>{{ post.created_at | days_ago }}</td>
+  </tr>
+{%- endmacro %}

--- a/src/domain/templates/posts/openings/list.html
+++ b/src/domain/templates/posts/openings/list.html
@@ -1,5 +1,5 @@
 {% extends "views/list.html" %}
-{%- from "posts/_shared/_item.html" import post_item with context -%}
+{%- from "posts/_shared/_row.html" import post_row with context -%}
 {% block resource_label %}Openings{% endblock %}
 {% block actions %}
   <li>
@@ -8,9 +8,11 @@
 {% endblock %}
 {% block content %}
   {% if openings %}
-    <section id="openings-list">
-      {%- for post in openings %}{{ post_item(post, entity_name) }}{%- endfor %}
-      </section>
+    <table id="openings-list" class="post-rows">
+      <tbody>
+        {%- for post in openings %}{{ post_row(post, entity_name) }}{%- endfor %}
+        </tbody>
+      </table>
     {% else %}
       <p>
         {% if active_filter_count %}

--- a/src/domain/templates/posts/referrals/list.html
+++ b/src/domain/templates/posts/referrals/list.html
@@ -1,5 +1,5 @@
 {% extends "views/list.html" %}
-{%- from "posts/_shared/_item.html" import post_item with context -%}
+{%- from "posts/_shared/_row.html" import post_row with context -%}
 {% block resource_label %}Referrals{% endblock %}
 {% block actions %}
   <li>
@@ -8,9 +8,11 @@
 {% endblock %}
 {% block content %}
   {% if referrals %}
-    <section id="referrals-list">
-      {%- for post in referrals %}{{ post_item(post, entity_name) }}{%- endfor %}
-      </section>
+    <table id="referrals-list" class="post-rows">
+      <tbody>
+        {%- for post in referrals %}{{ post_row(post, entity_name) }}{%- endfor %}
+        </tbody>
+      </table>
     {% else %}
       <p>
         {% if active_filter_count %}

--- a/src/framework/rendering/templating.py
+++ b/src/framework/rendering/templating.py
@@ -17,6 +17,29 @@ from src.framework.rendering.route_urls import entity_form_url, entity_url
 auto_reload = settings.ENVIRONMENT == "development"
 
 
+def days_ago(value: datetime | date | None) -> str:
+    """Compact relative age — '4d ago', '2mo ago', '1y ago', 'today'.
+
+    Used by the home-page 'My active posts' widget and any compact row
+    view that needs a terse timestamp rather than an absolute date.
+    """
+    if value is None:
+        return ""
+    d = value.date() if isinstance(value, datetime) else value
+    delta = date.today() - d
+    days = delta.days
+    if days <= 0:
+        return "today"
+    if days == 1:
+        return "1d ago"
+    if days < 30:
+        return f"{days}d ago"
+    months = days // 30
+    if months < 12:
+        return f"{months}mo ago"
+    return f"{days // 365}y ago"
+
+
 def format_post_date(value: datetime | date | None) -> str:
     """Craigslist-style short date — `May 15` for current-year posts,
     `May 15, 2025` for older. Used by the posts list/detail templates so
@@ -68,6 +91,7 @@ _env.globals["entity_create_label"] = entity_create_label
 _env.globals["entity_edit_label"] = entity_edit_label
 _env.globals["entity_filter_label"] = entity_filter_label
 _env.filters["format_post_date"] = format_post_date
+_env.filters["days_ago"] = days_ago
 
 
 def register_template_globals(**kwargs: Any) -> None:

--- a/src/framework/rendering/test_templating.py
+++ b/src/framework/rendering/test_templating.py
@@ -1,8 +1,9 @@
 """Tests for `src/framework/rendering/templating.py`."""
 
+from datetime import date, datetime, timedelta
 from unittest.mock import patch
 
-from .templating import _env, get_template_context, register_template_globals
+from .templating import _env, days_ago, get_template_context, register_template_globals
 
 
 def test_register_template_globals_updates_env():
@@ -66,3 +67,44 @@ def test_observability_frontend_none_when_disabled():
         mock_observability.frontend_context.return_value = None
         context = get_template_context()
     assert context["observability_frontend"] is None
+
+
+# --- days_ago ------------------------------------------------------------
+
+
+def test_days_ago_today():
+    assert days_ago(date.today()) == "today"
+
+
+def test_days_ago_yesterday():
+    assert days_ago(date.today() - timedelta(days=1)) == "1d ago"
+
+
+def test_days_ago_a_few_days():
+    assert days_ago(date.today() - timedelta(days=4)) == "4d ago"
+
+
+def test_days_ago_under_30():
+    assert days_ago(date.today() - timedelta(days=29)) == "29d ago"
+
+
+def test_days_ago_months():
+    assert days_ago(date.today() - timedelta(days=60)) == "2mo ago"
+
+
+def test_days_ago_over_a_year():
+    assert days_ago(date.today() - timedelta(days=400)) == "1y ago"
+
+
+def test_days_ago_accepts_datetime():
+    dt = datetime.combine(date.today() - timedelta(days=5), datetime.min.time())
+    assert days_ago(dt) == "5d ago"
+
+
+def test_days_ago_none_returns_empty_string():
+    assert days_ago(None) == ""
+
+
+def test_days_ago_filter_registered():
+    """The filter must be registered in the Jinja env for templates to use it."""
+    assert "days_ago" in _env.filters

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -595,6 +595,26 @@
         display: grid;
         grid-template-rows: auto 1fr auto;
       }
+      /* Compact post-rows table — kind badge column and meta columns.
+         Pico's table defaults supply row dividers and cell padding;
+         these two rules handle only what Pico can't infer semantically:
+         the uppercase small-caps badge treatment on the first cell and
+         the muted-text/nowrap treatment on the trailing meta cells. */
+      table.post-rows td:first-child {
+        font-size: 0.7rem;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--pico-muted-color);
+        white-space: nowrap;
+        width: 5rem;
+      }
+      table.post-rows td:last-child,
+      table.post-rows td:nth-last-child(2) {
+        color: var(--pico-muted-color);
+        font-size: 0.875rem;
+        white-space: nowrap;
+      }
     </style>
     <script src="https://unpkg.com/htmx.org@2.0.4"
             integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"

--- a/src/main.py
+++ b/src/main.py
@@ -14,7 +14,9 @@ from src.auth_config import (
 from src.db import check_database_health
 from src.domain import routes  # noqa: F401  # populates entity_registry
 from src.domain import template_globals  # noqa: F401  # populates Jinja env globals
+from src.domain.logic.posts.repository import get_post_repository
 from src.domain.logic.users.schema import UserRead
+from src.domain.models.posts.post import Post
 from src.domain.routes import auth_pages, auth_routes, dev_auth, verifications
 from src.framework.config import settings
 from src.framework.dispatch.registry import entity_registry
@@ -99,10 +101,21 @@ async def unauthorized_exception_handler(request: Request, exc: HTTPException):
 
 
 @app.get("/home")
-async def read_home(request: Request, _user=Depends(current_active_user)):
+async def read_home(
+    request: Request,
+    _user=Depends(current_active_user),
+    post_repo=Depends(get_post_repository),
+):
+    providers = getattr(_user, "providers", [])
+    p = providers[0] if providers else None
+    if p and (p.first_name or p.last_name):
+        display_name = " ".join(filter(None, [p.first_name, p.last_name]))
+    else:
+        display_name = _user.username
+    my_posts = await post_repo.list_owned_by(Post, _user.id, limit=5)
     return APIResponse.html_response(
         template_name="home.html",
-        context={},
+        context={"display_name": display_name, "my_posts": my_posts},
         request=request,
     )
 


### PR DESCRIPTION
## Summary

- Adds `/home` route and template with a "My active posts" section showing the user's 5 most recent posts
- Replaces the full card view on `/referrals` and `/openings` list pages with a new compact table-based row format
- New `post_row_summary(post)` helper builds a mid-dot summary line (description + carrier/city for referrals; description + settings/sliding-scale for openings)
- New `days_ago` Jinja filter for compact relative timestamps ("4d ago")
- Interest count stubbed as "No interest yet" — no engagement model exists yet

## Test plan

- [ ] Visit `/home` as a logged-in user — "My active posts" table appears with your posts, "No interest yet", and relative timestamps
- [ ] Visit `/referrals` and `/openings` — list pages now show compact rows instead of cards
- [ ] "See all" link on home page navigates to `/referrals`
- [ ] Post summary links navigate to the correct detail page
- [ ] `dev test` passes (1837 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)