### PR TITLE
refactor: tighten capability predicates against real schema (Phase 2)

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -15,12 +15,16 @@ This module is a domain-logic predicate set: it reads `User`/`Clinician`/
 lives in `domain/logic/` (not `framework/`) because framework code may
 not import domain models — see `src/README.md` import discipline.
 
-Phase status: placeholder bodies. The data columns the production
-predicates will read (`Clinician.clinician_verified`, `Clinician.ever_verified_at`,
-`Organization.org_verified`, `OrgRepresentation.authority_status`) do not
-yet exist; this module returns conservative answers from the columns that
-do exist (`User.is_verified`, `Clinician.npi`). Phase 2 of the rollout
-tightens these reads once the schema lands.
+Phase status: production reads. `clinician_verified` consults the
+`Clinician.clinician_verified` denorm cache; `org_rep_verified(user, org)`
+walks `User.org_representations` against `Organization.org_verified`;
+feed read-access honors `Clinician.ever_verified_at` (the once-verified
+retention rule per handoff §7.1).
+
+The predicates remain duck-typed via `getattr` so test stubs (and any
+non-ORM Actor-like object) keep working without constructing real
+SQLAlchemy rows. Templates and routes both call into the same surface,
+so a visible affordance and its server-side gate can't disagree.
 """
 
 from __future__ import annotations
@@ -74,39 +78,73 @@ def email_verified(user: Any) -> bool:
 
 
 def clinician_verified(user: Any) -> bool:
-    """Claim A: NPPES Type-1 name-matched + ≥1 active license.
-
-    Placeholder: returns True when the user has emailed-verified AND owns
-    at least one Clinician with a non-null `npi`. Phase 2 will read
-    `Clinician.clinician_verified` (the denorm cache) once that column
-    exists; until then, an NPI on file is the best signal available.
-    """
+    """Claim A: NPPES Type-1 name-matched + ≥1 active license. Reads the
+    `Clinician.clinician_verified` denorm cache so the predicate doesn't
+    re-derive from `npi_match_status` + licensure status per call. The
+    cache is recomputed by `recompute_clinician_claim(...)` on every
+    transition that touches its inputs."""
     if not email_verified(user):
         return False
     clinicians = getattr(user, "clinicians", None) or ()
-    return any(getattr(c, "npi", None) for c in clinicians)
+    return any(getattr(c, "clinician_verified", False) for c in clinicians)
+
+
+def _verified_active_reps(user: Any) -> tuple[Any, ...]:
+    """Filter `user.org_representations` to currently-verified, non-
+    archived rows. Used by `any_org_rep_verified` / `org_rep_verified` /
+    `claim_state` so the predicate set has a single way to read this."""
+    reps = getattr(user, "org_representations", None) or ()
+    return tuple(
+        r
+        for r in reps
+        if getattr(r, "authority_status", None) == "verified"
+        and getattr(r, "archived_at", None) is None
+    )
 
 
 def org_rep_verified(user: Any, org: Any) -> bool:
-    """Claim B per (user, org). Placeholder: always False until the
-    OrgRepresentation table lands in Phase 1 / Phase 4."""
-    return False
+    """Claim B for `(user, org)`. Requires:
+
+    1. The user's email is verified (floor for every claim).
+    2. The org's Type-2 NPI is `Organization.org_verified` (cached when
+       NPPES confirms — verified once per org).
+    3. The user holds a `verified` + non-archived `OrgRepresentation`
+       for this org.
+    """
+    if not email_verified(user):
+        return False
+    if not getattr(org, "org_verified", False):
+        return False
+    org_id = getattr(org, "id", None)
+    if org_id is None:
+        return False
+    return any(
+        getattr(r, "org_id", None) == org_id for r in _verified_active_reps(user)
+    )
 
 
 def any_org_rep_verified(user: Any) -> bool:
-    """True iff the user holds Claim B for at least one org. Placeholder:
-    always False until OrgRepresentation lands."""
-    return False
+    """True iff the user holds at least one verified, non-archived
+    OrgRepresentation. Skips the per-org `org_verified` gate — Claim B
+    by-any-org is a coarser check that the feed and chrome use to know
+    whether the user has *some* org-rep status, regardless of which
+    specific org is in scope."""
+    if not email_verified(user):
+        return False
+    return bool(_verified_active_reps(user))
 
 
 def can_read_full_feed(user: Any) -> bool:
     """Feed-teaser gate per handoff §7.1: full feed once any claim is
     verified; once-verified users retain read access after a lapse
