### PR TITLE
style: improve field order and section grouping across all three post forms

### DIFF
--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -14,6 +14,14 @@ Used by both `posts/new_clinician_opening.html` (create) and
 The `clinician_id` FK on the OpeningDetail links this announcement to
 the clinician whose practice it describes. The wrapper templates redirect
 to the clinician-create flow when `current_user.clinicians` is empty.
+
+Field order:
+  1. Which practice — establishes context for the whole form
+  2. About — description, referral instructions, website
+  3. Availability — desired times / schedule notes
+  4. Who you serve — age groups, languages, genders
+  5. Services & approach — services, treatment settings, modalities
+  6. Subject — optional, auto-generates; last because most users skip it
 #}
 {# `with context` lets the form_fields macros auto-resolve per-field
    `error=`/`current=` from the `form_errors`/`form_values` injected into
@@ -40,7 +48,6 @@ to the clinician-create flow when `current_user.clinicians` is empty.
   {%- set _hx_attrs = "hx-target=\"this\" hx-swap=\"outerHTML\" hx-target-4xx=\"this\" hx-swap-4xx=\"outerHTML\"" -%}
   <form hx-{{ hx_method }}="{{ action }}" {{ _hx_attrs|safe }}>
     <input type="hidden" name="kind" value="clinician_opening" />
-    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
     {# Practice picker. A Clinician may carry multiple Affiliations
      (clinician × org practice-role rows); the dropdown labels each
      option by the affiliation's org name so a clinician who works at
@@ -66,14 +73,17 @@ to the clinician-create flow when `current_user.clinicians` is empty.
       {{ multi_select_field("desired_times", "Desired times", DESIRED_TIME_SLOTS, labels=DESIRED_TIME_SLOT_LABELS, current=d.desired_times if d else None, required=false) }}
       {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
     {% endcall %}
-    {% call form_section("Featured services") %}
-      {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
-      {{ multi_select_field("settings", "Treatment settings", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
-      {{ multi_select_field("modalities", "Treatment modalities", TREATMENT_MODALITIES, labels=TREATMENT_MODALITY_LABELS, current=d.modalities if d else None, required=false) }}
+    {% call form_section("Who you serve") %}
       {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help() ) }}
       {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
       {{ multi_select_field("genders", "Genders served", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None) }}
     {% endcall %}
+    {% call form_section("Services & approach") %}
+      {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
+      {{ multi_select_field("settings", "Treatment settings", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
+      {{ multi_select_field("modalities", "Treatment modalities", TREATMENT_MODALITIES, labels=TREATMENT_MODALITY_LABELS, current=d.modalities if d else None, required=false) }}
+    {% endcall %}
+    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
     {{ actions(submit_label, cancel_url=cancel_url) }}
   </form>
 {%- endmacro -%}

--- a/src/domain/templates/posts/_form_program_intake.html
+++ b/src/domain/templates/posts/_form_program_intake.html
@@ -17,15 +17,36 @@ The wrapper templates `posts/new_program_intake.html` /
 `posts/edit_program_intake.html` redirect to the program-create flow
 when `current_user.programs` is empty, so this macro always renders
 with at least one Program available.
+
+Field order:
+  1. Which program — establishes context for the whole form
+  2. About — description, referral instructions, website
+  3. Availability — desired times / schedule notes
+  4. Who you serve — age groups, languages, genders
+  5. Services & approach — services, treatment settings, modalities
+  6. Subject — optional, auto-generates; last because most users skip it
 #}
+{# `with context` lets the form_fields macros auto-resolve per-field
+   `error=`/`current=` from the `form_errors`/`form_values` injected
+   into the render context by `mount_create` on a validation-failure
+   re-render (see `POST_ENTITY.form_error_render` + the docstring at
+   the top of `_shared/form_fields.html`). No per-field error or value
+   threading is required at the callsite. #}
 {%- from "_shared/form_fields.html" import text_field, textarea_field, select_field, multi_select_field, composite_select_field, field_for, form_section with context -%}
 {%- from "_shared/form_copy.html" import modality_help, schedule_notes_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- macro intake_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
   {%- set d = post.intake_detail if post else None -%}
-  <form hx-{{ hx_method }}="{{ action }}">
+  {# `hx-target="this" hx-swap="outerHTML"` for the error-rerender path;
+     bundled into `_hx_attrs` because `hx-{{ hx_method }}` is a
+     templated attribute *name* and djlint mis-wraps when the line
+     exceeds its budget. `hx-target-4xx`/`hx-swap-4xx` activate the
+     `response-targets` extension (loaded in `base.html`) so a 422
+     validation-error response — the status `mount_create` returns
+     on a Pydantic failure — still swaps the form fragment in place. #}
+  {%- set _hx_attrs = "hx-target=\"this\" hx-swap=\"outerHTML\" hx-target-4xx=\"this\" hx-swap-4xx=\"outerHTML\"" -%}
+  <form hx-{{ hx_method }}="{{ action }}" {{ _hx_attrs|safe }}>
     <input type="hidden" name="kind" value="program_intake" />
-    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
     {# Program picker — uses `composite_select_field` because the
      option label is a "<Program> · <Org>" composite derived from
      `p.organization.name`, not a flat attribute on `p`. Mirrors the
@@ -46,14 +67,17 @@ with at least one Program available.
       {{ multi_select_field("desired_times", "Desired times", DESIRED_TIME_SLOTS, labels=DESIRED_TIME_SLOT_LABELS, current=d.desired_times if d else None, required=false) }}
       {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
     {% endcall %}
-    {% call form_section("Featured services") %}
-      {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
-      {{ multi_select_field("settings", "Treatment settings", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
-      {{ multi_select_field("modalities", "Treatment modalities", TREATMENT_MODALITIES, labels=TREATMENT_MODALITY_LABELS, current=d.modalities if d else None, required=false) }}
+    {% call form_section("Who you serve") %}
       {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help() ) }}
       {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
       {{ multi_select_field("genders", "Genders served", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None) }}
     {% endcall %}
+    {% call form_section("Services & approach") %}
+      {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
+      {{ multi_select_field("settings", "Treatment settings", TREATMENT_SETTINGS, labels=TREATMENT_SETTINGS_LABELS, current=d.settings if d else None) }}
+      {{ multi_select_field("modalities", "Treatment modalities", TREATMENT_MODALITIES, labels=TREATMENT_MODALITY_LABELS, current=d.modalities if d else None, required=false) }}
+    {% endcall %}
+    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
     {{ actions(submit_label, cancel_url=cancel_url) }}
   </form>
 {%- endmacro -%}

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -8,9 +8,15 @@ Used by both `posts/new_referral.html` (create, no prefill) and
   - `submit_label`: the visible submit-button text
   - `post`: the persisted Post (for edit) or `None` (for create)
 
-Field set follows `notes/forms_spec.md` Form 1. Field order, labels,
-and required/optional state all live here in one place; new vs edit
-difference is the prefill, not the structure.
+Field order:
+  1. Referring clinician — establishes who is making the referral
+  2. About the client — narrative context before structured fields
+  3. Client demographics — age, language, gender
+  4. Client location — where / what format
+  5. Availability — when (split from location; parallels opening/intake)
+  6. Services needed — what kind of help
+  7. Insurance — payer posture
+  8. Subject — optional, auto-generates; last because most users skip it
 
 The `desired_times` checkbox grid sends form-encoded data with multiple
 values for the same field name. The form naturally encodes multiple
@@ -53,22 +59,23 @@ which FastAPI/Pydantic parses as a list.
       {%- endfor -%}
     {%- endfor -%}
     {{ composite_select_field("referring_clinician_id", "Referring clinician", _practices.opts, current=d.referring_clinician_id if d else None, default_first=true) }}
-    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
+    {{ textarea_field("description", "About the client", current=d.description if d else None, help="Anything else a clinician needs to know. Please don't include identifying details.") }}
+    {% call form_section("Client demographics") %}
+      {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help() ) }}
+      {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
+      {{ select_field("gender", "Gender", GENDERS, labels=GENDER_LABELS, current=d.gender if d else None) }}
+    {% endcall %}
     {% call form_section("Client location") %}
       {{ text_field("location_city", "City", current=d.location_city if d else None) }}
       {{ select_field("location_state", "State", US_STATES, current=d.location_state if d else None, placeholder=true) }}
       {{ text_field("location_zip", "ZIP", current=d.location_zip if d else None, pattern="\\d{5}", maxlength=5) }}
       {{ select_field("location_in_person", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.location_in_person if d else None, placeholder=true) }}
       {{ select_field("location_virtual", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=d.location_virtual if d else None, placeholder=true) }}
+    {% endcall %}
+    {% call form_section("Availability") %}
       {{ multi_select_field("desired_times", "Desired times", DESIRED_TIME_SLOTS, labels=DESIRED_TIME_SLOT_LABELS, current=d.desired_times if d else None, required=false) }}
     {% endcall %}
-    {% call form_section("Client demographics") %}
-      {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help() ) }}
-      {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
-      {{ select_field("gender", "Gender", GENDERS, labels=GENDER_LABELS, current=d.gender if d else None) }}
-    {% endcall %}
-    {{ textarea_field("description", "About the client", current=d.description if d else None, help="Anything else a clinician needs to know. Please don't include identifying details.") }}
-    {% call form_section("Services") %}
+    {% call form_section("Services needed") %}
       {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
       {{ multi_select_field("modalities", "Treatment modalities", TREATMENT_MODALITIES, labels=TREATMENT_MODALITY_LABELS, current=d.modalities if d else None, required=false) }}
     {% endcall %}
@@ -85,6 +92,7 @@ which FastAPI/Pydantic parses as a list.
       {{ select_field("network_preference", "Network preference", NETWORK_PREFERENCES, labels=NETWORK_PREFERENCE_LABELS, current=d.network_preference if d else None, placeholder=true) }}
       {{ select_field("insurance_carrier", "Insurance carrier", INSURANCE_CARRIERS, labels=INSURANCE_CARRIER_LABELS, current=d.insurance_carrier if d else None, placeholder=true, required=false, hidden=(d and d.network_preference == "no_preference") ) }}
     {% endcall %}
+    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
     {{ actions(submit_label, cancel_url=cancel_url) }}
   </form>
   <script>


### PR DESCRIPTION
## Summary

- **Referral**: narrative description moved above demographic checkboxes; `desired_times` split into its own Availability section (was inside Client location); renamed "Services" → "Services needed"; Subject field moved to the end
- **Clinician opening**: entity picker promoted above Subject; "Featured services" split into "Who you serve" (age groups, languages, genders) and "Services & approach" (services, settings, modalities); Subject moved to the end
- **Program intake**: same section restructuring as clinician opening; adds missing HTMX error-rerender attributes (`hx-target`/`hx-swap` + 4xx variants) that the other two forms already had, fixing a silent bug where validation errors wouldn't swap the form in place; Subject moved to the end

The guiding principles:
- Entity picker first — establishes context for everything that follows
- Narrative before grids — free-text description sets context before checkboxes
- Scheduling separate from location — `desired_times` is availability, not geography
- "Who you serve" vs "Services & approach" — two distinct concerns, two sections
- Subject last — optional auto-generating field; leading with it wastes attention

No schema, route, or logic changes. Template-only.

## Test plan
- [ ] Create a referral post — verify new field order matches description above
- [ ] Create a clinician opening post — verify entity picker is first, Subject is last, sections split correctly
- [ ] Create a program intake post — same checks plus confirm validation errors re-render in place (was broken before)
- [ ] Edit each post type — verify prefill still works correctly in new order
- [ ] `dev test` passes (2013 tests)
- [ ] `dev lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)