### PR TITLE
refactor: verification polymorphic across clinician + org (Phase 1b)

### DIFF
--- a/alembic/versions/76b43539731b_verification_polymorphic_refactor_phase_.py
+++ b/alembic/versions/76b43539731b_verification_polymorphic_refactor_phase_.py
@@ -1,0 +1,105 @@
+"""verification polymorphic refactor (Phase 1b)
+
+Revision ID: 76b43539731b
+Revises: 61a7dc389cac
+Create Date: 2026-05-31 13:10:03.321049
+
+`verifications` becomes polymorphic across `Clinician` (Claim A,
+NPPES Type-1) and `Organization` (Claim B, NPPES Type-2 + authority
+events).
+
+Schema delta:
+- new `subject_type` discriminator
+  (`'clinician'`/`'organization'`, default `'clinician'`)
+- new nullable `org_id` FK to `organizations` (CASCADE on delete)
+- existing `clinician_id` flipped to nullable
+- new `event_type` (default `'npi_resolved'`, CHECK against §9 vocab)
+- new `evidence` JSON for NPPES payloads / AO comparisons / admin notes
+- new CHECK enforcing exactly one of (`clinician_id`, `org_id`) per
+  discriminator value
+
+All ALTERs run inside `batch_alter_table` for SQLite safety (column
+nullability flip + adding CHECKs on an existing table). Pre-launch: no
+data backfill.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "76b43539731b"
+down_revision: Union[str, None] = "61a7dc389cac"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_SUBJECT_TYPES_SQL = "subject_type IN ('clinician', 'organization')"
+_EVENT_TYPES_SQL = (
+    "event_type IN ("
+    "'npi_submitted', 'npi_resolved', 'license_attested', "
+    "'license_expired', 'authority_proven', 'authority_revoked', "
+    "'role_set', 'admin_verify', 'admin_suspend', 'email_confirmed'"
+    ")"
+)
+_SUBJECT_SHAPE_SQL = (
+    "(subject_type = 'clinician' AND clinician_id IS NOT NULL AND org_id IS NULL) "
+    "OR (subject_type = 'organization' "
+    "AND clinician_id IS NULL AND org_id IS NOT NULL)"
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("verifications") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "subject_type",
+                sa.Text(),
+                server_default="clinician",
+                nullable=False,
+            )
+        )
+        batch_op.add_column(sa.Column("org_id", sa.Uuid(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "event_type",
+                sa.Text(),
+                server_default="npi_resolved",
+                nullable=False,
+            )
+        )
+        batch_op.add_column(sa.Column("evidence", sa.JSON(), nullable=True))
+        batch_op.alter_column("clinician_id", existing_type=sa.Uuid(), nullable=True)
+        batch_op.create_index("ix_verifications_org_id", ["org_id"], unique=False)
+        batch_op.create_foreign_key(
+            "fk_verifications_org_id",
+            "organizations",
+            ["org_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch_op.create_check_constraint(
+            "ck_verifications_subject_type", _SUBJECT_TYPES_SQL
+        )
+        batch_op.create_check_constraint(
+            "ck_verifications_event_type", _EVENT_TYPES_SQL
+        )
+        batch_op.create_check_constraint(
+            "ck_verifications_subject_shape", _SUBJECT_SHAPE_SQL
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("verifications") as batch_op:
+        batch_op.drop_constraint("ck_verifications_subject_shape", type_="check")
+        batch_op.drop_constraint("ck_verifications_event_type", type_="check")
+        batch_op.drop_constraint("ck_verifications_subject_type", type_="check")
+        batch_op.drop_constraint("fk_verifications_org_id", type_="foreignkey")
+        batch_op.drop_index("ix_verifications_org_id")
+        batch_op.alter_column("clinician_id", existing_type=sa.Uuid(), nullable=False)
+        batch_op.drop_column("evidence")
+        batch_op.drop_column("event_type")
+        batch_op.drop_column("org_id")
+        batch_op.drop_column("subject_type")

--- a/scripts/dev/seed/overrides/verifications.py
+++ b/scripts/dev/seed/overrides/verifications.py
@@ -9,8 +9,12 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.models import Clinician, Verification
-from src.domain.models.enums import VERIFICATION_STATUSES
+from src.domain.models import Clinician, Organization, Verification
+from src.domain.models.enums import (
+    VERIFICATION_EVENT_TYPES,
+    VERIFICATION_STATUSES,
+    VERIFICATION_SUBJECT_TYPES,
+)
 
 from .. import counts
 from ..generators import SeedPool
@@ -23,14 +27,25 @@ from . import register
 async def generate_verifications(
     rng: SeededRandom, pool: SeedPool, session: AsyncSession
 ) -> list[Verification]:
+    """Round-robin both `subject_type` values and the `event_type` vocab
+    across the dataset so seed-coverage CHECKs pass. Every row picks a
+    distinct subject (clinician or org) and the discriminator-shape
+    invariant is honored by `_subject_kwargs(...)`."""
     clinicians: list[Clinician] = pool.all("clinicians")
-    target = min(counts.VERIFICATION_COUNT, len(clinicians))
+    orgs: list[Organization] = pool.all("organizations")
+    target = min(counts.VERIFICATION_COUNT, len(clinicians) + len(orgs))
     out: list[Verification] = []
     for i in range(target):
-        clinician = clinicians[i]
+        subject_type = rng.round_robin(VERIFICATION_SUBJECT_TYPES, i)
+        subject_kwargs = (
+            {"clinician_id": clinicians[i % len(clinicians)].id, "org_id": None}
+            if subject_type == "clinician"
+            else {"clinician_id": None, "org_id": orgs[i % len(orgs)].id}
+        )
         row = Verification(
             id=deterministic_uuid("Verification", i),
-            clinician_id=clinician.id,
+            subject_type=subject_type,
+            event_type=rng.round_robin(VERIFICATION_EVENT_TYPES, i),
             status=rng.round_robin(VERIFICATION_STATUSES, i),
             flags=rng.nullable_subset(
                 JSON_LIST_SOURCE["flags"], min_size=0, max_size=3, p_empty=0.4
@@ -39,8 +54,10 @@ async def generate_verifications(
             # the call failed); a slice carries a minimal stub so the
             # nullable-coverage test sees both samples.
             nppes_result=(None if rng.bool(0.6) else {"npi": "0000000000"}),
+            evidence=(None if rng.bool(0.5) else {"note": "seed"}),
             oig_match=rng.bool(0.05),
             name_match_score=(None if rng.bool(0.2) else round(rng.random(), 3)),
+            **subject_kwargs,
         )
         await session.merge(row)
         out.append(row)

--- a/scripts/dev/seed/vocab.py
+++ b/scripts/dev/seed/vocab.py
@@ -699,6 +699,16 @@ PLACEHOLDER_OK: Final[frozenset[str]] = frozenset(
         # value here is meaningless — the column is only populated by
         # `run_org_verification` against real NPPES responses.
         "authorized_official_name",
+        # `verifications.subject_type` is covered by its own IN-CHECK
+        # (closed vocab via `VerificationSubjectType`); the polymorphic
+        # subject-shape CHECK is a cross-column XOR that the
+        # `verifications` seed override satisfies by construction. The
+        # per-column drift lint sees only the first lowercase word in
+        # the shape CHECK SQL (`clinician_id`, after skipping
+        # `(subject_type` which has a non-alnum char), so we
+        # acknowledge it here. `clinician_id` is an FK populated from
+        # the parent-row pool, not via COLUMN_VOCAB.
+        "clinician_id",
     }
 )
 

--- a/src/domain/logic/verifications/repository.py
+++ b/src/domain/logic/verifications/repository.py
@@ -11,9 +11,70 @@ from src.framework.persistence.dependencies import register_repository
 
 class VerificationRepository(BaseRepository):
     """Append-only persistence for `Verification` rows. The orchestrator