-    (`ever_verified_at`). Phase 0 placeholder: gate on current Claim A
-    only — `ever_verified_at` doesn't exist yet."""
+    (`ever_verified_at`). New users see the blurred teaser until they
+    clear the first verification."""
     if user is None:
         return False
-    return clinician_verified(user) or any_org_rep_verified(user)
+    if clinician_verified(user) or any_org_rep_verified(user):
+        return True
+    clinicians = getattr(user, "clinicians", None) or ()
+    return any(getattr(c, "ever_verified_at", None) for c in clinicians)
 
 
 def can_post_referral(user: Any) -> bool:
@@ -134,18 +172,22 @@ def can_post_program_intake(user: Any, org: Any) -> bool:
 
 def can_post_org_referral(user: Any, org: Any, clinician: Any) -> bool:
     """Posting an org-attributed referral requires Claim B for the org
-    AND the target clinician must have an active Affiliation to the org.
-    Placeholder: always False until OrgRepresentation lands."""
-    return False
+    AND the target clinician must have an active Affiliation to the org
+    (handoff §4.3 / §10.5)."""
+    if not org_rep_verified(user, org):
+        return False
+    org_id = getattr(org, "id", None)
+    affiliations = getattr(clinician, "affiliations", None) or ()
+    return any(getattr(a, "org_id", None) == org_id for a in affiliations)
 
 
 def directory_listed(clinician: Any) -> bool:
     """A clinician is shown in the public directory iff their Claim A is
     verified (handoff §4.3: `directory.listed = clinician_verified`).
-    Placeholder: presence of an NPI on the clinician row."""
+    Reads the `Clinician.clinician_verified` denorm cache."""
     if clinician is None:
         return False
-    return bool(getattr(clinician, "npi", None))
+    return bool(getattr(clinician, "clinician_verified", False))
 
 
 def can_save_favorite(user: Any) -> bool:
@@ -155,13 +197,24 @@ def can_save_favorite(user: Any) -> bool:
 
 def claim_state(user: Any) -> ClaimState:
     """Aggregate the per-claim flags into one object the profile-hub mode
-    dispatcher consumes."""
+    dispatcher consumes.
+
+    `b` is the set of org IDs the user is a verified rep for; the
+    profile hub's mode dispatcher reads `not state.a and not state.b`
+    to land on `setup` mode. `lapsed` tracking (license expiry,
+    authority revocation) lands when Phase 3 introduces the per-
+    transition recompute helpers; until then it stays empty so the
+    hub never spuriously surfaces a `re-verify` mode.
+    """
     if user is None:
         return ClaimState()
