### PR TITLE
fix: give program_intake its own 'Intake' tag in feed row

### DIFF
--- a/src/domain/templates/posts/_shared/_feed_row.html
+++ b/src/domain/templates/posts/_shared/_feed_row.html
@@ -3,7 +3,7 @@
 
 Layout per row:
 
-  [OPENING]  E. Stone · 2h ago
+  [OPENING|INTAKE]  E. Stone · 2h ago
   Headline text that wraps freely across the full width
   City, ST · In-person · Aetna
 
@@ -29,8 +29,8 @@ under the "Feed rows" section. #}
 {% macro post_feed_row(post, entity_name, show_poster=True) -%}
 {%- set view = post_card_view(post) -%}
 {%- set headline = post_feed_headline(post) -%}
-{%- set kind_class = "opening" if post.kind != "referral" else "referral" -%}
-{%- set kind_label = "Opening" if post.kind != "referral" else "Referral" -%}
+{%- set kind_class = "referral" if post.kind == "referral" else ("intake" if post.kind == "program_intake" else "opening") -%}
+{%- set kind_label = "Referral" if post.kind == "referral" else ("Intake" if post.kind == "program_intake" else "Opening") -%}
 <div class="post-feed-row" data-kind="{{ post.kind }}">
 {# ── Header: pill · poster · timestamp ───────────────────────── #}
 <div class="post-feed-header">

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -662,6 +662,10 @@
         color: var(--pico-primary);
         background: color-mix(in srgb, var(--pico-primary) 10%, transparent);
       }
+      .post-feed-type-tag--intake {
+        color: var(--pico-secondary);
+        background: color-mix(in srgb, var(--pico-secondary) 10%, transparent);
+      }
       /* Metadata strip */
       .post-feed-meta {
         display: flex;


### PR DESCRIPTION
## Summary
- The feed-row macro used a binary `if/else` that labeled anything non-referral as \"Opening\", so `program_intake` posts displayed the wrong tag
- Fixed with a three-way branch: `referral` → Referral, `program_intake` → Intake, `clinician_opening` → Opening
- Added `.post-feed-type-tag--intake` CSS pill class (uses `--pico-secondary`) to visually distinguish intake from opening

## Test plan
- [ ] Browse `/posts` and confirm program intake posts show \"Intake\" tag, clinician opening posts show \"Opening\", referrals show \"Referral\"
- [ ] Confirm intake pill renders with a distinct color from opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)