### PR TITLE
fix: always open filter sidebar details element

### DIFF
--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -10,7 +10,7 @@
   {%- set _list_url = entity_url("post") -%}
   <div class="posts-browse-layout">
     <aside class="posts-filter-sidebar">
-      <details class="posts-filter-disclosure">
+      <details class="posts-filter-disclosure" open>
         <summary class="posts-filter-summary">
           Filters
           {% if active_filter_count %}({{ active_filter_count }}){% endif %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -692,11 +692,10 @@
       .posts-filter-sidebar { flex: 0 0 220px; min-width: 0; }
       .posts-results { flex: 1 1 0; min-width: 0; }
 
-      /* Force the sidebar open on desktop — hide the <summary> toggle and
-         always show the form. On mobile the <details> stays closed by
-         default; the user taps the summary to reveal the form. */
+      /* On desktop hide the <summary> toggle — the <details open> is always
+         expanded so the form shows as a static sidebar. On mobile the
+         summary is visible; the user can tap it to collapse the form. */
       @media (min-width: 641px) {
-        .posts-filter-disclosure { display: block; }
         .posts-filter-disclosure > .posts-filter-summary { display: none; }
       }
       /* Narrow: stack sidebar full-width above results */


### PR DESCRIPTION
## Summary

- `<details>` without `open` hides children via the browser's UA stylesheet in a way that author CSS `display: block !important` cannot override
- Adds `open` attribute to the `<details class="posts-filter-disclosure">` element so it's always expanded
- On desktop (≥641px): the `<summary>` is hidden via CSS, making the sidebar look like a static left rail
- On mobile (≤640px): the `<summary>` is visible and the user can tap it to collapse the form

## Test plan

- [ ] Navigate to `/posts` on desktop — filter sidebar visible on left
- [ ] Navigate to `/posts` on mobile — "Filters" toggle visible, form starts open, can collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)