### PR TITLE
feat: two-line feed-row component for home and browse list views

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -7,6 +7,7 @@ import pytest
 from src.domain.logic.posts.view import (
     insurance_posture_for_post,
     post_card_view,
+    post_feed_headline,
     post_row_summary,
     referral_headline,
 )
@@ -678,3 +679,112 @@ def test_row_summary_program_name_and_description():
 def test_row_summary_unknown_kind_returns_empty_string():
     post = SimpleNamespace(kind="mystery")
     assert post_row_summary(post) == ""
+
+
+# --- post_feed_headline -------------------------------------------------
+
+
+def test_feed_headline_referral_with_services():
+    """Demographics form the left half; up to 2 service labels the right half."""
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            age_groups=["adults_25_64"],
+            gender="female",
+            services=["psychotherapy", "medication_management"],
+        ),
+    )
+    assert (
+        post_feed_headline(post)
+        == "Adult female (25–64) — Psychotherapy, Medication management"
+    )
+
+
+def test_feed_headline_referral_no_services_returns_demographics_only():
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            age_groups=["adolescents_14_18"],
+            gender="male",
+            services=[],
+        ),
+    )
+    assert post_feed_headline(post) == "Adolescent male (14–18)"
+
+
+def test_feed_headline_referral_caps_services_at_two():
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            age_groups=["adults_25_64"],
+            gender="non_binary",
+            services=["evaluation", "psychotherapy", "case_management"],
+        ),
+    )
+    headline = post_feed_headline(post)
+    # Only first two services should appear; third is dropped.
+    assert "Evaluation, Psychotherapy" in headline
+    assert "Case management" not in headline
+
+
+def test_feed_headline_referral_missing_detail_returns_fallback():
+    post = SimpleNamespace(kind="referral", referral_detail=None)
+    assert post_feed_headline(post) == "Referral"
+
+
+def test_feed_headline_opening_with_services():
+    """Practice name forms the left half; service labels the right half."""
+    post = _make_pa_post()
+    headline = post_feed_headline(post)
+    assert headline.startswith("Acme Counseling — ")
+    assert "Psychotherapy" in headline
+
+
+def test_feed_headline_opening_falls_back_to_settings_when_no_services():
+    """When an opening carries no services, settings labels are used for the focus."""
+    post = _make_pa_post(services=[], settings=["outpatient", "iop"])
+    headline = post_feed_headline(post)
+    assert "Outpatient" in headline
+    assert "IOP" in headline
+
+
+def test_feed_headline_opening_practice_name_only_when_no_focus():
+    """Practice name alone is returned when both services and settings are empty."""
+    post = _make_pa_post(services=[], settings=[])
+    assert post_feed_headline(post) == "Acme Counseling"
+
+
+def test_feed_headline_opening_missing_detail_returns_fallback():
+    post = SimpleNamespace(kind="clinician_opening", opening_detail=None)
+    assert post_feed_headline(post) == "Opening"
+
+
+def test_feed_headline_opening_missing_provider_returns_fallback():
+    post = SimpleNamespace(
+        kind="clinician_opening",
+        opening_detail=SimpleNamespace(
+            provider=None,
+            services=["psychotherapy"],
+            settings=[],
+        ),
+    )
+    # Practice name cannot be derived; headline falls back to "Opening — <service>".
+    headline = post_feed_headline(post)
+    assert "Psychotherapy" in headline
+
+
+def test_feed_headline_program_with_services():
+    post = _make_program_post()
+    headline = post_feed_headline(post)
+    assert headline.startswith("RISE IOP — ")
+    assert "Psychotherapy" in headline
+
+
+def test_feed_headline_program_no_services_returns_name_only():
+    post = _make_program_post(services=[])
+    assert post_feed_headline(post) == "RISE IOP"
+
+
+def test_feed_headline_unknown_kind_returns_empty_string():
+    post = SimpleNamespace(kind="mystery")
+    assert post_feed_headline(post) == ""

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -39,7 +39,12 @@ kind are ``None`` (or empty lists); templates render via
 lookup is the template's job (it's the same label dict pattern as
 elsewhere).
 
