### PR TITLE
feat(cd): write production .env from GitHub Secrets on every deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,6 +74,44 @@ jobs:
           # Clean up temporary key file
           rm -f /tmp/droplet_ssh_key
 
+      - name: Write production .env to droplet
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          APP_SECRET: ${{ secrets.APP_SECRET }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          APP_RELEASE: ${{ github.sha }}
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USERNAME }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          envs: APP_SECRET,RESEND_API_KEY,APP_BASE_URL,SENTRY_DSN,APP_RELEASE
+          script: |
+            set -e
+            # Validate required secrets are present
+            for var in APP_SECRET RESEND_API_KEY APP_BASE_URL SENTRY_DSN; do
+              if [ -z "${!var}" ]; then
+                echo "❌ GitHub Secret '$var' is not set — aborting" >&2
+                exit 1
+              fi
+            done
+
+            mkdir -p /opt/bedlam-connect/config
+            {
+              printf 'SECRET=%s\n'                         "$APP_SECRET"
+              printf 'DATABASE_URL=%s\n'                   'sqlite+aiosqlite:///data/bedlam-connect.db'
+              printf 'ACCESS_TOKEN_EXPIRE_MINUTES=%s\n'    '60'
+              printf 'EMAIL_BACKEND=%s\n'                  'resend'
+              printf 'EMAIL_FROM=%s\n'                     'no-reply@bedlamconnect.com'
+              printf 'RESEND_API_KEY=%s\n'                 "$RESEND_API_KEY"
+              printf 'APP_BASE_URL=%s\n'                   "$APP_BASE_URL"
+              printf 'SENTRY_DSN=%s\n'                     "$SENTRY_DSN"
+              printf 'APP_RELEASE=%s\n'                    "$APP_RELEASE"
+            } > /opt/bedlam-connect/config/.env
+            chmod 600 /opt/bedlam-connect/config/.env
+            echo "✅ Production .env written to droplet"
+
       - name: Run deployment
         uses: appleboy/ssh-action@v1.0.3
         with:

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -36,6 +36,11 @@ RUN chmod +x /app/start.sh /app/start-dev.sh
 # === PRODUCTION STAGE ===
 FROM app-setup AS production
 
+# Safe default baked into the image — the compose file also sets this
+# explicitly, but belt-and-suspenders ensures the image itself can
+# never accidentally run as "development".
+ENV ENVIRONMENT=production
+
 # Install only production dependencies
 RUN pip install --no-cache-dir -e .[app]
 


### PR DESCRIPTION
## Summary

- Eliminates the manually-maintained `.env` file on the droplet — no more SSH-in-to-rotate-a-secret
- Every deploy now regenerates `/opt/bedlam-connect/config/.env` from GitHub Secrets before `deploy.sh` runs
- Non-sensitive values (`DATABASE_URL`, `ACCESS_TOKEN_EXPIRE_MINUTES`, `EMAIL_BACKEND`, `EMAIL_FROM`) are hardcoded in the workflow; sensitive values are passed via `appleboy/ssh-action`'s `envs` mechanism so they're never embedded literally in the script text
- `APP_RELEASE` is set to the deploying commit SHA so Sentry tags releases automatically
- Step validates all required secrets are non-empty and fails fast if any are missing

## Before merging: add these 4 GitHub Secrets

Repo **Settings → Secrets and variables → Actions → New repository secret**:

| Secret name | Value |
|---|---|
| `APP_SECRET` | the value of `SECRET` in the current droplet `.env` (the JWT signing key) |
| `RESEND_API_KEY` | from current droplet `.env` |
| `APP_BASE_URL` | `https://aimagain.com` (or whatever's in current `.env`) |
| `SENTRY_DSN` | from current droplet `.env` |

After the first successful deploy with this change, you can delete `/opt/bedlam-connect/config/.env` from the droplet — it will be regenerated on every future deploy.

## Test plan
- [ ] Add the 4 GitHub Secrets above
- [ ] Merge and watch the CD run — the "Write production .env to droplet" step should print `✅ Production .env written to droplet`
- [ ] Verify the app still boots (health check passes, login works)
- [ ] Verify Sentry shows the commit SHA as the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)