+    rep_org_ids = frozenset(
+        getattr(r, "org_id", None) for r in _verified_active_reps(user)
+    ) - {None}
     return ClaimState(
         a=clinician_verified(user),
-        b=frozenset(),  # Phase 2 populates from OrgRepresentation rows.
-        lapsed=(),  # Phase 2 populates from license-expiry + authority-revoked signals.
+        b=rep_org_ids,
+        lapsed=(),
     )
 
 

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -18,7 +18,10 @@ from src.domain.logic import capabilities
 
 
 def _user(
-    *, is_verified: bool = False, clinicians: list | None = None
+    *,
+    is_verified: bool = False,
+    clinicians: list | None = None,
+    org_representations: list | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         id=uuid4(),
@@ -26,11 +29,41 @@ def _user(
         username="test",
         is_verified=is_verified,
         clinicians=clinicians or [],
+        org_representations=org_representations or [],
     )
 
 
-def _clinician(*, npi: str | None = None) -> SimpleNamespace:
-    return SimpleNamespace(npi=npi)
+def _clinician(
+    *,
+    npi: str | None = None,
+    clinician_verified: bool = False,
+    ever_verified_at=None,
+    affiliations: list | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        npi=npi,
+        clinician_verified=clinician_verified,
+        ever_verified_at=ever_verified_at,
+        affiliations=affiliations or [],
+    )
+
+
+def _org(*, org_verified: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid4(), org_verified=org_verified)
+
+
+def _rep(
+    *,
+    org_id,
+    authority_status: str = "verified",
+    archived_at=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        org_id=org_id,
+        authority_status=authority_status,
+        archived_at=archived_at,
+    )
 
 
 # ---------- email_verified ------------------------------------------------
@@ -70,40 +103,137 @@ def test_clinician_verified_no_clinicians():
     assert capabilities.clinician_verified(_user(is_verified=True)) is False
 
 
-def test_clinician_verified_clinician_without_npi():
+def test_clinician_verified_clinician_with_npi_but_cache_false():
+    """An NPI on file is no longer sufficient; the `clinician_verified`
+    denorm cache must also be True (post-NPPES match + license attest)."""
+    user = _user(
+        is_verified=True,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=False)],
+    )
+    assert capabilities.clinician_verified(user) is False
+
+
+def test_clinician_verified_clinician_without_clinician_verified_cache():
     user = _user(is_verified=True, clinicians=[_clinician(npi=None)])
     assert capabilities.clinician_verified(user) is False
 
 
 def test_clinician_verified_requires_email_verified():
-    user = _user(is_verified=False, clinicians=[_clinician(npi="1234567890")])
+    user = _user(
+        is_verified=False,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
+    )
     assert capabilities.clinician_verified(user) is False
 
 
 def test_clinician_verified_with_npi():
-    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
-    assert capabilities.clinician_verified(user) is True
-
-
-def test_clinician_verified_any_clinician_with_npi_suffices():
     user = _user(
         is_verified=True,
-        clinicians=[_clinician(npi=None), _clinician(npi="9876543210")],
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
     )
     assert capabilities.clinician_verified(user) is True
 
 
-# ---------- Claim B placeholders (always False until Phase 1/4) -----------
+def test_clinician_verified_any_verified_clinician_suffices():
+    """A user can own multiple `Clinician` rows; one with the
+    `clinician_verified` cache set is enough."""
+    user = _user(
+        is_verified=True,
+        clinicians=[
+            _clinician(npi=None, clinician_verified=False),
+            _clinician(npi="9876543210", clinician_verified=True),
+        ],
+    )
+    assert capabilities.clinician_verified(user) is True
 
 
-def test_org_rep_verified_placeholder_false():
-    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
-    org = SimpleNamespace(id=uuid4())
+# ---------- Claim B (OrgRepresentation-backed) ----------------------------
+
+
+def test_org_rep_verified_requires_org_verified():
+    """Even a verified rep against an unverified org returns False —
+    Claim B requires both `Organization.org_verified` and a verified
+    `OrgRepresentation` row."""
+    org = _org(org_verified=False)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+    )
     assert capabilities.org_rep_verified(user, org) is False
 
 
