### PR TITLE
feat(dev): quick sign-in dropdown on login page

### DIFF
--- a/src/domain/routes/auth_pages.py
+++ b/src/domain/routes/auth_pages.py
@@ -9,7 +9,9 @@ from pydantic import BaseModel, EmailStr, ValidationError
 
 from src.auth_config import auth_backend, current_active_user, get_user_manager
 from src.domain.models import User
+from src.domain.routes.dev_auth import DEV_SEED_USERS
 from src.framework import APIResponse, BaseRouter
+from src.framework.config import settings
 from src.framework.http.form_error_handler import form_error_handler
 from src.framework.http.form_error_registry import register_form_error
 
@@ -78,9 +80,14 @@ async def get_login_page(request: Request):
     next_url = request.query_params.get("next", "")
     # Show a contextual message when arriving from the registration flow
     just_registered = request.query_params.get("registered") == "1"
+    dev_users = DEV_SEED_USERS if settings.ENVIRONMENT == "development" else None
     return APIResponse.html_response(
         template_name="auth/login.html",
-        context={"next_url": next_url, "just_registered": just_registered},
+        context={
+            "next_url": next_url,
+            "just_registered": just_registered,
+            "dev_users": dev_users,
+        },
         request=request,
     )
 

--- a/src/domain/routes/dev_auth.py
+++ b/src/domain/routes/dev_auth.py
@@ -1,34 +1,32 @@
-"""Dev-only auto-login route.
+"""Dev-only auto-login routes.
 
-Visiting ``GET /dev/login-as-seed-user`` issues the same session
-cookie a production login would (via ``auth_backend.login`` with the
-JWT strategy from :mod:`src.auth_config`) for the user named by
-``settings.DEV_LOGIN_EMAIL``, then 302s to ``/posts``. Useful in two
-places:
+Two routes, both only mounted when ``settings.ENVIRONMENT == "development"``:
 
-  * Manual development — bookmark the URL. One click after starting
-    the dev server and you're authenticated; no form to fill.
-  * Playwright MCP agent — first tool call of a session navigates here,
-    then every subsequent navigate happens with the auth cookie set.
+``GET /dev/login-as-seed-user``
+    Logs in as the server-configured ``DEV_LOGIN_EMAIL`` (defaults to
+    ``admin@example.com``). No user input accepted — useful as a
+    bookmark or first Playwright MCP call.
 
-Security guards (defense in depth — both must pass):
+``GET /dev/login-as?email=<addr>``
+    Logs in as any user by email. The email comes from a query param
+    (selected from the quick-sign-in dropdown on the login page) rather
+    than from server config. Still dev-only — the route 404s outside
+    ``ENVIRONMENT=development`` — so it can't be used in production.
 
-  1. The route is only mounted on the FastAPI app when
-     ``settings.ENVIRONMENT == "development"`` — see
-     :func:`mount_dev_routes`. In production the route doesn't exist
-     and 404s without ever reaching this module.
-  2. The handler additionally raises 404 if ``settings.ENVIRONMENT``
-     somehow drifts out of "development" at request time. Belt-and-
-     suspenders against a future code path that toggles the env flag
-     after app boot.
+Security guards (defense in depth — both must pass for each route):
 
-The route never accepts user input — the seed-user identifier comes
-from the server-side ``DEV_LOGIN_EMAIL`` setting, not from query
-params — so it can't be tricked into authenticating as an arbitrary
-user. The seed user must already exist in the database; otherwise the
-handler 404s.
+  1. The router is only mounted when ``settings.ENVIRONMENT ==
+     "development"`` — see :func:`mount_dev_routes`. In production
+     neither route exists and both 404 without reaching this module.
+  2. Each handler raises 404 at request time if ``settings.ENVIRONMENT``
+     has somehow drifted. Belt-and-suspenders against a future code path
+     that toggles the env flag after app boot.
 
