### PR TITLE
feat(feed-row): header-first layout — pill · poster · timestamp above headline

### DIFF
--- a/src/domain/templates/posts/_shared/_feed_row.html
+++ b/src/domain/templates/posts/_shared/_feed_row.html
@@ -1,18 +1,15 @@
-{# Feed-row macro — renders a single two-line clickable row for the home
-   "Recent in the network" / "My active posts" sections and the browse
-   list views.  Both referrals and openings use this macro; per-kind
-   differences are handled with `{% if post.kind == "referral" %}` guards.
+{# Feed-row macro — renders a single clickable row for the home feed and
+   browse list views.
 
-Layout per row (three columns; only the headline text is a link):
+Layout per row:
 
-  ┌──────────────┬──────────────────────────────────┬─────────────┐
-  │  [TYPE TAG]  │ Headline text                    │  timestamp  │
-  │              │ City, ST · In-person · Aetna     │  E. Stone   │
-  └──────────────┴──────────────────────────────────┴─────────────┘
+  [OPENING]  E. Stone · 2h ago
+  Headline text that wraps freely across the full width
+  City, ST · In-person · Aetna
 
-Left column — fixed-width type-tag pill, vertically centred.
-Middle column (.post-feed-body) — two stacked rows: headline + meta strip.
-Right column (.post-feed-right) — timestamp above poster name, right-aligned.
+Header line — type-tag pill + poster name + timestamp, all inline.
+Headline — full-width link, wraps naturally.
+Meta strip — location, modality, insurance (muted, small).
 
 The macro reads view data via the `post_card_view(post)` global and the
 `post_feed_headline(post)` global.  Both are registered in
@@ -23,9 +20,9 @@ Parameters
                 program_intake).
   entity_name — URL family string ("referral", "opening", "intake");
                 passed unchanged to `entity_url()`.
-  show_poster — when False the poster-name metadata item is suppressed
-                (useful for "My active posts" where the viewer is the
-                poster).  Defaults to True.
+  show_poster — when False the poster-name item is suppressed (useful for
+                "My active posts" where the viewer is the poster).
+                Defaults to True.
 
 CSS lives in the `<style>` block of `src/framework/templates/base.html`
 under the "Feed rows" section. #}
@@ -35,13 +32,26 @@ under the "Feed rows" section. #}
 {%- set kind_class = "opening" if post.kind != "referral" else "referral" -%}
 {%- set kind_label = "Opening" if post.kind != "referral" else "Referral" -%}
 <div class="post-feed-row" data-kind="{{ post.kind }}">
+{# ── Header: pill · poster · timestamp ───────────────────────── #}
+<div class="post-feed-header">
 <span class="post-feed-type-tag post-feed-type-tag--{{ kind_class }}">{{ kind_label }}</span>
-<div class="post-feed-body">
-{# ── Line 1: Headline row ─────────────────────────────────────── #}
-<div class="post-feed-headline">
-<a href="{{ entity_url(entity_name, id=post.id) }}" class="post-feed-headline-text"><strong>{{ headline }}</strong></a>
+{%- if show_poster and post.owner -%}
+{%- set _fn = post.owner.first_name -%}
+{%- set _ln = post.owner.last_name -%}
+{%- set _poster_name -%}
+{%- if _fn and _ln %}{{ _fn[0] }}. {{ _ln }}
+{%- elif _fn %}{{ _fn }}
+{%- elif _ln %}{{ _ln }}
+{%- else %}{{ post.owner.email }}
+{%- endif %}
+{%- endset -%}
+<small>{{ _poster_name | trim }}</small>
+{%- endif -%}
+<small>{{ post.created_at | days_ago }}</small>
 </div>
-{# ── Line 2: Metadata strip ───────────────────────────────────── #}
+{# ── Headline ─────────────────────────────────────────────────── #}
+<a href="{{ entity_url(entity_name, id=post.id) }}" class="post-feed-headline-text"><strong>{{ headline }}</strong></a>
+{# ── Meta strip ───────────────────────────────────────────────── #}
 <div class="post-feed-meta">
 {# Item 1 ── Geography #}
 {%- if view.location_chunk -%}
@@ -97,23 +107,6 @@ under the "Feed rows" section. #}
 {%- elif view.sliding_scale -%}
 <span>Sliding scale</span>
 {%- endif -%}
-{%- endif -%}
-</div>
-</div>
-{# ── Right column: timestamp above poster name ────────────────── #}
-<div class="post-feed-right">
-<small>{{ post.created_at | days_ago }}</small>
-{%- if show_poster and post.owner -%}
-{%- set _fn = post.owner.first_name -%}
-{%- set _ln = post.owner.last_name -%}
-{%- set _poster_name -%}
-{%- if _fn and _ln %}{{ _fn[0] }}. {{ _ln }}
-{%- elif _fn %}{{ _fn }}
-{%- elif _ln %}{{ _ln }}
-{%- else %}{{ post.owner.email }}
-{%- endif %}
-{%- endset -%}
-<small class="post-feed-meta-poster">{{ _poster_name | trim }}</small>
 {%- endif -%}
 </div>
 </div>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -616,34 +616,33 @@
         white-space: nowrap;
       }
       /* ── Feed rows ────────────────────────────────────────────────
-         Two-line clickable rows for the home and browse list views.
-         Container is a Pico <article> (border, border-radius, margin
-         from Pico); these rules add only the bespoke two-column layout,
-         type-tag pill, middot dividers, and responsive overrides. */
+         Each row is a vertical flex column: header line (pill + poster
+         + timestamp), then headline link, then meta strip. Container is
+         a Pico <article>; these rules add only the bespoke layout,
+         type-tag pill, and middot dividers. */
       .post-feed-list { padding: 0; overflow: hidden; }
       .post-feed-row {
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        align-items: center;
-        gap: 0.75rem;
-        padding: 0.75rem 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.3rem;
+        padding: 0.875rem 1rem;
         border-top: 1px solid var(--pico-muted-border-color);
       }
       .post-feed-list .post-feed-row:first-child { border-top: none; }
       .post-feed-row--interest { opacity: 1; }
-      .post-feed-body { flex: 1; }
-      /* Headline row (line 1) */
-      .post-feed-headline { display: flex; align-items: center; }
-      .post-feed-headline-text { flex: 1; }
-      /* Right column — timestamp stacked above poster name */
-      .post-feed-right {
+      /* Header line — pill · poster · timestamp */
+      .post-feed-header {
         display: flex;
-        flex-direction: column;
-        align-items: flex-end;
-        flex-shrink: 0;
-        gap: 0.15rem;
+        align-items: center;
+        gap: 0.5rem;
         color: var(--pico-muted-color);
       }
+      .post-feed-header > small + small::before {
+        content: "·";
+        margin-right: 0.4em;
+      }
+      /* Headline link */
+      .post-feed-headline-text { display: block; }
       /* Type-tag pill */
       .post-feed-type-tag {
         font-size: 0.625rem;
@@ -654,8 +653,6 @@
         border-radius: 2em;
         white-space: nowrap;
         flex-shrink: 0;
-        min-width: 5.5rem;
-        text-align: center;
       }
       .post-feed-type-tag--referral {
         color: var(--pico-muted-color);
@@ -665,25 +662,10 @@
         color: var(--pico-primary);
         background: color-mix(in srgb, var(--pico-primary) 10%, transparent);
       }
-      /* State indicators */
-      .post-feed-state-urgent {
-        font-size: 0.65rem;
-        font-weight: 600;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-        padding: 0.15em 0.5em;
-        border-radius: 2em;
-        border: 1px solid var(--pico-mark-background-color);
-        color: var(--pico-muted-color);
-        white-space: nowrap;
-        flex-shrink: 0;
-      }
-      .post-feed-state-interest { color: var(--pico-primary); flex-shrink: 0; }
-      /* Metadata strip (line 2) */
+      /* Metadata strip */
       .post-feed-meta {
         display: flex;
         flex-wrap: wrap;
-        margin-top: 0.2rem;
         color: var(--pico-muted-color);
       }
       .post-feed-meta > span + span::before {
@@ -696,20 +678,9 @@
       .post-feed-headline-text:visited { color: var(--pico-muted-color); }
       /* Expressed-interest override */
       .post-feed-row--interest .post-feed-headline-text:visited { color: var(--pico-primary); }
-      /* Narrow screens — pill above headline, everything stacks */
+      /* Narrow screens */
       @media (max-width: 640px) {
-        .post-feed-row {
-          grid-template-columns: 1fr;
-          align-items: start;
-          padding: 0.6rem 0.75rem;
-          gap: 0.3rem;
-        }
-        .post-feed-type-tag { justify-self: start; }
-        .post-feed-right {
-          flex-direction: row;
-          justify-content: flex-start;
-          gap: 0.75rem;
-        }
+        .post-feed-row { padding: 0.75rem; }
       }
     </style>
     <script src="https://unpkg.com/htmx.org@2.0.4"


### PR DESCRIPTION
## Summary

Restructures the feed row from a three-column grid to a vertical flex column matching the design reference:

```
[OPENING]  E. Stone · 2h ago
3 slots — adults, relational/psychodynamic...
Springfield, AL · Out-of-network
```

- Header line: type-tag pill + poster name + timestamp, all inline with middot separator
- Headline: full-width link below the header
- Meta strip: location · modality · insurance at the bottom
- No separate mobile CSS needed — already a vertical column at all sizes

## Test plan

- [ ] Feed rows on `/home`, `/referrals`, `/openings` show header line above headline
- [ ] Poster name and timestamp appear inline next to pill, separated by ·
- [ ] Works correctly on mobile without extra layout changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)