### PR TITLE
fix: replace geography text input with separate city/state fields on posts sidebar

### DIFF
--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -37,18 +37,21 @@
           <fieldset class="posts-filter-section">
             <legend>Location</legend>
             <label>
-              City, state, or ZIP
+              City
               <input type="search"
-                     name="geography"
-                     value="{{ filter_values.get('geography') or '' }}"
-                     placeholder="e.g. Portland or 97201" />
+                     name="city"
+                     value="{{ filter_values.get('city') or '' }}"
+                     placeholder="e.g. Portland" />
             </label>
             <label>
-              <input type="checkbox"
-                     name="include_telehealth"
-                     value="1"
-                     {% if filter_values.get("include_telehealth") %}checked{% endif %} />
-              Include telehealth in CA {# title-case-ignore #}
+              State
+              <select name="state">
+                <option value="">Any</option>
+                {%- for s in US_STATES %}
+                  <option value="{{ s }}"
+                          {% if s in (filter_values.get('state') or []) %}selected{% endif %}>{{ s }}</option>
+                {%- endfor %}
+              </select>
             </label>
           </fieldset>
           {#-- 3. Level of care (openings/intakes only) --#}


### PR DESCRIPTION
## Summary
- Replaces the unified geography text input + include_telehealth checkbox with a City text field and State dropdown
- State dropdown uses `US_STATES` tuple (USPS abbreviations) from enums
- Pre-population fix: uses `s in (filter_values.get('state') or [])` since state is a multi-value ChoiceFilter

## Test plan
- [ ] Navigate to `/posts` — sidebar shows City input and State dropdown
- [ ] Type a city, select a state, apply — URL has `city=...&state=...`, results filtered
- [ ] Reload URL with `?city=Portland&state=OR` — fields pre-populated correctly
- [ ] Clear all — navigates to `/posts` with no query string

🤖 Generated with [Claude Code](https://claude.com/claude-code)