### PR TITLE
style: unify all entity forms on the referral-form grid pattern

### DIFF
--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -1,5 +1,5 @@
 {% extends "views/form_edit.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, text_field, select_field, radio_bool_field, multi_select_field -%}
+{%- from "_shared/form_fields.html" import entity_select_field, form_section, text_field, select_field, radio_bool_field, multi_select_field -%}
 {%- from "_shared/form_copy.html" import cost_help, npi_help, org_picker_help -%}
 {%- from "_shared/forms.html" import inline_add_form -%}
 {%- from "_shared/actions.html" import actions -%}
@@ -16,52 +16,41 @@
   {% endif %}
 {% endblock %}
 {% block form_content %}
-  <section>
-    <h2>Practice</h2>
-    {# `org_id` PATCH reassigns the clinician to a different Organization;
-     `org.name` itself changes by editing the Organization (not via this
-     form). To use a new Organization, create one via
-     `entity_form_url('organization')` first. #}
-    <form hx-patch="{{ entity_url('clinician', id=clinician.id) }}">
-      {# Person-level fields (name, NPI) — these live on the Clinician row,
-       so they follow the person across affiliations. #}
-      <fieldset>
-        <legend>Clinician</legend>
-        <div class="grid">
-          {{ text_field("first_name", "First name", current=clinician.first_name, required=false, maxlength=120) }}
-          {{ text_field("last_name", "Last name", current=clinician.last_name, required=false, maxlength=120) }}
-        </div>
-        {{ text_field("npi", "NPI", current=clinician.npi, required=false, pattern="\\d{10}", maxlength=10, help=npi_help() ) }}
-      </fieldset>
-      <fieldset>
-        <legend>Practice location</legend>
-        {{ entity_select_field("org_id", "Organization", orgs, current=clinician.org_id, help=org_picker_help() ) }}
-        <div class="grid">
-          {{ text_field("location_city", "City", current=clinician.location_city, maxlength=120) }}
-          {{ select_field("location_state", "State", US_STATES, current=clinician.location_state) }}
-          {{ text_field("location_zip", "ZIP", current=clinician.location_zip, pattern="\\d{5}", maxlength=5) }}
-        </div>
-      </fieldset>
-      <fieldset>
-        <legend>Session availability</legend>
-        <div class="grid">
-          {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=clinician.in_person_sessions) }}
-          {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=clinician.virtual_sessions) }}
-        </div>
-      </fieldset>
-      {# Insurance & payment. Empty carrier list = no in-network. #}
-      <fieldset>
-        <legend>Insurance &amp; payment</legend>
-        {{ multi_select_field("in_network_carriers", "In-network carriers", INSURANCE_CARRIERS, labels=INSURANCE_CARRIER_LABELS, current=clinician.in_network_carriers) }}
-        <div class="grid">
-          {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", current=clinician.accepts_out_of_network, required=false) }}
-          {{ radio_bool_field("sliding_scale", "Sliding scale?", current=clinician.sliding_scale, required=false) }}
-        </div>
-        {{ text_field("cost", "Cost", current=clinician.cost, required=false, help=cost_help() ) }}
-      </fieldset>
-      {{ actions("Save changes", cancel_url=entity_url('clinician', id=clinician.id) ) }}
-    </form>
-  </section>
+  {# `org_id` PATCH reassigns the clinician to a different Organization;
+   `org.name` itself changes by editing the Organization (not via this
+   form). To use a new Organization, create one via
+   `entity_form_url('organization')` first. #}
+  <form hx-patch="{{ entity_url('clinician', id=clinician.id) }}">
+    {# Person-level fields (name, NPI) — these live on the Clinician row,
+     so they follow the person across affiliations. #}
+    {% call form_section("Clinician") %}
+      {{ text_field("first_name", "First name", current=clinician.first_name, required=false, maxlength=120) }}
+      {{ text_field("last_name", "Last name", current=clinician.last_name, required=false, maxlength=120) }}
+      {{ text_field("npi", "NPI", current=clinician.npi, required=false, pattern="\\d{10}", maxlength=10, help=npi_help() ) }}
+    {% endcall %}
+    {% call form_section("Practice location") %}
+      {{ entity_select_field("org_id", "Organization", orgs, current=clinician.org_id, help=org_picker_help() ) }}
+      {{ text_field("location_city", "City", current=clinician.location_city, maxlength=120) }}
+      {{ select_field("location_state", "State", US_STATES, current=clinician.location_state) }}
+      {{ text_field("location_zip", "ZIP", current=clinician.location_zip, pattern="\\d{5}", maxlength=5) }}
+    {% endcall %}
+    {% call form_section("Session availability") %}
+      {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=clinician.in_person_sessions) }}
+      {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=clinician.virtual_sessions) }}
+    {% endcall %}
+    {# Insurance & payment. Empty carrier list = no in-network. #}
+    {% call form_section("Insurance & payment") %}
+      {{ multi_select_field("in_network_carriers", "In-network carriers", INSURANCE_CARRIERS, labels=INSURANCE_CARRIER_LABELS, current=clinician.in_network_carriers) }}
+      {{ radio_bool_field("accepts_out_of_network", "Accepts out-of-network?", current=clinician.accepts_out_of_network, required=false) }}
+      {{ radio_bool_field("sliding_scale", "Sliding scale?", current=clinician.sliding_scale, required=false) }}
+      {{ text_field("cost", "Cost", current=clinician.cost, required=false, help=cost_help() ) }}
+    {% endcall %}
+    {{ actions("Save changes", cancel_url=entity_url('clinician', id=clinician.id) ) }}
+  </form>
+  {# Sub-resource lists below the main entity form. These render outside
+   `.entity-form-page form`'s grid because each `inline_add_form` is its
+   own self-contained mini-form; the section headings group them
+   visually but they're not part of the clinician's edit grid. #}
   <section>
     {# Affiliations — clinician's practice-role rows. #}
     <h2>Affiliations</h2>

--- a/src/domain/templates/organizations/form_edit.html
+++ b/src/domain/templates/organizations/form_edit.html
@@ -1,19 +1,15 @@
 {% extends "views/form_edit.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, select_field, text_field -%}
+{%- from "_shared/form_fields.html" import entity_select_field, form_section, select_field, text_field -%}
 {%- from "_shared/actions.html" import actions -%}
 {% block resource_label %}Organizations{% endblock %}
 {% block current_label %}{{ organization.name }}{% endblock %}
 {% block form_content %}
   <form hx-patch="{{ entity_url('organization', id=organization.id) }}">
-    <fieldset>
-      <legend>Identity</legend>
-      <div class="grid">
-        {{ text_field("name", "Name", current=organization.name, maxlength=200) }}
-        {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, current=organization.type) }}
-      </div>
-    </fieldset>
-    <fieldset>
-      <legend>Hierarchy</legend>
+    {% call form_section("Identity") %}
+      {{ text_field("name", "Name", current=organization.name, maxlength=200) }}
+      {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, current=organization.type) }}
+    {% endcall %}
+    {% call form_section("Hierarchy") %}
       {# `root_org_id` is server-managed — see
        src/domain/models/organizations/README.md. The form exposes
        `parent_org_id` only; the repository recomputes `root_org_id`
@@ -32,7 +28,7 @@
             blank_label="(no parent)",
             required=false,
             help="Set one only if this is part of a larger network.",) }}
