### PR TITLE
fix: print cd && dev up hint in dev worktree add output

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -761,6 +761,8 @@ class WorktreeCommands:
         print(f"✅ Worktree ready: {path}")
         print(f"   Branch: {branch}")
         print(f"   App port: {app_port}  →  http://localhost:{app_port}")
+        print(f"\n   To start the dev server:")
+        print(f"       cd {path} && dev up")
         return 0
 
     def _assign_worktree_port(self) -> int:

--- a/scripts/test_dev_cli_worktree.py
+++ b/scripts/test_dev_cli_worktree.py
@@ -83,6 +83,15 @@ def test_add_refuses_uuid_shaped_names(tmp_path: Path, capsys) -> None:
     assert not (repo / ".claude" / "worktrees" / "a3f9c2deadbeef").exists()
 
 
+def test_add_prints_dev_up_hint(tmp_path: Path, capsys) -> None:
+    repo = _init_repo(tmp_path)
+    cmd = WorktreeCommands(_FakeRunner(repo))
+    assert cmd.add("707", base="origin/main") == 0
+    out = capsys.readouterr().out
+    assert "dev up" in out
+    assert str(repo / ".claude" / "worktrees" / "issue-707") in out
+
+
 def test_add_refuses_when_path_exists(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     cmd = WorktreeCommands(_FakeRunner(repo))


### PR DESCRIPTION
Closes #1027

## Summary
- Adds a "To start the dev server: cd <path> && dev up" line to the success output of `dev worktree add`, making it clear the command must be run from the worktree directory to pick up the right port

## Test plan
- [ ] `test_add_prints_dev_up_hint` — output includes `dev up` and the worktree path
- [ ] `dev test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)