-Tested in `test_dev_auth.py` (the colocated route test).
+``DEV_SEED_USERS`` is the canonical list surfaced in the login-page
+dropdown. It mirrors the anchor rows in
+``scripts/dev/seed/overrides/users.py``.
+
+Tested in ``test_dev_auth.py`` (colocated route tests).
 """
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
@@ -41,40 +39,64 @@ from src.framework.config import settings
 
 router = APIRouter(tags=["dev"])
 
+# Mirrors the anchor rows in scripts/dev/seed/overrides/users.py.
+# Shown in the login-page quick-sign-in dropdown when ENVIRONMENT=development.
+DEV_SEED_USERS: list[dict[str, str]] = [
+    {"email": "admin@example.com", "label": "admin (superuser)"},
+    {"email": "alice@example.com", "label": "alice"},
+    {"email": "bob@example.com", "label": "bob"},
+]
 
-@router.get("/dev/login-as-seed-user")
-async def login_as_seed_user(
-    user_manager: BaseUserManager[User, object] = Depends(get_user_manager),
+
+async def _login_response(
+    email: str, user_manager: BaseUserManager[User, object]
 ) -> Response:
-    """Issue a session cookie for the configured seed user and 302 to
-    ``/`` — root then decides where to land (see ``read_root`` in
-    ``src/main.py``), so this handler doesn't bake in a specific
-    resource path."""
-    if settings.ENVIRONMENT != "development":
-        raise HTTPException(status_code=404)
-
+    """Fetch user by email and return a 302 response with the session cookie set."""
     try:
-        user = await user_manager.get_by_email(settings.DEV_LOGIN_EMAIL)
+        user = await user_manager.get_by_email(email)
     except Exception as exc:  # fastapi-users raises UserNotExists
         raise HTTPException(
             status_code=404,
             detail=(
-                f"Seed user not found: {settings.DEV_LOGIN_EMAIL}. "
+                f"Seed user not found: {email}. "
                 "Run `dev seed` to populate the dev database."
             ),
         ) from exc
 
     # `auth_backend.login(strategy, user)` builds a Response with the
-    # cookie set by the transport (CookieTransport in our config). We
-    # then swap the status + Location header so the agent / browser
-    # lands on `/` (which redirects onward) carrying the freshly-set
-    # cookie. Routing the landing through `/` keeps the
-    # "where does an authenticated session land?" decision in one
-    # place — `src/main.py:read_root` — instead of duplicating it here.
+    # cookie set by CookieTransport. Swap status + Location so the browser
+    # lands on `/` carrying the freshly-set cookie; root decides the actual
+    # landing page (see `src/main.py:read_root`).
     response = await auth_backend.login(get_strategy(), user)
     response.status_code = 302
     response.headers["Location"] = "/"
     return response
+
+
+@router.get("/dev/login-as-seed-user")
+async def login_as_seed_user(
+    user_manager: BaseUserManager[User, object] = Depends(get_user_manager),
+) -> Response:
+    """Issue a session cookie for the configured seed user and 302 to ``/``."""
+    if settings.ENVIRONMENT != "development":
+        raise HTTPException(status_code=404)
+    return await _login_response(settings.DEV_LOGIN_EMAIL, user_manager)
+
+
+@router.get("/dev/login-as")
+async def login_as(
+    email: str,
+    user_manager: BaseUserManager[User, object] = Depends(get_user_manager),
+) -> Response:
+    """Issue a session cookie for any user by email and 302 to ``/``.
+
+    The email comes from the quick-sign-in dropdown on the login page.
+    Only reachable in ``ENVIRONMENT=development`` — the route is not
+    mounted in production.
+    """
+    if settings.ENVIRONMENT != "development":
+        raise HTTPException(status_code=404)
+    return await _login_response(email, user_manager)
 
 
 def mount_dev_routes(app: FastAPI, *, environment: str) -> None:

--- a/src/domain/routes/test_dev_auth.py
+++ b/src/domain/routes/test_dev_auth.py
@@ -1,22 +1,19 @@
-"""Tests for the dev-only auto-login route.
+"""Tests for the dev-only auto-login routes.
 
-Two layers of guarding:
+Two layers of guarding apply to both routes:
 
   1. ``mount_dev_routes`` only registers the router when the
      ``environment`` argument is ``"development"``. Tested with a
      fresh ``FastAPI()`` instance per case so the global
      ``src.main:app`` isn't mutated.
-  2. The handler additionally raises 404 if
-     ``settings.ENVIRONMENT`` doesn't read ``"development"`` at
-     request time (defense in depth).
+  2. Each handler raises 404 if ``settings.ENVIRONMENT`` doesn't read
+     ``"development"`` at request time (defense in depth).
 
-The happy-path test goes through the test client's already-mounted
-``app`` (which runs with ``ENVIRONMENT="development"`` via
-``.env.test``) and pins the contract a Playwright agent or a manual
-bookmark relies on: 302 + ``Location: /`` + ``Set-Cookie:
+Happy-path tests go through the test client's already-mounted ``app``
+(which runs with ``ENVIRONMENT="development"`` via ``.env.test``) and
+pin the shared contract: 302 + ``Location: /`` + ``Set-Cookie:
 fastapiusersauth=...``. The handler redirects to ``/`` so the root
-handler (``src/main.py:read_root``) owns the choice of landing page;
-this route only proves the cookie was issued.
+handler (``src/main.py:read_root``) owns the choice of landing page.
 """
 
 import pytest
@@ -34,23 +31,24 @@ from tests.fixtures import create_test_user
 
 
 def test_mount_dev_routes_registers_when_environment_is_development():
-    """A fresh app + `mount_dev_routes(env="development")` produces a
-    `/dev/login-as-seed-user` route on `app.routes`. Pins the dev-
-    mode mount."""
+    """A fresh app + `mount_dev_routes(env="development")` produces both
+    dev routes on `app.routes`. Pins the dev-mode mount."""
     app = FastAPI()
     dev_auth.mount_dev_routes(app, environment="development")
     paths = {getattr(r, "path", None) for r in app.routes}
     assert "/dev/login-as-seed-user" in paths
