### PR TITLE
fix: make dev quick sign-in the default on the login page

### DIFF
--- a/src/domain/templates/auth/login.html
+++ b/src/domain/templates/auth/login.html
@@ -13,26 +13,27 @@
         <p>Sign in to your Bedlam Connect account.</p>
       {% endif %}
     </header>
-    {# The form lives in `_login_form.html` so the error-rerender path
-       can re-render *just the form fragment* (`hx-target="this"
-       hx-swap="outerHTML"` would otherwise nest the entire page
-       chrome inside the form slot). See the partial's docstring +
-       `post_login`'s `form_rerender` call for the wiring. #}
-    {% include "auth/_login_form.html" %}
     {% if dev_users %}
-      {# Dev-only: quick sign-in as a seeded user without entering credentials.
-         Only rendered when ENVIRONMENT=development and /dev/login-as is mounted.
-         Never shown in production. #}
+      {# Dev-only: quick sign-in is the default; credentials form is tucked into
+         an accordion below. Only rendered when ENVIRONMENT=development and
+         /dev/login-as is mounted. Never shown in production. #}
+      <form method="get" action="/dev/login-as">
+        <label for="dev-user-select">Sign in as</label>
+        <select id="dev-user-select" name="email">
+          {% for u in dev_users %}<option value="{{ u.email }}">{{ u.label }} — {{ u.email }}</option>{% endfor %}
+        </select>
+        <button type="submit">Go</button>
+      </form>
       <details>
-        <summary>Dev: quick sign-in</summary>
-        <form method="get" action="/dev/login-as">
-          <label for="dev-user-select">Sign in as</label>
-          <select id="dev-user-select" name="email">
-            {% for u in dev_users %}<option value="{{ u.email }}">{{ u.label }} — {{ u.email }}</option>{% endfor %}
-          </select>
-          <button type="submit">Go</button>
-        </form>
+        <summary>Sign in with credentials</summary>
+        {# The form lives in `_login_form.html` so the error-rerender path
+           can re-render *just the form fragment*. See the partial's docstring +
+           `post_login`'s `form_rerender` call for the wiring. #}
+        {% include "auth/_login_form.html" %}
       </details>
+    {% else %}
+      {# Production: credentials form shown directly, no accordion. #}
+      {% include "auth/_login_form.html" %}
     {% endif %}
     <footer>
       <p>


### PR DESCRIPTION
## Summary

- Promotes the dev quick-sign-in dropdown to the top of the login page (no accordion) so it's the first thing you reach for in dev
- Moves the credentials form into a `<details>` accordion labelled "Sign in with credentials" — only present when `dev_users` is in context
- Production is unaffected: credentials form renders directly, no accordion

## Test plan

- [ ] Start the app in dev (`ENVIRONMENT=development`) and visit `/auth/login` — quick sign-in dropdown should be visible at top; click "Sign in with credentials" to expand accordion and verify login form is there
- [ ] Confirm selecting a user and clicking Go still works
- [ ] Visit `/auth/login` with `ENVIRONMENT=production` — accordion should not be present, credentials form shown directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)