### PR TITLE
Auto-forward passthrough fields in post_card_view

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 import pytest
 
 from src.domain.logic.posts.view import (
+    _LIST_PASSTHROUGH,
+    _SCALAR_PASSTHROUGH,
     insurance_posture_for_post,
     post_card_view,
     post_feed_headline,
@@ -883,3 +885,57 @@ def test_feed_headline_opening_none_subject_falls_back_to_auto():
     post.opening_detail.subject = None
     headline = post_feed_headline(post)
     assert headline.startswith("Acme Counseling — ")
+
+
+# --- post_card_view: detail-row auto-forward ---------------------
+# The passthrough fields are copied off the detail row by a single
+# table-driven helper, not hand-listed per kind. These pin that
+# contract so a new passthrough field can't be silently dropped from
+# one kind's block: add it to `_SCALAR_PASSTHROUGH` / `_LIST_PASSTHROUGH`
+# and it forwards for every kind that has the attribute.
+
+
+@pytest.mark.parametrize(
+    "make_post",
+    [_make_cr_post, _make_pa_post, _make_program_post],
+    ids=["referral", "opening", "intake"],
+)
+def test_passthrough_keys_present_for_every_kind(make_post):
+    """Every declared passthrough field surfaces in the view for every
+    kind — scalars as a value-or-None key, lists as a (possibly empty)
+    list. `genders` is excluded: referral overrides it from its single
+    `gender` column, so its forwarded value is recomputed downstream."""
+    v = post_card_view(make_post())
+    for view_key in _SCALAR_PASSTHROUGH:
+        assert view_key in v
+    for view_key in _LIST_PASSTHROUGH:
+        assert isinstance(v[view_key], list)
+
+
+def test_passthrough_forwards_detail_values_for_opening():
+    """An opening's detail-row scalars/lists land on the view verbatim,
+    proving the helper reads the right attributes (no rename drift)."""
+    v = post_card_view(
+        _make_pa_post(
+            description="Forwarded description",
+            schedule_text="Forwarded schedule",
+            treatment_modality="ACT",
+            services=["psychotherapy", "group_therapy"],
+            settings=["group"],
+        )
+    )
+    assert v["description"] == "Forwarded description"
+    assert v["schedule_text"] == "Forwarded schedule"
+    assert v["treatment_modality"] == "ACT"
+    assert v["services"] == ["psychotherapy", "group_therapy"]
+    assert v["settings"] == ["group"]
+
+
+def test_passthrough_missing_attr_falls_back_to_base_default():
+    """A referral detail row has no `settings` / `schedule_text`
+    columns. The helper uses `getattr(..., None)`, so those keep the
+    base defaults (`[]` for lists, `None` for scalars) rather than
+    raising — that's why referral can share the same forwarding pass."""
+    v = post_card_view(_make_cr_post())
+    assert v["settings"] == []
+    assert v["schedule_text"] is None

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -141,6 +141,42 @@ def _referral_or_none(website: str | None, instructions: str | None) -> dict | N
     return {"website": website, "instructions": instructions}
 
 
+# Fields copied straight off the kind's detail row with no transform, as
+# `view_key -> detail_attribute`. `_forward_detail_passthrough` applies these
+# for every kind before its per-kind block fills in computed/relational fields.
+# A kind whose detail lacks an attribute (referral has no `settings` /
+# `schedule_text` / `genders`) just keeps the base default. Adding a plain
+# field to a post kind means one line here, not an edit to three per-kind
+# blocks — so a passthrough field can't be silently dropped from the view-model.
+_SCALAR_PASSTHROUGH: dict[str, str] = {
+    "subject": "subject",
+    "description": "description",
+    "schedule_text": "schedule_text",
+    "treatment_modality": "treatment_modality",
+}
+_LIST_PASSTHROUGH: dict[str, str] = {
+    "services": "services",
+    "settings": "settings",
+    "ages": "age_groups",
+    "languages": "languages",
+    "genders": "genders",
+    "modalities": "modalities",
+    "desired_times": "desired_times",
+}
+
+
+def _forward_detail_passthrough(base: dict[str, Any], d: Any) -> None:
+    """Copy every passthrough field off detail row ``d`` into ``base``.
+
+    Scalars land as-is (``None`` when absent); list fields are normalized to
+    a fresh list (``[]`` when absent or empty) so templates can iterate
+    without nullability handling. Mutates ``base`` in place."""
+    for view_key, attr in _SCALAR_PASSTHROUGH.items():
+        base[view_key] = getattr(d, attr, None)
+    for view_key, attr in _LIST_PASSTHROUGH.items():
+        base[view_key] = list(getattr(d, attr, None) or [])
+
+
 def post_card_view(post) -> dict[str, Any]:
     """Normalize a `Post` of any kind into the flat shape both the
     listing card and the detail page render from.
@@ -261,24 +297,19 @@ def post_card_view(post) -> dict[str, Any]:
         d = getattr(post, "referral_detail", None)
         if d is None:
             return base
+        _forward_detail_passthrough(base, d)
         base.update(
-            subject=getattr(d, "subject", None),
             headline=referral_headline(d),
             in_person=getattr(d, "location_in_person", None),
             virtual=getattr(d, "location_virtual", None),
-            services=list(getattr(d, "services", None) or []),
-            ages=list(getattr(d, "age_groups", None) or []),
-            languages=list(getattr(d, "languages", None) or []),
+            # CR holds a single `gender`; wrap it so templates iterate
+            # `genders` uniformly across kinds.
             genders=([d.gender] if getattr(d, "gender", None) else []),
-            treatment_modality=getattr(d, "treatment_modality", None),
-            modalities=list(getattr(d, "modalities", None) or []),
             location_chunk=_location_chunk(
                 getattr(d, "location_city", None),
                 getattr(d, "location_state", None),
                 getattr(d, "location_zip", None),
             ),
-            description=getattr(d, "description", None),
-            desired_times=list(getattr(d, "desired_times", None) or []),
             full_address=full_address(
                 getattr(d, "location_city", None),
                 getattr(d, "location_state", None),
@@ -293,9 +324,9 @@ def post_card_view(post) -> dict[str, Any]:
         d = getattr(post, "opening_detail", None)
         if d is None:
             return base
+        _forward_detail_passthrough(base, d)
         p = getattr(d, "clinician", None)
         base.update(
-            subject=getattr(d, "subject", None),
             headline=(p.org.name if p and getattr(p, "org", None) else None),
             # `header_state` stays None — opening's location lives in
             # the demographics column via `location_chunk` (same row
@@ -314,16 +345,6 @@ def post_card_view(post) -> dict[str, Any]:
             ),
             in_person=(getattr(p, "in_person_sessions", None) if p else None),
             virtual=(getattr(p, "virtual_sessions", None) if p else None),
-            services=list(getattr(d, "services", None) or []),
-            settings=list(getattr(d, "settings", None) or []),
-            ages=list(getattr(d, "age_groups", None) or []),
-            languages=list(getattr(d, "languages", None) or []),
-            genders=list(getattr(d, "genders", None) or []),
-            treatment_modality=getattr(d, "treatment_modality", None),
-            modalities=list(getattr(d, "modalities", None) or []),
-            description=getattr(d, "description", None),
-            schedule_text=getattr(d, "schedule_text", None),
-            desired_times=list(getattr(d, "desired_times", None) or []),
             practice_link=(
                 {"id": p.id, "name": p.org.name}
                 if p and getattr(p, "org", None) and getattr(p, "id", None)
@@ -365,21 +386,11 @@ def post_card_view(post) -> dict[str, Any]:
         d = getattr(post, "intake_detail", None)
         if d is None:
             return base
+        _forward_detail_passthrough(base, d)
         prog = getattr(d, "program", None)
         base.update(
-            subject=getattr(d, "subject", None),
             headline=(getattr(prog, "name", None) if prog else None),
             header_state=(getattr(prog, "state_preference", None) if prog else None),
-            services=list(getattr(d, "services", None) or []),
-            settings=list(getattr(d, "settings", None) or []),
-            ages=list(getattr(d, "age_groups", None) or []),
-            languages=list(getattr(d, "languages", None) or []),
-            genders=list(getattr(d, "genders", None) or []),
-            treatment_modality=getattr(d, "treatment_modality", None),
-            modalities=list(getattr(d, "modalities", None) or []),
-            description=getattr(d, "description", None),
-            schedule_text=getattr(d, "schedule_text", None),
-            desired_times=list(getattr(d, "desired_times", None) or []),
             program_link=(
                 {"id": prog.id, "name": prog.name}
                 if prog and getattr(prog, "id", None) and getattr(prog, "name", None)


### PR DESCRIPTION
## Summary
- Collapse the hand-listed per-kind passthrough copies in `post_card_view` into one table-driven helper (`_forward_detail_passthrough`) keyed by `_SCALAR_PASSTHROUGH` / `_LIST_PASSTHROUGH`. A plain detail-row field now forwards for every kind from a single line instead of being repeated across three per-kind blocks where one could silently drop it.
- Each per-kind block (referral / opening / intake) keeps only its computed/relational fields (headlines, links, location, insurance derivations, gender override).
- Final PR in the `LabeledChoice` + view-model refactor series (#975, #977, #979, #981).

## Behavior
The output view dict is byte-identical — this is a pure restructuring. Verified by the existing comprehensive `test_view.py` suite (every kind's dict shape pinned) plus new auto-forward tests:
- every declared passthrough key is present for every kind,
- detail-row values forward verbatim (no attribute-rename drift),
- a kind whose detail lacks an attribute (referral has no `settings`/`schedule_text`) keeps the base default rather than raising.

## Test plan
- [x] `dev test` (1963 passed, 92 skipped)
- [x] `dev lint`
- [x] `dev test contract` (40 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)