### PR TITLE
feat: default clinician picker to first profile on post creation forms

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -411,3 +411,53 @@ async def test_create_form_shown_when_clinician_profile_exists(
     assert response.status_code == 200
     assert 'name="kind"' in response.text
     assert "Create your clinician profile" not in response.text
+
+
+_CLINICIAN_FIELD = {
+    "referral": "referring_clinician_id",
+    "clinician_opening": "clinician_id",
+}
+
+
+@pytest.mark.parametrize("kind", ["referral", "clinician_opening"])
+async def test_create_form_preselects_first_clinician(
+    kind: str,
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The clinician picker on new-post forms defaults to the user's first
+    clinician — no placeholder '-- ' option is rendered."""
+    clinician = make_clinician_with_org(
+        owner_id=logged_in_user.id, practice_name="First Practice"
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get(f"/posts/form?kind={kind}")
+    assert response.status_code == 200
+
+    tree = HTMLParser(response.text)
+    field_name = _CLINICIAN_FIELD[kind]
+    select = tree.css_first(f'select[name="{field_name}"]')
+    assert select is not None, f"no <select name={field_name!r}> in response"
+
+    options = select.css("option")
+    assert options, "clinician select rendered no options"
+
+    # No disabled placeholder.
+    assert not any(
+        o.attributes.get("disabled") is not None and "--" in (o.text() or "")
+        for o in options
+    ), "placeholder '--' option should not be present on new form"
+
+    # First (and only) option is pre-selected.
+    # selectolax stores boolean HTML attributes (e.g. `selected`) as None, so
+    # key presence — not a non-None value — is the correct sentinel.
+    assert (
+        "selected" in options[0].attributes
+    ), "first clinician option should carry the 'selected' attribute"
+    assert str(clinician.id) in (
+        options[0].attributes.get("value") or ""
+    ), "selected option value should be the first clinician's id"

--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -56,11 +56,13 @@ to the clinician-create flow when `current_user.clinicians` is empty.
     <label for="clinician_id">
       Which practice?
       <select id="clinician_id" name="clinician_id" required>
-        {%- if not d %}<option value="" disabled selected>--</option>{%- endif %}
         {%- for c in current_user.clinicians %}
+          {%- set outer_first = loop.first %}
           {%- for aff in c.affiliations %}
             <option value="{{ c.id }}"
-                    {% if d and d.clinician_id == c.id and loop.first %}selected{% endif %}>{{ aff.org.name }}</option>
+                    {% if (d and d.clinician_id == c.id and loop.first) or (not d and outer_first and loop.first) %}selected{% endif %}>
+              {{ aff.org.name }}
+            </option>
           {%- endfor %}
         {%- endfor %}
       </select>

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -46,11 +46,11 @@ which FastAPI/Pydantic parses as a list.
     <label for="referring_clinician_id">
       Referring clinician *
       <select id="referring_clinician_id" name="referring_clinician_id" required>
-        {%- if not d %}<option value="" disabled selected>--</option>{%- endif %}
         {%- for c in current_user.clinicians %}
+          {%- set outer_first = loop.first %}
           {%- for aff in c.affiliations %}
             <option value="{{ c.id }}"
-                    {% if d and d.referring_clinician_id == c.id and loop.first %}selected{% endif %}>
+                    {% if (d and d.referring_clinician_id == c.id and loop.first) or (not d and outer_first and loop.first) %}selected{% endif %}>
               {{ aff.org.name }}
             </option>
           {%- endfor %}


### PR DESCRIPTION
## Summary

- Removes the disabled `--` placeholder option from the `referring_clinician_id` (referral) and `clinician_id` (clinician opening) selects on new-post forms
- Pre-selects the user's first clinician instead, so users with a single practice can submit immediately without touching the dropdown
- Edit forms are unchanged — they still pre-fill from the saved post value
- Adds `test_create_form_preselects_first_clinician` parametrized across both kinds to pin the behavior

## Test plan

- [x] `dev test src/domain/routes/test_posts.py` — all 24 tests pass
- [x] `dev test` — 1862 passed, 92 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)