### PR TITLE
fix: hide filter form on mobile

### DIFF
--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -21,7 +21,7 @@
           {% if active_filter_count %}({{ active_filter_count }}){% endif %}
         </a>
       </hgroup>
-      {{ filter_form(_list_url, filter_values) }}
+      <div class="posts-filter-form">{{ filter_form(_list_url, filter_values) }}</div>
     </aside>
     <div class="posts-results">
       {% if posts %}


### PR DESCRIPTION
## Summary
- Wraps the `filter_form` macro call in `<div class="posts-filter-form">` so the existing CSS rule `(.posts-filter-form { display: none })` at ≤640px actually hides it on small screens

## Test plan
- [ ] Visual: `/posts` on narrow screen (≤640px) — filter form should not be visible; "Filters" link should still appear
- [ ] Visual: `/posts` on desktop — filter form visible as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)