-    is the only writer; callers compose `record(...)` with
-    `record_audit_for(...)` in the same transaction."""
+    is the only writer; callers compose `record_for_*(...)` with
+    `record_audit_for(...)` in the same transaction.
 
+    Verification rows are polymorphic: each row carries a `subject_type`
+    discriminator + exactly one of (`clinician_id`, `org_id`). The
+    `record_for_clinician` / `record_for_org` split keeps callers from
+    having to remember which fields belong to which side; the CHECK
+    constraint on the row enforces the invariant.
+    """
+
+    async def record_for_clinician(
+        self,
+        *,
+        clinician_id: UUID,
+        status: str,
+        flags: list[str],
+        nppes_result: dict[str, Any] | None,
+        oig_match: bool,
+        name_match_score: float | None,
+        event_type: str = "npi_resolved",
+        evidence: dict[str, Any] | None = None,
+    ) -> Verification:
+        return await self._persist_new(
+            Verification(
+                subject_type="clinician",
+                clinician_id=clinician_id,
+                event_type=event_type,
+                status=status,
+                flags=flags,
+                nppes_result=nppes_result,
+                evidence=evidence,
+                oig_match=oig_match,
+                name_match_score=name_match_score,
+            )
+        )
+
+    async def record_for_org(
+        self,
+        *,
+        org_id: UUID,
+        status: str,
+        flags: list[str],
+        nppes_result: dict[str, Any] | None,
+        name_match_score: float | None,
+        event_type: str = "npi_resolved",
+        evidence: dict[str, Any] | None = None,
+    ) -> Verification:
+        return await self._persist_new(
+            Verification(
+                subject_type="organization",
+                org_id=org_id,
+                event_type=event_type,
+                status=status,
+                flags=flags,
+                nppes_result=nppes_result,
+                evidence=evidence,
+                oig_match=False,
+                name_match_score=name_match_score,
+            )
+        )
+
+    # `record(...)` is kept as a thin alias for the old clinician-only
+    # signature so the existing orchestrator + tests keep working without
+    # threading the discriminator through every call site.
     async def record(
         self,
         *,
@@ -24,21 +85,29 @@ class VerificationRepository(BaseRepository):
         oig_match: bool,
         name_match_score: float | None,
     ) -> Verification:
