### PR TITLE
feat: add capabilities predicate module (Phase 0 of verification rollout)

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -1,0 +1,172 @@
+"""Single source of truth for "can this user do X".
+
+Routes (`write_authz`) and templates (Jinja global `capabilities`) call
+into the same predicates so the visible UI affordance and the server-side
+gate cannot disagree.
+
+The two-claim model: a `User` may hold **Claim A** (verified clinician —
+NPPES Type-1 + active license) and/or **Claim B** (verified org rep —
+NPPES Type-2 + authority proven), per (user, org). Capabilities derive
+from claim state; "solo / group / coordinator" labels are emergent, never
+stored.
+
+This module is a domain-logic predicate set: it reads `User`/`Clinician`/
+`Organization`/`OrgRepresentation` structurally and returns booleans. It
+lives in `domain/logic/` (not `framework/`) because framework code may
+not import domain models — see `src/README.md` import discipline.
+
+Phase status: placeholder bodies. The data columns the production
+predicates will read (`Clinician.clinician_verified`, `Clinician.ever_verified_at`,
+`Organization.org_verified`, `OrgRepresentation.authority_status`) do not
+yet exist; this module returns conservative answers from the columns that
+do exist (`User.is_verified`, `Clinician.npi`). Phase 2 of the rollout
+tightens these reads once the schema lands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+# Reason codes used by `_locked.html` partials and `fix_url_for(...)`.
+# Closed vocab: any new reason must be added here and mapped below.
+REASON_EMAIL_UNVERIFIED = "email_unverified"
+REASON_CLAIM_A_UNVERIFIED = "claim_a_unverified"
+REASON_CLAIM_B_UNVERIFIED = "claim_b_unverified"
+REASON_CLAIM_A_LAPSED = "claim_a_lapsed"
+REASON_AFFILIATION_MISSING = "affiliation_missing"
+
+_FIX_URLS = {
+    REASON_EMAIL_UNVERIFIED: "/profile?focus=email",
+    REASON_CLAIM_A_UNVERIFIED: "/profile?focus=claim_a",
+    REASON_CLAIM_A_LAPSED: "/profile?focus=claim_a",
+    REASON_CLAIM_B_UNVERIFIED: "/profile?focus=claim_b",
+    REASON_AFFILIATION_MISSING: "/profile?focus=claim_b",
+}
+
+
+@dataclass(frozen=True)
+class ClaimState:
+    """Aggregate claim shape consumed by the profile-hub mode dispatcher
+    and the claim-aware chrome banner.
+
+    - `a`: True iff the user holds a verified Claim A (Verified Clinician).
+    - `b`: set of org IDs the user is a verified rep for (Claim B per org).
+    - `lapsed`: reason codes (see module-level REASON_* constants) for
+      claims whose underlying requirements have regressed. A claim can be
+      in both `a` (current cache true) and `lapsed` (a license just
+      expired) simultaneously during the re-verify window.
+    """
+
+    a: bool = False
+    b: frozenset[UUID] = field(default_factory=frozenset)
+    lapsed: tuple[str, ...] = ()
+
+
+def email_verified(user: Any) -> bool:
+    """Email is the floor for every other claim. `User.is_verified` is
+    fastapi-users' email-confirmation flag; do not overload it for
+    clinician/org verification (per handoff §3)."""
+    if user is None:
+        return False
+    return bool(getattr(user, "is_verified", False))
+
+
+def clinician_verified(user: Any) -> bool:
+    """Claim A: NPPES Type-1 name-matched + ≥1 active license.
+
+    Placeholder: returns True when the user has emailed-verified AND owns
+    at least one Clinician with a non-null `npi`. Phase 2 will read
+    `Clinician.clinician_verified` (the denorm cache) once that column
+    exists; until then, an NPI on file is the best signal available.
+    """
+    if not email_verified(user):
+        return False
+    clinicians = getattr(user, "clinicians", None) or ()
+    return any(getattr(c, "npi", None) for c in clinicians)
+
+
+def org_rep_verified(user: Any, org: Any) -> bool:
+    """Claim B per (user, org). Placeholder: always False until the
+    OrgRepresentation table lands in Phase 1 / Phase 4."""
+    return False
+
+
+def any_org_rep_verified(user: Any) -> bool:
+    """True iff the user holds Claim B for at least one org. Placeholder:
+    always False until OrgRepresentation lands."""
+    return False
+
+
+def can_read_full_feed(user: Any) -> bool:
+    """Feed-teaser gate per handoff §7.1: full feed once any claim is
+    verified; once-verified users retain read access after a lapse
+    (`ever_verified_at`). Phase 0 placeholder: gate on current Claim A
+    only — `ever_verified_at` doesn't exist yet."""
+    if user is None:
+        return False
+    return clinician_verified(user) or any_org_rep_verified(user)
+
+
+def can_post_referral(user: Any) -> bool:
+    """Posting a referral as oneself requires Claim A (handoff §4.3)."""
+    return clinician_verified(user)
+
+
+def can_post_opening(user: Any) -> bool:
+    """Posting a clinician opening requires Claim A (handoff §4.3)."""
+    return clinician_verified(user)
+
+
+def can_message(user: Any) -> bool:
+    """Responding/messaging requires Claim A (handoff §4.3). The messages
+    cluster does not yet exist; the predicate is shipped so it can be
+    wired into route handlers the moment that cluster lands."""
+    return clinician_verified(user)
+
+
+def can_post_program_intake(user: Any, org: Any) -> bool:
+    """Posting a program intake on behalf of an org requires Claim B for
+    that org. Placeholder: always False until OrgRepresentation lands."""
+    return org_rep_verified(user, org)
+
+
+def can_post_org_referral(user: Any, org: Any, clinician: Any) -> bool:
+    """Posting an org-attributed referral requires Claim B for the org
+    AND the target clinician must have an active Affiliation to the org.
+    Placeholder: always False until OrgRepresentation lands."""
+    return False
+
+
+def directory_listed(clinician: Any) -> bool:
+    """A clinician is shown in the public directory iff their Claim A is
+    verified (handoff §4.3: `directory.listed = clinician_verified`).
+    Placeholder: presence of an NPI on the clinician row."""
+    if clinician is None:
+        return False
+    return bool(getattr(clinician, "npi", None))
+
+
+def can_save_favorite(user: Any) -> bool:
+    """Saving a favorite requires email verification only (handoff §4.3)."""
+    return email_verified(user)
+
+
+def claim_state(user: Any) -> ClaimState:
+    """Aggregate the per-claim flags into one object the profile-hub mode
+    dispatcher consumes."""
+    if user is None:
+        return ClaimState()
+    return ClaimState(
+        a=clinician_verified(user),
+        b=frozenset(),  # Phase 2 populates from OrgRepresentation rows.
+        lapsed=(),  # Phase 2 populates from license-expiry + authority-revoked signals.
+    )
+
+
+def fix_url_for(reason: str) -> str:
+    """Deep-link a "blocked action" partial into the relevant section of
+    `/profile`. The closed reason vocab keeps the partial / route / banner
+    from drifting. Unknown reasons fall back to the hub root."""
+    return _FIX_URLS.get(reason, "/profile")

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -1,0 +1,264 @@
+"""Truth-table tests for the capability predicates.
+
+This is the most load-bearing test file in the verification rollout: a
+single source of truth for every gate site (routes + templates) is only
+useful if its truth table is pinned. Phase 0 ships placeholder predicate
+bodies; the table below also serves as the regression line when Phase 2
+tightens those bodies against real schema columns — the truth values
+must not change for the inputs covered here, only sharpen for inputs
+involving `OrgRepresentation` and `ever_verified_at`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+from src.domain.logic import capabilities
+
+
+def _user(
+    *, is_verified: bool = False, clinicians: list | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        is_superuser=False,
+        username="test",
+        is_verified=is_verified,
+        clinicians=clinicians or [],
+    )
+
+
+def _clinician(*, npi: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(npi=npi)
+
+
+# ---------- email_verified ------------------------------------------------
+
+
+def test_email_verified_anon_false():
+    assert capabilities.email_verified(None) is False
+
+
+def test_email_verified_user_not_verified():
+    assert capabilities.email_verified(_user(is_verified=False)) is False
+
+
+def test_email_verified_user_verified():
+    assert capabilities.email_verified(_user(is_verified=True)) is True
+
+
+def test_email_verified_user_missing_attr_defaults_false():
+    """Actor stubs without `is_verified` are treated as not-verified.
+
+    This is the inverse of `base_context()`'s anonymous-defaults-to-True
+    rule: that rule keeps the email banner silent for anonymous viewers;
+    here, anything that isn't explicitly verified is denied.
+    """
+    bare = SimpleNamespace(id=uuid4(), is_superuser=False, username="t")
+    assert capabilities.email_verified(bare) is False
+
+
+# ---------- clinician_verified --------------------------------------------
+
+
+def test_clinician_verified_anon_false():
+    assert capabilities.clinician_verified(None) is False
+
+
+def test_clinician_verified_no_clinicians():
+    assert capabilities.clinician_verified(_user(is_verified=True)) is False
+
+
+def test_clinician_verified_clinician_without_npi():
+    user = _user(is_verified=True, clinicians=[_clinician(npi=None)])
+    assert capabilities.clinician_verified(user) is False
+
+
+def test_clinician_verified_requires_email_verified():
+    user = _user(is_verified=False, clinicians=[_clinician(npi="1234567890")])
+    assert capabilities.clinician_verified(user) is False
+
+
+def test_clinician_verified_with_npi():
+    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    assert capabilities.clinician_verified(user) is True
+
+
+def test_clinician_verified_any_clinician_with_npi_suffices():
+    user = _user(
+        is_verified=True,
+        clinicians=[_clinician(npi=None), _clinician(npi="9876543210")],
+    )
+    assert capabilities.clinician_verified(user) is True
+
+
+# ---------- Claim B placeholders (always False until Phase 1/4) -----------
+
+
+def test_org_rep_verified_placeholder_false():
+    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    org = SimpleNamespace(id=uuid4())
+    assert capabilities.org_rep_verified(user, org) is False
+
+
+def test_any_org_rep_verified_placeholder_false():
+    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    assert capabilities.any_org_rep_verified(user) is False
+
+
+# ---------- derived gates -------------------------------------------------
+
+
+def test_can_read_full_feed_anon_false():
+    assert capabilities.can_read_full_feed(None) is False
+
+
+def test_can_read_full_feed_unverified_clinician_false():
+    assert capabilities.can_read_full_feed(_user(is_verified=True)) is False
+
+
+def test_can_read_full_feed_verified_clinician_true():
+    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    assert capabilities.can_read_full_feed(user) is True
+
+
+def test_can_post_referral_tracks_clinician_verified():
+    verified = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    unverified = _user(is_verified=True)
+    assert capabilities.can_post_referral(verified) is True
+    assert capabilities.can_post_referral(unverified) is False
+
+
+def test_can_post_opening_tracks_clinician_verified():
+    verified = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    unverified = _user(is_verified=True)
+    assert capabilities.can_post_opening(verified) is True
+    assert capabilities.can_post_opening(unverified) is False
+
+
+def test_can_message_tracks_clinician_verified():
+    verified = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    assert capabilities.can_message(verified) is True
+    assert capabilities.can_message(None) is False
+
+
+def test_can_post_program_intake_placeholder_false():
+    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    org = SimpleNamespace(id=uuid4())
+    assert capabilities.can_post_program_intake(user, org) is False
+
+
+def test_can_post_org_referral_placeholder_false():
+    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    org = SimpleNamespace(id=uuid4())
+    clinician = _clinician(npi="1234567890")
+    assert capabilities.can_post_org_referral(user, org, clinician) is False
+
+
+# ---------- directory_listed ----------------------------------------------
+
+
+def test_directory_listed_none_false():
+    assert capabilities.directory_listed(None) is False
+
+
+def test_directory_listed_clinician_without_npi_false():
+    assert capabilities.directory_listed(_clinician(npi=None)) is False
+
+
+def test_directory_listed_clinician_with_npi_true():
+    assert capabilities.directory_listed(_clinician(npi="1234567890")) is True
+
+
+# ---------- can_save_favorite (only email_verified) -----------------------
+
+
+def test_can_save_favorite_anon_false():
+    assert capabilities.can_save_favorite(None) is False
+
+
+def test_can_save_favorite_email_verified_only():
+    assert capabilities.can_save_favorite(_user(is_verified=True)) is True
+    assert capabilities.can_save_favorite(_user(is_verified=False)) is False
+
+
+# ---------- claim_state ---------------------------------------------------
+
+
+def test_claim_state_anon_empty():
+    s = capabilities.claim_state(None)
+    assert s.a is False
+    assert s.b == frozenset()
+    assert s.lapsed == ()
+
+
+def test_claim_state_a_only():
+    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    s = capabilities.claim_state(user)
+    assert s.a is True
+    assert s.b == frozenset()
+    assert s.lapsed == ()
+
+
+def test_claim_state_b_set_is_frozenset():
+    """The `b` field is a frozenset so the dataclass stays hashable and
+    immutable — Phase 5 mode dispatch reads it under
+    `if not state.a and not state.b: mode = 'setup'`."""
+    s = capabilities.claim_state(None)
+    assert isinstance(s.b, frozenset)
+
+
+# ---------- fix_url_for ---------------------------------------------------
+
+
+def test_fix_url_for_known_reasons_routes_to_profile_focus():
+    assert (
+        capabilities.fix_url_for(capabilities.REASON_EMAIL_UNVERIFIED)
+        == "/profile?focus=email"
+    )
+    assert (
+        capabilities.fix_url_for(capabilities.REASON_CLAIM_A_UNVERIFIED)
+        == "/profile?focus=claim_a"
+    )
+    assert (
+        capabilities.fix_url_for(capabilities.REASON_CLAIM_A_LAPSED)
+        == "/profile?focus=claim_a"
+    )
+    assert (
+        capabilities.fix_url_for(capabilities.REASON_CLAIM_B_UNVERIFIED)
+        == "/profile?focus=claim_b"
+    )
+    assert (
+        capabilities.fix_url_for(capabilities.REASON_AFFILIATION_MISSING)
+        == "/profile?focus=claim_b"
+    )
+
+
+def test_fix_url_for_unknown_reason_falls_back_to_hub_root():
+    assert capabilities.fix_url_for("totally-not-a-reason") == "/profile"
+
+
+def test_fix_url_table_covers_every_reason_constant():
+    """Guardrail: every REASON_* constant must have a fix URL mapping —
+    otherwise an unknown-reason fallback masks the missing entry."""
+    declared_reasons = {
+        value
+        for name, value in vars(capabilities).items()
+        if name.startswith("REASON_") and isinstance(value, str)
+    }
+    assert declared_reasons, "no REASON_* constants found"
+    for reason in declared_reasons:
+        url = capabilities.fix_url_for(reason)
+        assert url != "/profile", f"REASON {reason!r} has no entry in _FIX_URLS"
+
+
+# ---------- UUID type sanity for claim_state.b ----------------------------
+
+
+def test_claim_state_b_typed_for_uuids():
+    """Phase 2 will populate `b` with org UUIDs. Sanity-check that a
+    frozenset of UUIDs is shape-compatible with the dataclass field."""
+    org_id = uuid4()
+    s = capabilities.ClaimState(a=True, b=frozenset({org_id}))
+    assert isinstance(next(iter(s.b)), UUID)

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -15,6 +15,7 @@ Two trigger points cover the real load paths:
   global.
 """
 