-def test_any_org_rep_verified_placeholder_false():
-    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+def test_org_rep_verified_requires_verified_authority_status():
+    """A pending or rejected representation does NOT confer Claim B."""
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="pending")],
+    )
+    assert capabilities.org_rep_verified(user, org) is False
+
+
+def test_org_rep_verified_ignores_archived_rows():
+    """Per handoff §10.8 archived rows pause authority — they don't
+    count toward Claim B."""
+    import datetime as _dt
+
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[
+            _rep(
+                org_id=org.id,
+                authority_status="verified",
+                archived_at=_dt.datetime(2026, 1, 1),
+            )
+        ],
+    )
+    assert capabilities.org_rep_verified(user, org) is False
+
+
+def test_org_rep_verified_happy_path():
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+    )
+    assert capabilities.org_rep_verified(user, org) is True
+
+
+def test_org_rep_verified_different_org_id_misses():
+    """A verified rep for org A does NOT confer Claim B for org B."""
+    other_org = _org(org_verified=True)
+    target_org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=other_org.id, authority_status="verified")],
+    )
+    assert capabilities.org_rep_verified(user, target_org) is False
+
+
+def test_any_org_rep_verified_true_with_verified_rep():
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+    )
+    assert capabilities.any_org_rep_verified(user) is True
+
+
+def test_any_org_rep_verified_false_when_only_pending():
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=uuid4(), authority_status="pending")],
+    )
+    assert capabilities.any_org_rep_verified(user) is False
+
+
+def test_any_org_rep_verified_requires_email_verified():
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=False,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+    )
     assert capabilities.any_org_rep_verified(user) is False
 
 
@@ -119,41 +249,105 @@ def test_can_read_full_feed_unverified_clinician_false():
 
 
 def test_can_read_full_feed_verified_clinician_true():
-    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    user = _user(
+        is_verified=True,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
+    )
     assert capabilities.can_read_full_feed(user) is True
 
 
+def test_can_read_full_feed_ever_verified_retains_access():
+    """Per handoff §7.1: once a user has been verified, they retain
+    feed read-access after a regression. A clinician with
+    `clinician_verified=False` but `ever_verified_at` set still passes."""
+    import datetime as _dt
+
+    user = _user(
+        is_verified=True,
+        clinicians=[
+            _clinician(
+                npi="1234567890",
+                clinician_verified=False,
+                ever_verified_at=_dt.datetime(2026, 1, 1),
+            )
+        ],
+    )
+    assert capabilities.can_read_full_feed(user) is True
+
+
+def test_can_read_full_feed_org_rep_unlocks_for_user_without_clinician():
+    """A program coordinator with no Type-1 NPI but a verified org rep
+    gets full feed access — handoff §3, §7.1."""
+    org = _org(org_verified=True)
+    coordinator = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+    )
+    assert capabilities.can_read_full_feed(coordinator) is True
+
+
 def test_can_post_referral_tracks_clinician_verified():
-    verified = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    verified = _user(
+        is_verified=True,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
+    )
     unverified = _user(is_verified=True)
     assert capabilities.can_post_referral(verified) is True
     assert capabilities.can_post_referral(unverified) is False
 
 
 def test_can_post_opening_tracks_clinician_verified():
-    verified = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    verified = _user(
+        is_verified=True,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
+    )
     unverified = _user(is_verified=True)
     assert capabilities.can_post_opening(verified) is True
     assert capabilities.can_post_opening(unverified) is False
 
 
 def test_can_message_tracks_clinician_verified():
-    verified = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    verified = _user(
+        is_verified=True,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
+    )
     assert capabilities.can_message(verified) is True
     assert capabilities.can_message(None) is False
 
 
-def test_can_post_program_intake_placeholder_false():
-    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
-    org = SimpleNamespace(id=uuid4())
+def test_can_post_program_intake_requires_claim_b_for_target_org():
+    org = _org(org_verified=True)
+    other_org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=other_org.id, authority_status="verified")],
+    )
+    # Verified rep for `other_org`, but the post targets `org` — denied.
     assert capabilities.can_post_program_intake(user, org) is False
