### PR TITLE
style: filter sidebar Kind label, filter icon, short kind labels

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -157,7 +157,7 @@ async def test_search_uses_shared_filter_form(
     logged_in_user,
 ):
     """`/posts/search` renders the same custom filter form component as the
-    list-page sidebar — `posts-filter-section` fieldsets for Type, Location,
+    list-page sidebar — `posts-filter-section` fieldsets for Kind, Location,
     Level of care, Modality, Populations, and Insurance — not the generic
     framework search form (`search-checkbox-fieldset`)."""
     response = await authenticated_client.get("/posts/search")
@@ -166,7 +166,7 @@ async def test_search_uses_shared_filter_form(
     sections = tree.css("fieldset.posts-filter-section")
     legends = [s.css_first("legend").text(strip=True) for s in sections]
     assert legends == [
-        "Type",
+        "Kind",
         "Location",
         "Level of care",
         "Modality",
@@ -193,7 +193,7 @@ async def test_list_sidebar_uses_shared_filter_form(
     sections = sidebar.css("fieldset.posts-filter-section")
     legends = [s.css_first("legend").text(strip=True) for s in sections]
     assert legends == [
-        "Type",
+        "Kind",
         "Location",
         "Level of care",
         "Modality",

--- a/src/domain/templates/posts/_shared/_filter_form.html
+++ b/src/domain/templates/posts/_shared/_filter_form.html
@@ -6,13 +6,13 @@
 {%- from "_shared/forms.html" import icon_legend, filter_checkbox -%}
 {% macro filter_form(list_url, filter_values) %}
   <form method="get" action="{{ list_url }}">
-    {#-- 1. Type --#}
+    {#-- 1. Kind --#}
     <fieldset class="posts-filter-section">
-      {{ icon_legend('tag', 'Type') }}
+      {{ icon_legend('filter', 'Kind') }}
       {%- for v, l in (
-        ("referral", "Client referrals"),
-        ("clinician_opening", "Clinician openings"),
-        ("program_intake", "Program intakes"),
+        ("referral", "Referral"),
+        ("clinician_opening", "Opening"),
+        ("program_intake", "Intake"),
         ) %}
         {{ filter_checkbox('kind', v, l, checked=(v in (filter_values.get("kind") or []))
         )


### PR DESCRIPTION
## Summary
- Renames the filter sidebar's first legend from "Type" → "Kind" to match the component library
- Swaps the icon from `tag` → `filter` (matches `components.html #checkboxes` and `#browse-layout`)
- Shortens checkbox labels: "Client referrals / Clinician openings / Program intakes" → "Referral / Opening / Intake"
- Updates the two route tests that asserted the old "Type" legend

## Test plan
- [ ] `dev test` passes (1964 passed before this change; same after)
- [ ] `dev lint` passes
- [ ] Visit `/posts` and `/posts/search` — filter sidebar shows "Kind" with filter icon and short labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)