### PR TITLE
fix: copy .env from main checkout into new worktree

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -4,6 +4,7 @@
 import argparse
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -758,6 +759,9 @@ class WorktreeCommands:
         app_port = self._assign_worktree_port()
         lr_port = 35729 + (app_port - 8000)
         (path / ".worktree-port").write_text(f"{app_port} {lr_port}\n")
+        root_env = self.runner.project_root / ".env"
+        if root_env.exists():
+            shutil.copy(root_env, path / ".env")
         print(f"✅ Worktree ready: {path}")
         print(f"   Branch: {branch}")
         print(f"   App port: {app_port}  →  http://localhost:{app_port}")

--- a/scripts/test_dev_cli_worktree.py
+++ b/scripts/test_dev_cli_worktree.py
@@ -92,6 +92,23 @@ def test_add_prints_dev_up_hint(tmp_path: Path, capsys) -> None:
     assert str(repo / ".claude" / "worktrees" / "issue-707") in out
 
 
+def test_add_copies_env_when_present(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    (repo / ".env").write_text("SECRET=abc\n")
+    cmd = WorktreeCommands(_FakeRunner(repo))
+    assert cmd.add("707", base="origin/main") == 0
+    assert (
+        repo / ".claude" / "worktrees" / "issue-707" / ".env"
+    ).read_text() == "SECRET=abc\n"
+
+
+def test_add_skips_env_copy_when_absent(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    cmd = WorktreeCommands(_FakeRunner(repo))
+    assert cmd.add("707", base="origin/main") == 0
+    assert not (repo / ".claude" / "worktrees" / "issue-707" / ".env").exists()
+
+
 def test_add_refuses_when_path_exists(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     cmd = WorktreeCommands(_FakeRunner(repo))


### PR DESCRIPTION
Closes #1026

## Summary
- Copies `.env` from the repo root into the new worktree directory after creation, so `dev up` finds the JWT signing key and other secrets without a manual copy step
- Skips silently if no `.env` exists in the repo root

## Test plan
- [ ] `test_add_copies_env_when_present` — worktree gets a copy of `.env`
- [ ] `test_add_skips_env_copy_when_absent` — no `.env` in worktree when root has none
- [ ] `dev test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)