### PR TITLE
feat: require clinician profile before creating any post

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -373,3 +373,41 @@ async def test_referral_create_form_error_render_is_wired(
     assert "<!DOCTYPE" not in response.text
     assert "<html" not in response.text
     assert "Bedlam Connect" not in response.text
+
+
+# --- Clinician-profile gate on create forms ------------------------------
+
+
+@pytest.mark.parametrize("kind", ["referral", "clinician_opening"])
+async def test_create_form_gate_shown_when_no_clinician_profile(
+    kind: str,
+    authenticated_client: AsyncClient,
+    logged_in_user,
+):
+    """GET /posts/form?kind=<kind> shows the clinician-profile gate when the
+    requesting user has no clinician profiles, not the create form."""
+    response = await authenticated_client.get(f"/posts/form?kind={kind}")
+    assert response.status_code == 200
+    assert "Create your clinician profile" in response.text
+    # The post-create form fields should not be rendered.
+    assert 'name="kind"' not in response.text
+
+
+@pytest.mark.parametrize("kind", ["referral", "clinician_opening"])
+async def test_create_form_shown_when_clinician_profile_exists(
+    kind: str,
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """GET /posts/form?kind=<kind> renders the create form once the user has
+    at least one clinician profile."""
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get(f"/posts/form?kind={kind}")
+    assert response.status_code == 200
+    assert 'name="kind"' in response.text
+    assert "Create your clinician profile" not in response.text

--- a/src/domain/templates/posts/_shared/_require_clinician_profile.html
+++ b/src/domain/templates/posts/_shared/_require_clinician_profile.html
@@ -1,0 +1,7 @@
+{# Shown when `current_user` has no clinician profiles, blocking post creation.
+   Include this partial inside the `{% if not current_user.clinicians %}` branch
+   of any create-form template that requires a clinician profile to proceed.
+   Relies on `entity_form_url` from the calling template's context. #}
+<p>
+  Set up your clinician profile first. <a href="{{ entity_form_url('clinician') }}">Create your clinician profile.</a>
+</p>

--- a/src/domain/templates/posts/new_clinician_opening.html
+++ b/src/domain/templates/posts/new_clinician_opening.html
@@ -8,9 +8,7 @@
 {% block resource_label %}Posts{% endblock %}
 {% block content %}
   {% if not current_user.clinicians %}
-    <p>
-      Set up your clinician profile first — every opening is tied to one. <a href="{{ entity_form_url('clinician') }}">Create your clinician profile.</a>
-    </p>
+    {% include "posts/_shared/_require_clinician_profile.html" %}
   {% else %}
     {{ opening_form("post", entity_url('post') , entity_create_label('post', kind='clinician_opening'), schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('post')) }}
   {% endif %}

--- a/src/domain/templates/posts/new_referral.html
+++ b/src/domain/templates/posts/new_referral.html
@@ -7,5 +7,9 @@
 {% from "posts/_form_referral.html" import referral_form with context %}
 {% block resource_label %}Posts{% endblock %}
 {% block content %}
-  {{ referral_form("post", entity_url('post') , entity_create_label('post', kind='referral'), schema=referral_create_schema, cancel_url=entity_url('post')) }}
+  {% if not current_user.clinicians %}
+    {% include "posts/_shared/_require_clinician_profile.html" %}
+  {% else %}
+    {{ referral_form("post", entity_url('post') , entity_create_label('post', kind='referral'), schema=referral_create_schema, cancel_url=entity_url('post')) }}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Adds the clinician-profile gate to the referral create form (`new_referral.html`), matching the existing gate already on `new_clinician_opening.html`
- Factors the shared CTA message into `posts/_shared/_require_clinician_profile.html` so neither form inlines the text
- Adds parametrized tests covering both `referral` and `clinician_opening` kinds: gate shown when no profile, form shown when profile exists

## Test plan

- [x] `dev test src/domain/routes/test_posts.py` — all 22 tests pass
- [x] `dev test` — 1846 passed, 0 failed
- [x] `dev lint` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)