### PR TITLE
docs: add git town sync to PR workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ A Stop hook checks the diff at end-of-turn and surfaces a reminder when source f
 
 A SessionStart hook prints the real current branch, dirty state, and stash list at session start — and warns loudly if you've landed on `main`/`master` in the shared working tree. Multi-agent sessions in this repo share one working directory; trust the hook's output over any harness-provided "current branch" line. A PreToolUse hook then enforces the rule: `Edit`/`Write`/`NotebookEdit` are refused on the main checkout when you're on `main`/`master`, so new work has to start on a worktree (`dev worktree add <slug>`). Feature branches on the main checkout are still allowed (for in-flight sessions); worktrees always are. See [`scripts/README.md`](scripts/README.md) for all three hooks.
 
-PRs land via Mergify on `main` — use `dev merge` to watch a PR until Mergify queues and merges it. See [`scripts/README.md#merging-prs`](scripts/README.md) for the flow, queue config, and recovery.
+PRs land via Mergify on `main`. Before pushing, run `git town sync` to rebase onto the latest `main` — this keeps the branch current when it enters CI. Once it's in the Mergify queue, Mergify handles any further rebasing speculatively. Use `dev merge` to watch a PR until it lands. See [`scripts/README.md#merging-prs`](scripts/README.md) for the full flow, queue config, and recovery.
 
 **Contract tests are not run by default.** `tests/test_contract` is excluded from the default `dev test` collection (see [`tests/test_contract/README.md`](tests/test_contract/README.md)). If you change templates, route response shapes, or anything mock data factories in `tests/test_contract` assume, also run `dev test contract` before pushing — otherwise CI is the first place the breakage surfaces.
 

--- a/git-town.toml
+++ b/git-town.toml
@@ -1,0 +1,9 @@
+[branches]
+main = "main"
+
+[hosting]
+dev-remote = "origin"
+
+[sync]
+feature-strategy = "rebase"
+perennial-strategy = "rebase"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,11 +31,11 @@ PRs land via [Mergify](https://mergify.com) on `main`. The full flow requires no
 
 **Flow:**
 
-1. `dev push` opens (or updates) a PR off your worktree branch.
-2. CI runs on the PR head (`pull_request` event) — four jobs in parallel.
-3. When all four pass, a fifth CI job (`queue`) automatically posts `@mergifyio queue` on the PR.
-4. Mergify admits the PR to the active queue, batching with any other waiting PRs (up to 3).
-5. Mergify creates a speculative branch combining the batch rebased onto current `main`, runs CI on that branch, and squash-merges when green.
+1. `git town sync` — rebase the branch onto the latest `main` before pushing. This ensures the branch is current when it enters CI; once the PR is in the Mergify queue, Mergify owns the rebase (see step 5).
+2. `dev push` opens (or updates) a PR off your worktree branch.
+3. CI runs on the PR head (`pull_request` event) — four jobs in parallel.
+4. When all four pass, a fifth CI job (`queue`) automatically posts `@mergifyio queue` on the PR.
+5. Mergify admits the PR to the active queue, batching with any other waiting PRs (up to 3). It creates a speculative branch rebased onto current `main` (absorbing any PRs that merged while yours was in CI), runs CI on that branch, and squash-merges when green. Conflicts that arise *after* the PR enters the queue are Mergify's problem, not yours.
 6. `dev merge [<pr>]` is optional — use it to block and get notified when the PR lands or a check fails.
 
 **Queue config:**


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: adds `git town sync` to the one-liner PR flow so agents know to sync before pushing
- `scripts/README.md`: expands the Merging PRs flow with sync as step 1, and clarifies that Mergify owns the rebase once a PR is queued

**The rule in one sentence:** sync before push so the branch is current when it enters CI; after that, Mergify's speculative rebase handles anything that merges while the PR is waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)