### PR TITLE
refactor: extract composite_select_field for nested/composite post pickers

### DIFF
--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -22,7 +22,7 @@ to the clinician-create flow when `current_user.clinicians` is empty.
    the top of `_shared/form_fields.html`). No per-field error or value
    threading is required at the callsite; explicit overrides still win
    if a future caller needs them. #}
-{%- from "_shared/form_fields.html" import entity_select_field, text_field, textarea_field, select_field, multi_select_field, field_for, form_section with context -%}
+{%- from "_shared/form_fields.html" import entity_select_field, text_field, textarea_field, select_field, multi_select_field, composite_select_field, field_for, form_section with context -%}
 {%- from "_shared/form_copy.html" import modality_help, schedule_notes_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro opening_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
@@ -45,30 +45,17 @@ to the clinician-create flow when `current_user.clinicians` is empty.
      (clinician × org practice-role rows); the dropdown labels each
      option by the affiliation's org name so a clinician who works at
      two practices sees both options. Each option's value is the
-     clinician id; the label comes from the affiliation's org. Hand-
-     written rather than via `entity_select_field` because the option
-     label is sourced from a nested `affiliations` loop, not a flat
-     attribute on the clinician — mirrors `_form_referral.html`'s
-     referring_clinician_id picker. The `.form-field` + `.form-field-label`
-     wrapper slots it into the canonical 2-column grid. #}
-    {%- set _cid_fv = (form_values|default({})).get('clinician_id') -%}
-    <label class="form-field" for="clinician_id">
-      <span class="form-field-label">Which practice?</span>
-      <select id="clinician_id" name="clinician_id" required>
-        {%- for c in current_user.clinicians %}
-          {%- set outer_first = loop.first %}
-          {%- for aff in c.affiliations %}
-            {%- set is_fv_match = _cid_fv and _cid_fv|string == c.id|string and loop.first -%}
-            {%- set is_edit_match = not _cid_fv and d and d.clinician_id == c.id and loop.first -%}
-            {%- set is_create_default = not _cid_fv and not d and outer_first and loop.first -%}
-            <option value="{{ c.id }}"
-                    {% if is_fv_match or is_edit_match or is_create_default %}selected{% endif %}>
-              {{ aff.org.name }}
-            </option>
-          {%- endfor %}
-        {%- endfor %}
-      </select>
-    </label>
+     clinician id; the label comes from the affiliation's org. Uses
+     `composite_select_field` because the label is sourced from a
+     nested `affiliations` loop, not a flat attribute on the clinician
+     — mirrors `_form_referral.html`'s referring_clinician_id picker. #}
+    {%- set _practices = namespace(opts=[]) -%}
+    {%- for c in current_user.clinicians -%}
+      {%- for aff in c.affiliations -%}
+        {%- set _practices.opts = _practices.opts + [(c.id, aff.org.name)] -%}
+      {%- endfor -%}
+    {%- endfor -%}
+    {{ composite_select_field("clinician_id", "Which practice?", _practices.opts, current=d.clinician_id if d else None, default_first=true) }}
     {# About: free-text core fields — description / referral / website. #}
     {% call form_section("About") %}
       {{ field_for(schema, "description", "Description", current=d.description if d else None) }}

--- a/src/domain/templates/posts/_form_program_intake.html
+++ b/src/domain/templates/posts/_form_program_intake.html
@@ -18,7 +18,7 @@ The wrapper templates `posts/new_program_intake.html` /
 when `current_user.programs` is empty, so this macro always renders
 with at least one Program available.
 #}
-{%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, multi_select_field, field_for, form_section with context -%}
+{%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, multi_select_field, composite_select_field, field_for, form_section with context -%}
 {%- from "_shared/form_copy.html" import modality_help, schedule_notes_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro intake_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
@@ -26,27 +26,16 @@ with at least one Program available.
   <form hx-{{ hx_method }}="{{ action }}">
     <input type="hidden" name="kind" value="program_intake" />
     {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
-    {# Program picker — hand-written rather than via `entity_select_field`
-     because the option label is a composite "<Program> · <Org>" derived
-     from `p.organization.name`, not a flat attribute on `p`. The
-     `.form-field` + `.form-field-label` wrapper slots it into the
-     canonical 2-column grid; mirrors the picker pattern in
-     `_form_referral.html` / `_form_clinician_opening.html`. #}
-    {%- set _pid_fv = (form_values|default({})).get('program_id') -%}
-    <label class="form-field" for="program_id">
-      <span class="form-field-label">Which program?</span>
-      <select id="program_id" name="program_id" required>
-        {%- if not _pid_fv and not d %}<option value="" disabled selected>--</option>{%- endif %}
-        {%- for p in current_user.programs %}
-          {%- set is_fv_match = _pid_fv and _pid_fv|string == p.id|string -%}
-          {%- set is_edit_match = not _pid_fv and d and d.program_id == p.id -%}
-          <option value="{{ p.id }}"
-                  {% if is_fv_match or is_edit_match %}selected{% endif %}>
-            {{ p.name }} &middot; {{ p.organization.name }}
-          </option>
-        {%- endfor %}
-      </select>
-    </label>
+    {# Program picker — uses `composite_select_field` because the
+     option label is a "<Program> · <Org>" composite derived from
+     `p.organization.name`, not a flat attribute on `p`. Mirrors the
+     picker pattern in `_form_referral.html` /
+     `_form_clinician_opening.html`. #}
+    {%- set _programs = namespace(opts=[]) -%}
+    {%- for p in current_user.programs -%}
+      {%- set _programs.opts = _programs.opts + [(p.id, p.name ~ ' · ' ~ p.organization.name)] -%}
+    {%- endfor -%}
+    {{ composite_select_field("program_id", "Which program?", _programs.opts, current=d.program_id if d else None) }}
     {# About: free-text core fields — description / referral / website. #}
     {% call form_section("About") %}
       {{ field_for(schema, "description", "Description", current=d.description if d else None) }}

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -23,7 +23,7 @@ which FastAPI/Pydantic parses as a list.
    re-render (see `POST_ENTITY.form_error_render` + the docstring
    at the top of `_shared/form_fields.html`). No per-field error or
    value threading is required at the callsite below. #}
-{%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, multi_select_field, field_for, form_section with context -%}
+{%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, multi_select_field, composite_select_field, field_for, form_section with context -%}
 {%- from "_shared/form_copy.html" import modality_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro referral_form(hx_method, action, submit_label, post=None, schema=None, cancel_url=None) -%}
@@ -42,25 +42,17 @@ which FastAPI/Pydantic parses as a list.
     {# Referring clinician picker — required; populated from the
        current user's owned clinicians. Each option value is the
        clinician id; the label is the affiliated org name, mirroring
-       the PA form's practice-picker pattern. #}
-    {%- set _cr_fv = (form_values|default({})).get('referring_clinician_id') -%}
-    <label class="form-field" for="referring_clinician_id">
-      <span class="form-field-label">Referring clinician</span>
-      <select id="referring_clinician_id" name="referring_clinician_id" required>
-        {%- for c in current_user.clinicians %}
-          {%- set outer_first = loop.first %}
-          {%- for aff in c.affiliations %}
-            {%- set is_fv_match = _cr_fv and _cr_fv|string == c.id|string and loop.first -%}
-            {%- set is_edit_match = not _cr_fv and d and d.referring_clinician_id == c.id and loop.first -%}
-            {%- set is_create_default = not _cr_fv and not d and outer_first and loop.first -%}
-            <option value="{{ c.id }}"
-                    {% if is_fv_match or is_edit_match or is_create_default %}selected{% endif %}>
-              {{ aff.org.name }}
-            </option>
-          {%- endfor %}
-        {%- endfor %}
-      </select>
-    </label>
+       the PA form's practice-picker pattern. Multi-affiliation
+       clinicians produce one option per affiliation; the macro's
+       first-match-wins prefill keeps the `selected` on the first
+       occurrence so the dropdown's displayed selection is stable. #}
+    {%- set _practices = namespace(opts=[]) -%}
+    {%- for c in current_user.clinicians -%}
+      {%- for aff in c.affiliations -%}
+        {%- set _practices.opts = _practices.opts + [(c.id, aff.org.name)] -%}
+      {%- endfor -%}
+    {%- endfor -%}
+    {{ composite_select_field("referring_clinician_id", "Referring clinician", _practices.opts, current=d.referring_clinician_id if d else None, default_first=true) }}
     {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
     {% call form_section("Client location") %}
       {{ text_field("location_city", "City", current=d.location_city if d else None) }}

--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -104,9 +104,11 @@ to override the schema-derived default.
 Picking an organization, a parent organization, a program — anywhere
 a form posts a foreign key to another resource — use
 `entity_select_field`. It takes a list of objects with `.id` + `.name`
-(or pass `option_template_attr` to name a different display attribute).
-Composite-label cases (e.g. "<Program> · <Org>") pre-build a list of
-`(id, label)` tuples and pass that via `options=...` instead.
+(or pass `value_attr`/`label_attr` to name different attributes).
+Composite labels (e.g. "<Program> · <Org>") and nested-flatten cases
+(one option per `(clinician, affiliation)` pair) don't fit a flat
+`.attr` shape — for those, build a list of `(value, label)` tuples at
+the call site and pass it to `composite_select_field`.
 
 #}
 {# ---- helpers (internal) ------------------------------------------- #}
@@ -246,9 +248,9 @@ emitted attribute string. #}
 
    `entities` is a sequence of objects with `.id` and `.name` (or
    another attribute pair — pass `value_attr`/`label_attr` to override).
-   For composite labels (e.g. "<Program> · <Org>"), build the list in
-   the route handler as `[(id, "Program · Org"), ...]` tuples and pass
-   `options=that_list` to `select_field` directly instead.
+   For composite labels (e.g. "<Program> · <Org>") or nested-flatten
+   cases, build a `(value, label)` tuple list at the call site and use
+   `composite_select_field` instead.
 
    `blank_label=None` (default) renders Pico's disabled "--" placeholder
    when the field is required and unset; pass `blank_label="(root — no
@@ -287,63 +289,110 @@ emitted attribute string. #}
     {{- _help_small(name, help, error) }}
   </label>
 {%- endmacro %}
-{# ---- radio groups ------------------------------------------------- #}
-{# Yes / No radio pair. `<fieldset>` + `<legend>` is the accessible
-   substitute for `<label>` when one logical question owns multiple
-   inputs. Each radio carries `aria-describedby` so screen readers
-   announce the helper text on either selection. #}
-{% macro radio_bool_field(name, label, current=None, required=True, help=None) -%}
-  <fieldset class="form-field">
-    <legend class="form-field-label">{{ _field_label(label, required) }}</legend>
-    <div class="form-field-control">
-      <label class="form-field-inline">
-        <input type="radio"
-               name="{{ name }}"
-               value="true"
-               {% if current is sameas true %}checked{% endif %}
-               {% if required %}required{% endif %}
-               {% if help %}aria-describedby="{{ name }}-helper"{% endif %} />
-        Yes
-      </label>
-      <label class="form-field-inline">
-        <input type="radio"
-               name="{{ name }}"
-               value="false"
-               {% if current is sameas false %}checked{% endif %}
-               {% if required %}required{% endif %}
-               {% if help %}aria-describedby="{{ name }}-helper"{% endif %} />
-        No
-      </label>
-      {{- _help_small(name, help) }}
-    </div>
-  </fieldset>
-{%- endmacro %}
-{# ---- schema-driven dispatch --------------------------------------- #}
-{# Reads `field_spec(schema, name)` and delegates to the right inner
-   macro. `current`, `required`, `help`, `invalid` pass through. Pass
-   `required=false` to override the schema-derived default (e.g. an
-   optional filter on a field that's required for create). #}
-{% macro field_for(schema, name, label, current=None, required=None, help=None, invalid=None, error=None) -%}
+{# `<select>` populated from a pre-built list of `(value, label)` tuples.
+   Use when the option label can't be expressed as a flat attribute on a
+   single entity — composite labels (`"<Program> · <Org>"`) or a flatten
+   across a nested relation (one option per `(clinician, affiliation)`
+   pair, with the clinician id repeated as the value). For the flat case
+   (label is one attribute on each entity) use `entity_select_field`.
+
+   `options` is an iterable of `(value, label)` 2-tuples. Order matters:
+   the **first** option whose value matches the resolved `current` is
+   the one marked `selected`. Same-value duplicates that come later in
+   the list are emitted un-selected — this lets a caller flatten
+   `clinician × affiliations` without two `selected` attrs landing on
+   the same value (which would otherwise let the browser pick the last).
+
+   `default_first=true` makes the first option the default selection
+   when neither `current` nor `form_values[name]` is set — used by the
+   create-mode pickers that always want a non-empty initial selection.
+   With `default_first=false` (the default), a missing current renders
+   Pico's disabled "--" placeholder when the field is required. #}
+{% macro composite_select_field(name, label, options, current=None, required=True, default_first=False, help=None, invalid=None, error=None) -%}
   {%- set _form_errors = form_errors|default({}, true) -%}
   {%- set _form_values = form_values|default({}, true) -%}
   {%- set error = error if error is not none else _form_errors.get(name) -%}
   {%- set current = _form_values[name] if name in _form_values else current -%}
-  {%- set spec = field_spec(schema, name) -%}
-  {%- set is_required = spec.required if required is none else required -%}
-  {%- if spec.kind == "select" -%}
-    {{ select_field(name, label, spec.choices, labels=spec.labels, current=current, required=is_required, placeholder=true, help=help, invalid=invalid, error=error) }}
-  {%- elif spec.kind == "multi_select" -%}
-    {{ multi_select_field(name, label, spec.choices, labels=spec.labels, current=current, help=help, invalid=invalid, error=error) }}
-  {%- elif spec.kind == "textarea" -%}
-    {{ textarea_field(name, label, current=current, required=is_required, help=help, invalid=invalid, error=error) }}
-  {%- elif spec.kind == "url" -%}
-    {{ url_field(name, label, current=current, required=is_required, help=help, invalid=invalid, error=error) }}
-  {%- elif spec.kind == "text" -%}
-    {{ text_field(name, label, current=current, required=is_required, pattern=spec.pattern, maxlength=spec.maxlength, help=help, invalid=invalid, error=error) }}
-  {%- endif -%}
-{%- endmacro %}
-{# ---- form section ------------------------------------------------- #}
-{# Canonical `<fieldset>` + `<legend>` wrapper for a named group of
+  {%- set current_s = current|string if current is not none else "" -%}
+  {%- set aria_invalid = true if error else invalid -%}
+  {%- set ns = namespace(matched=false) -%}
+  <label class="form-field" for="{{ name }}">
+    <span class="form-field-label">{{ _field_label(label, required) }}</span>
+    <select id="{{ name }}"
+            name="{{ name }}"
+            {% if required %}required{% endif %}
+            {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
+            {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>
+      {%- if not default_first and required and not current_s %}<option value="" disabled selected>--</option>{%- endif %}
+      {%- for v, l in options %}
+        {%- set vs = v|string -%}
+        {%- set is_current_match = current_s and current_s == vs and not ns.matched -%}
+        {%- set is_default = default_first and not current_s and loop.first -%}
+        {%- if is_current_match or is_default %}{%- set ns.matched = true -%}{%- endif -%}
+          <option value="{{ v }}"
+                  {% if is_current_match or is_default %}selected{% endif %}>{{ l }}</option>
+        {%- endfor %}
+      </select>
+      {{- _help_small(name, help, error) }}
+    </label>
+  {%- endmacro %}
+  {# ---- radio groups ------------------------------------------------- #}
+  {# Yes / No radio pair. `<fieldset>` + `<legend>` is the accessible
+   substitute for `<label>` when one logical question owns multiple
+   inputs. Each radio carries `aria-describedby` so screen readers
+   announce the helper text on either selection. #}
+  {% macro radio_bool_field(name, label, current=None, required=True, help=None) -%}
+    <fieldset class="form-field">
+      <legend class="form-field-label">{{ _field_label(label, required) }}</legend>
+      <div class="form-field-control">
+        <label class="form-field-inline">
+          <input type="radio"
+                 name="{{ name }}"
+                 value="true"
+                 {% if current is sameas true %}checked{% endif %}
+                 {% if required %}required{% endif %}
+                 {% if help %}aria-describedby="{{ name }}-helper"{% endif %} />
+          Yes
+        </label>
+        <label class="form-field-inline">
+          <input type="radio"
+                 name="{{ name }}"
+                 value="false"
+                 {% if current is sameas false %}checked{% endif %}
+                 {% if required %}required{% endif %}
+                 {% if help %}aria-describedby="{{ name }}-helper"{% endif %} />
+          No
+        </label>
+        {{- _help_small(name, help) }}
+      </div>
+    </fieldset>
+  {%- endmacro %}
+  {# ---- schema-driven dispatch --------------------------------------- #}
+  {# Reads `field_spec(schema, name)` and delegates to the right inner
+   macro. `current`, `required`, `help`, `invalid` pass through. Pass
+   `required=false` to override the schema-derived default (e.g. an
+   optional filter on a field that's required for create). #}
+  {% macro field_for(schema, name, label, current=None, required=None, help=None, invalid=None, error=None) -%}
+    {%- set _form_errors = form_errors|default({}, true) -%}
+    {%- set _form_values = form_values|default({}, true) -%}
+    {%- set error = error if error is not none else _form_errors.get(name) -%}
+    {%- set current = _form_values[name] if name in _form_values else current -%}
+    {%- set spec = field_spec(schema, name) -%}
+    {%- set is_required = spec.required if required is none else required -%}
+    {%- if spec.kind == "select" -%}
+      {{ select_field(name, label, spec.choices, labels=spec.labels, current=current, required=is_required, placeholder=true, help=help, invalid=invalid, error=error) }}
+    {%- elif spec.kind == "multi_select" -%}
+      {{ multi_select_field(name, label, spec.choices, labels=spec.labels, current=current, help=help, invalid=invalid, error=error) }}
+    {%- elif spec.kind == "textarea" -%}
+      {{ textarea_field(name, label, current=current, required=is_required, help=help, invalid=invalid, error=error) }}
+    {%- elif spec.kind == "url" -%}
+      {{ url_field(name, label, current=current, required=is_required, help=help, invalid=invalid, error=error) }}
+    {%- elif spec.kind == "text" -%}
+      {{ text_field(name, label, current=current, required=is_required, pattern=spec.pattern, maxlength=spec.maxlength, help=help, invalid=invalid, error=error) }}
+    {%- endif -%}
+  {%- endmacro %}
+  {# ---- form section ------------------------------------------------- #}
+  {# Canonical `<fieldset>` + `<legend>` wrapper for a named group of
    fields. Replaces hand-written fieldsets in every form template so
    the section chrome is defined once and layout changes apply
    everywhere.
@@ -354,14 +403,14 @@ emitted attribute string. #}
        {{ select_field("location_state", "State", US_STATES) }}
      {% endcall %}
 #}
-{% macro form_section(title) -%}
-  <fieldset class="form-section">
-    <legend>{{ title }}</legend>
-    {{ caller() }}
-  </fieldset>
-{%- endmacro %}
-{# ---- specialized widgets ------------------------------------------ #}
-{# Day × time-of-day checkbox grid. One checkbox per (day, part) pair;
+  {% macro form_section(title) -%}
+    <fieldset class="form-section">
+      <legend>{{ title }}</legend>
+      {{ caller() }}
+    </fieldset>
+  {%- endmacro %}
+  {# ---- specialized widgets ------------------------------------------ #}
+  {# Day × time-of-day checkbox grid. One checkbox per (day, part) pair;
    all share the same `name` so the json-enc-arrays extension serializes
    them as a single JSON array of `<day>_<part>` tokens. `current` is an
    iterable of currently-selected tokens (`[]` on create, the persisted

--- a/src/framework/templates/_shared/test_form_fields.py
+++ b/src/framework/templates/_shared/test_form_fields.py
@@ -46,7 +46,7 @@ def _render(env: Environment, body: str) -> str:
     it so tests can stay focused on the macro call under test.
     """
     template = textwrap.dedent(f"""\
-        {{%- from "_shared/form_fields.html" import text_field, textarea_field, url_field, select_field, multi_select_field, entity_select_field, radio_bool_field -%}}
+        {{%- from "_shared/form_fields.html" import text_field, textarea_field, url_field, select_field, multi_select_field, entity_select_field, composite_select_field, radio_bool_field -%}}
         {body}
         """)
     return env.from_string(template).render()
@@ -283,6 +283,90 @@ def test_entity_select_field_preselects_current() -> None:
     assert selected.attributes.get("value") == "2"
 
 
+# --- composite_select_field -----------------------------------------------
+
+
+def test_composite_select_field_renders_option_per_tuple() -> None:
+    """`options=[(value, label), ...]` produces one `<option>` per tuple
+    in iteration order, with no implicit dedupe — flatten-nested call
+    sites depend on getting both occurrences emitted."""
+    html = _render(
+        _make_env(),
+        '{{ composite_select_field("clinician_id", "Practice",'
+        ' [("c1", "Acme"), ("c1", "Beta"), ("c2", "Gamma")]) }}',
+    )
+    tree = HTMLParser(html)
+    opts = tree.css('select[name="clinician_id"] option')
+    # placeholder + 3 tuples
+    assert len(opts) == 4
+    assert [o.text().strip() for o in opts[1:]] == ["Acme", "Beta", "Gamma"]
+    assert [o.attributes.get("value") for o in opts[1:]] == ["c1", "c1", "c2"]
+
+
+def test_composite_select_field_default_first_selects_first_when_no_current() -> None:
+    """`default_first=true` + no current/form_value → first option is
+    `selected` and no `--` placeholder is emitted. This is the
+    create-mode contract for the clinician practice pickers."""
+    html = _render(
+        _make_env(),
+        '{{ composite_select_field("x", "X",'
+        ' [("a", "A"), ("b", "B")], default_first=true) }}',
+    )
+    tree = HTMLParser(html)
+    opts = tree.css('select[name="x"] option')
+    assert len(opts) == 2
+    assert "selected" in opts[0].attributes
+    assert "selected" not in opts[1].attributes
+
+
+def test_composite_select_field_first_match_wins_on_duplicate_values() -> None:
+    """When `current` matches a value that appears multiple times in
+    `options`, only the FIRST occurrence is marked `selected` — keeps
+    the visible selection stable for nested-flatten pickers (a clinician
+    with two affiliations shouldn't render two `selected` options on
+    the same value)."""
+    html = _render(
+        _make_env(),
+        '{{ composite_select_field("x", "X",'
+        ' [("c1", "Acme"), ("c1", "Beta"), ("c2", "Gamma")], current="c1") }}',
+    )
+    tree = HTMLParser(html)
+    selected = tree.css('select[name="x"] option[selected]')
+    assert len(selected) == 1
+    assert selected[0].text().strip() == "Acme"
+
+
+def test_composite_select_field_required_no_current_emits_placeholder() -> None:
+    """Default mode (no `default_first`, no `current`) renders Pico's
+    disabled `--` placeholder so the user is forced to pick — same
+    behavior as `entity_select_field` for required selects."""
+    html = _render(
+        _make_env(),
+        '{{ composite_select_field("x", "X", [("a", "A")]) }}',
+    )
+    tree = HTMLParser(html)
+    placeholder = tree.css_first('select[name="x"] option[disabled]')
+    assert placeholder is not None
+    assert "selected" in placeholder.attributes
+    assert placeholder.text().strip() == "--"
+
+
+def test_composite_select_field_current_wins_over_default_first() -> None:
+    """If both `current` and `default_first=true` are set, `current`
+    selects the matching option — `default_first` only kicks in when
+    no current/form_value is set. Pins the precedence so the create-
+    mode default doesn't override a validation-rerender's form_value."""
+    html = _render(
+        _make_env(),
+        '{{ composite_select_field("x", "X",'
+        ' [("a", "A"), ("b", "B")], current="b", default_first=true) }}',
+    )
+    tree = HTMLParser(html)
+    selected = tree.css('select[name="x"] option[selected]')
+    assert len(selected) == 1
+    assert selected[0].attributes.get("value") == "b"
+
+
 # --- optional indicator ---------------------------------------------------
 
 
@@ -368,7 +452,7 @@ def _render_macro(macro_call: str) -> "HTMLParser":
     template = (
         '{%- from "_shared/form_fields.html" import text_field, textarea_field,'
         " url_field, select_field, multi_select_field, entity_select_field,"
-        " field_for -%}\n"
+        " composite_select_field, field_for -%}\n"
         f"{macro_call}"
     )
     return HTMLParser(env.from_string(template).render())
@@ -396,6 +480,11 @@ _INPUT_MACROS = [
     (
         "entity_select_field",
         '{{ entity_select_field("x", "X", entities, error="bad") }}',
+        "select",
+    ),
+    (
+        "composite_select_field",
+        '{{ composite_select_field("x", "X", [("1", "Alpha")], error="bad") }}',
         "select",
     ),
 ]
@@ -554,7 +643,7 @@ def _render_macro_with_context(macro_call: str, **context: dict) -> "HTMLParser"
     template = (
         '{%- from "_shared/form_fields.html" import text_field, textarea_field,'
         " url_field, select_field, multi_select_field, entity_select_field,"
-        " field_for with context -%}\n"
+        " composite_select_field, field_for with context -%}\n"
         f"{macro_call}"
     )
     return HTMLParser(env.from_string(template).render(**context))
@@ -573,6 +662,11 @@ _AUTO_RESOLVE_MACROS = [
     (
         "entity_select_field",
         '{{ entity_select_field("x", "X", entities) }}',
+        "select",
+    ),
+    (
+        "composite_select_field",
+        '{{ composite_select_field("x", "X", [("1", "Alpha")]) }}',
         "select",
     ),
 ]
@@ -674,6 +768,12 @@ _AUTO_RESOLVE_VALUE_CASES = [
     (
         "entity_select_field",
         '{{ entity_select_field("x", "X", entities) }}',
+        "1",
+        _select_selected_check(["1"]),
+    ),
+    (
+        "composite_select_field",
+        '{{ composite_select_field("x", "X", [("1", "Alpha")]) }}',
         "1",
         _select_selected_check(["1"]),
     ),


### PR DESCRIPTION
## Summary

- Extract a new `composite_select_field` macro into `_shared/form_fields.html` that takes a pre-built `(value, label)` tuple list, handles `form_values` prefill, required-placeholder, and first-match-wins selection internally.
- Refactor the three hand-rolled post-kind pickers (`_form_referral.html`, `_form_clinician_opening.html`, `_form_program_intake.html`) to use it.
- Behavior preserved exactly: `default_first=True` keeps the create-mode practice pickers' "first option selected" semantics; first-match-wins keeps the visible selection stable when a clinician appears across multiple affiliations.

## Test plan

- [x] `dev test` — 1995 passed, 92 skipped
- [x] `dev test contract` — 40 passed (template + factory contracts)
- [x] `dev lint` — clean
- [x] Added 5 dedicated tests for the new macro + 3 parametrized contract rows (`_INPUT_MACROS`, `_AUTO_RESOLVE_MACROS`, `_AUTO_RESOLVE_VALUE_CASES`)
- [ ] Smoke the three pickers in the running app (create + edit + validation-rerender) — recommended before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)