-All three helpers are exposed as Jinja globals by
+`post_feed_headline(post)` builds the two-part headline for the
+feed-row component used in the home and browse list views. Format is
+``"<identity> — <clinical focus>"``: demographics + services for
+referrals, practice name + services/settings for openings.
+
+All helpers are exposed as Jinja globals by
 `src/framework/rendering/templating.py`.
 """
 
@@ -487,5 +492,67 @@ def post_row_summary(post) -> str:
         if desc:
             parts.append(desc[:80])
         return " · ".join(parts) if parts else "Program"
+
+    return ""
+
+
+def post_feed_headline(post) -> str:
+    """Build the two-part feed-row headline for any post kind.
+
+    Referrals: ``"<demographics> — <services>"``, e.g.
+    ``"Adult female (25–64) — Psychotherapy, Medication management"``.
+    When the referral carries no services the demographics alone are returned.
+
+    Openings: ``"<practice name> — <clinical focus>"``, e.g.
+    ``"Acme Counseling — Psychotherapy, Outpatient"``. Clinical focus
+    comes from the opening's services list; settings are used as a
+    fallback when services are absent. Falls back to practice name alone
+    when neither is set.
+
+    Program intakes follow the same ``"<name> — <services>"`` pattern.
+    """
+    kind = getattr(post, "kind", None)
+
+    if kind == "referral":
+        d = getattr(post, "referral_detail", None)
+        if d is None:
+            return "Referral"
+        demo = referral_headline(d)
+        services = list(getattr(d, "services", None) or [])
+        if services:
+            labels = [REFERRAL_SERVICE_LABELS.get(s, s) for s in services[:2]]
+            return f"{demo} — {', '.join(labels)}"
+        return demo
+
+    if kind == "clinician_opening":
+        d = getattr(post, "opening_detail", None)
+        if d is None:
+            return "Opening"
+        p = getattr(d, "provider", None)
+        practice = (
+            p.org.name
+            if p and getattr(p, "org", None) and getattr(p.org, "name", None)
+            else "Opening"
+        )
+        services = list(getattr(d, "services", None) or [])
+        focus_parts = [REFERRAL_SERVICE_LABELS.get(s, s) for s in services[:2]]
+        if not focus_parts:
+            settings = list(getattr(d, "settings", None) or [])
+            focus_parts = [TREATMENT_SETTINGS_LABELS.get(s, s) for s in settings[:2]]
+        if focus_parts:
+            return f"{practice} — {', '.join(focus_parts)}"
+        return practice
+
+    if kind == "program_intake":
+        d = getattr(post, "intake_detail", None)
+        if d is None:
+            return "Program"
+        prog = getattr(d, "program", None)
+        name = (getattr(prog, "name", None) if prog else None) or "Program"
+        services = list(getattr(d, "services", None) or [])
+        focus_parts = [REFERRAL_SERVICE_LABELS.get(s, s) for s in services[:2]]
+        if focus_parts:
+            return f"{name} — {', '.join(focus_parts)}"
+        return name
 
     return ""

--- a/src/domain/routes/test_post_families.py
+++ b/src/domain/routes/test_post_families.py
@@ -266,7 +266,7 @@ async def test_list_only_includes_own_kind(
     response = await authenticated_client.get(f"/{collection}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    cards = tree.css(f"#{collection}-list > tbody > tr")
+    cards = tree.css(f"#{collection}-list a.post-feed-row")
     kinds = {c.attributes.get("data-kind") for c in cards}
     assert kinds == {kind}, f"/{collection} leaked a non-{kind} row: {kinds!r}"
 
@@ -299,7 +299,7 @@ async def test_list_kind_query_param_does_not_override_lock(
     response = await authenticated_client.get(f"/{collection}?kind={other_kind}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    cards = tree.css(f"#{collection}-list > tbody > tr")
+    cards = tree.css(f"#{collection}-list a.post-feed-row")
     kinds_in_page = {c.attributes.get("data-kind") for c in cards}
     # Foreign-kind row never leaks in; for the subset face this means
     # the wrong-kind value was clamped out of the intersection. The
@@ -337,7 +337,7 @@ async def test_openings_kind_filter_narrows_to_one_subkind(
     assert response.status_code == 200
     kinds_unfiltered = {
         c.attributes.get("data-kind")
-        for c in HTMLParser(response.text).css("#openings-list > tbody > tr")
+        for c in HTMLParser(response.text).css("#openings-list a.post-feed-row")
     }
     assert {"clinician_opening", "program_intake"} <= kinds_unfiltered
 
@@ -346,7 +346,7 @@ async def test_openings_kind_filter_narrows_to_one_subkind(
     assert response.status_code == 200
     kinds_filtered = {
         c.attributes.get("data-kind")
-        for c in HTMLParser(response.text).css("#openings-list > tbody > tr")
+        for c in HTMLParser(response.text).css("#openings-list a.post-feed-row")
     }
     assert kinds_filtered == {
         "clinician_opening"

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -23,6 +23,7 @@ from src.domain.logic.posts.schema import (
 from src.domain.logic.posts.view import (
     insurance_posture_for_post,
     post_card_view,
+    post_feed_headline,
     post_row_summary,
     referral_headline,
 )
@@ -107,6 +108,9 @@ register_template_globals(
     # `post_row_summary(post)` — compact mid-dot summary line for the row
     # layout used by the home-page widget and list-page compact view.
     post_row_summary=post_row_summary,
+    # `post_feed_headline(post)` — two-part "<identity> — <focus>" headline
+    # for the feed-row component in home and browse list views.
+    post_feed_headline=post_feed_headline,
     # `provider_card_view(provider)` is the unified view-model
     # `providers/detail.html` reads from — see its docstring in
     # `src.domain.logic.providers.view`.

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -41,14 +41,12 @@
         <a href="{{ entity_url('referral') }}">Adjust filters</a>
         {# djlint:on #}
       </p>
-      <table class="post-rows">
-        <tbody>
-          {%- for post in network_posts -%}
-            {%- set ename = "referral" if post.kind == "referral" else "opening" -%}
-            {{ post_row(post, ename) }}
-          {%- endfor -%}
-        </tbody>
-      </table>
+      <div class="post-feed-list">
+        {%- for post in network_posts -%}
+          {%- set ename = "referral" if post.kind == "referral" else "opening" -%}
+          {{ post_feed_row(post, ename) }}
+        {%- endfor -%}
+      </div>
     </section>
   {% endif %}
 {% endblock %}

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{%- from "posts/_shared/_row.html" import post_row with context -%}
+{%- from "posts/_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {% block title %}Home{% endblock %}
 {% block content %}
   <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
@@ -16,14 +16,12 @@
         <h2>My active posts</h2>
         <a href="{{ entity_url('referral') }}">See all</a>
       </header>
-      <table class="post-rows">
-        <tbody>
-          {%- for post in my_posts -%}
-            {%- set ename = "referral" if post.kind == "referral" else "opening" -%}
-            {{ post_row(post, ename) }}
-          {%- endfor -%}
-        </tbody>
-      </table>
+      <div class="post-feed-list">
+        {%- for post in my_posts -%}
+          {%- set ename = "referral" if post.kind == "referral" else "opening" -%}
+          {{ post_feed_row(post, ename, show_poster=False) }}
+        {%- endfor -%}
+      </div>
     </section>
   {% endif %}
   {% if network_posts %}

--- a/src/domain/templates/posts/_shared/_feed_row.html
+++ b/src/domain/templates/posts/_shared/_feed_row.html
@@ -1,0 +1,136 @@
+{# Feed-row macro — renders a single two-line clickable row for the home
+   "Recent in the network" / "My active posts" sections and the browse
+   list views.  Both referrals and openings use this macro; per-kind
+   differences are handled with `{% if post.kind == "referral" %}` guards.
+
+Layout per row (two stacked lines inside a single `<a>`):
+
+  ┌────────────────────────────────────────────────────────────────┐
+  │ [TYPE TAG]  Headline text                [state] [timestamp]   │
+  │             City, ST · Outpatient · Aetna           poster     │
+  └────────────────────────────────────────────────────────────────┘
+
+Line 1 — Headline row: type-tag pill · headline text · optional state
+  indicators · right-aligned timestamp (hidden on narrow screens).
+Line 2 — Metadata strip: 3–5 small items with middot dividers; poster
+  name pushed right with `margin-left: auto` (referrals only).
+
+The macro reads view data via the `post_card_view(post)` global and the
+`post_feed_headline(post)` global.  Both are registered in
+`src/domain/template_globals.py`.
+
+Parameters
+  post        — any `Post` ORM instance (referral / clinician_opening /
+                program_intake).
+  entity_name — URL family string ("referral", "opening", "intake");
+                passed unchanged to `entity_url()`.
+  show_poster — when False the poster-name metadata item is suppressed
+                (useful for "My active posts" where the viewer is the
+                poster).  Defaults to True.
+
+CSS lives in the `<style>` block of `src/framework/templates/base.html`
+under the "Feed rows" section. #}
+{% macro post_feed_row(post, entity_name, show_poster=True) -%}
+{%- set view = post_card_view(post) -%}
+{%- set headline = post_feed_headline(post) -%}
+{%- set kind_class = "opening" if post.kind != "referral" else "referral" -%}
+{%- set kind_label = "Opening" if post.kind != "referral" else "Referral" -%}
+<a href="{{ entity_url(entity_name, id=post.id) }}" class="post-feed-row" data-kind="{{ post.kind }}">
+{# ── Line 1: Headline row ─────────────────────────────────────── #}
+<div class="post-feed-headline">
+<span class="post-feed-type-tag post-feed-type-tag--{{ kind_class }}">{{ kind_label }}</span>
+<span class="post-feed-headline-text"><strong>{{ headline }}</strong></span>
+{# State indicators — rendered when applicable (currently stubbed;
+         time-sensitive and interest state require future model support). #}
+<small class="post-feed-ts post-feed-ts--headline">{{ post.created_at | days_ago }}</small>
+</div>
+{# ── Line 2: Metadata strip ───────────────────────────────────── #}
+<div class="post-feed-meta">
+{# Item 1 ── Modality / level of care #}
+{%- if post.kind == "referral" -%}
+{%- set _mod = [] -%}
+{%- if view.in_person == "yes" -%}{%- set _ = _mod.append("In-person") -%}{%- endif -%}
+{%- if view.virtual == "yes" -%}{%- set _ = _mod.append("Telehealth") -%}{%- endif -%}
+{%- if _mod -%}
+<span class="post-feed-meta-item">{{ _mod | join(" · ") }}</span>
+{%- endif -%}
+{%- else -%}
+{%- if view.settings -%}
+<span class="post-feed-meta-item">
+{%- for s in view.settings[:3] -%}
+{%- if not loop.first %} ·
+{% endif -%}
+{{ TREATMENT_SETTINGS_LABELS[s] }}
+{%- endfor -%}
+</span>
+{%- endif -%}
+{%- endif -%}
+{# Item 2 ── Geography #}
+{%- if view.location_chunk -%}
+<span class="post-feed-meta-item">
+{%- if view.location_chunk.city -%}
+{{ view.location_chunk.city }}
+{% if view.location_chunk.state %}, {{ view.location_chunk.state }}{% endif %}
+{%- elif view.location_chunk.state -%}
+{{ view.location_chunk.state }}
+{%- endif -%}
+</span>
+{%- endif -%}
+{# Item 3 ── Clinical preferences / populations #}
+{%- if post.kind == "referral" -%}
+{%- if view.treatment_modality -%}
+<span class="post-feed-meta-item">{{ view.treatment_modality }}</span>
+{%- endif -%}
+{%- else -%}
+{%- if view.ages -%}
+<span class="post-feed-meta-item">
+{%- for a in view.ages[:2] -%}
+{%- if not loop.first %},
+{% endif -%}
+{{ CLIENT_AGE_GROUP_LABELS[a] }}
+{%- endfor -%}
+</span>
+{%- endif -%}
+{%- endif -%}
+{# Item 4 ── Insurance #}
+{%- if post.kind == "referral" -%}
+{%- if view.insurance_carrier -%}
+<span class="post-feed-meta-item">{{ INSURANCE_CARRIER_LABELS[view.insurance_carrier] }}</span>
+{%- elif view.network_preference == "no_preference" -%}
+<span class="post-feed-meta-item">No insurance req.</span>
+{%- endif -%}
+{%- else -%}
+{%- if view.in_network_carriers -%}
+<span class="post-feed-meta-item post-feed-meta-insurance--match">
+<i class="icon-check"></i>
+{%- for c in view.in_network_carriers[:2] -%}
+{%- if not loop.first %},
+{% endif -%}
+{{ INSURANCE_CARRIER_LABELS[c] }}
+{%- endfor -%}
+{%- if view.in_network_carriers | length > 2 %} +{{ view.in_network_carriers | length - 2 }}
+{% endif -%}
+</span>
+{%- elif view.accepts_out_of_network -%}
+<span class="post-feed-meta-item">Out-of-network</span>
+{%- elif view.sliding_scale -%}
+<span class="post-feed-meta-item">Sliding scale</span>
+{%- endif -%}
+{%- endif -%}
+{# Item 5 ── Poster name (referrals only, right-aligned on wide screens) #}
+{%- if show_poster and post.kind == "referral" and post.owner -%}
+<span class="post-feed-meta-item post-feed-meta-poster">{{ post.owner.email }}</span>
+{%- endif -%}
+{# Timestamp in meta strip — visible only on narrow screens #}
+<small class="post-feed-meta-item post-feed-ts post-feed-ts--meta">{{ post.created_at | days_ago }}</small>
+</div>
+</a>
+{%- endmacro %}
+{% macro post_feed_empty(message="No recent posts match your filters.", link_href=None, link_label="See all recent activity →") -%}
+<div class="post-feed-empty">
+<p>{{ message }}</p>
+{%- if link_href -%}
+<a href="{{ link_href }}">{{ link_label }}</a>
+{%- endif -%}
+</div>
+{%- endmacro %}

--- a/src/domain/templates/posts/openings/list.html
+++ b/src/domain/templates/posts/openings/list.html
@@ -1,5 +1,5 @@
 {% extends "views/list.html" %}
-{%- from "posts/_shared/_row.html" import post_row with context -%}
+{%- from "posts/_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {% block resource_label %}Openings{% endblock %}
 {% block actions %}
   <li>
@@ -8,18 +8,12 @@
 {% endblock %}
 {% block content %}
   {% if openings %}
-    <table id="openings-list" class="post-rows">
-      <tbody>
-        {%- for post in openings %}{{ post_row(post, entity_name) }}{%- endfor %}
-        </tbody>
-      </table>
+    <div id="openings-list" class="post-feed-list">
+      {%- for post in openings %}{{ post_feed_row(post, entity_name) }}{%- endfor %}
+      </div>
     {% else %}
-      <p>
-        {% if active_filter_count %}
-          No openings match these filters.
-        {% else %}
-          No openings found.
-        {% endif %}
-      </p>
+      {{ post_feed_empty("No openings match these filters." if active_filter_count else "No openings found.",
+            link_href=entity_url(entity_name) if active_filter_count else None
+      ) }}
     {% endif %}
   {% endblock %}

--- a/src/domain/templates/posts/referrals/list.html
+++ b/src/domain/templates/posts/referrals/list.html
@@ -1,5 +1,5 @@
 {% extends "views/list.html" %}
-{%- from "posts/_shared/_row.html" import post_row with context -%}
+{%- from "posts/_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {% block resource_label %}Referrals{% endblock %}
 {% block actions %}
   <li>
@@ -8,18 +8,12 @@
 {% endblock %}
 {% block content %}
   {% if referrals %}
-    <table id="referrals-list" class="post-rows">
-      <tbody>
-        {%- for post in referrals %}{{ post_row(post, entity_name) }}{%- endfor %}
-        </tbody>
-      </table>
+    <div id="referrals-list" class="post-feed-list">
+      {%- for post in referrals %}{{ post_feed_row(post, entity_name) }}{%- endfor %}
+      </div>
     {% else %}
-      <p>
-        {% if active_filter_count %}
-          No referrals match these filters.
-        {% else %}
-          No referrals found.
-        {% endif %}
-      </p>
+      {{ post_feed_empty("No referrals match these filters." if active_filter_count else "No referrals found.",
+            link_href=entity_url(entity_name) if active_filter_count else None
+      ) }}
     {% endif %}
   {% endblock %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -615,6 +615,92 @@
         font-size: 0.875rem;
         white-space: nowrap;
       }
+      /* ── Feed rows ────────────────────────────────────────────────
+         Two-line clickable rows for the home and browse list views.
+         Each `.post-feed-row` is an `<a>` element; `.post-feed-list`
+         is the parent container that provides the outer border and
+         dividers between rows. Pico supplies typography, color tokens,
+         and base link styles — these rules cover only the bespoke
+         two-line layout, the type-tag pill, the metadata strip with
+         middot dividers, and the narrow-screen adjustments. */
+      .post-feed-list {
+        border: 1px solid var(--pico-muted-border-color);
+        border-radius: var(--pico-border-radius);
+        overflow: hidden;
+      }
+      .post-feed-row {
+        display: block;
+        padding: 0.75rem 1rem;
+        border-top: 1px solid var(--pico-muted-border-color);
+        text-decoration: none;
+        color: inherit;
+      }
+      .post-feed-list .post-feed-row:first-child { border-top: none; }
+      .post-feed-row:hover { background: var(--pico-secondary-background); }
+      .post-feed-row--viewed { opacity: 0.6; }
+      .post-feed-row--interest { opacity: 1; }
+      /* Headline row (line 1) */
+      .post-feed-headline { display: flex; align-items: center; gap: 8px; }
+      .post-feed-headline-text { flex: 1; min-width: 0; }
+      .post-feed-ts { flex-shrink: 0; color: var(--pico-muted-color); }
+      .post-feed-ts--meta { display: none; }
+      /* Type-tag pill */
+      .post-feed-type-tag {
+        font-size: 0.625rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        padding: 0.15em 0.5em;
+        border-radius: 2em;
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+      .post-feed-type-tag--referral {
+        color: var(--pico-muted-color);
+        background: color-mix(in srgb, var(--pico-muted-color) 8%, transparent);
+      }
+      .post-feed-type-tag--opening {
+        color: var(--pico-primary);
+        background: color-mix(in srgb, var(--pico-primary) 10%, transparent);
+      }
+      /* State indicators */
+      .post-feed-state-urgent {
+        font-size: 0.65rem;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        padding: 0.15em 0.5em;
+        border-radius: 2em;
+        border: 1px solid var(--pico-mark-background-color);
+        color: var(--pico-muted-color);
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+      .post-feed-state-interest { color: var(--pico-primary); flex-shrink: 0; }
+      /* Metadata strip (line 2) */
+      .post-feed-meta {
+        display: flex;
+        flex-wrap: wrap;
+        margin-top: 0.2rem;
+        font-size: 0.875rem;
+        color: var(--pico-muted-color);
+      }
+      .post-feed-meta-item + .post-feed-meta-item::before {
+        content: "·";
+        margin: 0 0.4em;
+      }
+      .post-feed-meta-poster { margin-left: auto; }
+      .post-feed-meta-insurance--match { color: var(--pico-ins-color); }
+      /* Empty state */
+      .post-feed-empty { text-align: center; padding: 2rem 1rem; color: var(--pico-muted-color); }
+      /* Narrow screens */
+      @media (max-width: 640px) {
+        .post-feed-row { padding: 0.6rem 0.75rem; }
+        .post-feed-ts--headline { display: none; }
+        .post-feed-ts--meta { display: inline; }
+        .post-feed-meta-item + .post-feed-meta-item::before { display: none; }
+        .post-feed-meta-poster { margin-left: 0; }
+      }
     </style>
     <script src="https://unpkg.com/htmx.org@2.0.4"
             integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"


### PR DESCRIPTION
## Summary

- Replaces the flat `<table>` row layout with a structured two-line clickable `<a>` row used in "My active posts", "Recent in the network" (home), and both browse list views (referrals, openings)
- Each row: type-tag pill (Referral / Opening) · structured headline · metadata strip (modality · geography · clinical prefs · insurance · poster) · right-aligned timestamp
- Narrow-screen layout: timestamp moves from headline row to metadata strip; middot dividers hidden; poster name inline
- Adds `post_feed_headline(post)` view helper: `"Adult female (25–64) — Psychotherapy"` for referrals, `"Acme Counseling — Psychotherapy"` for openings
- All colors/spacing inherited from Pico CSS custom properties; ~80 lines of bespoke structural CSS

## Test plan

- [ ] `dev test` passes (1855 tests, 0 failures)
- [ ] `dev lint` passes
- [ ] Visit `/referrals` and `/openings` browse pages — rows render with type tag, two-line layout, metadata strip
- [ ] Visit `/home` — "My active posts" and "Recent in the network" sections render with the new rows (poster name hidden on "My active posts")
- [ ] Resize to ≤640px — timestamp moves to metadata strip, middot dividers disappear
- [ ] Click a row — navigates to the correct detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)