### PR TITLE
fix: strip list-item markers from entity-list and post-feed-list <li>s

### DIFF
--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -104,7 +104,7 @@ ul.post-feed-list {
   padding: 0;
   margin: 0;
 }
-ul.post-feed-list > li { padding: 0; }
+ul.post-feed-list > li { list-style: none; padding: 0; }
 .post-feed-row {
   display: flex;
   flex-direction: column;

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -25,7 +25,9 @@ ul.entity-list {
   padding: 0;
   margin: 0;
 }
-ul.entity-list > li { padding: 0; }
+/* Pico v2 sets list-style-type on <li> itself, not the <ul>, so the
+   parent reset doesn't cascade — mirror the rule on the child. */
+ul.entity-list > li { list-style: none; padding: 0; }
 /* Card chrome (background, border, padding, rounded corners,
    tinted header/footer bands) is reserved for items inside a
    possible list of items — post-list cards, the per-affiliation


### PR DESCRIPTION
## Summary

- Pico v2 sets `list-style-type` on `<li>` itself rather than the `<ul>`, so the `list-style: none` reset on the parent doesn't cascade down — bullet markers and left-indent were still rendering on feed rows and entity cards
- Added `list-style: none` to `ul.entity-list > li` and `ul.post-feed-list > li`, matching the existing pattern already used for `.glyph-list li`

## Test plan

- [x] `dev lint` passes
- [ ] Visual check: feed rows and entity cards show no bullet markers or list indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)