### PR TITLE
fix: disable static asset caching in development

### DIFF
--- a/src/framework/http/middleware.py
+++ b/src/framework/http/middleware.py
@@ -7,6 +7,33 @@ where the convention belongs, instead of every handler remembering it.
 
 from typing import Callable
 
+from starlette.datastructures import MutableHeaders
+
+
+class StaticNoCacheMiddleware:
+    """Add ``Cache-Control: no-store`` to every ``/static/`` response.
+
+    Prevents the browser from caching CSS/JS/font assets between reloads
+    so edits are visible without a hard refresh. Only mount this in
+    development — production static assets should be far-future cached.
+    """
+
+    def __init__(self, app: Callable):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope.get("path", "").startswith("/static/"):
+
+            async def send_no_cache(message):
+                if message["type"] == "http.response.start":
+                    headers = MutableHeaders(scope=message)
+                    headers["Cache-Control"] = "no-store"
+                await send(message)
+
+            await self.app(scope, receive, send_no_cache)
+        else:
+            await self.app(scope, receive, send)
+
 
 class StripEmptyQueryParamsMiddleware:
     """Treat ``?key=`` (and bare ``?key``) as if the key were absent.

--- a/src/framework/http/test_middleware.py
+++ b/src/framework/http/test_middleware.py
@@ -1,6 +1,37 @@
 """Tests for `src/framework/http/middleware.py`."""
 
-from .middleware import _strip_empty_pairs
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from fastapi.testclient import TestClient
+
+from .middleware import StaticNoCacheMiddleware, _strip_empty_pairs
+
+
+def _make_client() -> TestClient:
+    app = FastAPI()
+    app.add_middleware(StaticNoCacheMiddleware)
+
+    @app.get("/static/fw/css/framework.css")
+    def static_css():
+        return PlainTextResponse("body{}")
+
+    @app.get("/page")
+    def page():
+        return PlainTextResponse("hi")
+
+    return TestClient(app)
+
+
+def test_static_path_gets_no_store():
+    client = _make_client()
+    r = client.get("/static/fw/css/framework.css")
+    assert r.headers["cache-control"] == "no-store"
+
+
+def test_non_static_path_unaffected():
+    client = _make_client()
+    r = client.get("/page")
+    assert "cache-control" not in r.headers
 
 
 def test_strip_empty_value():

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,10 @@ from src.domain.routes import (
 )
 from src.framework.config import settings
 from src.framework.dispatch.registry import entity_registry
-from src.framework.http.middleware import StripEmptyQueryParamsMiddleware
+from src.framework.http.middleware import (
+    StaticNoCacheMiddleware,
+    StripEmptyQueryParamsMiddleware,
+)
 from src.framework.http.responses import APIResponse
 from src.framework.observability import observability
 from src.jobs.scheduler import make_scheduler, register_jobs
@@ -91,6 +94,9 @@ observability.init_app(app)
 # as omitting the param. See `src/framework/http/middleware.py` for the
 # full convention rationale.
 app.add_middleware(StripEmptyQueryParamsMiddleware)
+
+if settings.ENVIRONMENT == "development":
+    app.add_middleware(StaticNoCacheMiddleware)
 
 
 @app.exception_handler(HTTPException)


### PR DESCRIPTION
## Summary

- Adds `StaticNoCacheMiddleware` to `src/framework/http/middleware.py` — intercepts `/static/` responses and sets `Cache-Control: no-store`
- Only mounted in `src/main.py` when `ENVIRONMENT=development`; production is unaffected
- 2 new tests in `test_middleware.py` pin the behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)