### PR TITLE
fix: dev seed falls back to host mode when running inside a container

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -471,18 +471,31 @@ class SeedCommands:
     def __init__(self, runner: CLIRunner):
         self.runner = runner
 
+    @staticmethod
+    def _in_container() -> bool:
+        """True when already running inside a Docker container."""
+        import os
+
+        return os.path.exists("/.dockerenv")
+
     def seed(self) -> int:
         # `dev seed` runs in a one-off `docker compose run --no-deps` container
         # that bypasses start-dev.sh, so migrations must be applied explicitly
         # here — otherwise a freshly added revision crashes seed against a
         # stale schema with a raw OperationalError.
+        #
+        # When invoked from *inside* a container (e.g. on the prod droplet via
+        # `docker exec … dev seed`), docker is not available so we skip the
+        # compose wrapper and run alembic + the seed script directly.
         from scripts.dev.migrate import run_alembic
+
+        in_container = self._in_container()
 
         print("🧱 Applying migrations before seeding...")
         rc = run_alembic(
             self.runner,
             ["upgrade", "head"],
-            mode="compose",
+            mode="host" if in_container else "compose",
             service_name=self.SERVICE_NAME,
         )
         if rc != 0:
@@ -490,9 +503,9 @@ class SeedCommands:
             return rc
 
         print("🌱 Seeding fixture users...")
-        seed_cmd = self.runner.wrap_for_compose(
-            self.SERVICE_NAME, ["python", "-m", "scripts.dev.seed"]
-        )
+        seed_cmd = ["python", "-m", "scripts.dev.seed"]
+        if not in_container:
+            seed_cmd = self.runner.wrap_for_compose(self.SERVICE_NAME, seed_cmd)
         return self.runner.run_command(seed_cmd)
 
 

--- a/scripts/test_dev_cli.py
+++ b/scripts/test_dev_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-from scripts.dev_cli import CLIRunner, TestCommands
+from scripts.dev_cli import CLIRunner, SeedCommands, TestCommands
 
 
 def test_clirunner_resolves_project_root_from_cwd(tmp_path: Path, monkeypatch):
@@ -240,6 +240,25 @@ def test_run_tests_affected_full_suite_runs_pytest_with_no_paths(monkeypatch):
     rc = TestCommands(runner, quality).run_tests(affected=True, skip_lint=True)
     assert rc == 0
     assert runner.last_cmd == ["pytest"]
+
+
+# ---------------------------------------------------------------------------
+# SeedCommands._in_container
+# ---------------------------------------------------------------------------
+
+
+def test_in_container_true_when_dockerenv_exists():
+    import unittest.mock as mock
+
+    with mock.patch("os.path.exists", side_effect=lambda p: p == "/.dockerenv"):
+        assert SeedCommands._in_container() is True
+
+
+def test_in_container_false_when_dockerenv_absent():
+    import unittest.mock as mock
+
+    with mock.patch("os.path.exists", return_value=False):
+        assert SeedCommands._in_container() is False
 
 
 def test_run_tests_affected_empty_selection_skips_pytest(monkeypatch):


### PR DESCRIPTION
## Summary

- `docker exec … dev seed` on the prod droplet crashed with `FileNotFoundError: docker` because `SeedCommands.seed()` always used `mode="compose"`, which shells out to `docker` — not available inside the container.
- Adds `SeedCommands._in_container()` (detects `/.dockerenv`) and skips the compose wrapper when already inside a container, running alembic and the seed script directly instead.
- Two unit tests pin the `_in_container` true/false branches.

## Test plan

- [ ] `dev test scripts/test_dev_cli.py` passes (16 tests, including 2 new ones)
- [ ] `dev lint` passes
- [ ] On the droplet: `docker exec bedlam-connect-green dev seed` completes without `FileNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)