### PR TITLE
fix(hooks): allow writes when file_path is inside a worktree but cwd is main

### DIFF
--- a/scripts/preflight_worktree_check.py
+++ b/scripts/preflight_worktree_check.py
@@ -19,6 +19,14 @@ Worktree detection: ``git rev-parse --git-dir`` differs from
 sits under ``<main>/.git/worktrees/<name>`` while ``--git-common-dir`` returns
 the shared ``<main>/.git``). In the main checkout the two are equal.
 
+The check runs twice:
+
+  1. Against the payload ``cwd`` — the session's reported working directory.
+  2. Against the target ``file_path`` — needed because the harness ``cwd``
+     may still point at the main checkout even after ``EnterWorktree`` has
+     switched the session into a linked worktree. If the file being written
+     lives inside a worktree, that's sufficient evidence to allow it.
+
 Exits 2 with a stderr message on block (Claude Code surfaces stderr to the
 model so the next step is actionable). Exits 0 (allow) on every other path
 and on any internal failure — the hook must not wedge the session if git
@@ -62,6 +70,36 @@ def _in_worktree() -> bool:
     return git_abs != common_abs
 
 
+def _path_in_worktree(file_path: str) -> bool:
+    """True if file_path (or its nearest existing ancestor) is inside a linked worktree.
+
+    Used as a fallback when the harness ``cwd`` lags behind an ``EnterWorktree``
+    call — the payload cwd may still point at the main checkout while the target
+    file already lives in the worktree.
+    """
+    if not file_path:
+        return False
+    p = Path(file_path).resolve()
+    # Walk up to the nearest existing directory; the file itself may not exist yet.
+    while not p.exists():
+        parent = p.parent
+        if parent == p:
+            return False  # reached filesystem root without finding anything
+        p = parent
+    check_dir = p if p.is_dir() else p.parent
+    old_cwd = Path.cwd()
+    try:
+        os.chdir(check_dir)
+        return _in_worktree()
+    except OSError:
+        return False
+    finally:
+        try:
+            os.chdir(old_cwd)
+        except OSError:
+            pass
+
+
 def main() -> int:
     raw = sys.stdin.read()
     if not raw.strip():
@@ -75,6 +113,8 @@ def main() -> int:
     if tool_name not in GUARDED_TOOLS:
         return 0
 
+    file_path = payload.get("tool_input", {}).get("file_path", "")
+
     # Move to the cwd Claude Code reports — the hook process inherits its own
     # cwd from the harness, which is not necessarily the session's cwd.
     cwd = payload.get("cwd") or os.getcwd()
@@ -86,13 +126,17 @@ def main() -> int:
     if _in_worktree():
         return 0
 
+    # The harness cwd may not reflect an EnterWorktree switch — also check
+    # whether the target file itself lives inside a worktree.
+    if _path_in_worktree(file_path):
+        return 0
+
     branch = _git(["branch", "--show-current"])
     if branch not in {"main", "master"}:
         return 0
 
     # Pick a slug hint from the file being edited so the suggested command
     # is concrete. Fallback to "task" so the message stays valid.
-    file_path = payload.get("tool_input", {}).get("file_path", "")
     slug_hint = "task"
     if file_path:
         parts = [p for p in Path(file_path).parts if p not in {"/", ".", ".."}]

--- a/scripts/test_preflight_worktree_check.py
+++ b/scripts/test_preflight_worktree_check.py
@@ -131,3 +131,29 @@ def test_all_guarded_tools_are_blocked(tool: str, tmp_path: Path) -> None:
     }
     result = _run_hook(repo, payload)
     assert result.returncode == 2, result.stderr
+
+
+def test_allows_when_file_path_is_inside_worktree_even_if_cwd_is_main(
+    tmp_path: Path,
+) -> None:
+    """EnterWorktree switches the session into a linked worktree but the
+    harness payload ``cwd`` may still report the main checkout. The hook
+    must allow the write when the *target file* lives inside a worktree,
+    even when ``cwd`` would otherwise trigger a block.
+
+    This is the bug fixed by the _path_in_worktree fallback: previously,
+    Edit/Write calls after EnterWorktree were erroneously blocked because
+    the hook only checked cwd, not file_path."""
+    repo = _init_main_checkout(tmp_path / "repo")
+    worktree = tmp_path / "worktrees" / "feature"
+    _git(repo, "worktree", "add", "-b", "fix/feature-y", str(worktree))
+
+    # Payload simulates what the harness sends after EnterWorktree:
+    # cwd is still the main checkout, but file_path is inside the worktree.
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": str(worktree / "src" / "foo.py")},
+        "cwd": str(repo),  # main checkout — the stale harness cwd
+    }
+    result = _run_hook(repo, payload)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

After `EnterWorktree` switches the session into a linked worktree, the harness payload `cwd` may still report the main checkout path. The preflight hook was blocking `Edit`/`Write` calls whose `file_path` pointed into the worktree, because it only checked `cwd` for worktree status — not the target file.

**Root cause:** The hook does `os.chdir(payload["cwd"])` then checks `_in_worktree()`. If `cwd` is the main checkout (stale after `EnterWorktree`), the check returns False and the hook blocks on branch=main.

**Fix:** Adds `_path_in_worktree(file_path)` as a fallback. It walks up from `file_path` to its nearest existing ancestor, `chdir`s there, and re-runs `_in_worktree()`. If the file lives inside a linked worktree the write is allowed, regardless of the stale `cwd`.

## Test plan

- [ ] `dev test scripts/test_preflight_worktree_check.py` — 9/9 pass (8 existing + 1 new regression test)
- [ ] New test: `test_allows_when_file_path_is_inside_worktree_even_if_cwd_is_main` reproduces the exact failure scenario: `cwd=main checkout`, `file_path=file inside a linked worktree`

🤖 Generated with [Claude Code](https://claude.com/claude-code)