-        return await self._persist_new(
-            Verification(
-                clinician_id=clinician_id,
-                status=status,
-                flags=flags,
-                nppes_result=nppes_result,
-                oig_match=oig_match,
-                name_match_score=name_match_score,
-            )
+        return await self.record_for_clinician(
+            clinician_id=clinician_id,
+            status=status,
+            flags=flags,
+            nppes_result=nppes_result,
+            oig_match=oig_match,
+            name_match_score=name_match_score,
         )
 
     async def latest_for_clinician(self, clinician_id: UUID) -> Verification | None:
         stmt = (
             select(Verification)
             .filter(Verification.clinician_id == clinician_id)
+            .order_by(Verification.created_at.desc())
+            .limit(1)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().first()
+
+    async def latest_for_org(self, org_id: UUID) -> Verification | None:
+        stmt = (
+            select(Verification)
+            .filter(Verification.org_id == org_id)
             .order_by(Verification.created_at.desc())
             .limit(1)
         )
@@ -55,6 +124,20 @@ class VerificationRepository(BaseRepository):
         stmt = (
             select(Verification)
             .filter(Verification.clinician_id == clinician_id)
+            .order_by(Verification.created_at.desc())
+        )
+        return await self._list(stmt, offset=offset, limit=limit)
+
+    async def list_for_org(
+        self,
+        org_id: UUID,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> Sequence[Verification]:
+        stmt = (
+            select(Verification)
+            .filter(Verification.org_id == org_id)
             .order_by(Verification.created_at.desc())
         )
         return await self._list(stmt, offset=offset, limit=limit)

--- a/src/domain/logic/verifications/schema.py
+++ b/src/domain/logic/verifications/schema.py
@@ -11,16 +11,24 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal
 
-from src.domain.models.enums import VERIFICATION_STATUSES
+from src.domain.models.enums import (
+    VERIFICATION_EVENT_TYPES,
+    VERIFICATION_STATUSES,
+    VERIFICATION_SUBJECT_TYPES,
+)
 from src.framework.schema_validators import ReadProjection, WirePayload
 
 
 class VerificationRead(ReadProjection):
     id: uuid.UUID
-    clinician_id: uuid.UUID
+    subject_type: str
+    clinician_id: uuid.UUID | None = None
+    org_id: uuid.UUID | None = None
+    event_type: str
     status: str
     flags: list[str] = []
     nppes_result: dict[str, Any] | None = None
+    evidence: dict[str, Any] | None = None
     oig_match: bool
     name_match_score: float | None = None
     created_at: datetime
@@ -32,9 +40,13 @@ class VerificationCreate(WirePayload):
     `handlers.py` (#528 / A4) from the NPPES / OIG check results and the
     scoring function. Not accepted from any wire surface."""
 
-    clinician_id: uuid.UUID
+    subject_type: Literal[*VERIFICATION_SUBJECT_TYPES] = "clinician"
+    clinician_id: uuid.UUID | None = None
+    org_id: uuid.UUID | None = None
+    event_type: Literal[*VERIFICATION_EVENT_TYPES] = "npi_resolved"
     status: Literal[*VERIFICATION_STATUSES]
     flags: list[str] = []
     nppes_result: dict[str, Any] | None = None
+    evidence: dict[str, Any] | None = None
     oig_match: bool = False
     name_match_score: float | None = None

--- a/src/domain/models/enums.py
+++ b/src/domain/models/enums.py
@@ -493,6 +493,40 @@ LICENSE_STATUSES: Final[tuple[str, ...]] = LicenseStatus.values()
 LICENSE_STATUS_LABELS: Final[dict[str, str]] = LicenseStatus.labels()
 
 
+# Closed vocab of state transitions that append a `Verification` event
+# row. Mirrors handoff §9: every transition that recomputes a claim flag
+# writes one row of this `event_type` with the relevant `evidence`
+# payload. The pipeline-end NPPES write currently in
+# `run_clinician_verification` is `npi_resolved`; admin overrides go
+# through `admin_verify`/`admin_suspend`; org authority transitions go
+# through `authority_proven` / `authority_revoked` / `role_set`. Value-
+# only — `.labels()` falls back to the storage value.
+class VerificationEventType(LabeledChoice):
+    npi_submitted = "npi_submitted"
+    npi_resolved = "npi_resolved"
+    license_attested = "license_attested"
+    license_expired = "license_expired"
+    authority_proven = "authority_proven"
+    authority_revoked = "authority_revoked"
+    role_set = "role_set"
+    admin_verify = "admin_verify"
+    admin_suspend = "admin_suspend"
+    email_confirmed = "email_confirmed"
+
+
+VERIFICATION_EVENT_TYPES: Final[tuple[str, ...]] = VerificationEventType.values()
+
+
+# Discriminator vocab for the polymorphic `Verification` row. Drives the
+# CHECK ensuring exactly one of (`clinician_id`, `org_id`) is set.
+class VerificationSubjectType(LabeledChoice):
+    clinician = "clinician"
+    organization = "organization"
+
+
+VERIFICATION_SUBJECT_TYPES: Final[tuple[str, ...]] = VerificationSubjectType.values()
+
+
 def check_in_tuple_sql(column: str, values: tuple[str, ...]) -> str:
     """SQL fragment for a `column IN (...)` CHECK constraint, rendered
     from a tuple. Used by per-kind detail tables so the DB-level

--- a/src/domain/models/test_enums.py
+++ b/src/domain/models/test_enums.py
@@ -126,6 +126,19 @@ MIGRATED_VALUES = {
     e.VerificationStatus: ("verified", "needs_review", "failed"),
     e.NpiMatchStatus: ("none", "pending", "matched", "mismatch"),
     e.LicenseStatus: ("active", "expired", "pending"),
+    e.VerificationEventType: (
+        "npi_submitted",
+        "npi_resolved",
+        "license_attested",
+        "license_expired",
+        "authority_proven",
+        "authority_revoked",
+        "role_set",
+        "admin_verify",
+        "admin_suspend",
+        "email_confirmed",
+    ),
+    e.VerificationSubjectType: ("clinician", "organization"),
     e.ClientAgeGroup: (
         "children_0_5",
         "children_6_10",
@@ -181,6 +194,8 @@ ALIAS_BINDINGS = [
     (e.NPI_MATCH_STATUS_LABELS, e.NpiMatchStatus, "labels"),
     (e.LICENSE_STATUSES, e.LicenseStatus, "values"),
     (e.LICENSE_STATUS_LABELS, e.LicenseStatus, "labels"),
+    (e.VERIFICATION_EVENT_TYPES, e.VerificationEventType, "values"),
+    (e.VERIFICATION_SUBJECT_TYPES, e.VerificationSubjectType, "values"),
     # Multi-attribute vocabularies — the standard-kind aliases still bind to
     # `.values()` / `.labels()` / `.icons()`; the extra-attribute derivations
     # (`*_BY_KEY`, `*_SINGULAR`, `*_SHORT_LABELS`, composite slots) are pinned

--- a/src/domain/models/verifications/test_verification.py
+++ b/src/domain/models/verifications/test_verification.py
@@ -4,6 +4,12 @@ Exercises the DB-layer invariants: the named `status` CHECK constraint
 rejects bogus values, defaults for `flags` / `oig_match` apply when the
 columns are omitted, and clinician cascade removes verification history
 when its parent clinician is deleted (so orphan rows can't pile up).
+
+After the polymorphic refactor (Phase 1b), the table also enforces a
+`subject_type` discriminator (`'clinician'` | `'organization'`) plus a
+shape CHECK pinning exactly one of (`clinician_id`, `org_id`) per
+discriminator value. These are exercised in the dedicated "polymorphic"
+section near the bottom of the file.
 """
 
 import pytest
@@ -11,7 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import Clinician, Verification
+from src.domain.models import Clinician, Organization, Verification
 from tests.helpers import create_test_user, make_organization_row
 
 pytestmark = pytest.mark.asyncio
@@ -141,6 +147,172 @@ async def test_verification_cascades_on_clinician_delete(
                     select(Verification).filter(
                         Verification.clinician_id == clinician_id
                     )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert rows == []
+
+
+# --- polymorphic subject (Phase 1b) --------------------------------------
+
+
+async def test_verification_defaults_to_clinician_subject(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """A row inserted with only `clinician_id` + `status` falls into the
+    `'clinician'` discriminator path via server-default."""
+    clinician = await _seed_clinician(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(Verification(clinician_id=clinician.id, status="verified"))
+
+    async with db_test_session_manager() as session:
+        row = (
+            (
+                await session.execute(
+                    select(Verification).filter(
+                        Verification.clinician_id == clinician.id
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert row.subject_type == "clinician"
+        assert row.event_type == "npi_resolved"
+        assert row.org_id is None
+
+
+async def test_verification_accepts_org_subject(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """An org-scoped verification row carries `org_id` and discards
+    `clinician_id` — the shape CHECK enforces the invariant."""
+    user = create_test_user()
+    org = make_organization_row(owner_id=user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                Verification(
+                    subject_type="organization",
+                    org_id=org.id,
+                    event_type="npi_resolved",
+                    status="verified",
+                )
+            )
+
+    async with db_test_session_manager() as session:
+        row = (
+            (
+                await session.execute(
+                    select(Verification).filter(Verification.org_id == org.id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert row.subject_type == "organization"
+        assert row.clinician_id is None
+        assert row.org_id == org.id
+
+
+async def test_verification_shape_check_rejects_both_subjects(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`ck_verifications_subject_shape` refuses rows that set both
+    `clinician_id` AND `org_id` — exactly one must be present."""
+    clinician = await _seed_clinician(db_test_session_manager)
+    user = create_test_user()
+    org = make_organization_row(owner_id=user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org)
+
+    with pytest.raises(IntegrityError):
+        async with db_test_session_manager() as session:
+            async with session.begin():
+                session.add(
+                    Verification(
+                        subject_type="clinician",
+                        clinician_id=clinician.id,
+                        org_id=org.id,
+                        status="verified",
+                    )
+                )
+
+
+async def test_verification_shape_check_rejects_neither_subject(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Rows with neither `clinician_id` nor `org_id` are also rejected."""
+    with pytest.raises(IntegrityError):
+        async with db_test_session_manager() as session:
+            async with session.begin():
+                session.add(
+                    Verification(
+                        subject_type="clinician",
+                        status="verified",
+                    )
+                )
+
+
+async def test_verification_rejects_unknown_event_type(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`ck_verifications_event_type` keeps `event_type` on the §9 closed
+    vocab."""
+    clinician = await _seed_clinician(db_test_session_manager)
+    with pytest.raises(IntegrityError):
+        async with db_test_session_manager() as session:
+            async with session.begin():
+                session.add(
+                    Verification(
+                        clinician_id=clinician.id,
+                        status="verified",
+                        event_type="not_a_real_event_type",
+                    )
+                )
+
+
+async def test_verification_cascades_on_org_delete(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Deleting an `Organization` removes its verification history via
+    the `org_id` FK `ON DELETE CASCADE` — symmetric with the clinician
+    cascade."""
+    user = create_test_user()
+    org = make_organization_row(owner_id=user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org)
+            session.add(
+                Verification(
+                    subject_type="organization",
+                    org_id=org.id,
+                    status="verified",
+                )
+            )
+    org_id = org.id
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            loaded = await session.get(Organization, org_id)
+            await session.delete(loaded)
+
+    async with db_test_session_manager() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(Verification).filter(Verification.org_id == org_id)
                 )
             )
             .scalars()

--- a/src/domain/models/verifications/verification.py
+++ b/src/domain/models/verifications/verification.py
@@ -1,38 +1,106 @@
 from functools import partial
 
-from sqlalchemy import JSON, Boolean, Column, Float, ForeignKey, Text, text
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    Column,
+    Float,
+    ForeignKey,
+    Text,
+    text,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.types import Uuid
 
 from src.framework.persistence.base_model import BaseModel
 
-from ..enums import VERIFICATION_STATUSES, named_check_in
+from ..enums import (
+    VERIFICATION_EVENT_TYPES,
+    VERIFICATION_STATUSES,
+    VERIFICATION_SUBJECT_TYPES,
+    named_check_in,
+)
 
 _TABLE = "verifications"
 _ck = partial(named_check_in, _TABLE)
 
+# Exactly-one subject: either a clinician (Type-1 NPPES) or an
+# organization (Type-2 NPPES + authority transitions). The discriminator
+# + the per-side FK presence must agree. Pre-launch refactor — existing
+# rows would have been clinician-only, but we don't backfill.
+_SUBJECT_SHAPE_CHECK = CheckConstraint(
+    "(subject_type = 'clinician' AND clinician_id IS NOT NULL AND org_id IS NULL) "
+    "OR (subject_type = 'organization' AND clinician_id IS NULL AND org_id IS NOT NULL)",
+    name=f"ck_{_TABLE}_subject_shape",
+)
+
 
 class Verification(BaseModel):
-    """One row per nightly verification attempt against a `Clinician`.
-    Append-only by convention — no UI exposes update or delete, the
-    orchestrator only ever calls `repo.record(...)`. `created_at` is
-    the effective `checked_at`.
+    """One row per verification event against a `Clinician` (Claim A,
+    NPPES Type-1) or an `Organization` (Claim B, NPPES Type-2 + authority
+    transitions).
+
+    Append-only by convention — no UI exposes update or delete; the
+    orchestrator only ever calls `repo.record_for_clinician(...)` /
+    `repo.record_for_org(...)`. `created_at` is the effective
+    `checked_at`.
+
+    Polymorphic via `subject_type`: a CHECK enforces that exactly one of
+    (`clinician_id`, `org_id`) is set, matching the discriminator. Both
+    FKs CASCADE on subject delete; the constraint ensures rows never
+    orphan-load.
+
+    `evidence` carries the raw NPPES payload + scoring inputs + AO name
+    comparison data for `npi_resolved` / `authority_proven` events.
+    `event_type` is the §9 closed vocab — every transition that
+    recomputes a claim flag appends one event row of the matching type.
     """
 
     __tablename__ = _TABLE
-    __table_args__ = (_ck("status", VERIFICATION_STATUSES),)
+    __table_args__ = (
+        _ck("status", VERIFICATION_STATUSES),
+        _ck("subject_type", VERIFICATION_SUBJECT_TYPES),
+        _ck("event_type", VERIFICATION_EVENT_TYPES),
+        _SUBJECT_SHAPE_CHECK,
+    )
+
+    subject_type = Column(
+        Text,
+        nullable=False,
+        server_default="clinician",
+        default="clinician",
+    )
 
     clinician_id = Column(
         Uuid(as_uuid=True),
         ForeignKey("clinicians.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
     clinician = relationship("Clinician")
 
+    org_id = Column(
+        Uuid(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    organization = relationship("Organization")
+
     status = Column(Text, nullable=False)
+    event_type = Column(
+        Text,
+        nullable=False,
+        server_default="npi_resolved",
+        default="npi_resolved",
+    )
 
     flags = Column(JSON, nullable=False, server_default=text("'[]'"), default=list)
     nppes_result = Column(JSON, nullable=True)
+    # Raw payload — NPPES response, scoring inputs, AO comparison, admin
+    # note. The shape varies by `event_type`; readers branch on the
+    # discriminator.
+    evidence = Column(JSON, nullable=True)
     oig_match = Column(Boolean, nullable=False, server_default=text("0"), default=False)
     name_match_score = Column(Float, nullable=True)


### PR DESCRIPTION
## Summary
`Verification` becomes polymorphic across **Claim A** (`Clinician`, NPPES Type-1) and **Claim B** (`Organization`, NPPES Type-2 + authority events). Same append-only event log; a `subject_type` discriminator decides which subject each row belongs to.

- New `subject_type` discriminator + nullable `org_id` FK; `clinician_id` flipped to nullable.
- New `event_type` column (closed §9 vocab: `npi_submitted` / `npi_resolved` / `license_attested` / `license_expired` / `authority_proven` / `authority_revoked` / `role_set` / `admin_verify` / `admin_suspend` / `email_confirmed`) + `evidence` JSON.
- New `ck_verifications_subject_shape` CHECK enforcing exactly one of (`clinician_id`, `org_id`) per discriminator value.
- `VerificationRepository`: new `record_for_clinician(...)` / `record_for_org(...)` + `latest_for_org` / `list_for_org`. Existing `record(...)` kept as a thin alias so the orchestrator and current tests keep working unchanged.
- Migration `76b43539731b` — SQLite-safe via `batch_alter_table`; CHECKs added explicitly since autogen doesn't emit them.

Phase 1b. No behavior change yet — `run_clinician_verification` keeps writing clinician rows; the new org-side path is tested but not yet called from production code. Phase 3 wires `run_org_verification`.

## Test plan
- [x] `dev migrate roundtrip` succeeds
- [x] `dev test` — 2076 passed, 92 skipped
- [x] `dev lint` clean (including seed coverage + drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)