### PR TITLE
fix: wrap all entity/feed lists in <ul>/<li> for valid semantic HTML

### DIFF
--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -94,16 +94,23 @@ table.post-rows td:nth-last-child(2) {
   white-space: nowrap;
 }
 /* ── Feed rows ────────────────────────────────────────────────
-   Each row is a vertical flex column: header line (pill + poster
-   + timestamp), then headline link, then meta strip. Container is
-   a Pico <article>; these rules add only the bespoke layout,
-   type-tag pill, and middot dividers. */
+   Container is <ul class="post-feed-list">; each item is
+   <li><article class="post-feed-row">. The <ul>/<li> reset removes
+   browser list chrome without affecting the accessibility tree —
+   screen readers still announce "list of N items". Each row is a
+   vertical flex column: header line, headline link, meta strip. */
+ul.post-feed-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+ul.post-feed-list > li { padding: 0; }
 .post-feed-row {
   display: flex;
   flex-direction: column;
   border-top: 1px solid var(--pico-muted-border-color);
 }
-.post-feed-list .post-feed-row:first-child { border-top: none; }
+.post-feed-list > li:first-child > .post-feed-row { border-top: none; }
 /* Header line — pill · poster · timestamp */
 .post-feed-header {
   display: flex;

--- a/src/domain/templates/clinicians/list.html
+++ b/src/domain/templates/clinicians/list.html
@@ -11,7 +11,9 @@
 {% block content %}
   {% if clinicians %}
     <section id="clinicians-list">
-      {%- for clinician in clinicians %}{{ clinician_card(clinician) }}{%- endfor %}
+      <ul class="entity-list">
+        {%- for clinician in clinicians %}{{ clinician_card(clinician) }}{%- endfor %}
+        </ul>
       </section>
     {% else %}
       <p>No clinicians found.</p>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -469,54 +469,60 @@ it's dev-only chrome that should never ship to production. #}
         <p>
           <small>CSS classes in <code>domain.css</code>. template macro: <code>posts/_shared/_feed_row.html</code> → <code>post_feed_row()</code>.</small>
         </p>
-        <div class="post-feed-list">
-          <article class="post-feed-row" data-kind="referral">
-            <div class="post-feed-header">
-              <span class="post-feed-type-tag post-feed-type-tag--referral">Referral</span>
-              <span class="post-feed-byline">
-                <small>A . Stone</small>
-                <small>2h ago</small>
-              </span>
-            </div>
-            <a href="#" class="post-feed-headline-text"><strong>Adult female (25–64) — psychotherapy, DBT</strong></a>
-            <div class="post-feed-meta">
-              <span><i class="icon-map-pin"></i>San Francisco, CA</span>
-              <span><i class="icon-monitor"></i>In-person · Telehealth</span>
-              <span><i class="icon-shield"></i>Aetna</span>
-            </div>
-          </article>
-          <article class="post-feed-row" data-kind="clinician_opening">
-            <div class="post-feed-header">
-              <span class="post-feed-type-tag post-feed-type-tag--opening">Opening</span>
-              <span class="post-feed-byline">
-                <small>B . Chen</small>
-                <small>1d ago</small>
-              </span>
-            </div>
-            <a href="#"
-               class="post-feed-headline-text post-feed-headline-text:visited"><strong>Sunrise Therapy — psychotherapy, outpatient</strong></a>
-            <div class="post-feed-meta">
-              <span><i class="icon-map-pin"></i>Oakland, CA</span>
-              <span><i class="icon-layers"></i>Outpatient</span>
-              <span><i class="icon-shield"></i>Blue Cross · Aetna</span>
-            </div>
-          </article>
-          <article class="post-feed-row post-feed-row--interest"
-                   data-kind="program_intake">
-            <div class="post-feed-header">
-              <span class="post-feed-type-tag post-feed-type-tag--intake">Intake</span>
-              <span class="post-feed-byline">
-                <small>C . Rivera</small>
-                <small>3d ago</small>
-              </span>
-            </div>
-            <a href="#" class="post-feed-headline-text"><strong>Healing Path DBT Program — DBT, group therapy</strong></a>
-            <div class="post-feed-meta">
-              <span><i class="icon-map-pin"></i>Berkeley, CA</span>
-              <span><i class="icon-layers"></i>Outpatient · Intensive outpatient</span>
-            </div>
-          </article>
-        </div>
+        <ul class="post-feed-list">
+          <li>
+            <article class="post-feed-row" data-kind="referral">
+              <div class="post-feed-header">
+                <span class="post-feed-type-tag post-feed-type-tag--referral">Referral</span>
+                <span class="post-feed-byline">
+                  <small>A . Stone</small>
+                  <small>2h ago</small>
+                </span>
+              </div>
+              <a href="#" class="post-feed-headline-text"><strong>Adult female (25–64) — psychotherapy, DBT</strong></a>
+              <div class="post-feed-meta">
+                <span><i class="icon-map-pin"></i>San Francisco, CA</span>
+                <span><i class="icon-monitor"></i>In-person · Telehealth</span>
+                <span><i class="icon-shield"></i>Aetna</span>
+              </div>
+            </article>
+          </li>
+          <li>
+            <article class="post-feed-row" data-kind="clinician_opening">
+              <div class="post-feed-header">
+                <span class="post-feed-type-tag post-feed-type-tag--opening">Opening</span>
+                <span class="post-feed-byline">
+                  <small>B . Chen</small>
+                  <small>1d ago</small>
+                </span>
+              </div>
+              <a href="#"
+                 class="post-feed-headline-text post-feed-headline-text:visited"><strong>Sunrise Therapy — psychotherapy, outpatient</strong></a>
+              <div class="post-feed-meta">
+                <span><i class="icon-map-pin"></i>Oakland, CA</span>
+                <span><i class="icon-layers"></i>Outpatient</span>
+                <span><i class="icon-shield"></i>Blue Cross · Aetna</span>
+              </div>
+            </article>
+          </li>
+          <li>
+            <article class="post-feed-row post-feed-row--interest"
+                     data-kind="program_intake">
+              <div class="post-feed-header">
+                <span class="post-feed-type-tag post-feed-type-tag--intake">Intake</span>
+                <span class="post-feed-byline">
+                  <small>C . Rivera</small>
+                  <small>3d ago</small>
+                </span>
+              </div>
+              <a href="#" class="post-feed-headline-text"><strong>Healing Path DBT Program — DBT, group therapy</strong></a>
+              <div class="post-feed-meta">
+                <span><i class="icon-map-pin"></i>Berkeley, CA</span>
+                <span><i class="icon-layers"></i>Outpatient · Intensive outpatient</span>
+              </div>
+            </article>
+          </li>
+        </ul>
       </section>
       <section class="gallery-section" id="credentials">
         <h2>Credential rows</h2>
@@ -569,28 +575,32 @@ it's dev-only chrome that should never ship to production. #}
             </form>
           </aside>
           <div class="posts-results">
-            <div class="post-feed-list">
-              <article class="post-feed-row">
-                <div class="post-feed-header">
-                  <span class="post-feed-type-tag post-feed-type-tag--referral">Referral</span>
-                  <span class="post-feed-byline"><small>2h ago</small></span>
-                </div>
-                <a href="#" class="post-feed-headline-text"><strong>Adult female (25–64) — psychotherapy</strong></a>
-                <div class="post-feed-meta">
-                  <span><i class="icon-map-pin"></i>San Francisco, CA</span>
-                </div>
-              </article>
-              <article class="post-feed-row">
-                <div class="post-feed-header">
-                  <span class="post-feed-type-tag post-feed-type-tag--opening">Opening</span>
-                  <span class="post-feed-byline"><small>1d ago</small></span>
-                </div>
-                <a href="#" class="post-feed-headline-text"><strong>Sunrise Therapy — outpatient</strong></a>
-                <div class="post-feed-meta">
-                  <span><i class="icon-map-pin"></i>Oakland, CA</span>
-                </div>
-              </article>
-            </div>
+            <ul class="post-feed-list">
+              <li>
+                <article class="post-feed-row">
+                  <div class="post-feed-header">
+                    <span class="post-feed-type-tag post-feed-type-tag--referral">Referral</span>
+                    <span class="post-feed-byline"><small>2h ago</small></span>
+                  </div>
+                  <a href="#" class="post-feed-headline-text"><strong>Adult female (25–64) — psychotherapy</strong></a>
+                  <div class="post-feed-meta">
+                    <span><i class="icon-map-pin"></i>San Francisco, CA</span>
+                  </div>
+                </article>
+              </li>
+              <li>
+                <article class="post-feed-row">
+                  <div class="post-feed-header">
+                    <span class="post-feed-type-tag post-feed-type-tag--opening">Opening</span>
+                    <span class="post-feed-byline"><small>1d ago</small></span>
+                  </div>
+                  <a href="#" class="post-feed-headline-text"><strong>Sunrise Therapy — outpatient</strong></a>
+                  <div class="post-feed-meta">
+                    <span><i class="icon-map-pin"></i>Oakland, CA</span>
+                  </div>
+                </article>
+              </li>
+            </ul>
           </div>
         </div>
       </section>

--- a/src/domain/templates/favorites/list.html
+++ b/src/domain/templates/favorites/list.html
@@ -4,7 +4,9 @@
 {% block content %}
   {% if clinicians %}
     <section id="favorites-list">
-      {%- for clinician in clinicians %}{{ clinician_card(clinician) }}{%- endfor %}
+      <ul class="entity-list">
+        {%- for clinician in clinicians %}{{ clinician_card(clinician) }}{%- endfor %}
+        </ul>
       </section>
     {% else %}
       <p id="favorites-empty">

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -18,11 +18,11 @@
         <h2>My active posts</h2>
         <a href="{{ entity_url('post') }}">See all</a>
       </header>
-      <article class="post-feed-list">
+      <ul class="post-feed-list">
         {%- for post in my_posts -%}
           {{ post_feed_row(post, "post", show_poster=False) }}
         {%- endfor -%}
-      </article>
+      </ul>
     </section>
   {% endif %}
   {% if network_posts %}
@@ -42,11 +42,11 @@
         <a href="{{ entity_url('post') }}">Adjust filters</a>
         {# djlint:on #}
       </p>
-      <article class="post-feed-list">
+      <ul class="post-feed-list">
         {%- for post in network_posts -%}
           {{ post_feed_row(post, "post") }}
         {%- endfor -%}
-      </article>
+      </ul>
     </section>
   {% endif %}
 {% endblock %}

--- a/src/domain/templates/organizations/list.html
+++ b/src/domain/templates/organizations/list.html
@@ -10,22 +10,24 @@
 {% block content %}
   {% if organizations %}
     <section id="organizations-list">
-      {%- for org in organizations %}
-        {% call card(
-          id=org.id,
-          headline_url=entity_url('organization', id=org.id),
-          headline=org.name) -%}
-          <section class="entity-facts">
-            <dl>
-              {{ fact('type', 'Type', ORGANIZATION_TYPES_LABELS[org.type]) }}
-              {%- if org.parent_org_id %}
-                {%- call fact('parent', 'Parent') %}<a href="{{ entity_url('organization', id=org.parent_org_id) }}">View parent</a>
-              {% endcall %}
-            {%- endif %}
-          </dl>
-        </section>
-      {%- endcall %}
-    {%- endfor %}
+      <ul class="entity-list">
+        {%- for org in organizations %}
+          {% call card(
+            id=org.id,
+            headline_url=entity_url('organization', id=org.id),
+            headline=org.name) -%}
+            <section class="entity-facts">
+              <dl>
+                {{ fact('type', 'Type', ORGANIZATION_TYPES_LABELS[org.type]) }}
+                {%- if org.parent_org_id %}
+                  {%- call fact('parent', 'Parent') %}<a href="{{ entity_url('organization', id=org.parent_org_id) }}">View parent</a>
+                {% endcall %}
+              {%- endif %}
+            </dl>
+          </section>
+        {%- endcall %}
+      {%- endfor %}
+    </ul>
   </section>
 {% else %}
   <p>No organizations found.</p>

--- a/src/domain/templates/posts/_shared/_feed_row.html
+++ b/src/domain/templates/posts/_shared/_feed_row.html
@@ -31,6 +31,7 @@ under the "Feed rows" section. #}
 {%- set headline = post_feed_headline(post) -%}
 {%- set kind_class = "referral" if post.kind == "referral" else ("intake" if post.kind == "program_intake" else "opening") -%}
 {%- set kind_label = "Referral" if post.kind == "referral" else ("Intake" if post.kind == "program_intake" else "Opening") -%}
+<li>
 <article class="post-feed-row" data-kind="{{ post.kind }}">
 {# ── Header: pill · poster · timestamp ───────────────────────── #}
 <div class="post-feed-header">
@@ -112,6 +113,7 @@ under the "Feed rows" section. #}
 {%- endif -%}
 </div>
 </article>
+</li>
 {%- endmacro %}
 {% macro post_feed_empty(message="No recent posts match your filters.", link_href=None, link_label="See all recent activity →") -%}
 <article class="post-feed-empty">

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -26,7 +26,9 @@
     <div class="posts-results">
       {% if posts %}
         <section id="posts-list">
-          {%- for post in posts %}{{ post_feed_row(post, entity_name) }}{%- endfor %}
+          <ul class="post-feed-list">
+            {%- for post in posts %}{{ post_feed_row(post, entity_name) }}{%- endfor %}
+            </ul>
           </section>
         {% else %}
           {{ post_feed_empty("No posts match these filters." if active_filter_count else "No posts found.",

--- a/src/domain/templates/programs/list.html
+++ b/src/domain/templates/programs/list.html
@@ -10,24 +10,26 @@
 {% block content %}
   {% if programs %}
     <section id="programs-list">
-      {%- for program in programs %}
-        {%- set subtitle %}
-          <span>{{ "Accepting referrals" if program.accepting_referrals else "Not accepting referrals" }}</span>
-          {%- if program.state_preference %}<span>{{ program.state_preference }}</span>{%- endif %}
-        {%- endset %}
-        {% call card(
-          id=program.id,
-          headline_url=entity_url('program', id=program.id),
-          headline=program.name,
-          subtitle=subtitle) -%}
-          <section class="entity-facts">
-            <dl>
-              {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a>
-            {% endcall %}
-          </dl>
-        </section>
-      {%- endcall %}
-    {%- endfor %}
+      <ul class="entity-list">
+        {%- for program in programs %}
+          {%- set subtitle %}
+            <span>{{ "Accepting referrals" if program.accepting_referrals else "Not accepting referrals" }}</span>
+            {%- if program.state_preference %}<span>{{ program.state_preference }}</span>{%- endif %}
+          {%- endset %}
+          {% call card(
+            id=program.id,
+            headline_url=entity_url('program', id=program.id),
+            headline=program.name,
+            subtitle=subtitle) -%}
+            <section class="entity-facts">
+              <dl>
+                {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a>
+              {% endcall %}
+            </dl>
+          </section>
+        {%- endcall %}
+      {%- endfor %}
+    </ul>
   </section>
 {% else %}
   {# Empty state owns its own CTA so the next action is in the eye-line of

--- a/src/domain/templates/users/clinicians_list.html
+++ b/src/domain/templates/users/clinicians_list.html
@@ -20,7 +20,9 @@
 {% block content %}
   {% if clinicians %}
     <section id="user-clinicians-list">
-      {%- for clinician in clinicians %}{{ clinician_card(clinician) }}{%- endfor %}
+      <ul class="entity-list">
+        {%- for clinician in clinicians %}{{ clinician_card(clinician) }}{%- endfor %}
+        </ul>
       </section>
     {% else %}
       <p id="user-clinicians-empty">

--- a/src/domain/templates/users/list.html
+++ b/src/domain/templates/users/list.html
@@ -4,37 +4,39 @@
 {% block content %}
   {% if users %}
     <section id="user-list">
-      {%- for user in users %}
-        {%- set status_subtitle %}
-          <span>
-            {% if user.is_active %}
-              Active
-            {% else %}
-              Deactivated
-            {% endif %}
-          </span>
-        {%- endset %}
-        {% call card(
-          id=user.id,
-          headline_url=entity_url('user', id=user.id),
-          headline=user.username,
-          subtitle=status_subtitle) -%}
-          {# Admin actions live in the card footer. The partial renders
+      <ul class="entity-list">
+        {%- for user in users %}
+          {%- set status_subtitle %}
+            <span>
+              {% if user.is_active %}
+                Active
+              {% else %}
+                Deactivated
+              {% endif %}
+            </span>
+          {%- endset %}
+          {% call card(
+            id=user.id,
+            headline_url=entity_url('user', id=user.id),
+            headline=user.username,
+            subtitle=status_subtitle) -%}
+            {# Admin actions live in the card footer. The partial renders
      nothing when `can_admin_actions` is False (e.g. a non-admin
      viewer). `<menu>` parent gives the `<li>` children valid HTML
      structure — same shape `_admin_actions.html` expects on the
      detail page's toolbar. #}
-          {%- if can_admin_actions %}
-            <footer>
-              <menu>
-                {%- with target_user = user, can_admin_actions = can_admin_actions -%}
-                  {%- include "users/_admin_actions.html" -%}
-                {%- endwith -%}
-              </menu>
-            </footer>
-          {%- endif %}
-        {%- endcall %}
-      {%- endfor %}
+            {%- if can_admin_actions %}
+              <footer>
+                <menu>
+                  {%- with target_user = user, can_admin_actions = can_admin_actions -%}
+                    {%- include "users/_admin_actions.html" -%}
+                  {%- endwith -%}
+                </menu>
+              </footer>
+            {%- endif %}
+          {%- endcall %}
+        {%- endfor %}
+      </ul>
     </section>
   {% else %}
     <p>No users found.</p>

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -16,6 +16,16 @@ html { scrollbar-gutter: stable; }
   --pico-font-size-h3: 1.125rem;
   --pico-font-size-h4: 1rem;
 }
+/* Entity list — <ul class="entity-list"> wraps every list of entity
+   cards. Resets remove browser list chrome while keeping the <ul>/<li>
+   in the accessibility tree so screen readers announce "list of N items".
+   Each <li> contains one <article class="entity-card">. */
+ul.entity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+ul.entity-list > li { padding: 0; }
 /* Card chrome (background, border, padding, rounded corners,
    tinted header/footer bands) is reserved for items inside a
    possible list of items — post-list cards, the per-affiliation

--- a/src/framework/templates/_shared/_card.html
+++ b/src/framework/templates/_shared/_card.html
@@ -53,15 +53,17 @@ For a card that needs a footer, emit `<footer>...</footer>` inside the
 caller body — Pico will tint it automatically.
 #}
 {% macro card(id, headline_url, headline, subtitle=None, data_kind=None) -%}
-  <article class="entity-card"
-           data-row-id="{{ id }}"
-           {% if data_kind %}data-kind="{{ data_kind }}"{% endif %}>
-    <header>
-      <h3>
-        <a href="{{ headline_url }}">{{ headline }}</a>
-      </h3>
-      {%- if subtitle %}<small class="meta">{{ subtitle }}</small>{%- endif %}
-    </header>
-    {{ caller() }}
-  </article>
+  <li>
+    <article class="entity-card"
+             data-row-id="{{ id }}"
+             {% if data_kind %}data-kind="{{ data_kind }}"{% endif %}>
+      <header>
+        <h3>
+          <a href="{{ headline_url }}">{{ headline }}</a>
+        </h3>
+        {%- if subtitle %}<small class="meta">{{ subtitle }}</small>{%- endif %}
+      </header>
+      {{ caller() }}
+    </article>
+  </li>
 {%- endmacro %}


### PR DESCRIPTION
## Summary

- Fixes #1006 — nested `<article>` elements caused by using `<article class="post-feed-list">` as a container for `post_feed_row()` macros that themselves emit `<article class="post-feed-row">`
- `card()` and `post_feed_row()` macros now emit `<li>` wrappers internally, so every call site gets proper list-item semantics without manual changes at each call site
- All list containers changed from `<div>`/`<article>` to `<ul class="entity-list">` / `<ul class="post-feed-list">` — screen readers now announce "list of N items"
- CSS list resets (`list-style: none; padding: 0`) on `ul.entity-list` and `ul.post-feed-list` preserve existing visual layout
- Updated `.post-feed-list > li:first-child > .post-feed-row` selector (was `.post-feed-list .post-feed-row:first-child`) to correctly target the first row now that `<li>` sits between `<ul>` and `<article>`

## Files changed

**Macros (emit `<li>` once; every caller inherits it):**
- `src/framework/templates/_shared/_card.html` — `card()` wraps `<article>` in `<li>`
- `src/domain/templates/posts/_shared/_feed_row.html` — `post_feed_row()` wraps `<article>` in `<li>`

**List containers (swapped to `<ul>`):**
- `src/domain/templates/home.html`
- `src/domain/templates/posts/list.html`
- `src/domain/templates/clinicians/list.html`
- `src/domain/templates/favorites/list.html`
- `src/domain/templates/users/clinicians_list.html`
- `src/domain/templates/organizations/list.html`
- `src/domain/templates/programs/list.html`
- `src/domain/templates/users/list.html`

**CSS:**
- `src/framework/static/css/framework.css` — `ul.entity-list` resets
- `src/domain/static/css/domain.css` — `ul.post-feed-list` resets + updated `:first-child` selector

**Gallery:**
- `src/domain/templates/dev/components.html` — inline HTML updated to match new structure

## Test plan

- [x] `dev test` — 1966 passed, 92 skipped
- [x] `dev lint` — all checks passed
- [x] `dev test contract` — 40 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)