### PR TITLE
feat(feed-row): subject field, CSS cleanup, and list view polish

### DIFF
--- a/alembic/versions/0a3de87a9217_add_subject_to_post_details.py
+++ b/alembic/versions/0a3de87a9217_add_subject_to_post_details.py
@@ -1,0 +1,30 @@
+"""Add subject to post detail tables
+
+Revision ID: 0a3de87a9217
+Revises: ff47c5267ea2
+Create Date: 2026-05-25 18:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0a3de87a9217"
+down_revision: Union[str, None] = "9e1f7b3c4a2d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable subject column to the three post detail tables."""
+    for table in ("referral_details", "opening_details", "intake_details"):
+        op.add_column(table, sa.Column("subject", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove subject column from the three post detail tables."""
+    for table in ("referral_details", "opening_details", "intake_details"):
+        op.drop_column(table, "subject")

--- a/scripts/dev/seed/overrides/posts.py
+++ b/scripts/dev/seed/overrides/posts.py
@@ -37,6 +37,9 @@ from .. import counts
 from ..generators import SeedPool, build_row
 from ..rng import SeededRandom, deterministic_uuid
 from ..vocab import (
+    intake_subject,
+    opening_subject,
+    referral_subject,
     render_intake_description,
     render_opening_description,
     render_referral_description,
@@ -70,6 +73,7 @@ async def generate_posts(
         detail = build_row(ReferralDetail, i, rng, pool)
         # FK + description: generic builder can't infer either.
         detail.post_id = post_id
+        detail.subject = None if rng.bool(0.2) else referral_subject(rng, i)
         detail.description = render_referral_description(rng, i)
         # Sidecar PK isn't an FK-pool target; just give it a stable
         # ID equal to its post_id (post_id is PK on detail).
@@ -87,6 +91,7 @@ async def generate_posts(
         detail = build_row(OpeningDetail, i, rng, pool)
         detail.post_id = post_id
         detail.provider_id = providers[i % len(providers)].id
+        detail.subject = None if rng.bool(0.2) else opening_subject(rng, i)
         # `description` is nullable — populate most rows for narrative,
         # leave a slice NULL so the empty-state card renders too.
         detail.description = (
@@ -107,6 +112,7 @@ async def generate_posts(
             detail = build_row(IntakeDetail, i, rng, pool)
             detail.post_id = post_id
             detail.program_id = programs[i % len(programs)].id
+            detail.subject = None if rng.bool(0.2) else intake_subject(rng, i)
             # `description` is nullable — same posture as OpeningDetail.
             detail.description = (
                 None if rng.bool(0.15) else render_intake_description(rng, i)

--- a/scripts/dev/seed/vocab.py
+++ b/scripts/dev/seed/vocab.py
@@ -434,6 +434,30 @@ MODALITIES_FREETEXT: Final[tuple[str, ...]] = (
     "Mindfulness-based",
     "Exposure and response prevention",
 )
+REFERRAL_SUBJECTS: Final[tuple[str, ...]] = (
+    "Child female (0–5) — Group therapy, Family therapy",
+    "Adult male seeking CBT, in-person only",
+    "Adolescent — trauma-informed care, Telehealth OK",
+    "Adult female — perinatal, EMDR preferred",
+    "Senior with depression, SF Bay Area",
+    "Adult — anxiety/OCD, sliding scale needed",
+    "Child (6–12) — ADHD, family involvement required",
+    "Young adult — first episode psychosis, Aetna",
+)
+OPENING_SUBJECTS: Final[tuple[str, ...]] = (
+    "3 slots — adults, relational/psychodynamic · $200/session",
+    "Accepting new clients for trauma work",
+    "2 openings — perinatal, EMDR, sliding scale",
+    "Adolescent caseload openings — DBT, Anthem in-network",
+    "Immediate availability — adults, CBT, Telehealth",
+    "Opening: older adults, grief/loss, in-person SF",
+)
+INTAKE_SUBJECTS: Final[tuple[str, ...]] = (
+    "Program intake — adolescents, DBT",
+    "IOP accepting referrals — adults, anxiety/depression",
+    "Residential: youth 12–17, trauma-informed",
+    "PHP cohort starting soon — adults, psychosis stabilization",
+)
 REFERRAL_TEMPLATES: Final[tuple[str, ...]] = (
     "Looking for a clinician for a {age_descriptor} with {condition}. "
     "{insurance_note}",
@@ -603,6 +627,13 @@ def _description_fallback(rng: SeededRandom, index: int) -> str:
     return render_opening_description(rng, index)
 
 
+def _subject_fallback(rng: SeededRandom, index: int) -> str:
+    """Generic subject fallback — uses opening subjects as the neutral
+    option. Per-kind overrides in `overrides/posts.py` replace this with
+    kind-appropriate vocabulary before it reaches the DB."""
+    return opening_subject(rng, index)
+
+
 def _name_fallback(rng: SeededRandom, index: int) -> str:
     """Late-binding wrapper around `practice_name` — same module-order
     rationale as `_description_fallback`."""
@@ -644,6 +675,7 @@ COLUMN_VOCAB: Final[dict[str, ColumnStrategy]] = {
     # populating a column.
     "name": _name_fallback,
     "description": _description_fallback,
+    "subject": _subject_fallback,
 }
 
 # Columns whose values the generator may auto-fill with
@@ -721,6 +753,18 @@ def render_intake_description(rng: SeededRandom, index: int) -> str:
     )
 
 
+def referral_subject(rng: SeededRandom, index: int) -> str:
+    return rng.round_robin(REFERRAL_SUBJECTS, index)
+
+
+def opening_subject(rng: SeededRandom, index: int) -> str:
+    return rng.round_robin(OPENING_SUBJECTS, index)
+
+
+def intake_subject(rng: SeededRandom, index: int) -> str:
+    return rng.round_robin(INTAKE_SUBJECTS, index)
+
+
 def practice_name(rng: SeededRandom, index: int) -> str:
     adj = rng.round_robin(PRACTICE_ADJECTIVES, index)
     nature = rng.round_robin(PRACTICE_NATURE, index // len(PRACTICE_ADJECTIVES))
@@ -756,6 +800,9 @@ __all__ = [
     "render_intake_description",
     "practice_name",
     "program_name",
+    "referral_subject",
+    "opening_subject",
+    "intake_subject",
     "US_STATES",
     "EDUCATION_TYPES",
     "LICENSE_TYPES",

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -203,6 +203,7 @@ class ReferralRead(_PostReadBase):
     age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     gender: Literal[*GENDERS]
+    subject: str | None = None
     description: str
     services: ServicesField = []
     treatment_modality: str | None = None
@@ -220,6 +221,7 @@ class ReferralRead(_PostReadBase):
 
 class ClinicianOpeningRead(_PostReadBase):
     kind: Literal["clinician_opening"]
+    subject: str | None = None
     description: str | None = None
     referral_instructions: str | None = None
     website: str | None = None
@@ -240,6 +242,7 @@ class ClinicianOpeningRead(_PostReadBase):
 
 class ProgramIntakeRead(_PostReadBase):
     kind: Literal["program_intake"]
+    subject: str | None = None
     description: str | None = None
     referral_instructions: str | None = None
     website: str | None = None
@@ -297,6 +300,7 @@ class ReferralCreate(FlatLocationSchema, WirePayload):
     # include the field still validate; the form's <select> defaults
     # to the same value.
     gender: Literal[*GENDERS] = "prefer_not_to_say"
+    subject: StrippedOptionalText = None
     description: StrippedText
     services: ServicesField = []
     treatment_modality: StrippedOptionalText = None
@@ -317,6 +321,7 @@ class ClinicianOpeningCreate(WirePayload):
     the provider-availability intake form."""
 
     kind: Literal["clinician_opening"]
+    subject: StrippedOptionalText = None
     # Optional initially — graduates to required once seed posts confirm
     # the shape works.
     description: TextareaOptional = None
@@ -352,6 +357,7 @@ class ProgramIntakeCreate(WirePayload):
     not a specific clinician."""
 
     kind: Literal["program_intake"]
+    subject: StrippedOptionalText = None
     description: TextareaOptional = None
     referral_instructions: TextareaOptional = None
     website: UrlOptional = None
@@ -427,6 +433,7 @@ class ReferralUpdate(FlatLocationSchema, PartialUpdate):
     languages: RequiredLanguagesField | None = None
     # `None` = leave unchanged; any enum value sets it.
     gender: Literal[*GENDERS] | None = None
+    subject: StrippedOptionalText = None
     description: StrippedText | None = None
     services: ServicesField | None = None
     treatment_modality: StrippedOptionalText = None
@@ -441,6 +448,7 @@ class ClinicianOpeningUpdate(PartialUpdate):
     at_least_one_field_exclude = frozenset({"kind"})
 
     kind: Literal["clinician_opening"]
+    subject: StrippedOptionalText = None
     description: TextareaOptional = None
     referral_instructions: TextareaOptional = None
     website: UrlOptional = None
@@ -469,6 +477,7 @@ class ProgramIntakeUpdate(PartialUpdate):
     at_least_one_field_exclude = frozenset({"kind"})
 
     kind: Literal["program_intake"]
+    subject: StrippedOptionalText = None
     description: TextareaOptional = None
     referral_instructions: TextareaOptional = None
     website: UrlOptional = None
@@ -525,6 +534,7 @@ class ReferralAuditSnapshot(_PostAuditSnapshotBase):
     age_groups: AgeGroupsField = []
     languages: LanguagesField = []
     gender: Literal[*GENDERS]
+    subject: str | None = None
     description: str
     services: ServicesField = []
     treatment_modality: str | None = None
@@ -539,6 +549,7 @@ class ReferralAuditSnapshot(_PostAuditSnapshotBase):
 
 class ClinicianOpeningAuditSnapshot(_PostAuditSnapshotBase):
     kind: Literal["clinician_opening"]
+    subject: str | None = None
     description: str | None = None
     referral_instructions: str | None = None
     website: str | None = None
@@ -557,6 +568,7 @@ class ClinicianOpeningAuditSnapshot(_PostAuditSnapshotBase):
 
 class ProgramIntakeAuditSnapshot(_PostAuditSnapshotBase):
     kind: Literal["program_intake"]
+    subject: str | None = None
     description: str | None = None
     referral_instructions: str | None = None
     website: str | None = None

--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -788,3 +788,49 @@ def test_feed_headline_program_no_services_returns_name_only():
 def test_feed_headline_unknown_kind_returns_empty_string():
     post = SimpleNamespace(kind="mystery")
     assert post_feed_headline(post) == ""
+
+
+# --- subject override ---------------------------------------------------
+
+
+def test_feed_headline_referral_subject_overrides_auto_generation():
+    """When subject is set on a referral, it is returned as-is."""
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            subject="Child female (0–5) — Group therapy",
+            age_groups=["children_0_5"],
+            gender="female",
+            services=["group_therapy"],
+        ),
+    )
+    assert post_feed_headline(post) == "Child female (0–5) — Group therapy"
+
+
+def test_feed_headline_referral_none_subject_falls_back_to_auto():
+    """When subject is None, auto-generation runs normally."""
+    post = SimpleNamespace(
+        kind="referral",
+        referral_detail=SimpleNamespace(
+            subject=None,
+            age_groups=["adults_25_64"],
+            gender="female",
+            services=["psychotherapy"],
+        ),
+    )
+    assert post_feed_headline(post) == "Adult female (25–64) — Psychotherapy"
+
+
+def test_feed_headline_opening_subject_overrides_auto_generation():
+    """When subject is set on an opening, it is returned as-is."""
+    post = _make_pa_post()
+    post.opening_detail.subject = "3 slots — adults, relational/psychodynamic"
+    assert post_feed_headline(post) == "3 slots — adults, relational/psychodynamic"
+
+
+def test_feed_headline_opening_none_subject_falls_back_to_auto():
+    """When subject is None on an opening, practice name + services are used."""
+    post = _make_pa_post()
+    post.opening_detail.subject = None
+    headline = post_feed_headline(post)
+    assert headline.startswith("Acme Counseling — ")

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -517,6 +517,8 @@ def post_feed_headline(post) -> str:
         d = getattr(post, "referral_detail", None)
         if d is None:
             return "Referral"
+        if subject := getattr(d, "subject", None):
+            return subject
         demo = referral_headline(d)
         services = list(getattr(d, "services", None) or [])
         if services:
@@ -528,6 +530,8 @@ def post_feed_headline(post) -> str:
         d = getattr(post, "opening_detail", None)
         if d is None:
             return "Opening"
+        if subject := getattr(d, "subject", None):
+            return subject
         p = getattr(d, "provider", None)
         practice = (
             p.org.name
@@ -547,6 +551,8 @@ def post_feed_headline(post) -> str:
         d = getattr(post, "intake_detail", None)
         if d is None:
             return "Program"
+        if subject := getattr(d, "subject", None):
+            return subject
         prog = getattr(d, "program", None)
         name = (getattr(prog, "name", None) if prog else None) or "Program"
         services = list(getattr(d, "services", None) or [])

--- a/src/domain/models/posts/intake_detail.py
+++ b/src/domain/models/posts/intake_detail.py
@@ -65,6 +65,7 @@ class IntakeDetail(Base):
     genders = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
 
     # Section 6 — about (free-text core fields)
+    subject = Column(Text, nullable=True)
     description = Column(Text, nullable=True)
     referral_instructions = Column(Text, nullable=True)
     website = Column(Text, nullable=True)

--- a/src/domain/models/posts/opening_detail.py
+++ b/src/domain/models/posts/opening_detail.py
@@ -58,6 +58,7 @@ class OpeningDetail(Base):
     genders = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
 
     # Section 6 — about (free-text core fields)
+    subject = Column(Text, nullable=True)
     description = Column(Text, nullable=True)
     referral_instructions = Column(Text, nullable=True)
     website = Column(Text, nullable=True)

--- a/src/domain/models/posts/referral_detail.py
+++ b/src/domain/models/posts/referral_detail.py
@@ -60,7 +60,8 @@ class ReferralDetail(LocationMixin, Base):
     # rows. CHECK constraint above pins the vocabulary to `GENDERS`.
     gender = Column(Text, nullable=False, server_default=text("'prefer_not_to_say'"))
 
-    # Section 3 — description
+    # Section 3 — subject / description
+    subject = Column(Text, nullable=True)
     description = Column(Text, nullable=False)
 
     # Section 4 — services

--- a/src/domain/routes/test_post_families.py
+++ b/src/domain/routes/test_post_families.py
@@ -266,7 +266,7 @@ async def test_list_only_includes_own_kind(
     response = await authenticated_client.get(f"/{collection}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    cards = tree.css(f"#{collection}-list a.post-feed-row")
+    cards = tree.css(f"#{collection}-list [data-kind]")
     kinds = {c.attributes.get("data-kind") for c in cards}
     assert kinds == {kind}, f"/{collection} leaked a non-{kind} row: {kinds!r}"
 
@@ -299,7 +299,7 @@ async def test_list_kind_query_param_does_not_override_lock(
     response = await authenticated_client.get(f"/{collection}?kind={other_kind}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    cards = tree.css(f"#{collection}-list a.post-feed-row")
+    cards = tree.css(f"#{collection}-list [data-kind]")
     kinds_in_page = {c.attributes.get("data-kind") for c in cards}
     # Foreign-kind row never leaks in; for the subset face this means
     # the wrong-kind value was clamped out of the intersection. The
@@ -337,7 +337,7 @@ async def test_openings_kind_filter_narrows_to_one_subkind(
     assert response.status_code == 200
     kinds_unfiltered = {
         c.attributes.get("data-kind")
-        for c in HTMLParser(response.text).css("#openings-list a.post-feed-row")
+        for c in HTMLParser(response.text).css("#openings-list [data-kind]")
     }
     assert {"clinician_opening", "program_intake"} <= kinds_unfiltered
 
@@ -346,7 +346,7 @@ async def test_openings_kind_filter_narrows_to_one_subkind(
     assert response.status_code == 200
     kinds_filtered = {
         c.attributes.get("data-kind")
-        for c in HTMLParser(response.text).css("#openings-list a.post-feed-row")
+        for c in HTMLParser(response.text).css("#openings-list [data-kind]")
     }
     assert kinds_filtered == {
         "clinician_opening"

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -16,12 +16,12 @@
         <h2>My active posts</h2>
         <a href="{{ entity_url('referral') }}">See all</a>
       </header>
-      <div class="post-feed-list">
+      <article class="post-feed-list">
         {%- for post in my_posts -%}
           {%- set ename = "referral" if post.kind == "referral" else "opening" -%}
           {{ post_feed_row(post, ename, show_poster=False) }}
         {%- endfor -%}
-      </div>
+      </article>
     </section>
   {% endif %}
   {% if network_posts %}
@@ -41,12 +41,12 @@
         <a href="{{ entity_url('referral') }}">Adjust filters</a>
         {# djlint:on #}
       </p>
-      <div class="post-feed-list">
+      <article class="post-feed-list">
         {%- for post in network_posts -%}
           {%- set ename = "referral" if post.kind == "referral" else "opening" -%}
           {{ post_feed_row(post, ename) }}
         {%- endfor -%}
-      </div>
+      </article>
     </section>
   {% endif %}
 {% endblock %}

--- a/src/domain/templates/posts/_shared/_feed_row.html
+++ b/src/domain/templates/posts/_shared/_feed_row.html
@@ -3,17 +3,16 @@
    list views.  Both referrals and openings use this macro; per-kind
    differences are handled with `{% if post.kind == "referral" %}` guards.
 
-Layout per row (two stacked lines inside a single `<a>`):
+Layout per row (three columns; only the headline text is a link):
 
-  ┌────────────────────────────────────────────────────────────────┐
-  │ [TYPE TAG]  Headline text                [state] [timestamp]   │
-  │             City, ST · Outpatient · Aetna           poster     │
-  └────────────────────────────────────────────────────────────────┘
+  ┌──────────────┬──────────────────────────────────┬─────────────┐
+  │  [TYPE TAG]  │ Headline text                    │  timestamp  │
+  │              │ City, ST · In-person · Aetna     │  E. Stone   │
+  └──────────────┴──────────────────────────────────┴─────────────┘
 
-Line 1 — Headline row: type-tag pill · headline text · optional state
-  indicators · right-aligned timestamp (hidden on narrow screens).
-Line 2 — Metadata strip: 3–5 small items with middot dividers; poster
-  name pushed right with `margin-left: auto` (referrals only).
+Left column — fixed-width type-tag pill, vertically centred.
+Middle column (.post-feed-body) — two stacked rows: headline + meta strip.
+Right column (.post-feed-right) — timestamp above poster name, right-aligned.
 
 The macro reads view data via the `post_card_view(post)` global and the
 `post_feed_headline(post)` global.  Both are registered in
@@ -35,28 +34,38 @@ under the "Feed rows" section. #}
 {%- set headline = post_feed_headline(post) -%}
 {%- set kind_class = "opening" if post.kind != "referral" else "referral" -%}
 {%- set kind_label = "Opening" if post.kind != "referral" else "Referral" -%}
-<a href="{{ entity_url(entity_name, id=post.id) }}" class="post-feed-row" data-kind="{{ post.kind }}">
+<div class="post-feed-row" data-kind="{{ post.kind }}">
+<span class="post-feed-type-tag post-feed-type-tag--{{ kind_class }}">{{ kind_label }}</span>
+<div class="post-feed-body">
 {# ── Line 1: Headline row ─────────────────────────────────────── #}
 <div class="post-feed-headline">
-<span class="post-feed-type-tag post-feed-type-tag--{{ kind_class }}">{{ kind_label }}</span>
-<span class="post-feed-headline-text"><strong>{{ headline }}</strong></span>
-{# State indicators — rendered when applicable (currently stubbed;
-         time-sensitive and interest state require future model support). #}
-<small class="post-feed-ts post-feed-ts--headline">{{ post.created_at | days_ago }}</small>
+<a href="{{ entity_url(entity_name, id=post.id) }}" class="post-feed-headline-text"><strong>{{ headline }}</strong></a>
 </div>
 {# ── Line 2: Metadata strip ───────────────────────────────────── #}
 <div class="post-feed-meta">
-{# Item 1 ── Modality / level of care #}
+{# Item 1 ── Geography #}
+{%- if view.location_chunk -%}
+<span>
+<i class="icon-map-pin"></i>
+{%- if view.location_chunk.city -%}
+{{ view.location_chunk.city -}}
+{%- if view.location_chunk.state %}, {{ view.location_chunk.state }}{% endif %}
+{%- elif view.location_chunk.state -%}
+{{ view.location_chunk.state }}
+{%- endif -%}
+</span>
+{%- endif -%}
+{# Item 2 ── Modality / level of care #}
 {%- if post.kind == "referral" -%}
 {%- set _mod = [] -%}
 {%- if view.in_person == "yes" -%}{%- set _ = _mod.append("In-person") -%}{%- endif -%}
 {%- if view.virtual == "yes" -%}{%- set _ = _mod.append("Telehealth") -%}{%- endif -%}
 {%- if _mod -%}
-<span class="post-feed-meta-item">{{ _mod | join(" · ") }}</span>
+<span>{{ _mod | join(" · ") }}</span>
 {%- endif -%}
 {%- else -%}
 {%- if view.settings -%}
-<span class="post-feed-meta-item">
+<span>
 {%- for s in view.settings[:3] -%}
 {%- if not loop.first %} ·
 {% endif -%}
@@ -65,44 +74,16 @@ under the "Feed rows" section. #}
 </span>
 {%- endif -%}
 {%- endif -%}
-{# Item 2 ── Geography #}
-{%- if view.location_chunk -%}
-<span class="post-feed-meta-item">
-{%- if view.location_chunk.city -%}
-{{ view.location_chunk.city }}
-{% if view.location_chunk.state %}, {{ view.location_chunk.state }}{% endif %}
-{%- elif view.location_chunk.state -%}
-{{ view.location_chunk.state }}
-{%- endif -%}
-</span>
-{%- endif -%}
-{# Item 3 ── Clinical preferences / populations #}
-{%- if post.kind == "referral" -%}
-{%- if view.treatment_modality -%}
-<span class="post-feed-meta-item">{{ view.treatment_modality }}</span>
-{%- endif -%}
-{%- else -%}
-{%- if view.ages -%}
-<span class="post-feed-meta-item">
-{%- for a in view.ages[:2] -%}
-{%- if not loop.first %},
-{% endif -%}
-{{ CLIENT_AGE_GROUP_LABELS[a] }}
-{%- endfor -%}
-</span>
-{%- endif -%}
-{%- endif -%}
-{# Item 4 ── Insurance #}
+{# Item 3 ── Insurance #}
 {%- if post.kind == "referral" -%}
 {%- if view.insurance_carrier -%}
-<span class="post-feed-meta-item">{{ INSURANCE_CARRIER_LABELS[view.insurance_carrier] }}</span>
+<span>{{ INSURANCE_CARRIER_LABELS[view.insurance_carrier] }}</span>
 {%- elif view.network_preference == "no_preference" -%}
-<span class="post-feed-meta-item">No insurance req.</span>
+<span>No insurance req.</span>
 {%- endif -%}
 {%- else -%}
 {%- if view.in_network_carriers -%}
-<span class="post-feed-meta-item post-feed-meta-insurance--match">
-<i class="icon-check"></i>
+<span>
 {%- for c in view.in_network_carriers[:2] -%}
 {%- if not loop.first %},
 {% endif -%}
@@ -112,19 +93,30 @@ under the "Feed rows" section. #}
 {% endif -%}
 </span>
 {%- elif view.accepts_out_of_network -%}
-<span class="post-feed-meta-item">Out-of-network</span>
+<span>Out-of-network</span>
 {%- elif view.sliding_scale -%}
-<span class="post-feed-meta-item">Sliding scale</span>
+<span>Sliding scale</span>
 {%- endif -%}
 {%- endif -%}
-{# Item 5 ── Poster name (referrals only, right-aligned on wide screens) #}
-{%- if show_poster and post.kind == "referral" and post.owner -%}
-<span class="post-feed-meta-item post-feed-meta-poster">{{ post.owner.email }}</span>
-{%- endif -%}
-{# Timestamp in meta strip — visible only on narrow screens #}
-<small class="post-feed-meta-item post-feed-ts post-feed-ts--meta">{{ post.created_at | days_ago }}</small>
 </div>
-</a>
+</div>
+{# ── Right column: timestamp above poster name ────────────────── #}
+<div class="post-feed-right">
+<small>{{ post.created_at | days_ago }}</small>
+{%- if show_poster and post.owner -%}
+{%- set _fn = post.owner.first_name -%}
+{%- set _ln = post.owner.last_name -%}
+{%- set _poster_name -%}
+{%- if _fn and _ln %}{{ _fn[0] }}. {{ _ln }}
+{%- elif _fn %}{{ _fn }}
+{%- elif _ln %}{{ _ln }}
+{%- else %}{{ post.owner.email }}
+{%- endif %}
+{%- endset -%}
+<small class="post-feed-meta-poster">{{ _poster_name | trim }}</small>
+{%- endif -%}
+</div>
+</div>
 {%- endmacro %}
 {% macro post_feed_empty(message="No recent posts match your filters.", link_href=None, link_label="See all recent activity →") -%}
 <div class="post-feed-empty">

--- a/src/domain/templates/posts/openings/_form_clinician_opening.html
+++ b/src/domain/templates/posts/openings/_form_clinician_opening.html
@@ -43,6 +43,14 @@ with at least one provider available.
   {%- set _hx_attrs = "hx-target=\"this\" hx-swap=\"outerHTML\" hx-target-4xx=\"this\" hx-swap-4xx=\"outerHTML\"" -%}
   <form hx-{{ hx_method }}="{{ action }}" {{ _hx_attrs|safe }}>
     <input type="hidden" name="kind" value="clinician_opening" />
+    <label for="subject">
+      Subject <small>(optional — leave blank to auto-generate)</small>
+      <input type="text"
+             name="subject"
+             id="subject"
+             maxlength="120"
+             value="{{ (form_values|default({}) ).get('subject') or (d.subject if d else '') or '' }}" />
+    </label>
     {# Practice picker. After #642 PR 1 a Provider may carry multiple
      Affiliations (clinician × org practice-role rows); the dropdown
      labels each option by the affiliation's org name so a clinician

--- a/src/domain/templates/posts/openings/_form_program_intake.html
+++ b/src/domain/templates/posts/openings/_form_program_intake.html
@@ -25,6 +25,14 @@ with at least one Program available.
   {%- set d = post.intake_detail if post else None -%}
   <form hx-{{ hx_method }}="{{ action }}">
     <input type="hidden" name="kind" value="program_intake" />
+    <label for="subject">
+      Subject <small>(optional — leave blank to auto-generate)</small>
+      <input type="text"
+             name="subject"
+             id="subject"
+             maxlength="120"
+             value="{{ (form_values|default({}) ).get('subject') or (d.subject if d else '') or '' }}" />
+    </label>
     <label for="program_id">
       Which program?
       <select id="program_id" name="program_id" required>

--- a/src/domain/templates/posts/openings/list.html
+++ b/src/domain/templates/posts/openings/list.html
@@ -8,9 +8,9 @@
 {% endblock %}
 {% block content %}
   {% if openings %}
-    <div id="openings-list" class="post-feed-list">
+    <article id="openings-list" class="post-feed-list">
       {%- for post in openings %}{{ post_feed_row(post, entity_name) }}{%- endfor %}
-      </div>
+      </article>
     {% else %}
       {{ post_feed_empty("No openings match these filters." if active_filter_count else "No openings found.",
             link_href=entity_url(entity_name) if active_filter_count else None

--- a/src/domain/templates/posts/referrals/_form.html
+++ b/src/domain/templates/posts/referrals/_form.html
@@ -39,6 +39,14 @@ which FastAPI/Pydantic parses as a list.
   {%- set _hx_attrs = "hx-target=\"this\" hx-swap=\"outerHTML\" hx-target-4xx=\"this\" hx-swap-4xx=\"outerHTML\"" -%}
   <form hx-{{ hx_method }}="{{ action }}" {{ _hx_attrs|safe }}>
     <input type="hidden" name="kind" value="referral" />
+    <label for="subject">
+      Subject <small>(optional — leave blank to auto-generate)</small>
+      <input type="text"
+             name="subject"
+             id="subject"
+             maxlength="120"
+             value="{{ (form_values|default({}) ).get('subject') or (d.subject if d else '') or '' }}" />
+    </label>
     <fieldset>
       <legend>Client location</legend>
       <div class="grid">

--- a/src/domain/templates/posts/referrals/list.html
+++ b/src/domain/templates/posts/referrals/list.html
@@ -8,9 +8,9 @@
 {% endblock %}
 {% block content %}
   {% if referrals %}
-    <div id="referrals-list" class="post-feed-list">
+    <article id="referrals-list" class="post-feed-list">
       {%- for post in referrals %}{{ post_feed_row(post, entity_name) }}{%- endfor %}
-      </div>
+      </article>
     {% else %}
       {{ post_feed_empty("No referrals match these filters." if active_filter_count else "No referrals found.",
             link_href=entity_url(entity_name) if active_filter_count else None

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -92,7 +92,7 @@
          space (icon-only buttons, etc.) should override locally. */
       [class^="icon-"], [class*=" icon-"] {
         font-size: 1.1em;
-        vertical-align: -0.15em;
+        vertical-align: -0.05em;
         line-height: 1;
         color: inherit;
         margin-inline-end: 0.25em;
@@ -617,33 +617,32 @@
       }
       /* ── Feed rows ────────────────────────────────────────────────
          Two-line clickable rows for the home and browse list views.
-         Each `.post-feed-row` is an `<a>` element; `.post-feed-list`
-         is the parent container that provides the outer border and
-         dividers between rows. Pico supplies typography, color tokens,
-         and base link styles — these rules cover only the bespoke
-         two-line layout, the type-tag pill, the metadata strip with
-         middot dividers, and the narrow-screen adjustments. */
-      .post-feed-list {
-        border: 1px solid var(--pico-muted-border-color);
-        border-radius: var(--pico-border-radius);
-        overflow: hidden;
-      }
+         Container is a Pico <article> (border, border-radius, margin
+         from Pico); these rules add only the bespoke two-column layout,
+         type-tag pill, middot dividers, and responsive overrides. */
+      .post-feed-list { padding: 0; overflow: hidden; }
       .post-feed-row {
-        display: block;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
         padding: 0.75rem 1rem;
         border-top: 1px solid var(--pico-muted-border-color);
-        text-decoration: none;
-        color: inherit;
       }
       .post-feed-list .post-feed-row:first-child { border-top: none; }
-      .post-feed-row:hover { background: var(--pico-secondary-background); }
-      .post-feed-row--viewed { opacity: 0.6; }
       .post-feed-row--interest { opacity: 1; }
+      .post-feed-body { flex: 1; min-width: 0; }
       /* Headline row (line 1) */
-      .post-feed-headline { display: flex; align-items: center; gap: 8px; }
+      .post-feed-headline { display: flex; align-items: center; }
       .post-feed-headline-text { flex: 1; min-width: 0; }
-      .post-feed-ts { flex-shrink: 0; color: var(--pico-muted-color); }
-      .post-feed-ts--meta { display: none; }
+      /* Right column — timestamp stacked above poster name */
+      .post-feed-right {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        flex-shrink: 0;
+        gap: 0.15rem;
+        color: var(--pico-muted-color);
+      }
       /* Type-tag pill */
       .post-feed-type-tag {
         font-size: 0.625rem;
@@ -654,6 +653,8 @@
         border-radius: 2em;
         white-space: nowrap;
         flex-shrink: 0;
+        min-width: 5.5rem;
+        text-align: center;
       }
       .post-feed-type-tag--referral {
         color: var(--pico-muted-color);
@@ -682,24 +683,22 @@
         display: flex;
         flex-wrap: wrap;
         margin-top: 0.2rem;
-        font-size: 0.875rem;
         color: var(--pico-muted-color);
       }
-      .post-feed-meta-item + .post-feed-meta-item::before {
+      .post-feed-meta > span + span::before {
         content: "·";
         margin: 0 0.4em;
       }
-      .post-feed-meta-poster { margin-left: auto; }
-      .post-feed-meta-insurance--match { color: var(--pico-ins-color); }
       /* Empty state */
       .post-feed-empty { text-align: center; padding: 2rem 1rem; color: var(--pico-muted-color); }
+      /* Viewed state — browser :visited on the headline link */
+      .post-feed-headline-text:visited { color: var(--pico-muted-color); }
+      /* Expressed-interest override */
+      .post-feed-row--interest .post-feed-headline-text:visited { color: var(--pico-primary); }
       /* Narrow screens */
       @media (max-width: 640px) {
         .post-feed-row { padding: 0.6rem 0.75rem; }
-        .post-feed-ts--headline { display: none; }
-        .post-feed-ts--meta { display: inline; }
-        .post-feed-meta-item + .post-feed-meta-item::before { display: none; }
-        .post-feed-meta-poster { margin-left: 0; }
+        .post-feed-meta > span + span::before { display: none; }
       }
     </style>
     <script src="https://unpkg.com/htmx.org@2.0.4"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -56,6 +56,7 @@ def create_test_user(
 # spec-compliant defaults and let callers override per field.
 
 _REFERRAL_DEFAULTS: dict[str, Any] = {
+    "subject": None,
     "location_city": "Springfield",
     "location_state": "IL",
     "location_zip": "62701",
@@ -73,6 +74,7 @@ _REFERRAL_DEFAULTS: dict[str, Any] = {
 }
 
 _OPENING_DEFAULTS: dict[str, Any] = {
+    "subject": None,
     "description": None,
     "referral_instructions": None,
     "website": None,
@@ -128,6 +130,7 @@ def make_referral_detail(**overrides: Any) -> ReferralDetail:
 # below use the same defaults to keep round-trip tests aligned.
 
 _PROGRAM_AVAILABILITY_DEFAULTS: dict[str, Any] = {
+    "subject": None,
     "description": None,
     "referral_instructions": None,
     "website": None,


### PR DESCRIPTION
## Summary

- Add optional `subject` field to all three post kinds (referral, opening, intake) — stored on detail tables, shown as feed headline when set, falls back to auto-generation when blank; includes Alembic migration, schema updates, seed data, and tests
- Feed-row layout cleanup: type-tag | body | right-column (timestamp stacked above poster name); only the headline text is a link; meta strip trimmed to location, in-person/telehealth, and insurance only
- CSS cleanup: drop custom classes in favour of Pico semantic HTML (`<article>` container, element-level middot selectors, `<small>` for muted meta); `:visited` dim via headline link

## Test plan

- [ ] `dev test` passes
- [ ] `dev migrate up` applies cleanly
- [ ] `dev seed` populates subject lines on seeded posts
- [ ] Home feed and browse lists show subject lines where set, auto-generated headlines where not
- [ ] Create a new post without subject → auto-generated headline appears
- [ ] Create a new post with subject → subject appears in feed
- [ ] Feed rows: only headline text is clickable; type-tag, meta strip, and right column are not links

🤖 Generated with [Claude Code](https://claude.com/claude-code)