### PR TITLE
refactor: remove redundant ENVIRONMENT setters

### DIFF
--- a/deployment/droplet-files/docker-compose.blue-green.yml
+++ b/deployment/droplet-files/docker-compose.blue-green.yml
@@ -9,8 +9,6 @@ services:
       - /opt/bedlam-connect/data:/app/data
     env_file:
       - /opt/bedlam-connect/config/.env
-    environment:
-      - ENVIRONMENT=production
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/health']
       interval: 30s
@@ -28,8 +26,6 @@ services:
       - /opt/bedlam-connect/data:/app/data
     env_file:
       - /opt/bedlam-connect/config/.env
-    environment:
-      - ENVIRONMENT=production
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/health']
       interval: 30s

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,6 @@ services:
       - SECRET=${SECRET}
       - DATABASE_URL=${DATABASE_URL:-sqlite+aiosqlite:///./data/bedlam-connect.db}
       - ACCESS_TOKEN_EXPIRE_MINUTES=${ACCESS_TOKEN_EXPIRE_MINUTES:-60}
-      - ENVIRONMENT=development # Enable template auto-reload
       - DISABLE_SCHEDULER=1
     volumes:
       - ./data:/app/data


### PR DESCRIPTION
## Why

While debugging the dev-login-on-prod bug we added `ENVIRONMENT=production` in two places as belt-and-suspenders. But the actual root cause was a missing `target: production` in the CD build step (fixed in #913), not a missing env var. Those belt-and-suspenders are now noise that makes the codebase harder to reason about.

## What changed

Two deletions, no logic changes:

| Removed | From | Why redundant |
|---|---|---|
| `environment: - ENVIRONMENT=production` | `docker-compose.blue-green.yml` (both services) | Pydantic default is already `"production"` |
| `ENVIRONMENT=development` | `docker-compose.dev.yml` | `start-dev.sh` exports this before `exec uvicorn` |

## Single source of truth after this PR

| Value | Owner |
|---|---|
| `"production"` | Pydantic default in `src/framework/config.py` |
| `"development"` | `scripts/runtime/start-dev.sh` (processes) · `.env.test` (tests) |

Nothing else sets `ENVIRONMENT` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)