### PR TITLE
fix: exclude dev/templates from title-case lint

### DIFF
--- a/src/domain/templates/dev/.titleignore
+++ b/src/domain/templates/dev/.titleignore
@@ -1,0 +1,3 @@
+# Dev-only templates contain fixture data that represents arbitrary
+# user-generated content. Title-case rules don't apply.
+*.html

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -273,26 +273,25 @@ it's dev-only chrome that should never ship to production. #}
           <small>Rendered via <code>_shared/_card.html</code> → <code>card()</code> macro. Used by every list page.</small>
         </p>
         {# Full card with fact rows #}
-        {# title-case-ignore #}
         {% call card(id="1", headline_url="/example/1", headline="Dr. Jane Smith", subtitle="Sunrise Therapy · San Francisco, CA") %}
           <section class="entity-facts">
             <dl>
               <div data-fact="practice">
                 <dt>Practice</dt>
                 <dd>
-                  {# title-case-ignore #}Sunrise Therapy
+                  Sunrise Therapy
                 </dd>
               </div>
               <div data-fact="location">
                 <dt>Location</dt>
                 <dd>
-                  {# title-case-ignore #}San Francisco, CA
+                  San Francisco, CA
                 </dd>
               </div>
               <div data-fact="licensed_in">
                 <dt>Licensed in</dt>
                 <dd>
-                  {# title-case-ignore #}CA, NY
+                  CA, NY
                 </dd>
               </div>
             </dl>
@@ -305,7 +304,7 @@ it's dev-only chrome that should never ship to production. #}
               <div data-fact="location">
                 <dt>Location</dt>
                 <dd>
-                  {# title-case-ignore #}Oakland, CA
+                  Oakland, CA
                 </dd>
               </div>
             </dl>
@@ -481,7 +480,7 @@ it's dev-only chrome that should never ship to production. #}
             </div>
             <a href="#" class="post-feed-headline-text"><strong>Adult female (25–64) — psychotherapy, DBT</strong></a>
             <div class="post-feed-meta">
-              <span><i class="icon-map-pin"></i>{# title-case-ignore #}San Francisco, CA</span>
+              <span><i class="icon-map-pin"></i>San Francisco, CA</span>
               <span><i class="icon-monitor"></i>In-person · Telehealth</span>
               <span><i class="icon-shield"></i>Aetna</span>
             </div>
@@ -495,9 +494,9 @@ it's dev-only chrome that should never ship to production. #}
               </span>
             </div>
             <a href="#"
-               class="post-feed-headline-text post-feed-headline-text:visited"><strong>{# title-case-ignore #}Sunrise Therapy — psychotherapy, outpatient</strong></a>
+               class="post-feed-headline-text post-feed-headline-text:visited"><strong>Sunrise Therapy — psychotherapy, outpatient</strong></a>
             <div class="post-feed-meta">
-              <span><i class="icon-map-pin"></i>{# title-case-ignore #}Oakland, CA</span>
+              <span><i class="icon-map-pin"></i>Oakland, CA</span>
               <span><i class="icon-layers"></i>Outpatient</span>
               <span><i class="icon-shield"></i>Blue Cross · Aetna</span>
             </div>
@@ -511,10 +510,9 @@ it's dev-only chrome that should never ship to production. #}
                 <small>3d ago</small>
               </span>
             </div>
-            {# title-case-ignore #}
             <a href="#" class="post-feed-headline-text"><strong>Healing Path DBT Program — DBT, group therapy</strong></a>
             <div class="post-feed-meta">
-              <span><i class="icon-map-pin"></i>{# title-case-ignore #}Berkeley, CA</span>
+              <span><i class="icon-map-pin"></i>Berkeley, CA</span>
               <span><i class="icon-layers"></i>Outpatient · Intensive outpatient</span>
             </div>
           </article>
@@ -579,7 +577,7 @@ it's dev-only chrome that should never ship to production. #}
                 </div>
                 <a href="#" class="post-feed-headline-text"><strong>Adult female (25–64) — psychotherapy</strong></a>
                 <div class="post-feed-meta">
-                  <span><i class="icon-map-pin"></i>{# title-case-ignore #}San Francisco, CA</span>
+                  <span><i class="icon-map-pin"></i>San Francisco, CA</span>
                 </div>
               </article>
               <article class="post-feed-row">
@@ -587,10 +585,9 @@ it's dev-only chrome that should never ship to production. #}
                   <span class="post-feed-type-tag post-feed-type-tag--opening">Opening</span>
                   <span class="post-feed-byline"><small>1d ago</small></span>
                 </div>
-                {# title-case-ignore #}
                 <a href="#" class="post-feed-headline-text"><strong>Sunrise Therapy — outpatient</strong></a>
                 <div class="post-feed-meta">
-                  <span><i class="icon-map-pin"></i>{# title-case-ignore #}Oakland, CA</span>
+                  <span><i class="icon-map-pin"></i>Oakland, CA</span>
                 </div>
               </article>
             </div>


### PR DESCRIPTION
## Summary

- Adds `src/domain/templates/dev/.titleignore` so the title-case checker skips the component gallery
- Removes all `{# title-case-ignore #}` markers that were scattered through `components.html` — one ignore file is cleaner than per-line markers throughout a dev-only template

**Why:** Fixture data in the gallery represents arbitrary user-generated content (clinic names, city/state strings, credential acronyms) — exactly the kind of content the title-case rule wasn't designed to police.

The `ALWAYS_CAPITALIZE` additions from PR #1010 (LCSW, LMFT, LPC, LMHC, Lucide) are kept — those will appear in real production templates too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)