### PR TITLE
refactor: share posts filter form between sidebar and /posts/search

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -152,6 +152,56 @@ async def test_search_form_renders_kind_filter(
     assert {"referral", "clinician_opening", "program_intake"} <= values
 
 
+async def test_search_uses_shared_filter_form(
+    authenticated_client: AsyncClient,
+    logged_in_user,
+):
+    """`/posts/search` renders the same custom filter form component as the
+    list-page sidebar — `posts-filter-section` fieldsets for Type, Location,
+    Level of care, Modality, Populations, and Insurance — not the generic
+    framework search form (`search-checkbox-fieldset`)."""
+    response = await authenticated_client.get("/posts/search")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    sections = tree.css("fieldset.posts-filter-section")
+    legends = [s.css_first("legend").text(strip=True) for s in sections]
+    assert legends == [
+        "Type",
+        "Location",
+        "Level of care",
+        "Modality",
+        "Populations",
+        "Insurance",
+    ], f"Unexpected filter sections on /posts/search: {legends}"
+    # Generic framework fieldset class must not appear — the shared macro owns the form.
+    assert not tree.css(
+        "fieldset.search-checkbox-fieldset"
+    ), "/posts/search should not render the generic framework search form"
+
+
+async def test_list_sidebar_uses_shared_filter_form(
+    authenticated_client: AsyncClient,
+    logged_in_user,
+):
+    """`/posts` list sidebar renders the same `posts-filter-section` fieldsets
+    as `/posts/search`, confirming both surfaces share the same component."""
+    response = await authenticated_client.get("/posts")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    sidebar = tree.css_first(".posts-filter-sidebar")
+    assert sidebar, "/posts did not render a .posts-filter-sidebar element"
+    sections = sidebar.css("fieldset.posts-filter-section")
+    legends = [s.css_first("legend").text(strip=True) for s in sections]
+    assert legends == [
+        "Type",
+        "Location",
+        "Level of care",
+        "Modality",
+        "Populations",
+        "Insurance",
+    ], f"Unexpected filter sections in /posts sidebar: {legends}"
+
+
 # --- List filter: ?kind= narrows the feed --------------------------------
 
 

--- a/src/domain/templates/posts/_shared/_filter_form.html
+++ b/src/domain/templates/posts/_shared/_filter_form.html
@@ -1,0 +1,108 @@
+{# Shared filter form for the posts feed.
+   Used by the sidebar on /posts and the full-page /posts/search view.
+   `list_url`     — form action and "Clear all" href (the /posts list URL)
+   `filter_values` — dict of active filter values (same shape both handlers inject)
+#}
+{% macro filter_form(list_url, filter_values) %}
+  <form method="get" action="{{ list_url }}">
+    {#-- 1. Type --#}
+    <fieldset class="posts-filter-section">
+      <legend>Type</legend>
+      {%- for v, l in (
+        ("referral",          "Client referrals"),
+        ("clinician_opening", "Clinician openings"),
+        ("program_intake",    "Program intakes"),
+        ) %}
+        <label>
+          <input type="checkbox"
+                 name="kind"
+                 value="{{ v }}"
+                 {% if v in (filter_values.get("kind") or []) %}checked{% endif %} />
+          {{ l }}
+        </label>
+      {%- endfor %}
+    </fieldset>
+    {#-- 2. Location --#}
+    <fieldset class="posts-filter-section">
+      <legend>Location</legend>
+      <label style="flex-direction: column; align-items: stretch;">
+        City
+        <input type="search"
+               name="city"
+               value="{{ filter_values.get('city') or '' }}"
+               placeholder="e.g. Portland" />
+      </label>
+      <label style="flex-direction: column; align-items: stretch;">
+        State
+        <select name="state">
+          <option value="">Any</option>
+          {%- for s in US_STATES %}
+            <option value="{{ s }}"
+                    {% if s in (filter_values.get('state') or []) %}selected{% endif %}>{{ s }}</option>
+          {%- endfor %}
+        </select>
+      </label>
+    </fieldset>
+    {#-- 3. Level of care (openings/intakes only) --#}
+    <fieldset class="posts-filter-section">
+      <legend>Level of care</legend>
+      {%- for v in TREATMENT_SETTINGS %}
+        <label>
+          <input type="checkbox"
+                 name="level_of_care"
+                 value="{{ v }}"
+                 {% if v in (filter_values.get("level_of_care") or []) %}checked{% endif %} />
+          {{ TREATMENT_SETTINGS_LABELS[v] }}
+        </label>
+      {%- endfor %}
+    </fieldset>
+    {#-- 4. Modality --#}
+    <fieldset class="posts-filter-section">
+      <legend>Modality</legend>
+      {%- set modality_active = filter_values.get("modality") or [] %}
+      {%- for v in TREATMENT_MODALITIES %}
+        <label>
+          <input type="checkbox"
+                 name="modality"
+                 value="{{ v }}"
+                 {% if v in modality_active %}checked{% endif %} />
+          {{ TREATMENT_MODALITY_LABELS[v] }}
+        </label>
+      {%- endfor %}
+    </fieldset>
+    {#-- 5. Populations (age_group) --#}
+    <fieldset class="posts-filter-section">
+      <legend>Populations</legend>
+      {%- for v in CLIENT_AGE_GROUPS %}
+        <label>
+          <input type="checkbox"
+                 name="age_group"
+                 value="{{ v }}"
+                 {% if v in (filter_values.get("age_group") or []) %}checked{% endif %} />
+          {{ CLIENT_AGE_GROUP_LABELS[v] }}
+        </label>
+      {%- endfor %}
+    </fieldset>
+    {#-- 6. Insurance --#}
+    <fieldset class="posts-filter-section">
+      <legend>Insurance</legend>
+      {%- for v in INSURANCE_CARRIERS %}
+        <label>
+          <input type="checkbox"
+                 name="insurance"
+                 value="{{ v }}"
+                 {% if v in (filter_values.get("insurance") or []) %}checked{% endif %} />
+          {{ INSURANCE_CARRIER_LABELS[v] }}
+        </label>
+      {%- endfor %}
+    </fieldset>
+    <menu class="posts-filter-actions">
+      <li>
+        <button type="submit">Apply filters</button>
+      </li>
+      <li>
+        <a href="{{ list_url }}" role="button" class="secondary outline">Clear all</a>
+      </li>
+    </menu>
+  </form>
+{% endmacro %}

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -1,6 +1,7 @@
 {% extends "views/list.html" %}
 {%- from "posts/_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {%- from "posts/_shared/_filter_form.html" import filter_form -%}
+{%- from "_shared/pagination.html" import pagination -%}
 {% block resource_label %}Posts{% endblock %}
 {% block actions %}
   <li>
@@ -29,6 +30,8 @@
                     link_href=entity_url(entity_name) if active_filter_count else None
           ) }}
         {% endif %}
+      {%- if page_meta is defined %}{{ pagination(page_meta, paginator_base_query|default("")) }}{%- endif %}
       </div>
     </div>
   {% endblock %}
+{% block after_content %}{% endblock %}

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -1,5 +1,6 @@
 {% extends "views/list.html" %}
 {%- from "posts/_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
+{%- from "posts/_shared/_filter_form.html" import filter_form -%}
 {% block resource_label %}Posts{% endblock %}
 {% block actions %}
   <li>
@@ -15,107 +16,7 @@
           Filters
           {% if active_filter_count %}({{ active_filter_count }}){% endif %}
         </summary>
-        <form method="get" action="{{ _list_url }}">
-          {#-- 1. Type --#}
-          <fieldset class="posts-filter-section">
-            <legend>Type</legend>
-            {%- for v, l in (
-              ("referral",          "Client referrals"),
-              ("clinician_opening", "Clinician openings"),
-              ("program_intake",    "Program intakes"),
-              ) %}
-              <label>
-                <input type="checkbox"
-                       name="kind"
-                       value="{{ v }}"
-                       {% if v in (filter_values.get("kind") or []) %}checked{% endif %} />
-                {{ l }}
-              </label>
-            {%- endfor %}
-          </fieldset>
-          {#-- 2. Location --#}
-          <fieldset class="posts-filter-section">
-            <legend>Location</legend>
-            <label style="flex-direction: column; align-items: stretch;">
-              City
-              <input type="search"
-                     name="city"
-                     value="{{ filter_values.get('city') or '' }}"
-                     placeholder="e.g. Portland" />
-            </label>
-            <label style="flex-direction: column; align-items: stretch;">
-              State
-              <select name="state">
-                <option value="">Any</option>
-                {%- for s in US_STATES %}
-                  <option value="{{ s }}"
-                          {% if s in (filter_values.get('state') or []) %}selected{% endif %}>{{ s }}</option>
-                {%- endfor %}
-              </select>
-            </label>
-          </fieldset>
-          {#-- 3. Level of care (openings/intakes only) --#}
-          <fieldset class="posts-filter-section">
-            <legend>Level of care</legend>
-            {%- for v in TREATMENT_SETTINGS %}
-              <label>
-                <input type="checkbox"
-                       name="level_of_care"
-                       value="{{ v }}"
-                       {% if v in (filter_values.get("level_of_care") or []) %}checked{% endif %} />
-                {{ TREATMENT_SETTINGS_LABELS[v] }}
-              </label>
-            {%- endfor %}
-          </fieldset>
-          {#-- 4. Modality --#}
-          <fieldset class="posts-filter-section">
-            <legend>Modality</legend>
-            {%- set modality_active = filter_values.get("modality") or [] %}
-            {%- for v in TREATMENT_MODALITIES %}
-              <label>
-                <input type="checkbox"
-                       name="modality"
-                       value="{{ v }}"
-                       {% if v in modality_active %}checked{% endif %} />
-                {{ TREATMENT_MODALITY_LABELS[v] }}
-              </label>
-            {%- endfor %}
-          </fieldset>
-          {#-- 5. Populations (age_group) --#}
-          <fieldset class="posts-filter-section">
-            <legend>Populations</legend>
-            {%- for v in CLIENT_AGE_GROUPS %}
-              <label>
-                <input type="checkbox"
-                       name="age_group"
-                       value="{{ v }}"
-                       {% if v in (filter_values.get("age_group") or []) %}checked{% endif %} />
-                {{ CLIENT_AGE_GROUP_LABELS[v] }}
-              </label>
-            {%- endfor %}
-          </fieldset>
-          {#-- 6. Insurance --#}
-          <fieldset class="posts-filter-section">
-            <legend>Insurance</legend>
-            {%- for v in INSURANCE_CARRIERS %}
-              <label>
-                <input type="checkbox"
-                       name="insurance"
-                       value="{{ v }}"
-                       {% if v in (filter_values.get("insurance") or []) %}checked{% endif %} />
-                {{ INSURANCE_CARRIER_LABELS[v] }}
-              </label>
-            {%- endfor %}
-          </fieldset>
-          <menu class="posts-filter-actions">
-            <li>
-              <button type="submit">Apply filters</button>
-            </li>
-            <li>
-              <a href="{{ _list_url }}" role="button" class="secondary outline">Clear all</a>
-            </li>
-          </menu>
-        </form>
+        {{ filter_form(_list_url, filter_values) }}
       </details>
     </aside>
     <div class="posts-results">

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -30,8 +30,8 @@
                     link_href=entity_url(entity_name) if active_filter_count else None
           ) }}
         {% endif %}
-      {%- if page_meta is defined %}{{ pagination(page_meta, paginator_base_query|default("")) }}{%- endif %}
+        {%- if page_meta is defined %}{{ pagination(page_meta, paginator_base_query|default("") ) }}{%- endif %}
+        </div>
       </div>
-    </div>
-  {% endblock %}
-{% block after_content %}{% endblock %}
+    {% endblock %}
+    {% block after_content %}{% endblock %}

--- a/src/domain/templates/posts/search.html
+++ b/src/domain/templates/posts/search.html
@@ -1,2 +1,4 @@
 {% extends "views/search.html" %}
+{%- from "posts/_shared/_filter_form.html" import filter_form -%}
 {% block resource_label %}Posts{% endblock %}
+{% block content %}{{ filter_form(list_action, filter_values) }}{% endblock %}


### PR DESCRIPTION
## Summary

- Extracts the posts filter sidebar into a `filter_form(list_url, filter_values)` Jinja macro in `posts/_shared/_filter_form.html`
- `posts/list.html` sidebar imports and calls the macro (replaces ~120 lines of inline form HTML)
- `posts/search.html` overrides the generic framework content block with the same macro — giving mobile users a full-page filter view at `/posts/search` with identical filter fields and pre-populated values

## Test plan

- [ ] `dev test src/domain/routes/test_posts.py` — 26 tests pass including two new ones that assert both surfaces render `posts-filter-section` fieldsets (Type, Location, Level of care, Modality, Populations, Insurance) and that the search page no longer uses the generic `search-checkbox-fieldset` framework form
- [ ] Visit `/posts` on desktop — sidebar filter form looks and works as before
- [ ] Visit `/posts/search` — renders the same custom filter form (not the old generic one)
- [ ] Apply filters on `/posts/search` — submits to `/posts` with query params, results filtered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)