### PR TITLE
fix(docker): bake ENVIRONMENT=production into production image stage

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -36,6 +36,11 @@ RUN chmod +x /app/start.sh /app/start-dev.sh
 # === PRODUCTION STAGE ===
 FROM app-setup AS production
 
+# Safe default baked into the image — the compose file also sets this
+# explicitly, but belt-and-suspenders ensures the image itself can
+# never accidentally run as "development".
+ENV ENVIRONMENT=production
+
 # Install only production dependencies
 RUN pip install --no-cache-dir -e .[app]
 


### PR DESCRIPTION
## Summary

- Adds `ENV ENVIRONMENT=production` to the `production` Dockerfile stage so the image itself sets a safe default
- Guards against the class of bug where `ENVIRONMENT=development` was previously set in the droplet's `.env` file and survived container restarts (env vars are injected at startup from `env_file`, not re-read live)
- The docker-compose `environment:` block already sets this, so this is a belt-and-suspenders backstop

## Root cause

Production containers were started when the droplet's `/opt/bedlam-connect/config/.env` had `ENVIRONMENT=development`. Changing the `.env` file doesn't affect already-running containers. The fix is: (1) this PR + redeploy to restart containers cleanly, (2) the image-level `ENV` ensures future images can never silently ship as "development" even if the compose `environment:` block is absent.

## Test plan
- [ ] Deploy and verify `/auth/login` no longer shows the dev quick-sign-in dropdown in production
- [ ] Verify Sentry environment tag switches from `development` → `production` after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)