+    # Same user posting against `other_org` is allowed.
+    assert capabilities.can_post_program_intake(user, other_org) is True
 
 
-def test_can_post_org_referral_placeholder_false():
-    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
-    org = SimpleNamespace(id=uuid4())
-    clinician = _clinician(npi="1234567890")
-    assert capabilities.can_post_org_referral(user, org, clinician) is False
+def test_can_post_org_referral_requires_clinician_affiliation():
+    """Per handoff §10.5: org-attributed referrals require the target
+    clinician to have an active Affiliation to the org. Claim B alone
+    is not enough — the org must be allowed to speak for the clinician
+    in question."""
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+    )
+    # Clinician with no affiliation to the target org → denied.
+    unaffiliated = _clinician(clinician_verified=True)
+    assert capabilities.can_post_org_referral(user, org, unaffiliated) is False
+
+    # Affiliated clinician → allowed.
+    affiliated = _clinician(
+        clinician_verified=True,
+        affiliations=[SimpleNamespace(org_id=org.id)],
+    )
+    assert capabilities.can_post_org_referral(user, org, affiliated) is True
 
 
 # ---------- directory_listed ----------------------------------------------
@@ -163,12 +357,19 @@ def test_directory_listed_none_false():
     assert capabilities.directory_listed(None) is False
 
 
-def test_directory_listed_clinician_without_npi_false():
-    assert capabilities.directory_listed(_clinician(npi=None)) is False
+def test_directory_listed_unverified_clinician_false():
+    """NPI presence alone is no longer enough; the `clinician_verified`
+    denorm cache must be True (post-NPPES + license attest)."""
+    assert capabilities.directory_listed(_clinician(npi="1234567890")) is False
 
 
-def test_directory_listed_clinician_with_npi_true():
-    assert capabilities.directory_listed(_clinician(npi="1234567890")) is True
+def test_directory_listed_verified_clinician_true():
+    assert (
+        capabilities.directory_listed(
+            _clinician(npi="1234567890", clinician_verified=True)
+        )
+        is True
+    )
 
 
 # ---------- can_save_favorite (only email_verified) -----------------------
@@ -194,11 +395,54 @@ def test_claim_state_anon_empty():
 
 
 def test_claim_state_a_only():
-    user = _user(is_verified=True, clinicians=[_clinician(npi="1234567890")])
+    user = _user(
+        is_verified=True,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
+    )
     s = capabilities.claim_state(user)
     assert s.a is True
     assert s.b == frozenset()
     assert s.lapsed == ()
+
+
+def test_claim_state_b_only_coordinator():
+    """A user with only verified `OrgRepresentation` rows (no clinician)
+    lands at `a=False` + `b={org_id, ...}`."""
+    org_a = _org(org_verified=True)
+    org_b = _org(org_verified=True)
+    coordinator = _user(
+        is_verified=True,
+        org_representations=[
+            _rep(org_id=org_a.id, authority_status="verified"),
+            _rep(org_id=org_b.id, authority_status="verified"),
+        ],
+    )
+    s = capabilities.claim_state(coordinator)
+    assert s.a is False
+    assert s.b == frozenset({org_a.id, org_b.id})
+
+
+def test_claim_state_b_excludes_pending_and_archived():
+    """Only verified, non-archived rows count toward `b`."""
+    import datetime as _dt
+
+    pending_org = _org(org_verified=True)
+    archived_org = _org(org_verified=True)
+    active_org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[
+            _rep(org_id=pending_org.id, authority_status="pending"),
+            _rep(
+                org_id=archived_org.id,
+                authority_status="verified",
+                archived_at=_dt.datetime(2026, 1, 1),
+            ),
+            _rep(org_id=active_org.id, authority_status="verified"),
+        ],
+    )
+    s = capabilities.claim_state(user)
+    assert s.b == frozenset({active_org.id})
 
 
 def test_claim_state_b_set_is_frozenset():

--- a/src/domain/models/users/user.py
+++ b/src/domain/models/users/user.py
@@ -31,3 +31,15 @@ class User(SQLAlchemyBaseUserTable[uuid.UUID], BaseModel):
         lazy="selectin",
         viewonly=True,
     )
