### PR TITLE
feat: seed modalities field on post detail tables

### DIFF
--- a/scripts/dev/seed/vocab.py
+++ b/scripts/dev/seed/vocab.py
@@ -39,6 +39,7 @@ from src.domain.models.enums import (
     LANGUAGES,
     LICENSE_TYPES,
     REFERRAL_SERVICES,
+    TREATMENT_MODALITIES,
     TREATMENT_SETTINGS,
     US_STATES,
 )
@@ -702,6 +703,7 @@ PLACEHOLDER_OK: Final[frozenset[str]] = frozenset(
 JSON_LIST_SOURCE: Final[dict[str, tuple[str, ...]]] = {
     "age_groups": CLIENT_AGE_GROUPS,
     "languages": LANGUAGES,
+    "modalities": TREATMENT_MODALITIES,
     "services": REFERRAL_SERVICES,
     "settings": TREATMENT_SETTINGS,
     "desired_times": DESIRED_TIME_SLOTS,


### PR DESCRIPTION
## Summary

- The `/posts` filter sidebar has a modality filter backed by `TREATMENT_MODALITIES`, but the `modalities` JSON column on `ReferralDetail`, `OpeningDetail`, and `IntakeDetail` was not wired into `JSON_LIST_SOURCE` — so the seed generator always wrote empty arrays
- Adds `"modalities": TREATMENT_MODALITIES` to `JSON_LIST_SOURCE` in `scripts/dev/seed/vocab.py` so the generator produces realistic 1–6 item subsets per post
- No schema, model, or template changes needed — the column, the filter, and the template context already existed

## Test plan

- [ ] `dev test scripts/dev/test_seed.py` passes (all 6 seed invariant tests)
- [ ] `dev test` passes (1887 tests, 0 failures)
- [ ] Run `dev seed` locally and verify `/posts` modality filter returns non-empty results

🤖 Generated with [Claude Code](https://claude.com/claude-code)