### PR TITLE
fix(home): pass current_user so primary nav renders on /home

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -117,6 +117,7 @@ async def read_home(
         template_name="home.html",
         context={"display_name": display_name, "my_posts": my_posts},
         request=request,
+        current_user=_user,
     )
 
 

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -44,6 +44,20 @@ async def test_home_page_shows_post_buttons(authenticated_client: AsyncClient):
     assert tree.css_first('a[href="/openings/form"]') is not None
 
 
+async def test_home_page_shows_primary_nav(authenticated_client: AsyncClient):
+    """The home page passes current_user so is_authenticated=True and the
+    primary nav links (Home, Referrals, Openings, Profile, Sign out) render."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    nav = tree.css_first('nav[aria-label="Primary"]')
+    assert nav is not None
+    links = {a.attributes.get("href") for a in nav.css("a")}
+    assert "/home" in links
+    assert "/referrals" in links
+    assert "/openings" in links
+
+
 # --- lifespan -----------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- `read_home` had the authenticated user in `_user` but wasn't forwarding it to `html_response`, so `base_context` received `None` and returned `is_authenticated=False`
- This caused the primary nav links (Home, Referrals, Openings, Profile, Sign out) to be hidden on `/home`
- Fix: add `current_user=_user` to the `html_response` call

## Test plan

- [ ] `dev test src/test_main.py` passes (new `test_home_page_shows_primary_nav` test pins the fix)
- [ ] Load `/home` as an authenticated user and confirm nav links appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)