+from src.domain.logic import capabilities
 from src.domain.logic.clinicians.view import clinician_card_view
 from src.domain.logic.posts.schema import (
     ClinicianOpeningCreate,
@@ -108,6 +109,13 @@ register_template_globals(
     # `clinicians/detail.html` reads from — see its docstring in
     # `src.domain.logic.clinicians.view`.
     clinician_card_view=clinician_card_view,
+    # `capabilities` is the single-source-of-truth predicate module
+    # (`src.domain.logic.capabilities`) registered as a Jinja namespace
+    # so templates can write
+    # `{% if capabilities.can_post_referral(current_user) %}...`.
+    # The same predicates are called from route `write_authz` paths, so
+    # the visible-button and server-side block can't disagree.
+    capabilities=capabilities,
 )
 
 # Register the choice-tuple → labels-dict mapping that `field_spec` uses

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -37,7 +37,18 @@ def base_context(user: Actor | None) -> dict:
     users are auto-verified on registration
     (see `src.auth_config.UserManager.on_after_register`) so the
     banner is silent for the seed flow.
+
+    `claims`, `claim_a_lapsed`, `claim_b_lapsed_orgs`, `any_claim_lapsed`
+    power the claim-aware chrome (`_verify_banner.html`, the profile-hub
+    mode header, the `/home` "Finish setup" / "Action needed" sub-states).
+    They flow through `claim_state(...)` in `src.domain.logic.capabilities`
+    so the single-source-of-truth predicate set computes them once per
+    request. The import is lazy to keep this framework module from taking
+    a hard `domain/` import.
     """
+    from src.domain.logic.capabilities import claim_state
+
+    state = claim_state(user)
     return {
         "is_authenticated": user is not None,
         "is_admin": is_admin(user),
@@ -47,6 +58,10 @@ def base_context(user: Actor | None) -> dict:
         "current_user_is_verified": (
             True if user is None else bool(getattr(user, "is_verified", True))
         ),
+        "claims": {"a": state.a, "b": list(state.b)},
+        "claim_a_lapsed": False,
+        "claim_b_lapsed_orgs": [],
+        "any_claim_lapsed": bool(state.lapsed),
     }
 
 

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -28,6 +28,12 @@ def test_base_context_anonymous():
         # Anonymous users don't get the verify nag — default True so
         # the banner stays silent.
         "current_user_is_verified": True,
+        # Claim-aware chrome (claim-based verification rollout) — anon
+        # holds no claims and has no lapsed claims.
+        "claims": {"a": False, "b": []},
+        "claim_a_lapsed": False,
+        "claim_b_lapsed_orgs": [],
+        "any_claim_lapsed": False,
     }
 
 
@@ -43,7 +49,30 @@ def test_base_context_regular_user():
         "current_user_id": user_id,
         "has_clinician_profile": False,
         "current_user_is_verified": True,
+        # No clinicians on this stub → Claim A is False; OrgRepresentation
+        # placeholders keep `b` empty.
+        "claims": {"a": False, "b": []},
+        "claim_a_lapsed": False,
+        "claim_b_lapsed_orgs": [],
+        "any_claim_lapsed": False,
     }
+
+
+def test_base_context_claim_a_verified_user():
+    """A user with a verified Clinician (placeholder: any clinician with
+    an `npi`) flips `claims.a` to True. Pins the wiring between
+    `base_context()` and `capabilities.claim_state()` — Phase 5's
+    profile-hub mode dispatcher reads this same shape."""
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        username="alice",
+        is_superuser=False,
+        is_verified=True,
+        clinicians=[SimpleNamespace(npi="1234567890")],
+    )
+    ctx = base_context(user)
+    assert ctx["claims"] == {"a": True, "b": []}
+    assert ctx["any_claim_lapsed"] is False
 
 
 def test_base_context_unverified_user_surfaces_for_nag_banner():


### PR DESCRIPTION
## Summary
- Adds `src/domain/logic/capabilities.py` — a single source of truth for "can this user do X". Used by routes (`write_authz`) and templates (Jinja namespace `capabilities`) so the visible UI affordance and the server-side gate cannot disagree.
- Extends `base_context()` with claim-aware chrome scalars (`claims`, `claim_a_lapsed`, `claim_b_lapsed_orgs`, `any_claim_lapsed`) so banners and the profile hub read one computed shape.
- 32 truth-table tests pin every predicate. Includes a guardrail asserting every `REASON_*` constant has a `_FIX_URLS` entry.

This is Phase 0 of the [Provider/Org Verification & Profile Hub](https://github.com/willthefirst/bedlam-connect/tree/main/CLAUDE.md) rollout (see `~/.claude/plans/mutable-churning-sifakis.md`). Placeholder predicate bodies read existing columns (`User.is_verified`, `Clinician.npi`); the same signatures will tighten once the schema lands in Phase 1, without breaking any caller.

The plan defines two NPPES-anchored claims:
- **Claim A** — Verified Clinician (Type-1 NPI + active license).
- **Claim B** — Verified Org Representative (Type-2 NPI + authority proven), per (user, org).

Capabilities derive from claim state; the framing replaces any "solo / group / coordinator" account-type model.

## Test plan
- [x] `dev test` — 2046 passed, 92 skipped
- [x] `dev lint` — all checks green
- [ ] Manual smoke: load `/home` anon and authed, confirm no chrome regression
- [ ] Manual smoke: confirm `{% if capabilities.can_post_referral(current_user) %}` resolves in templates (will be exercised once any gate point migrates in Phase 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)