### PR TITLE
fix(observability): select SentryBackend when either DSN set; guard init_app

### DIFF
--- a/src/framework/observability/__init__.py
+++ b/src/framework/observability/__init__.py
@@ -27,10 +27,13 @@ from src.framework.observability.sentry_backend import SentryBackend
 def _select_backend() -> ObservabilityBackend:
     """Pick a backend from settings.
 
-    Empty DSN → `NoopBackend` so the app runs locally without any
-    provider credentials. Add new providers as additional branches.
+    Either DSN set → `SentryBackend`; `init_app` skips SDK init when
+    `SENTRY_DSN` is empty, `frontend_context` returns None when
+    `SENTRY_BROWSER_DSN` is empty — each side is independently optional.
+    Both empty → `NoopBackend` so the app runs locally with no provider.
+    Add new providers as additional branches.
     """
-    if settings.SENTRY_DSN:
+    if settings.SENTRY_DSN or settings.SENTRY_BROWSER_DSN:
         return SentryBackend()
     return NoopBackend()
 

--- a/src/framework/observability/sentry_backend.py
+++ b/src/framework/observability/sentry_backend.py
@@ -16,6 +16,8 @@ from src.framework.config import settings
 
 class SentryBackend:
     def init_app(self, app: FastAPI) -> None:
+        if not settings.SENTRY_DSN:
+            return
         # `release=None` (rather than empty string) tells Sentry "no
         # release tag" — important so events from un-tagged builds don't
         # cluster into a synthetic "" release.

--- a/src/framework/observability/test_backend.py
+++ b/src/framework/observability/test_backend.py
@@ -19,16 +19,26 @@ def _import_factory():
     return _select_backend
 
 
-def test_select_backend_returns_sentry_when_dsn_set():
+def test_select_backend_returns_sentry_when_backend_dsn_set():
     with patch("src.framework.observability.settings") as mock_settings:
         mock_settings.SENTRY_DSN = "https://abc@sentry.io/1"
+        mock_settings.SENTRY_BROWSER_DSN = ""
         backend = _import_factory()()
     assert isinstance(backend, SentryBackend)
 
 
-def test_select_backend_returns_noop_when_dsn_empty():
+def test_select_backend_returns_sentry_when_browser_dsn_set():
     with patch("src.framework.observability.settings") as mock_settings:
         mock_settings.SENTRY_DSN = ""
+        mock_settings.SENTRY_BROWSER_DSN = "https://xyz@sentry.io/2"
+        backend = _import_factory()()
+    assert isinstance(backend, SentryBackend)
+
+
+def test_select_backend_returns_noop_when_both_dsns_empty():
+    with patch("src.framework.observability.settings") as mock_settings:
+        mock_settings.SENTRY_DSN = ""
+        mock_settings.SENTRY_BROWSER_DSN = ""
         backend = _import_factory()()
     assert isinstance(backend, NoopBackend)
 

--- a/src/framework/observability/test_sentry_backend.py
+++ b/src/framework/observability/test_sentry_backend.py
@@ -55,6 +55,21 @@ def test_init_app_passes_release_as_none_when_unset():
         assert mock_sdk.init.call_args.kwargs["release"] is None
 
 
+def test_init_app_skips_sdk_init_when_backend_dsn_empty():
+    """SentryBackend may be selected (e.g. browser-only DSN set) without a
+    backend DSN. In that case `init_app` must not call `sentry_sdk.init` —
+    passing an empty DSN would disable or misconfigure the SDK silently."""
+    with (
+        patch("src.framework.observability.sentry_backend.sentry_sdk") as mock_sdk,
+        patch("src.framework.observability.sentry_backend.settings") as mock_settings,
+    ):
+        mock_settings.SENTRY_DSN = ""
+
+        SentryBackend().init_app(FastAPI())
+
+        mock_sdk.init.assert_not_called()
+
+
 def test_set_user_includes_email_when_provided():
     with patch("src.framework.observability.sentry_backend.sentry_sdk") as mock_sdk:
         mock_sdk.set_user = MagicMock()


### PR DESCRIPTION
## Summary

- `_select_backend()` was only checking `SENTRY_DSN`, so setting only `SENTRY_BROWSER_DSN` (no backend DSN) silently fell through to `NoopBackend` — the browser SDK block in `base.html` never rendered
- `_select_backend()` now checks `SENTRY_DSN or SENTRY_BROWSER_DSN`; either side being set activates `SentryBackend`
- `init_app()` now early-returns when `SENTRY_DSN` is empty, preventing `sentry_sdk.init(dsn="", ...)` in the browser-only case

## Test plan

- [ ] `dev test src/framework/observability/` — all 14 tests pass (added browser-only factory case, both-empty factory case, and `init_app` guard test)
- [ ] View-source on a production page after deploy: `browser.sentry-cdn.com` script tag should be present when `SENTRY_BROWSER_DSN` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)