### PR TITLE
feat: each worktree gets its own host port for dev up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .claude/scheduled_tasks.lock
 .claude/worktrees/
 
+# Per-worktree host port assignment (written by `dev worktree add`, read by `dev up`)
+.worktree-port
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,16 +4,17 @@ services:
       context: .
       dockerfile: deployment/docker/Dockerfile
       target: development
-    container_name: bedlam-connect-dev
     restart: unless-stopped
     ports:
-      - '8000:8000'
-      - '35729:35729' # LiveReload server port for development hot reloading
+      - '${APP_PORT:-8000}:8000'
+      - '${LIVERELOAD_PORT:-35729}:35729'
     environment:
       - SECRET=${SECRET}
       - DATABASE_URL=${DATABASE_URL:-sqlite+aiosqlite:///./data/bedlam-connect.db}
       - ACCESS_TOKEN_EXPIRE_MINUTES=${ACCESS_TOKEN_EXPIRE_MINUTES:-60}
       - DISABLE_SCHEDULER=1
+      - APP_PORT=${APP_PORT:-8000}
+      - LIVERELOAD_PORT=${LIVERELOAD_PORT:-35729}
     volumes:
       - ./data:/app/data
       - ./src:/app/src

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ This directory holds the project's developer CLI plus a handful of standalone sc
 
 `dev_cli.py` is the source of truth for `dev <command>`. It's installed as a console script via `pip install -e .` and auto-detects the current project root by walking up to `pyproject.toml`, so it operates on the worktree you're sitting in.
 
-Each worktree also runs under its own `docker compose` project name (derived from the project-root directory), so `dev up` / `dev seed` / `dev logs` in a worktree never collide with the main checkout. Export `COMPOSE_PROJECT_NAME` to override.
+Each worktree runs under its own `docker compose` project name (derived from the project-root directory) and its own host port (assigned at `dev worktree add` time, stored in `.worktree-port`), so `dev up` in a worktree binds a different port and never collides with the main checkout (port 8000) or other running worktrees. `dev up` prints the URL before starting. Export `COMPOSE_PROJECT_NAME`, `APP_PORT`, or `LIVERELOAD_PORT` to override.
 
 Run `dev --help` for the command list and `dev <command> --help` for per-command details. Help strings are co-located with the argparse definitions in [`dev_cli.py`](dev_cli.py), so they cannot drift from the implementation.
 

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -51,6 +51,26 @@ class CLIRunner:
         # can still override by exporting COMPOSE_PROJECT_NAME themselves;
         # we only set it when nothing else has.
         self.compose_project_name = self._derive_compose_project_name()
+        # Per-worktree ports (see #1007). Each worktree stores its assigned
+        # host port in .worktree-port; main checkout defaults to 8000/35729.
+        self.app_port, self.livereload_port = self._derive_ports()
+
+    def _derive_ports(self) -> "tuple[int, int]":
+        # Worktrees store their assigned host ports in .worktree-port
+        # (written by `dev worktree add`). The main checkout has no such
+        # file and uses the defaults. Format: "<app_port> <livereload_port>".
+        port_file = self.project_root / ".worktree-port"
+        if port_file.exists():
+            try:
+                parts = port_file.read_text().split()
+                app_port = int(parts[0])
+                livereload_port = (
+                    int(parts[1]) if len(parts) > 1 else 35729 + (app_port - 8000)
+                )
+                return app_port, livereload_port
+            except (ValueError, IndexError):
+                pass
+        return 8000, 35729
 
     def _derive_compose_project_name(self) -> str:
         # docker-compose project names must be lowercase alnum + `-`/`_`,
@@ -64,6 +84,8 @@ class CLIRunner:
     def _compose_env(self, extra: Optional[dict] = None) -> dict:
         env = os.environ.copy()
         env.setdefault("COMPOSE_PROJECT_NAME", self.compose_project_name)
+        env.setdefault("APP_PORT", str(self.app_port))
+        env.setdefault("LIVERELOAD_PORT", str(self.livereload_port))
         if extra:
             env.update(extra)
         return env
@@ -182,6 +204,10 @@ class DevCommands:
 
     def up(self, build: bool = False, detach: bool = False) -> int:
         print("🛠️ Starting development environment...")
+        app_port = self.runner.app_port
+        lr_port = self.runner.livereload_port
+        print(f"   App:        http://localhost:{app_port}")
+        print(f"   LiveReload: http://localhost:{lr_port}")
 
         cmd = ["docker", "compose", "-f", DOCKER_COMPOSE_DEV_FILE, "up"]
         if build:
@@ -645,8 +671,9 @@ class PlaywrightCommands:
         print("\nNext steps:")
         print("  1. Start the dev server:    dev up")
         print("  2. Seed the dev DB:         dev seed")
+        port = self.runner.app_port
         print("  3. Log in (bookmark this):")
-        print("       http://localhost:8000/dev/login-as-seed-user")
+        print(f"       http://localhost:{port}/dev/login-as-seed-user")
         print(
             "     Visiting it sets the session cookie for the seed admin user "
             "and redirects to /posts."
@@ -728,9 +755,29 @@ class WorktreeCommands:
         if result.returncode != 0:
             print(result.stderr.rstrip())
             return result.returncode
+        app_port = self._assign_worktree_port()
+        lr_port = 35729 + (app_port - 8000)
+        (path / ".worktree-port").write_text(f"{app_port} {lr_port}\n")
         print(f"✅ Worktree ready: {path}")
         print(f"   Branch: {branch}")
+        print(f"   App port: {app_port}  →  http://localhost:{app_port}")
         return 0
+
+    def _assign_worktree_port(self) -> int:
+        # Find the lowest unused port starting from 8001 by scanning all
+        # existing .worktree-port files under the worktrees root.
+        used: set = set()
+        wt_root = self._worktrees_root()
+        if wt_root.is_dir():
+            for port_file in wt_root.glob("*/.worktree-port"):
+                try:
+                    used.add(int(port_file.read_text().split()[0]))
+                except (ValueError, IndexError):
+                    pass
+        port = 8001
+        while port in used:
+            port += 1
+        return port
 
     def _looks_like_uuid(self, name: str) -> bool:
         # Heuristic: 6+ consecutive hex chars and no human-meaningful

--- a/scripts/runtime/start-dev.sh
+++ b/scripts/runtime/start-dev.sh
@@ -109,7 +109,7 @@ main() {
     setup_database
     run_migrations
     start_livereload_server
-    echo "🔥 Dev server: http://0.0.0.0:8000 (hot reload + LiveReload on :$LIVERELOAD_PORT)"
+    echo "🔥 Dev server: http://localhost:${APP_PORT:-8000} (hot reload + LiveReload on :$LIVERELOAD_PORT)"
     start_fastapi_dev
 }
 

--- a/scripts/test_dev_cli.py
+++ b/scripts/test_dev_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 
-from scripts.dev_cli import CLIRunner, SeedCommands, TestCommands
+from scripts.dev_cli import CLIRunner, SeedCommands, TestCommands, WorktreeCommands
 
 
 def test_clirunner_resolves_project_root_from_cwd(tmp_path: Path, monkeypatch):
@@ -279,3 +279,88 @@ def test_run_tests_affected_empty_selection_skips_pytest(monkeypatch):
     rc = TestCommands(runner, quality).run_tests(affected=True, skip_lint=True)
     assert rc == 0
     assert runner.last_cmd is None
+
+
+# ---------------------------------------------------------------------------
+# CLIRunner._derive_ports  (issue #1007)
+# ---------------------------------------------------------------------------
+
+
+def test_derive_ports_defaults_when_no_port_file(tmp_path: Path, monkeypatch):
+    """Main checkout (no .worktree-port) returns the standard defaults."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+    monkeypatch.chdir(tmp_path)
+    runner = CLIRunner()
+    assert runner.app_port == 8000
+    assert runner.livereload_port == 35729
+
+
+def test_derive_ports_reads_port_file(tmp_path: Path, monkeypatch):
+    """Worktree with .worktree-port uses the stored ports."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+    (tmp_path / ".worktree-port").write_text("8002 35731\n")
+    monkeypatch.chdir(tmp_path)
+    runner = CLIRunner()
+    assert runner.app_port == 8002
+    assert runner.livereload_port == 35731
+
+
+def test_derive_ports_falls_back_on_corrupt_port_file(tmp_path: Path, monkeypatch):
+    """Corrupt .worktree-port silently falls back to defaults."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+    (tmp_path / ".worktree-port").write_text("not-a-number\n")
+    monkeypatch.chdir(tmp_path)
+    runner = CLIRunner()
+    assert runner.app_port == 8000
+    assert runner.livereload_port == 35729
+
+
+def test_compose_env_injects_ports(tmp_path: Path, monkeypatch):
+    """`_compose_env` injects APP_PORT and LIVERELOAD_PORT."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+    (tmp_path / ".worktree-port").write_text("8003 35732\n")
+    monkeypatch.chdir(tmp_path)
+    runner = CLIRunner()
+    env = runner._compose_env()
+    assert env["APP_PORT"] == "8003"
+    assert env["LIVERELOAD_PORT"] == "35732"
+
+
+# ---------------------------------------------------------------------------
+# WorktreeCommands._assign_worktree_port  (issue #1007)
+# ---------------------------------------------------------------------------
+
+
+def _make_worktree_runner(tmp_path: Path, monkeypatch) -> CLIRunner:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'fake'\n")
+    monkeypatch.chdir(tmp_path)
+    return CLIRunner()
+
+
+def test_assign_worktree_port_starts_at_8001(tmp_path: Path, monkeypatch):
+    """First worktree gets port 8001."""
+    runner = _make_worktree_runner(tmp_path, monkeypatch)
+    wt_cmds = WorktreeCommands(runner)
+    assert wt_cmds._assign_worktree_port() == 8001
+
+
+def test_assign_worktree_port_skips_used_ports(tmp_path: Path, monkeypatch):
+    """Ports already taken by existing .worktree-port files are skipped."""
+    runner = _make_worktree_runner(tmp_path, monkeypatch)
+    wt_root = tmp_path / ".claude" / "worktrees"
+    (wt_root / "issue-1").mkdir(parents=True)
+    (wt_root / "issue-2").mkdir(parents=True)
+    (wt_root / "issue-1" / ".worktree-port").write_text("8001 35730\n")
+    (wt_root / "issue-2" / ".worktree-port").write_text("8002 35731\n")
+    wt_cmds = WorktreeCommands(runner)
+    assert wt_cmds._assign_worktree_port() == 8003
+
+
+def test_assign_worktree_port_ignores_corrupt_sibling(tmp_path: Path, monkeypatch):
+    """A corrupt sibling .worktree-port is skipped without raising."""
+    runner = _make_worktree_runner(tmp_path, monkeypatch)
+    wt_root = tmp_path / ".claude" / "worktrees"
+    (wt_root / "issue-bad").mkdir(parents=True)
+    (wt_root / "issue-bad" / ".worktree-port").write_text("oops\n")
+    wt_cmds = WorktreeCommands(runner)
+    assert wt_cmds._assign_worktree_port() == 8001

--- a/scripts/test_dev_cli_compose_project.py
+++ b/scripts/test_dev_cli_compose_project.py
@@ -10,7 +10,6 @@ subprocess.run env.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 from scripts.dev_cli import CLIRunner
@@ -24,6 +23,7 @@ def _make_runner_at(root: Path) -> CLIRunner:
     runner = CLIRunner.__new__(CLIRunner)
     runner.project_root = root
     runner.compose_project_name = runner._derive_compose_project_name()
+    runner.app_port, runner.livereload_port = runner._derive_ports()
     return runner
 
 


### PR DESCRIPTION
## Summary

- `dev worktree add` now assigns a unique host port (8001, 8002, …) and stores it in `.worktree-port` at the worktree root
- `dev up` reads `.worktree-port`, injects `APP_PORT`/`LIVERELOAD_PORT` into the compose env, and prints the app URL before starting
- `docker-compose.dev.yml` uses `${APP_PORT:-8000}:8000` so each worktree binds a different host port; main checkout keeps port 8000
- Removed hardcoded `container_name` so Docker Compose project-name namespacing handles container uniqueness (avoids name collision when multiple worktrees run simultaneously)
- `.worktree-port` added to `.gitignore`

Closes #1007

## Test plan

- [ ] `dev worktree add <name>` prints the assigned port and creates `.worktree-port` in the new worktree
- [ ] Running `dev up` in a worktree prints `http://localhost:8001` (or the worktree's assigned port)
- [ ] Running `dev up` in the main checkout still uses port 8000
- [ ] Two worktrees can run `dev up` simultaneously without port or container conflicts
- [ ] `dev test scripts/test_dev_cli.py` passes (23 tests, 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)