-    </fieldset>
+    {% endcall %}
     {{ actions("Save changes",
         cancel_url=entity_url('organization', id=organization.id) ,
     delete_url=entity_url('organization', id=organization.id),

--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -40,27 +40,29 @@ to the clinician-create flow when `current_user.clinicians` is empty.
   {%- set _hx_attrs = "hx-target=\"this\" hx-swap=\"outerHTML\" hx-target-4xx=\"this\" hx-swap-4xx=\"outerHTML\"" -%}
   <form hx-{{ hx_method }}="{{ action }}" {{ _hx_attrs|safe }}>
     <input type="hidden" name="kind" value="clinician_opening" />
-    <label for="subject">
-      Subject <small>(optional — leave blank to auto-generate)</small>
-      <input type="text"
-             name="subject"
-             id="subject"
-             maxlength="120"
-             value="{{ (form_values|default({}) ).get('subject') or (d.subject if d else '') or '' }}" />
-    </label>
+    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
     {# Practice picker. A Clinician may carry multiple Affiliations
      (clinician × org practice-role rows); the dropdown labels each
      option by the affiliation's org name so a clinician who works at
      two practices sees both options. Each option's value is the
-     clinician id; the label comes from the affiliation's org. #}
-    <label for="clinician_id">
-      Which practice?
+     clinician id; the label comes from the affiliation's org. Hand-
+     written rather than via `entity_select_field` because the option
+     label is sourced from a nested `affiliations` loop, not a flat
+     attribute on the clinician — mirrors `_form_referral.html`'s
+     referring_clinician_id picker. The `.form-field` + `.form-field-label`
+     wrapper slots it into the canonical 2-column grid. #}
+    {%- set _cid_fv = (form_values|default({})).get('clinician_id') -%}
+    <label class="form-field" for="clinician_id">
+      <span class="form-field-label">Which practice?</span>
       <select id="clinician_id" name="clinician_id" required>
         {%- for c in current_user.clinicians %}
           {%- set outer_first = loop.first %}
           {%- for aff in c.affiliations %}
+            {%- set is_fv_match = _cid_fv and _cid_fv|string == c.id|string and loop.first -%}
+            {%- set is_edit_match = not _cid_fv and d and d.clinician_id == c.id and loop.first -%}
+            {%- set is_create_default = not _cid_fv and not d and outer_first and loop.first -%}
             <option value="{{ c.id }}"
-                    {% if (d and d.clinician_id == c.id and loop.first) or (not d and outer_first and loop.first) %}selected{% endif %}>
+                    {% if is_fv_match or is_edit_match or is_create_default %}selected{% endif %}>
               {{ aff.org.name }}
             </option>
           {%- endfor %}

--- a/src/domain/templates/posts/_form_program_intake.html
+++ b/src/domain/templates/posts/_form_program_intake.html
@@ -18,28 +18,30 @@ The wrapper templates `posts/new_program_intake.html` /
 when `current_user.programs` is empty, so this macro always renders
 with at least one Program available.
 #}
-{%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, multi_select_field, field_for, form_section -%}
+{%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, multi_select_field, field_for, form_section with context -%}
 {%- from "_shared/form_copy.html" import modality_help, schedule_notes_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro intake_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
   {%- set d = post.intake_detail if post else None -%}
   <form hx-{{ hx_method }}="{{ action }}">
     <input type="hidden" name="kind" value="program_intake" />
-    <label for="subject">
-      Subject <small>(optional — leave blank to auto-generate)</small>
-      <input type="text"
-             name="subject"
-             id="subject"
-             maxlength="120"
-             value="{{ (form_values|default({}) ).get('subject') or (d.subject if d else '') or '' }}" />
-    </label>
-    <label for="program_id">
-      Which program?
+    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
+    {# Program picker — hand-written rather than via `entity_select_field`
+     because the option label is a composite "<Program> · <Org>" derived
+     from `p.organization.name`, not a flat attribute on `p`. The
+     `.form-field` + `.form-field-label` wrapper slots it into the
+     canonical 2-column grid; mirrors the picker pattern in
+     `_form_referral.html` / `_form_clinician_opening.html`. #}
+    {%- set _pid_fv = (form_values|default({})).get('program_id') -%}
+    <label class="form-field" for="program_id">
+      <span class="form-field-label">Which program?</span>
       <select id="program_id" name="program_id" required>
-        {%- if not d %}<option value="" disabled selected>--</option>{%- endif %}
+        {%- if not _pid_fv and not d %}<option value="" disabled selected>--</option>{%- endif %}
         {%- for p in current_user.programs %}
+          {%- set is_fv_match = _pid_fv and _pid_fv|string == p.id|string -%}
+          {%- set is_edit_match = not _pid_fv and d and d.program_id == p.id -%}
           <option value="{{ p.id }}"
-                  {% if d and d.program_id == p.id %}selected{% endif %}>
+                  {% if is_fv_match or is_edit_match %}selected{% endif %}>
             {{ p.name }} &middot; {{ p.organization.name }}
           </option>
         {%- endfor %}

--- a/src/domain/templates/programs/form_edit.html
+++ b/src/domain/templates/programs/form_edit.html
@@ -1,5 +1,5 @@
 {% extends "views/form_edit.html" %}
-{%- from "_shared/form_fields.html" import entity_select_field, radio_bool_field, select_field, text_field -%}
+{%- from "_shared/form_fields.html" import entity_select_field, form_section, radio_bool_field, select_field, text_field -%}
 {%- from "_shared/form_copy.html" import org_picker_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {% block resource_label %}Programs{% endblock %}
@@ -11,24 +11,19 @@
    the user doesn't own it, so the form doesn't silently drop the
    FK on submit). #}
   <form hx-patch="{{ entity_url('program', id=program.id) }}">
-    <fieldset>
-      <legend>Identity</legend>
+    {% call form_section("Identity") %}
       {{ entity_select_field("org_id", "Organization", organizations, current=program.org_id, help=org_picker_help() ) }}
       {{ text_field("name", "Name", current=program.name) }}
       {{ text_field("description", "Description", current=program.description, required=false) }}
-    </fieldset>
-    <fieldset>
-      <legend>Where and when</legend>
+    {% endcall %}
+    {% call form_section("Where and when") %}
       {{ select_field("state_preference", "State served", US_STATES, current=program.state_preference, required=false, placeholder=true) }}
-      <div class="grid">
-        {{ text_field("start_date", "Start date", current=program.start_date, required=false, type="date") }}
-        {{ text_field("end_date", "End date", current=program.end_date, required=false, type="date") }}
-      </div>
-    </fieldset>
-    <fieldset>
-      <legend>Intake</legend>
+      {{ text_field("start_date", "Start date", current=program.start_date, required=false, type="date") }}
+      {{ text_field("end_date", "End date", current=program.end_date, required=false, type="date") }}
+    {% endcall %}
+    {% call form_section("Intake") %}
       {{ radio_bool_field("accepting_referrals", "Accepting referrals?", current=program.accepting_referrals, required=false) }}
-    </fieldset>
+    {% endcall %}
     {{ actions("Save changes",
         cancel_url=entity_url('program', id=program.id) ,
     delete_url=entity_url('program', id=program.id),


### PR DESCRIPTION
## Summary

- Migrates the five entity forms that diverged from the canonical 2-column grid established in #1033 (the referral form is the model).
- No new macros or CSS — uses the existing `form_section` macro and `.form-field` subgrid; divergent templates just had to opt in.
- Three classes of divergence fixed: hand-written labels at the top of posts kind partials, raw `<fieldset><legend>` + `<div class="grid">` wrappers on programs/organizations forms, and `<section><h2>` + nested fieldsets on clinicians form.

## Notes

- `clinicians/form_edit.html` sub-resource lists (affiliations / licensures / education / certifications, via `inline_add_form`) are deliberately left untouched — they're a separate UI pattern below the main entity form.
- The `subject` and practice/program picker on `_form_clinician_opening.html` / `_form_program_intake.html` use the same `<label class="form-field"><span class="form-field-label">…</span>` hand-written wrapper as `_form_referral.html`'s `referring_clinician_id` picker, because the nested-affiliation option labels can't go through `entity_select_field` cleanly.

## Test plan

- [x] `dev test` — 1984 passed, 92 skipped
- [x] `dev test contract` — 40 passed
- [x] `dev lint` — passes
- [ ] Visual spot-check: open `/posts/form?kind=clinician_opening`, `/posts/form?kind=program_intake`, `/programs/<id>/form`, `/organizations/<id>/form`, `/clinicians/<id>/form` and confirm labels left / inputs right / legends spanning both columns / mobile (≤640px) collapse — all should look like `/posts/form?kind=referral`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)