### PR TITLE
fix(cd): build production Docker stage, not development

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,6 +74,44 @@ jobs:
           # Clean up temporary key file
           rm -f /tmp/droplet_ssh_key
 
+      - name: Write production .env to droplet
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          APP_SECRET: ${{ secrets.APP_SECRET }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          APP_RELEASE: ${{ github.sha }}
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USERNAME }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          envs: APP_SECRET,RESEND_API_KEY,APP_BASE_URL,SENTRY_DSN,APP_RELEASE
+          script: |
+            set -e
+            # Validate required secrets are present
+            for var in APP_SECRET RESEND_API_KEY APP_BASE_URL SENTRY_DSN; do
+              if [ -z "${!var}" ]; then
+                echo "❌ GitHub Secret '$var' is not set — aborting" >&2
+                exit 1
+              fi
+            done
+
+            mkdir -p /opt/bedlam-connect/config
+            {
+              printf 'SECRET=%s\n'                         "$APP_SECRET"
+              printf 'DATABASE_URL=%s\n'                   'sqlite+aiosqlite:///data/bedlam-connect.db'
+              printf 'ACCESS_TOKEN_EXPIRE_MINUTES=%s\n'    '60'
+              printf 'EMAIL_BACKEND=%s\n'                  'resend'
+              printf 'EMAIL_FROM=%s\n'                     'no-reply@bedlamconnect.com'
+              printf 'RESEND_API_KEY=%s\n'                 "$RESEND_API_KEY"
+              printf 'APP_BASE_URL=%s\n'                   "$APP_BASE_URL"
+              printf 'SENTRY_DSN=%s\n'                     "$SENTRY_DSN"
+              printf 'APP_RELEASE=%s\n'                    "$APP_RELEASE"
+            } > /opt/bedlam-connect/config/.env
+            chmod 600 /opt/bedlam-connect/config/.env
+            echo "✅ Production .env written to droplet"
+
       - name: Run deployment
         uses: appleboy/ssh-action@v1.0.3
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           context: .
           file: ./deployment/docker/Dockerfile
+          target: production
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -36,6 +36,11 @@ RUN chmod +x /app/start.sh /app/start-dev.sh
 # === PRODUCTION STAGE ===
 FROM app-setup AS production
 
+# Safe default baked into the image — the compose file also sets this
+# explicitly, but belt-and-suspenders ensures the image itself can
+# never accidentally run as "development".
+ENV ENVIRONMENT=production
+
 # Install only production dependencies
 RUN pip install --no-cache-dir -e .[app]
 


### PR DESCRIPTION
## Root cause

The `build-and-push` step was missing `target: production`. Without it, Docker builds the **last stage** in the Dockerfile, which is `development`. That stage's startup script (`start-dev.sh`) explicitly runs:

```bash
export ENVIRONMENT="development"
```

...before launching uvicorn. This overrides everything — the compose `environment:` block, Pydantic's default, the `ENV` instruction we added in #909. Production has been running the dev image the entire time, which explains both symptoms:

1. Dev login dropdown visible on the login page
2. Sentry tagging all events as `environment=development`

## Fix

One line: add `target: production` to the Docker build step so the image uses the `production` stage (`start.sh`, production deps only, `ENV ENVIRONMENT=production`).

## Test plan
- [ ] Merge and watch the CD run — build should target `production` stage
- [ ] Visit `/auth/login` in production — dev dropdown should be gone
- [ ] Verify Sentry starts tagging new events as `environment=production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)