### PR TITLE
chore: add git-town config

### DIFF
--- a/git-town.toml
+++ b/git-town.toml
@@ -1,0 +1,9 @@
+[branches]
+main = "main"
+
+[hosting]
+dev-remote = "origin"
+
+[sync]
+feature-strategy = "rebase"
+perennial-strategy = "rebase"


### PR DESCRIPTION
## Summary

Commits `git-town.toml` so the repo's stacking workflow is shared without each contributor running `git town init` manually.

**Settings:**
- Main branch: `main`
- Sync strategy: `rebase` for both feature and perennial branches — keeps stacked branches rebased cleanly when a base merges
- Dev remote: `origin`

## Setup (one-time, per machine)

```
brew install git-town
```

That's it — the config file is picked up automatically.

**Key commands:**
- `git town sync` — rebase current branch (and all ancestors) onto latest main
- `git town append <name>` — create a child branch in a stack
- `git town set-parent <branch>` — re-parent a branch after rebasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)