### PR TITLE
style: clean up post feed CSS and semantic HTML

### DIFF
--- a/src/domain/templates/posts/_shared/_feed_row.html
+++ b/src/domain/templates/posts/_shared/_feed_row.html
@@ -31,7 +31,7 @@ under the "Feed rows" section. #}
 {%- set headline = post_feed_headline(post) -%}
 {%- set kind_class = "referral" if post.kind == "referral" else ("intake" if post.kind == "program_intake" else "opening") -%}
 {%- set kind_label = "Referral" if post.kind == "referral" else ("Intake" if post.kind == "program_intake" else "Opening") -%}
-<div class="post-feed-row" data-kind="{{ post.kind }}">
+<article class="post-feed-row" data-kind="{{ post.kind }}">
 {# ── Header: pill · poster · timestamp ───────────────────────── #}
 <div class="post-feed-header">
 <span class="post-feed-type-tag post-feed-type-tag--{{ kind_class }}">{{ kind_label }}</span>
@@ -109,13 +109,13 @@ under the "Feed rows" section. #}
 {%- endif -%}
 {%- endif -%}
 </div>
-</div>
+</article>
 {%- endmacro %}
 {% macro post_feed_empty(message="No recent posts match your filters.", link_href=None, link_label="See all recent activity →") -%}
-<div class="post-feed-empty">
+<article class="post-feed-empty">
 <p>{{ message }}</p>
 {%- if link_href -%}
 <a href="{{ link_href }}">{{ link_label }}</a>
 {%- endif -%}
-</div>
+</article>
 {%- endmacro %}

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -25,9 +25,9 @@
     </aside>
     <div class="posts-results">
       {% if posts %}
-        <article id="posts-list" class="post-feed-list">
+        <section id="posts-list">
           {%- for post in posts %}{{ post_feed_row(post, entity_name) }}{%- endfor %}
-          </article>
+          </section>
         {% else %}
           {{ post_feed_empty("No posts match these filters." if active_filter_count else "No posts found.",
                     link_href=entity_url(entity_name) if active_filter_count else None

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -663,16 +663,12 @@
          + timestamp), then headline link, then meta strip. Container is
          a Pico <article>; these rules add only the bespoke layout,
          type-tag pill, and middot dividers. */
-      .post-feed-list { padding: 0; overflow: hidden; }
       .post-feed-row {
         display: flex;
         flex-direction: column;
-        gap: 0.3rem;
-        padding: 0.875rem 1rem;
         border-top: 1px solid var(--pico-muted-border-color);
       }
       .post-feed-list .post-feed-row:first-child { border-top: none; }
-      .post-feed-row--interest { opacity: 1; }
       /* Header line — pill · poster · timestamp */
       .post-feed-header {
         display: flex;
@@ -725,10 +721,6 @@
       .post-feed-headline-text:visited { color: var(--pico-muted-color); }
       /* Expressed-interest override */
       .post-feed-row--interest .post-feed-headline-text:visited { color: var(--pico-primary); }
-      /* Narrow screens */
-      @media (max-width: 640px) {
-        .post-feed-row { padding: 0.75rem; }
-      }
 
       /* ---- Posts browse two-column layout -------------------------------- */
       .posts-browse-layout {
@@ -744,18 +736,6 @@
         .posts-browse-layout { flex-direction: column; }
         .posts-filter-sidebar { flex: unset; width: 100%; }
         .posts-filter-form { display: none; }
-      }
-
-      /* Filter form internals */
-      fieldset.posts-filter-section { padding: 0; margin-bottom: var(--pico-spacing); }
-      fieldset.posts-filter-section label { display: flex; align-items: center; }
-      .posts-filter-actions {
-        display: flex;
-        flex-direction: column;
-        gap: var(--pico-spacing);
-        list-style: none;
-        padding: 0;
-        margin: 0;
       }
     </style>
     <script src="https://unpkg.com/htmx.org@2.0.4"


### PR DESCRIPTION
## Summary
- Convert `post-feed-row` and `post-feed-empty` containers from `<div>` to `<article>`
- Replace `post-feed-list` `<article>` wrapper with `<section>` (since children are now `<article>`)
- Remove `post-feed-row` gap/padding rules (relying on Pico defaults)
- Remove unused `posts-filter-section` and `posts-filter-actions` CSS
- Remove `post-feed-row--interest` opacity override

## Test plan
- [ ] `/posts` renders feed rows correctly at desktop and mobile widths
- [ ] Empty state renders correctly when no posts match filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)