### PR TITLE
feat: mobile hamburger nav, filter sidebar link, legend styles

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -24,13 +24,11 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """Authenticated pages render the primary nav as a single `<ul>`
-    with the brand on the left and five inline links pushed to the
-    right via `margin-left: auto` on the first link: Home, Referrals
-    (= "find new clients"), Openings (= "refer out a client"), Profile,
-    and Sign out. Other URL families — `/intakes`, `/clinicians`,
-    `/organizations`, `/programs`, `/users` — stay live and reachable
-    by URL/bookmark, but are no longer chrome-promoted.
+    """Authenticated pages render a primary nav with a brand link on the
+    left and a <details>/<summary> collapsible menu containing four
+    destination links: Home, Posts, Profile, and Sign out. The <details>
+    pattern supports a mobile hamburger toggle at narrow widths while
+    keeping all links visible inline on desktop via CSS.
 
     The "Create clinician" chrome CTA was removed in #697 — the
     /users/me onboarding checklist is the discoverable entry point."""
@@ -39,17 +37,18 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     # "Create clinician" button no longer lives in the nav (#697).
-    cta_items = tree.css("#primary-nav > li > a[href='/clinicians/form']")
+    cta_items = tree.css("#primary-nav a[href='/clinicians/form']")
     assert len(cta_items) == 0, "Create-clinician CTA should be removed from nav (#697)"
-    # Profile link is one of the five inline nav links.
+    # Brand link is a direct child of the nav element.
+    assert tree.css_first('#primary-nav > a[href="/"]') is not None
+    # Profile link is in the collapsible nav menu.
     assert tree.css_first('#primary-nav a[href="/users/me"]') is not None
-    # All five authed-chrome destinations render in this exact order
-    # inside #primary-nav. Sign-out is the `#` placeholder href on the
+    # The four authed-chrome destinations render in this exact order
+    # inside #nav-menu. Sign-out is the `#` placeholder href on the
     # `<a hx-post>` that drives the HTMX POST.
-    nav_items = tree.css("#primary-nav > li > a")
+    nav_items = tree.css("#nav-menu ul li a")
     nav_hrefs = [a.attributes.get("href") for a in nav_items]
     assert nav_hrefs == [
-        "/",
         "/home",
         "/posts",
         "/users/me",

--- a/src/domain/templates/posts/_shared/_filter_form.html
+++ b/src/domain/templates/posts/_shared/_filter_form.html
@@ -6,7 +6,7 @@
 {% macro filter_form(list_url, filter_values) %}
   <form method="get" action="{{ list_url }}">
     {#-- 1. Type --#}
-    <fieldset class="posts-filter-section">
+    <fieldset>
       <legend>Type</legend>
       {%- for v, l in (
         ("referral",          "Client referrals"),
@@ -23,16 +23,16 @@
       {%- endfor %}
     </fieldset>
     {#-- 2. Location --#}
-    <fieldset class="posts-filter-section">
+    <fieldset>
       <legend>Location</legend>
-      <label style="flex-direction: column; align-items: stretch;">
+      <label>
         City
         <input type="search"
                name="city"
                value="{{ filter_values.get('city') or '' }}"
                placeholder="e.g. Portland" />
       </label>
-      <label style="flex-direction: column; align-items: stretch;">
+      <label>
         State
         <select name="state">
           <option value="">Any</option>
@@ -44,7 +44,7 @@
       </label>
     </fieldset>
     {#-- 3. Level of care (openings/intakes only) --#}
-    <fieldset class="posts-filter-section">
+    <fieldset>
       <legend>Level of care</legend>
       {%- for v in TREATMENT_SETTINGS %}
         <label>
@@ -57,7 +57,7 @@
       {%- endfor %}
     </fieldset>
     {#-- 4. Modality --#}
-    <fieldset class="posts-filter-section">
+    <fieldset>
       <legend>Modality</legend>
       {%- set modality_active = filter_values.get("modality") or [] %}
       {%- for v in TREATMENT_MODALITIES %}
@@ -71,7 +71,7 @@
       {%- endfor %}
     </fieldset>
     {#-- 5. Populations (age_group) --#}
-    <fieldset class="posts-filter-section">
+    <fieldset>
       <legend>Populations</legend>
       {%- for v in CLIENT_AGE_GROUPS %}
         <label>
@@ -84,7 +84,7 @@
       {%- endfor %}
     </fieldset>
     {#-- 6. Insurance --#}
-    <fieldset class="posts-filter-section">
+    <fieldset>
       <legend>Insurance</legend>
       {%- for v in INSURANCE_CARRIERS %}
         <label>
@@ -96,7 +96,7 @@
         </label>
       {%- endfor %}
     </fieldset>
-    <menu class="posts-filter-actions">
+    <menu>
       <li>
         <button type="submit">Apply filters</button>
       </li>

--- a/src/domain/templates/posts/_shared/_filter_form.html
+++ b/src/domain/templates/posts/_shared/_filter_form.html
@@ -6,7 +6,7 @@
 {% macro filter_form(list_url, filter_values) %}
   <form method="get" action="{{ list_url }}">
     {#-- 1. Type --#}
-    <fieldset>
+    <fieldset class="posts-filter-section">
       <legend>Type</legend>
       {%- for v, l in (
         ("referral",          "Client referrals"),
@@ -23,7 +23,7 @@
       {%- endfor %}
     </fieldset>
     {#-- 2. Location --#}
-    <fieldset>
+    <fieldset class="posts-filter-section">
       <legend>Location</legend>
       <label>
         City
@@ -44,7 +44,7 @@
       </label>
     </fieldset>
     {#-- 3. Level of care (openings/intakes only) --#}
-    <fieldset>
+    <fieldset class="posts-filter-section">
       <legend>Level of care</legend>
       {%- for v in TREATMENT_SETTINGS %}
         <label>
@@ -57,7 +57,7 @@
       {%- endfor %}
     </fieldset>
     {#-- 4. Modality --#}
-    <fieldset>
+    <fieldset class="posts-filter-section">
       <legend>Modality</legend>
       {%- set modality_active = filter_values.get("modality") or [] %}
       {%- for v in TREATMENT_MODALITIES %}
@@ -71,7 +71,7 @@
       {%- endfor %}
     </fieldset>
     {#-- 5. Populations (age_group) --#}
-    <fieldset>
+    <fieldset class="posts-filter-section">
       <legend>Populations</legend>
       {%- for v in CLIENT_AGE_GROUPS %}
         <label>
@@ -84,7 +84,7 @@
       {%- endfor %}
     </fieldset>
     {#-- 6. Insurance --#}
-    <fieldset>
+    <fieldset class="posts-filter-section">
       <legend>Insurance</legend>
       {%- for v in INSURANCE_CARRIERS %}
         <label>

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -2,23 +2,26 @@
 {%- from "posts/_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {%- from "posts/_shared/_filter_form.html" import filter_form -%}
 {%- from "_shared/pagination.html" import pagination -%}
+{%- from "_shared/_toolbar.html" import page_toolbar -%}
 {% block resource_label %}Posts{% endblock %}
-{% block actions %}
-  <li>
-    <a href="{{ entity_form_url('post') }}" role="button">{{ entity_create_label("post") }}</a>
-  </li>
+{% block toolbar %}
+  {% call page_toolbar(heading="Posts") %}
+    <li>
+      <a href="{{ entity_form_url('post') }}" role="button">{{ entity_create_label("post") }}</a>
+    </li>
+  {% endcall %}
 {% endblock %}
+{% block actions %}{% endblock %}
 {% block content %}
   {%- set _list_url = entity_url("post") -%}
   <div class="posts-browse-layout">
     <aside class="posts-filter-sidebar">
-      <details class="posts-filter-disclosure" open>
-        <summary class="posts-filter-summary">
-          Filters
+      <hgroup>
+        <a href="{{ entity_url("post") }}/search">Filters
           {% if active_filter_count %}({{ active_filter_count }}){% endif %}
-        </summary>
-        {{ filter_form(_list_url, filter_values) }}
-      </details>
+        </a>
+      </hgroup>
+      {{ filter_form(_list_url, filter_values) }}
     </aside>
     <div class="posts-results">
       {% if posts %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -584,6 +584,8 @@
          of `<header>` and `<main>`). Centered chrome line, present on
          every page via the default `{% raw %}{% block footer %}{% endraw %}` body. */
       footer.container { text-align: center; }
+      fieldset { border: none; padding: 0; margin: 0 0 1.25rem; }
+      legend { font-size: 0.8em; text-transform: uppercase; color: var(--pico-muted-color); font-weight: 500; padding: 0; }
       /* Primary nav — brand always visible; links in a <details> so mobile
          can collapse them behind a hamburger toggle. */
       #primary-nav {

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -584,6 +584,47 @@
          of `<header>` and `<main>`). Centered chrome line, present on
          every page via the default `{% raw %}{% block footer %}{% endraw %}` body. */
       footer.container { text-align: center; }
+      /* Primary nav — brand always visible; links in a <details> so mobile
+         can collapse them behind a hamburger toggle. */
+      #primary-nav {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding-block: 0.5rem;
+      }
+      /* Primary nav hamburger — strip Pico's built-in chevron */
+      .nav-menu-toggle { list-style: none; margin-bottom: 0; }
+      #primary-nav > details { margin: 0; }
+      #primary-nav > details[open] > summary { margin-bottom: 0; }
+      .nav-menu-toggle::-webkit-details-marker { display: none; }
+      .nav-menu-toggle::marker { display: none; }
+      .nav-menu-toggle::after { display: none; }
+      /* Desktop: summary hidden, links always visible inline */
+      @media (min-width: 641px) {
+        .nav-menu-toggle { display: none; }
+        #nav-menu, #nav-menu[open] { display: contents; }
+        #nav-menu > ul { display: flex !important; list-style: none; padding: 0; margin: 0 0 0 auto; gap: 1rem; }
+      }
+      /* Mobile: hamburger shows, open menu covers full screen below nav */
+      @media (max-width: 640px) {
+        header.container { position: relative; }
+        #nav-menu:not([open]) .nav-menu-close-icon { display: none; }
+        #nav-menu[open] .nav-menu-open-icon { display: none; }
+        #nav-menu[open] > ul {
+          position: absolute;
+          top: 100%;
+          left: 0;
+          right: 0;
+          min-height: 100dvh;
+          z-index: 10;
+          background: var(--pico-background-color);
+          display: flex;
+          flex-direction: column;
+          list-style: none;
+          padding: 0;
+          margin: 0;
+        }
+      }
       /* Sticky-footer layout. The body is a three-row grid
          (`<header>` / `<main>` / `<footer>`) sized to the viewport, so
          short pages pin the footer at the bottom instead of leaving it
@@ -696,22 +737,17 @@
       .posts-filter-sidebar { flex: 0 0 220px; min-width: 0; }
       .posts-results { flex: 1 1 0; min-width: 0; }
 
-      /* On desktop hide the <summary> toggle — the <details open> is always
-         expanded so the form shows as a static sidebar. On mobile the
-         summary is visible; the user can tap it to collapse the form. */
-      @media (min-width: 641px) {
-        .posts-filter-disclosure > .posts-filter-summary { display: none; }
-      }
-      /* Narrow: stack sidebar full-width above results */
+      /* Narrow: stack sidebar full-width above results; hide inline form */
       @media (max-width: 640px) {
         .posts-browse-layout { flex-direction: column; }
         .posts-filter-sidebar { flex: unset; width: 100%; }
+        .posts-filter-form { display: none; }
       }
 
       /* Filter form internals */
       fieldset.posts-filter-section { padding: 0; margin-bottom: var(--pico-spacing); }
       fieldset.posts-filter-section label { display: flex; align-items: center; }
-.posts-filter-actions {
+      .posts-filter-actions {
         display: flex;
         flex-direction: column;
         gap: var(--pico-spacing);
@@ -814,38 +850,33 @@
     {%- set _posts_path = entity_url('post') -%}
     {%- set _on_posts = is_authenticated and (request.url.path == _posts_path or request.url.path.startswith(_posts_path + '/')) -%}
     <header class="container">
-      <nav aria-label="Primary">
-        <ul id="primary-nav">
-          <li>
-            <a href="/"><strong>Bedlam Connect</strong></a>
-          </li>
-          {% if is_authenticated %}
-            {# Flat nav: brand on the left, five links pushed right via
-             `margin-left: auto` on the first item. Sign-out uses
-             `hx-post` because the route returns `HX-Redirect`; HTMX
-             handles the full-page navigation to `/auth/login`.
-             Overflow on narrow viewports is a known follow-up — for
-             now the row may wrap or scroll horizontally on small
-             screens. #}
-            <li style="margin-left: auto;">
-              <a href="/home" {% if _on_home %}aria-current="page"{% endif %}>Home</a>
-            </li>
-            <li>
-              <a href="{{ entity_url('post') }}"
-                 {% if _on_posts %}aria-current="page"{% endif %}>Posts</a>
-            </li>
-            <li>
-              <a href="{{ entity_url('user', id='me') }}"
-                 {% if _on_profile %}aria-current="page"{% endif %}>Profile</a>
-            </li>
-            <li>
-              <a href="#" hx-post="/auth/sign-out">Sign out</a>
-            </li>
-          {% endif %}
-          {# Anonymous visitors get only the brand link; the chrome
-             carries no Login shortcut. Visitors enter the auth flow
-             from the landing page CTA. #}
-        </ul>
+      <nav aria-label="Primary" id="primary-nav">
+        <a href="/"><strong>Bedlam Connect</strong></a>
+        {% if is_authenticated %}
+          <details id="nav-menu">
+            <summary class="nav-menu-toggle" aria-label="Menu">
+              <i class="icon-menu nav-menu-open-icon"></i>
+              <i class="icon-x nav-menu-close-icon"></i>
+            </summary>
+            <ul>
+              <li>
+                <a href="/home" {% if _on_home %}aria-current="page"{% endif %}>Home</a>
+              </li>
+              <li>
+                <a href="{{ entity_url('post') }}"
+                   {% if _on_posts %}aria-current="page"{% endif %}>Posts</a>
+              </li>
+              <li>
+                <a href="{{ entity_url('user', id='me') }}"
+                   {% if _on_profile %}aria-current="page"{% endif %}>Profile</a>
+              </li>
+              <li>
+                <a href="#" hx-post="/auth/sign-out">Sign out</a>
+              </li>
+            </ul>
+          </details>
+        {% endif %}
+        {# Anonymous visitors get only the brand link. #}
       </nav>
     </header>
     <main class="container">


### PR DESCRIPTION
## Summary

- Mobile nav hidden behind Lucide hamburger toggle (`icon-menu`/`icon-x`); opens as full-screen overlay below the nav bar; desktop nav unchanged
- Posts filter sidebar: replace `<details>` collapsible with a plain `Filters` `<h2>` link to `/posts/search` on mobile; inline filter form stays on desktop, hidden on mobile
- Remove toolbar filter link from posts list (sidebar link replaces it)
- Global `fieldset`/`legend` styles: border/padding/margin reset + uppercase 0.8em muted label treatment

## Test plan

- [ ] Desktop: nav links visible inline as before
- [ ] Mobile (≤640px): hamburger shows, tap opens full-screen menu with Home/Posts/Profile/Sign out; tap × closes
- [ ] `/posts` desktop: Filters h2 link + inline filter form in sidebar
- [ ] `/posts` mobile: only Filters link visible, tap goes to `/posts/search`
- [ ] Fieldset legends across the app render as small uppercase muted labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)