### PR TITLE
fix: /users/me crashes for users with a clinician profile

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -543,6 +543,34 @@ async def test_users_me_shows_onboarding_create_clinician_cta_when_no_profile(
     assert "Create your clinician profile" in cta.text()
 
 
+async def test_users_me_onboarding_post_opening_cta_when_has_clinician(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """`GET /users/me` for a user with a clinician profile renders the
+    'Post an opening' CTA pointing at `/posts/form?kind=clinician_opening`.
+    Regression for the bug where the template called
+    `entity_form_url('opening')` after the opening entity was consolidated
+    into `/posts` — the ValueError crashed the page for any user who had
+    already created a clinician profile."""
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/users/me")
+    assert response.status_code == 200, response.text
+    tree = HTMLParser(response.text)
+    cta = tree.css_first(
+        "section.entity-card a[href='/posts/form?kind=clinician_opening'][role='button']"
+    )
+    assert (
+        cta is not None
+    ), "onboarding card is missing 'Post an opening' CTA after having a clinician"
+    assert "Post an opening" in cta.text()
+
+
 async def test_users_me_onboarding_not_shown_for_other_users(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -94,7 +94,9 @@
         </li>
         {% if clinicians %}
           <li>
-            <a href="{{ entity_form_url('opening') }}" role="button" class="outline">Post an opening</a>
+            <a href="{{ entity_form_url("post") }}?kind=clinician_opening"
+               role="button"
+               class="outline">Post an opening</a>
           </li>
         {% endif %}
       </ul>


### PR DESCRIPTION
## Summary

- `users/detail.html` called `entity_form_url('opening')` inside the `{% if clinicians %}` branch of the Getting started onboarding card
- PR #949 removed the `opening` entity (consolidated into `/posts`), so `_spec_by_name('opening')` raised `ValueError` at template-render time
- Any logged-in user who had already created a clinician profile got "an unexpected error has occurred" when visiting `/users/me`
- Fixed by updating the link to `{{ entity_form_url("post") }}?kind=clinician_opening`, matching the pattern used in `home.html`

## Why tests didn't catch it

The two existing tests that hit `/users/me` both run with a user who has **no** clinician profile. The broken line is inside `{% if clinicians %}`, so it was never evaluated in any test. The test that _does_ create a clinician (`test_detail_lists_owned_clinicians`) views the clinician owner's profile as a _different_ user, so `is_self=False` and the onboarding section never renders.

Added `test_users_me_onboarding_post_opening_cta_when_has_clinician`: creates a clinician for `logged_in_user`, hits `/users/me`, and asserts 200 + correct `/posts/form?kind=clinician_opening` href.

## Test plan

- [x] `dev test src/domain/routes/test_users.py` — 46 passed (including new regression test)
- [x] `dev test --skip-lint` — 1861 passed, 0 failures
- [x] `dev lint` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>