+    # Reverse of `OrgRepresentation.user_id`. Drives Claim B in the
+    # capability predicates (`capabilities.any_org_rep_verified(user)`,
+    # `capabilities.org_rep_verified(user, org)`,
+    # `capabilities.claim_state(user)`). Lazy selectin so a single
+    # `user`-shaped read picks up the rep set without a follow-up query
+    # — same pattern as `clinicians` / `programs`.
+    org_representations = relationship(
+        "OrgRepresentation",
+        foreign_keys="OrgRepresentation.user_id",
+        lazy="selectin",
+        viewonly=True,
+    )

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -59,8 +59,8 @@ def test_base_context_regular_user():
 
 
 def test_base_context_claim_a_verified_user():
-    """A user with a verified Clinician (placeholder: any clinician with
-    an `npi`) flips `claims.a` to True. Pins the wiring between
+    """A user with a `clinician_verified=True` cache on at least one
+    `Clinician` flips `claims.a` to True. Pins the wiring between
     `base_context()` and `capabilities.claim_state()` — Phase 5's
     profile-hub mode dispatcher reads this same shape."""
     user = SimpleNamespace(
@@ -68,11 +68,41 @@ def test_base_context_claim_a_verified_user():
         username="alice",
         is_superuser=False,
         is_verified=True,
-        clinicians=[SimpleNamespace(npi="1234567890")],
+        clinicians=[
+            SimpleNamespace(
+                npi="1234567890",
+                clinician_verified=True,
+                ever_verified_at=None,
+            )
+        ],
+        org_representations=[],
     )
     ctx = base_context(user)
     assert ctx["claims"] == {"a": True, "b": []}
     assert ctx["any_claim_lapsed"] is False
+
+
+def test_base_context_claim_b_coordinator():
+    """A program coordinator (no clinician profile) with a verified
+    OrgRepresentation gets `claims.b` populated with the org id."""
+    org_id = uuid.uuid4()
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        username="dana",
+        is_superuser=False,
+        is_verified=True,
+        clinicians=[],
+        org_representations=[
+            SimpleNamespace(
+                org_id=org_id,
+                authority_status="verified",
+                archived_at=None,
+            )
+        ],
+    )
+    ctx = base_context(user)
+    assert ctx["claims"]["a"] is False
+    assert ctx["claims"]["b"] == [org_id]
 
 
 def test_base_context_unverified_user_surfaces_for_nag_banner():


### PR DESCRIPTION
## Summary
Replaces the Phase-0 placeholder predicate bodies (which read `Clinician.npi` presence as a proxy for Claim A) with reads against the denorm caches + relationship rows that now exist after Phases 1a–1c.

- `clinician_verified(user)` → `Clinician.clinician_verified` cache
- `org_rep_verified(user, org)` → `User.org_representations` × `Organization.org_verified` + verified+non-archived rep
- `can_read_full_feed(user)` → adds `Clinician.ever_verified_at` retention path (handoff §7.1)
- `can_post_org_referral(...)` → enforces the Affiliation existence rule (handoff §10.5)
- `directory_listed(clinician)` → `Clinician.clinician_verified` cache
- `claim_state(user).b` → populated with verified org IDs

New `User.org_representations` relationship (`lazy="selectin"`), symmetric with `User.clinicians` and `User.programs`. Predicates remain duck-typed so test stubs work.

A new `_verified_active_reps(user)` helper consolidates the `authority_status='verified' AND archived_at IS NULL` filter so there's only one definition of "currently a rep" — no way to forget the archive check at one call site and remember at another.

Truth-table tests extended: Claim-B four-corner cases (org_verified × authority_status × archived × org_id_match), ever_verified_at retention pinned, can_post_org_referral Affiliation check pinned, `claim_state.b` exclusion of pending/archived rows. `base_context()` test gets a Claim-B-only coordinator case.

No behavior is gated yet — Phase 7 wires the predicates into route `write_authz`, the feed-read template, and the directory filter.

## Test plan
- [x] `dev test` — 2128 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)