+    assert "/dev/login-as" in paths
 
 
 def test_mount_dev_routes_skips_when_environment_is_production():
-    """The production mount path MUST NOT register the dev route.
+    """The production mount path MUST NOT register the dev routes.
     This is the canary against an accidental env-flag flip leaking the
     auto-login backdoor into prod."""
     app = FastAPI()
     dev_auth.mount_dev_routes(app, environment="production")
     paths = {getattr(r, "path", None) for r in app.routes}
     assert "/dev/login-as-seed-user" not in paths
+    assert "/dev/login-as" not in paths
 
 
 def test_mount_dev_routes_skips_when_environment_is_arbitrary_other():
@@ -62,6 +60,7 @@ def test_mount_dev_routes_skips_when_environment_is_arbitrary_other():
         dev_auth.mount_dev_routes(app, environment=env)
     paths = {getattr(r, "path", None) for r in app.routes}
     assert "/dev/login-as-seed-user" not in paths
+    assert "/dev/login-as" not in paths
 
 
 # --- Handler: happy path ------------------------------------------------
@@ -123,4 +122,54 @@ async def test_dev_login_404s_when_environment_is_not_development(
     code path that toggles the env at runtime."""
     monkeypatch.setattr(settings, "ENVIRONMENT", "production")
     response = await test_client.get("/dev/login-as-seed-user", follow_redirects=False)
+    assert response.status_code == 404
+
+
+# --- /dev/login-as: quick-sign-in by email --------------------------------
+
+
+async def test_login_as_issues_session_cookie_and_redirects(
+    test_client: AsyncClient,
+    test_app: FastAPI,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Hitting /dev/login-as?email=<addr> with an existing user issues
+    the session cookie and 302s to `/`, matching the contract of the
+    existing /dev/login-as-seed-user route."""
+    email = "quick-signin-test@example.com"
+    user_data = UserCreate(email=email, password="anything", username="quick-signin")
+    await create_test_user(db_test_session_manager, user_data, get_user_manager)
+
+    response = await test_client.get(
+        f"/dev/login-as?email={email}", follow_redirects=False
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/"
+    assert "fastapiusersauth=" in response.headers.get("Set-Cookie", "")
+
+
+async def test_login_as_404s_when_user_missing(
+    test_client: AsyncClient,
+    test_app: FastAPI,
+):
+    """If the email query param doesn't match any user, the route 404s
+    with a hint to run `dev seed`."""
+    response = await test_client.get(
+        "/dev/login-as?email=nobody@example.com", follow_redirects=False
+    )
+    assert response.status_code == 404
+    assert "dev seed" in response.text
+
+
+async def test_login_as_404s_when_environment_is_not_development(
+    test_client: AsyncClient,
+    test_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Defense-in-depth: request-time env check 404s even when the route
+    is mounted."""
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    response = await test_client.get(
+        "/dev/login-as?email=admin@example.com", follow_redirects=False
+    )
     assert response.status_code == 404

--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -19,6 +19,21 @@
        chrome inside the form slot). See the partial's docstring +
        `post_login`'s `form_rerender` call for the wiring. #}
     {% include "auth/_login_form.html" %}
+    {% if dev_users %}
+      {# Dev-only: quick sign-in as a seeded user without entering credentials.
+         Only rendered when ENVIRONMENT=development and /dev/login-as is mounted.
+         Never shown in production. #}
+      <details>
+        <summary>Dev: quick sign-in</summary>
+        <form method="get" action="/dev/login-as">
+          <label for="dev-user-select">Sign in as</label>
+          <select id="dev-user-select" name="email">
+            {% for u in dev_users %}<option value="{{ u.email }}">{{ u.label }} — {{ u.email }}</option>{% endfor %}
+          </select>
+          <button type="submit">Go</button>
+        </form>
+      </details>
+    {% endif %}
     <footer>
       <p>
         Forgot your password?


### PR DESCRIPTION
## Summary

- Adds a collapsible **Dev: quick sign-in** panel to `/auth/login`, rendered only when `ENVIRONMENT=development`
- Panel contains a `<select>` of the three anchor seed users (admin, alice, bob) and a **Go** button
- Selecting a user and clicking Go hits a new `GET /dev/login-as?email=<addr>` route, which issues the session cookie and 302s to `/` — same mechanics as the existing `/dev/login-as-seed-user` bookmark
- Both dev routes share the same `_login_response` helper, same two-layer security guards (mount-gated + request-time env check)
- `DEV_SEED_USERS` list in `dev_auth.py` is the single source of truth for what appears in the dropdown

## Test plan

- [ ] `dev test src/domain/routes/test_dev_auth.py` — 9/9 pass (6 existing + 3 new for `/dev/login-as`)
- [ ] `dev lint` — clean
- [ ] Manual: start dev server, visit `/auth/login`, expand "Dev: quick sign-in", pick alice, click Go → lands authenticated as alice

🤖 Generated with [Claude Code](https://claude.com/claude-code)