### PR TITLE
refactor: rely on Pico CSS defaults for posts filter sidebar

### DIFF
--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -15,7 +15,7 @@
           Filters
           {% if active_filter_count %}({{ active_filter_count }}){% endif %}
         </summary>
-        <form method="get" action="{{ _list_url }}" class="posts-filter-form">
+        <form method="get" action="{{ _list_url }}">
           {#-- 1. Type --#}
           <fieldset class="posts-filter-section">
             <legend>Type</legend>
@@ -84,7 +84,7 @@
               {%- endif %}
             {%- endfor %}
             {%- if TREATMENT_MODALITIES | length > _cutoff %}
-              <details class="posts-filter-more">
+              <details>
                 <summary>Show all ({{ TREATMENT_MODALITIES | length }})</summary>
                 <div class="posts-filter-scroll">
                   {%- for v in TREATMENT_MODALITIES %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -709,40 +709,13 @@
       }
 
       /* Filter form internals */
-      .posts-filter-summary {
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        font-weight: 600;
-        cursor: pointer;
-        list-style: none;
-      }
-      fieldset.posts-filter-section {
-        border: none;
-        padding: 0;
-        margin: 0 0 1rem;
-      }
-      fieldset.posts-filter-section legend {
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        font-weight: 600;
-        padding: 0;
-        margin-bottom: 0.25rem;
-      }
-      fieldset.posts-filter-section label {
-        display: flex;
-        gap: 0.4rem;
-        align-items: center;
-        margin-bottom: 0.15rem;
-        font-size: 0.875rem;
-      }
+      fieldset.posts-filter-section { padding: 0; margin-bottom: var(--pico-spacing); }
+      fieldset.posts-filter-section label { display: flex; align-items: center; }
       .posts-filter-scroll { max-height: 130px; overflow-y: auto; }
-      .posts-filter-more > summary { font-size: 0.8rem; cursor: pointer; }
       .posts-filter-actions {
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: var(--pico-spacing);
         list-style: none;
         padding: 0;
         margin: 0;


### PR DESCRIPTION
## Summary

- Removes bespoke typography/appearance CSS from the filter sidebar (font-size, text-transform, letter-spacing, font-weight, cursor, list-style on summary/legend/label, and the `.posts-filter-more > summary` rule)
- Keeps only layout rules (two-column flex, sidebar width, responsive stacking) and functional rules (scroll cap, button column layout)
- Cleans up now-unused class attributes from the template (`posts-filter-form`, `posts-filter-more`)

## Test plan

- [x] Desktop: two-column layout intact, sidebar renders with Pico defaults for legends/labels
- [x] Mobile (≤640px): sidebar stacks full-width, "Filters" toggle collapses correctly
- [x] "Show all (10)" disclosure expands and scrollable modality list renders
- [x] Apply/Clear buttons stacked via retained flex layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)