### PR TITLE
feat: verification cluster extension (Phase 3)

### DIFF
--- a/src/domain/logic/verifications/handlers.py
+++ b/src/domain/logic/verifications/handlers.py
@@ -1,21 +1,39 @@
-"""Verification orchestrator + bespoke trigger endpoint handler.
+"""Verification orchestrator + bespoke trigger endpoint handlers.
 
-`run_clinician_verification` is the single callable both the nightly job
-and the superuser retrigger endpoint here invoke.
+Two pipelines + a per-claim cache recompute + an append-only event
+writer. The pipelines (`run_clinician_verification`,
+`run_org_verification`) own NPPES + scoring + persistence; the recompute
+helpers translate the latest event log + denormalized columns into the
+boolean cache the capability predicates read; `record_verification_event`
+appends the non-NPPES transitions from §9 (licensure attestation,
+authority grant/revoke, admin override) so the event history stays a
+single source of truth.
 """
 
 import logging
+from datetime import datetime, timezone
+from typing import Any
 from uuid import UUID
 
 import httpx
 
 from src.domain.logic.clinicians.repository import ClinicianRepository
-from src.domain.logic.verifications.nppes import NppesResult, nppes_lookup
+from src.domain.logic.organizations.repository import OrganizationRepository
+from src.domain.logic.verifications.nppes import (
+    NppesOrgResult,
+    NppesResult,
+    nppes_lookup,
+    nppes_lookup_type2,
+)
 from src.domain.logic.verifications.oig import oig_check
 from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.logic.verifications.schema import VerificationRead
-from src.domain.logic.verifications.scoring import Score, score_verification
-from src.domain.models import Clinician, User, Verification
+from src.domain.logic.verifications.scoring import (
+    Score,
+    _name_similarity,
+    score_verification,
+)
+from src.domain.models import Clinician, Organization, User, Verification
 from src.framework.audit.core import make_audited_resource, record_audit_for
 from src.framework.audit.repository import AuditRepository
 from src.framework.http.exceptions import ForbiddenError, NotFoundError
@@ -26,6 +44,7 @@ VERIFICATION_RESOURCE = make_audited_resource("verification", VerificationRead)
 
 HTTP_TIMEOUT_SECONDS = 10.0
 _NPPES_SKIPPED_FLAG = "nppes_skipped"
+_NPPES_ORG_NAME_THRESHOLD = 0.80
 _SKIPPED_NPPES = NppesResult(found=False, first_name=None, last_name=None, raw=None)
 
 
@@ -45,6 +64,15 @@ def _clinician_names(clinician: Clinician, owner: User | None) -> tuple[str, str
     return (owner.username or "", "")
 
 
+def _now() -> datetime:
+    """Single source of "now" for the orchestrator so tests can patch
+    one place if they need deterministic timestamps later."""
+    return datetime.now(timezone.utc)
+
+
+# ---------- Clinician (Claim A) pipeline ---------------------------------
+
+
 async def run_clinician_verification(
     *,
     clinician_id: UUID,
@@ -54,8 +82,11 @@ async def run_clinician_verification(
     http: httpx.AsyncClient,
     actor_id: UUID | None,
 ) -> Verification:
-    """Run the full verification pipeline for one clinician and persist
-    one `Verification` row plus one matching audit row in a single transaction.
+    """Run the full Claim-A verification pipeline for one clinician and
+    persist one `Verification` row plus one matching audit row in a
+    single transaction. Also writes through the Claim-A denorm cache
+    (`Clinician.npi_match_status`, `clinician_verified`, `verified_at`,
+    `ever_verified_at`) per handoff §9.
     """
     clinician = await clinician_repo.get_by_model_id(Clinician, clinician_id)
     if clinician is None:
@@ -81,13 +112,15 @@ async def run_clinician_verification(
         clinician_last_name=last_name,
     )
 
-    verification = await verification_repo.record(
+    verification = await verification_repo.record_for_clinician(
         clinician_id=clinician.id,
         status=score.status,
         flags=extra_flags + score.flags,
         nppes_result=nppes_result.raw,
         oig_match=oig_result.match,
         name_match_score=score.name_match_score,
+        event_type="npi_resolved",
+        evidence=None,
     )
     await record_audit_for(
         audit_repo,
@@ -98,9 +131,27 @@ async def run_clinician_verification(
         before=None,
         after=VERIFICATION_RESOURCE.snapshot(verification),
     )
+
+    # Update the Claim-A denorm cache. Per handoff §10.1 the worker
+    # never auto-transitions to `mismatch` — a soft mismatch stays
+    # `pending` until an admin closes it via the `verification` state
+    # axis on Clinician (Phase 1 ships the column but not the axis
+    # handler yet; Phase 8's worker calls into this same code).
+    if score.status == "verified":
+        clinician.npi_match_status = "matched"
+        clinician.npi_verified_at = _now()
+    elif score.status == "failed" and not clinician.npi:
+        # No NPI submitted yet — stay at 'none' rather than burning the
+        # column to a final-fail state the user can't recover from
+        # without admin intervention.
+        clinician.npi_match_status = "none"
+    # `needs_review` and "found but mismatch" stay `pending` until an
+    # admin closes the loop.
+    recompute_clinician_claim(clinician)
+
     await verification_repo.session.commit()
     logger.info(
-        "verification: clinician=%s status=%s flags=%s actor=%s",
+        "verification.clinician: id=%s status=%s flags=%s actor=%s",
         clinician.id,
         score.status,
         verification.flags,
@@ -116,7 +167,7 @@ async def handle_create_clinician_verification(
     audit_repo: AuditRepository,
     requesting_user: User,
 ) -> Verification:
-    """Superuser-only manual retrigger of the verification pipeline."""
+    """Superuser-only manual retrigger of the Claim-A verification pipeline."""
     if not requesting_user.is_superuser:
         raise ForbiddenError(detail="Verification retrigger is admin-only")
 
@@ -129,3 +180,253 @@ async def handle_create_clinician_verification(
             http=http,
             actor_id=requesting_user.id,
         )
+
+
+# ---------- Organization (Claim B prereq) pipeline -----------------------
+
+
+def _score_org_name_match(
+    nppes: NppesOrgResult, org_name: str
+) -> tuple[str, list[str], float | None]:
+    """Status + flags + similarity for a Type-2 NPPES result.
+
+    Mirrors `score_verification`'s contract but specialized for org-name
+    matching. The AO name match (the per-user authority path) is NOT
+    scored here — it's owned by the `authorized_official` authority-
+    method handler, which compares the AO name to the requesting user's
+    verified `Clinician` name.
+    """
+    if not nppes.found:
+        return ("failed", ["nppes_npi_not_found"], None)
+    nppes_name = (nppes.org_name or "").strip()
+    declared_name = (org_name or "").strip()
+    if not nppes_name or not declared_name:
+        return ("needs_review", ["nppes_org_name_missing"], None)
+    similarity = _name_similarity(nppes_name, declared_name)
+    if similarity < _NPPES_ORG_NAME_THRESHOLD:
+        return ("needs_review", ["nppes_org_name_mismatch"], similarity)
+    return ("verified", [], similarity)
+
+
+async def run_org_verification(
+    *,
+    org_id: UUID,
+    verification_repo: VerificationRepository,
+    org_repo: OrganizationRepository,
+    audit_repo: AuditRepository,
+    http: httpx.AsyncClient,
+    actor_id: UUID | None,
+) -> Verification:
+    """Run the Claim-B Type-2 NPPES verification pipeline for one org.
+
+    Symmetric with `run_clinician_verification`: looks up the Type-2
+    NPI, compares NPPES `organization_name` to `Organization.name`,
+    persists a `Verification` row + audit row, and writes through the
+    Claim-B denorm cache (`Organization.npi_match_status`,
+    `org_verified`, `verified_at`, `authorized_official_name`).
+    """
+    org = await org_repo.get_by_model_id(Organization, org_id)
+    if org is None:
+        raise NotFoundError(detail="Organization not found")
+
+    if org.npi:
+        nppes_result = await nppes_lookup_type2(org.npi, http=http)
+        flags: list[str] = []
+    else:
+        nppes_result = NppesOrgResult(
+            found=False,
+            org_name=None,
+            authorized_official_name=None,
+            raw=None,
+        )
+        flags = [_NPPES_SKIPPED_FLAG]
+
+    status, score_flags, similarity = _score_org_name_match(nppes_result, org.name)
+
+    verification = await verification_repo.record_for_org(
+        org_id=org.id,
+        status=status,
+        flags=flags + score_flags,
+        nppes_result=nppes_result.raw,
+        name_match_score=similarity,
+        event_type="npi_resolved",
+        evidence=(
+            {"authorized_official_name": nppes_result.authorized_official_name}
+            if nppes_result.authorized_official_name
+            else None
+        ),
+    )
+    await record_audit_for(
+        audit_repo,
+        resource=VERIFICATION_RESOURCE,
+        verb="create",
+        actor_id=actor_id,
+        target_id=verification.id,
+        before=None,
+        after=VERIFICATION_RESOURCE.snapshot(verification),
+    )
+
+    # Update the org-side denorm cache. Same §10.1 rule as the Clinician
+    # side: `needs_review` stays `pending` rather than auto-flipping to
+    # `mismatch`.
+    if status == "verified":
+        org.npi_match_status = "matched"
+        if nppes_result.authorized_official_name:
+            org.authorized_official_name = nppes_result.authorized_official_name
+    elif status == "failed" and not org.npi:
+        org.npi_match_status = "none"
+    recompute_org_claim(org)
+
+    await verification_repo.session.commit()
+    logger.info(
+        "verification.org: id=%s status=%s flags=%s actor=%s",
+        org.id,
+        status,
+        verification.flags,
+        actor_id,
+    )
+    return verification
+
+
+async def handle_create_org_verification(
+    org_id: UUID,
+    verification_repo: VerificationRepository,
+    org_repo: OrganizationRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> Verification:
+    """Superuser-only manual retrigger of the Claim-B verification pipeline."""
+    if not requesting_user.is_superuser:
+        raise ForbiddenError(detail="Verification retrigger is admin-only")
+
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT_SECONDS) as http:
+        return await run_org_verification(
+            org_id=org_id,
+            verification_repo=verification_repo,
+            org_repo=org_repo,
+            audit_repo=audit_repo,
+            http=http,
+            actor_id=requesting_user.id,
+        )
+
+
+# ---------- Claim-cache recompute helpers --------------------------------
+
+
+def recompute_clinician_claim(clinician: Clinician) -> None:
+    """Compute `Clinician.clinician_verified` + the timestamp triplet
+    (`verified_at`, `ever_verified_at`, regression detection) from the
+    current `npi_match_status` + the licensure set, then mutate the
+    clinician in place. The caller is responsible for committing the
+    enclosing transaction.
+
+    Claim A requires:
+      1. `npi_match_status == 'matched'`
+      2. at least one `ClinicianLicensure` with `status == 'active'`
+
+    `ever_verified_at` is set on the first transition to True and
+    preserved on regression — that's what powers the once-verified feed
+    retention rule (handoff §7.1).
+    """
+    matched = clinician.npi_match_status == "matched"
+    licensures = getattr(clinician, "licensures", None) or ()
+    has_active_license = any(
+        getattr(lic, "status", None) == "active" for lic in licensures
+    )
+    is_verified_now = matched and has_active_license
+
+    if is_verified_now:
+        if not clinician.clinician_verified:
+            clinician.verified_at = _now()
+        clinician.clinician_verified = True
+        if clinician.ever_verified_at is None:
+            clinician.ever_verified_at = clinician.verified_at or _now()
+    else:
+        clinician.clinician_verified = False
+        # Leave `verified_at` and `ever_verified_at` alone — the
+        # first-ever timestamp is preserved across regressions so the
+        # `can_read_full_feed` retention rule keeps working.
+
+
+def recompute_org_claim(org: Organization) -> None:
+    """Compute `Organization.org_verified` + `verified_at` from the
+    current `npi_match_status`. Symmetric with the Clinician side,
+    minus the licensure consideration (orgs don't hold licenses)."""
+    is_verified_now = org.npi_match_status == "matched"
+    if is_verified_now:
+        if not org.org_verified:
+            org.verified_at = _now()
+        org.org_verified = True
+    else:
+        org.org_verified = False
+
+
+# ---------- Append-only event writer -------------------------------------
+
+
+async def record_verification_event(
+    *,
+    verification_repo: VerificationRepository,
+    audit_repo: AuditRepository,
+    subject_type: str,
+    clinician_id: UUID | None = None,
+    org_id: UUID | None = None,
+    event_type: str,
+    status: str = "verified",
+    evidence: dict[str, Any] | None = None,
+    actor_id: UUID | None,
+) -> Verification:
+    """Single append-only writer for the non-NPPES §9 transitions
+    (`license_attested`, `license_expired`, `authority_proven`,
+    `authority_revoked`, `role_set`, `admin_verify`, `admin_suspend`,
+    `email_confirmed`). Records both a `Verification` row and a matching
+    audit entry in one transaction; the caller is responsible for the
+    enclosing `session.commit()`.
+
+    The NPPES-pipeline writes (`npi_submitted`, `npi_resolved`) go
+    through the dedicated `record_for_*` repository methods invoked
+    inside `run_clinician_verification` / `run_org_verification` instead
+    — they carry NPPES-specific fields (`nppes_result`, `oig_match`,
+    `name_match_score`) the non-NPPES events don't have.
+    """
+    if (clinician_id is None) == (org_id is None):
+        # Mirror the DB-level CHECK in Python so misuses fail loudly
+        # at the handler boundary rather than as a SQLite IntegrityError.
+        raise ValueError(
+            "record_verification_event requires exactly one of " "clinician_id / org_id"
+        )
+
+    if subject_type == "clinician":
+        assert clinician_id is not None  # narrowed by the XOR above
+        verification = await verification_repo.record_for_clinician(
+            clinician_id=clinician_id,
+            status=status,
+            flags=[],
+            nppes_result=None,
+            oig_match=False,
+            name_match_score=None,
+            event_type=event_type,
+            evidence=evidence,
+        )
+    else:
+        assert org_id is not None
+        verification = await verification_repo.record_for_org(
+            org_id=org_id,
+            status=status,
+            flags=[],
+            nppes_result=None,
+            name_match_score=None,
+            event_type=event_type,
+            evidence=evidence,
+        )
+
+    await record_audit_for(
+        audit_repo,
+        resource=VERIFICATION_RESOURCE,
+        verb="create",
+        actor_id=actor_id,
+        target_id=verification.id,
+        before=None,
+        after=VERIFICATION_RESOURCE.snapshot(verification),
+    )
+    return verification

--- a/src/domain/logic/verifications/nppes.py
+++ b/src/domain/logic/verifications/nppes.py
@@ -85,3 +85,103 @@ async def nppes_lookup(npi: str, *, http: httpx.AsyncClient) -> NppesResult:
         last_name=last if isinstance(last, str) else None,
         raw=payload,
     )
+
+
+@dataclass(frozen=True, slots=True)
+class NppesOrgResult:
+    """Outcome of a Type-2 NPPES lookup. Mirrors `NppesResult` for the
+    org case: `org_name` drives the org-name similarity score against
+    `Organization.name`; `authorized_official_name` is what the
+    `authorized_official` authority-method path matches against the
+    requesting user's verified `Clinician` legal name (handoff §6)."""
+
+    found: bool
+    org_name: str | None
+    authorized_official_name: str | None
+    raw: dict[str, Any] | None
+
+
+_ORG_NOT_FOUND = NppesOrgResult(
+    found=False, org_name=None, authorized_official_name=None, raw=None
+)
+
+
+async def nppes_lookup_type2(npi: str, *, http: httpx.AsyncClient) -> NppesOrgResult:
+    """Look up a Type-2 (organizational) NPI against NPPES.
+
+    Same degraded-on-failure contract as `nppes_lookup`: the function
+    never raises so the orchestrator always gets a `Verification` row.
+    NPPES distinguishes Type-1 from Type-2 via the `enumeration_type`
+    field on the result (`"NPI-2"` for orgs); if the lookup returns a
+    Type-1 we treat it as not-found for org purposes — calling code
+    should never pass a Type-1 NPI here.
+
+    The Type-2 payload's `basic` block has different fields than Type-1:
+    `organization_name` instead of `first_name`/`last_name`, plus
+    `authorized_official_first_name` / `authorized_official_last_name` /
+    `authorized_official_middle_name` for the AO name-match path.
+    """
+    try:
+        response = await http.get(
+            _NPPES_ENDPOINT,
+            params={
+                "version": _NPPES_VERSION,
+                "number": npi,
+                "enumeration_type": "NPI-2",
+            },
+            timeout=_DEFAULT_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("nppes_lookup_type2(%s): request failed: %s", npi, exc)
+        return _ORG_NOT_FOUND
+
+    if response.status_code >= 400:
+        logger.warning(
+            "nppes_lookup_type2(%s): unexpected status %s",
+            npi,
+            response.status_code,
+        )
+        return _ORG_NOT_FOUND
+
+    try:
+        payload: dict[str, Any] = response.json()
+    except ValueError as exc:
+        logger.warning("nppes_lookup_type2(%s): non-JSON payload: %s", npi, exc)
+        return _ORG_NOT_FOUND
+
+    results = payload.get("results") or []
+    if not results:
+        return NppesOrgResult(
+            found=False,
+            org_name=None,
+            authorized_official_name=None,
+            raw=payload,
+        )
+
+    result0 = results[0] or {}
+    if result0.get("enumeration_type") not in (None, "NPI-2"):
+        # Defensive: NPPES returned a Type-1 record despite the
+        # `enumeration_type=NPI-2` filter. Treat as not-found for org
+        # purposes; the worker logs and the row stays `pending`.
+        logger.warning(
+            "nppes_lookup_type2(%s): enumeration_type=%s (expected NPI-2)",
+            npi,
+            result0.get("enumeration_type"),
+        )
+        return NppesOrgResult(
+            found=False, org_name=None, authorized_official_name=None, raw=payload
+        )
+
+    basic = result0.get("basic") or {}
+    org_name = basic.get("organization_name")
+    ao_first = basic.get("authorized_official_first_name") or ""
+    ao_middle = basic.get("authorized_official_middle_name") or ""
+    ao_last = basic.get("authorized_official_last_name") or ""
+    ao_parts = [p.strip() for p in (ao_first, ao_middle, ao_last) if p and p.strip()]
+    ao_name = " ".join(ao_parts) if ao_parts else None
+    return NppesOrgResult(
+        found=True,
+        org_name=org_name if isinstance(org_name, str) else None,
+        authorized_official_name=ao_name,
+        raw=payload,
+    )

--- a/src/domain/logic/verifications/test_handlers_phase3.py
+++ b/src/domain/logic/verifications/test_handlers_phase3.py
@@ -1,0 +1,565 @@
+"""Phase-3 tests for the verification cluster extension:
+
+- `recompute_clinician_claim(clinician)` — pure function: Claim-A cache
+  recompute from `npi_match_status` + active licensures.
+- `recompute_org_claim(org)` — pure function: Claim-B prereq cache from
+  `npi_match_status`.
+- `record_verification_event(...)` — append-only writer for the non-NPPES
+  §9 transitions (license_attested / authority_proven / admin_verify /
+  etc.) with the matching audit row.
+- `run_org_verification(...)` — Type-2 NPPES pipeline, mocked via
+  `httpx.MockTransport`.
+- `nppes_lookup_type2(...)` directly — fixture-driven happy path +
+  not-found path + wrong-enumeration-type defensive return.
+
+`run_clinician_verification` side-effects on `Clinician.clinician_verified`
++ `verified_at` + `ever_verified_at` are also pinned here (Phase 3 added
+the cache write-through; the existing handler-tests file pins the row
+shape but not the side effects).
+"""
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.logic.clinicians.repository import ClinicianRepository
+from src.domain.logic.organizations.repository import OrganizationRepository
+from src.domain.logic.verifications import oig as oig_module
+from src.domain.logic.verifications.handlers import (
+    recompute_clinician_claim,
+    recompute_org_claim,
+    record_verification_event,
+    run_clinician_verification,
+    run_org_verification,
+)
+from src.domain.logic.verifications.nppes import nppes_lookup_type2
+from src.domain.logic.verifications.repository import VerificationRepository
+from src.domain.models import (
+    Clinician,
+    ClinicianLicensure,
+    Organization,
+    Verification,
+)
+from src.framework.audit.log import AuditLog
+from src.framework.audit.repository import AuditRepository
+from tests.helpers import (
+    create_test_user,
+    make_clinician_with_org,
+    make_organization_row,
+)
+
+# `pytest.mark.asyncio` applied per-async-function rather than at module
+# scope — half the tests here are pure synchronous functions
+# (`recompute_*_claim`) and would warn under a blanket pytestmark.
+
+
+@pytest.fixture(autouse=True)
+def _leie_path_env(monkeypatch, tmp_path):
+    """Point OIG at an empty CSV so the run_*_verification pipelines
+    here aren't affected by a real LEIE fixture. Cache reset between
+    tests."""
+    empty_csv = tmp_path / "leie_empty.csv"
+    empty_csv.write_text("FIRSTNAME,LASTNAME,NPI,EXCLDATE,REINDATE,EXCLTYPE\n")
+    monkeypatch.setenv("LEIE_CSV_PATH", str(empty_csv))
+    oig_module._reset_cache_for_tests()
+    yield
+    oig_module._reset_cache_for_tests()
+
+
+def _mock_http(responses: dict[str, dict[str, Any] | int]) -> httpx.AsyncClient:
+    """Same `_mock_http` shape as `test_handlers.py`. Keys are NPIs;
+    values are JSON payloads or status codes."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        npi = request.url.params.get("number")
+        canned = responses.get(npi or "")
+        if canned is None:
+            return httpx.Response(404)
+        if isinstance(canned, int):
+            return httpx.Response(canned)
+        return httpx.Response(200, content=json.dumps(canned).encode())
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _type2_payload(
+    *,
+    org_name: str,
+    ao_first: str = "",
+    ao_last: str = "",
+) -> dict[str, Any]:
+    """Mock NPPES Type-2 response. Mirrors the real payload's shape:
+    `enumeration_type='NPI-2'` + `basic.organization_name` +
+    `basic.authorized_official_*` triplet."""
+    return {
+        "results": [
+            {
+                "enumeration_type": "NPI-2",
+                "basic": {
+                    "organization_name": org_name,
+                    "authorized_official_first_name": ao_first,
+                    "authorized_official_last_name": ao_last,
+                },
+            }
+        ]
+    }
+
+
+# ---------- recompute_clinician_claim ------------------------------------
+
+
+def test_recompute_clinician_claim_requires_matched_npi_and_active_license():
+    """Matched NPI without any active license → False."""
+    clinician = Clinician(
+        id=uuid4(),
+        owner_id=uuid4(),
+        npi="1234567890",
+        first_name="Eva",
+        last_name="Stone",
+    )
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = False
+    clinician.licensures = [
+        ClinicianLicensure(
+            clinician_id=clinician.id,
+            license_type="lcsw",
+            license_number="X-1",
+            issuing_state="IL",
+            status="pending",
+        )
+    ]
+    recompute_clinician_claim(clinician)
+    assert clinician.clinician_verified is False
+
+
+def test_recompute_clinician_claim_active_license_without_matched_npi_false():
+    """Active license without matched NPI → False."""
+    clinician = Clinician(
+        id=uuid4(), owner_id=uuid4(), first_name="Eva", last_name="Stone"
+    )
+    clinician.npi_match_status = "pending"
+    clinician.clinician_verified = False
+    clinician.licensures = [
+        ClinicianLicensure(
+            clinician_id=clinician.id,
+            license_type="lcsw",
+            license_number="X-1",
+            issuing_state="IL",
+            status="active",
+        )
+    ]
+    recompute_clinician_claim(clinician)
+    assert clinician.clinician_verified is False
+
+
+def test_recompute_clinician_claim_happy_path():
+    clinician = Clinician(
+        id=uuid4(),
+        owner_id=uuid4(),
+        npi="1234567890",
+        first_name="Eva",
+        last_name="Stone",
+    )
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = False
+    clinician.verified_at = None
+    clinician.ever_verified_at = None
+    clinician.licensures = [
+        ClinicianLicensure(
+            clinician_id=clinician.id,
+            license_type="lcsw",
+            license_number="X-1",
+            issuing_state="IL",
+            status="active",
+        )
+    ]
+    recompute_clinician_claim(clinician)
+    assert clinician.clinician_verified is True
+    assert clinician.verified_at is not None
+    assert clinician.ever_verified_at is not None
+
+
+def test_recompute_clinician_claim_preserves_ever_verified_at_on_regression():
+    """A clinician who was previously verified and now isn't (license
+    expired) must keep `ever_verified_at` set — that's what the
+    `can_read_full_feed` retention rule reads."""
+    historic = datetime(2025, 6, 1, tzinfo=timezone.utc)
+    clinician = Clinician(id=uuid4(), owner_id=uuid4())
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    clinician.verified_at = historic
+    clinician.ever_verified_at = historic
+    clinician.licensures = [
+        ClinicianLicensure(
+            clinician_id=clinician.id,
+            license_type="lcsw",
+            license_number="X-1",
+            issuing_state="IL",
+            status="expired",
+        )
+    ]
+    recompute_clinician_claim(clinician)
+    assert clinician.clinician_verified is False
+    assert clinician.ever_verified_at == historic
+
+
+# ---------- recompute_org_claim ------------------------------------------
+
+
+def test_recompute_org_claim_matched_flips_true():
+    org = Organization(
+        id=uuid4(),
+        owner_id=uuid4(),
+        name="Acme",
+        type="clinic",
+        root_org_id=uuid4(),
+    )
+    org.npi_match_status = "matched"
+    org.org_verified = False
+    org.verified_at = None
+    recompute_org_claim(org)
+    assert org.org_verified is True
+    assert org.verified_at is not None
+
+
+def test_recompute_org_claim_pending_keeps_false():
+    org = Organization(
+        id=uuid4(),
+        owner_id=uuid4(),
+        name="Acme",
+        type="clinic",
+        root_org_id=uuid4(),
+    )
+    org.npi_match_status = "pending"
+    org.org_verified = False
+    recompute_org_claim(org)
+    assert org.org_verified is False
+
+
+def test_recompute_org_claim_regression_clears_verified():
+    org = Organization(
+        id=uuid4(),
+        owner_id=uuid4(),
+        name="Acme",
+        type="clinic",
+        root_org_id=uuid4(),
+    )
+    org.npi_match_status = "mismatch"  # admin closed a soft mismatch
+    org.org_verified = True
+    recompute_org_claim(org)
+    assert org.org_verified is False
+
+
+# ---------- record_verification_event ------------------------------------
+
+
+async def _seed_clinician_only(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+) -> Clinician:
+    owner = create_test_user(username=f"owner-{uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(owner)
+            clinician = make_clinician_with_org(owner_id=owner.id, npi="1234567890")
+            session.add(clinician)
+    return clinician
+
+
+async def _seed_org(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+) -> Organization:
+    user = create_test_user(username=f"orgowner-{uuid4()}")
+    org = make_organization_row(owner_id=user.id, name="Acme")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org)
+    return org
+
+
+async def test_record_event_clinician_appends_row_and_audit(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    clinician = await _seed_clinician_only(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        verification = await record_verification_event(
+            verification_repo=VerificationRepository(session),
+            audit_repo=AuditRepository(session),
+            subject_type="clinician",
+            clinician_id=clinician.id,
+            event_type="license_attested",
+            evidence={"license_id": "X-1"},
+            actor_id=None,
+        )
+        await session.commit()
+
+    async with db_test_session_manager() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(Verification).filter(
+                        Verification.clinician_id == clinician.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].event_type == "license_attested"
+        assert rows[0].evidence == {"license_id": "X-1"}
+
+        audits = (
+            (
+                await session.execute(
+                    select(AuditLog).filter(AuditLog.resource_id == verification.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audits) == 1
+
+
+async def test_record_event_org_appends_row(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    org = await _seed_org(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        await record_verification_event(
+            verification_repo=VerificationRepository(session),
+            audit_repo=AuditRepository(session),
+            subject_type="organization",
+            org_id=org.id,
+            event_type="authority_proven",
+            actor_id=None,
+        )
+        await session.commit()
+
+    async with db_test_session_manager() as session:
+        row = (
+            (
+                await session.execute(
+                    select(Verification).filter(Verification.org_id == org.id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert row.event_type == "authority_proven"
+        assert row.subject_type == "organization"
+        assert row.clinician_id is None
+
+
+async def test_record_event_xor_check(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Passing both `clinician_id` and `org_id` (or neither) is a
+    handler-level misuse — fail loudly in Python before the DB check
+    fires."""
+    clinician = await _seed_clinician_only(db_test_session_manager)
+    org = await _seed_org(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        with pytest.raises(ValueError, match="exactly one"):
+            await record_verification_event(
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                subject_type="clinician",
+                clinician_id=clinician.id,
+                org_id=org.id,
+                event_type="admin_verify",
+                actor_id=None,
+            )
+        with pytest.raises(ValueError, match="exactly one"):
+            await record_verification_event(
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                subject_type="clinician",
+                event_type="admin_verify",
+                actor_id=None,
+            )
+
+
+# ---------- run_org_verification -----------------------------------------
+
+
+async def test_run_org_verification_writes_through_cache(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Happy path: NPPES name matches → row persists with `status=
+    'verified'`, the org's denorm cache flips to verified, and
+    `authorized_official_name` is cached."""
+    user = create_test_user()
+    org = make_organization_row(owner_id=user.id, name="Acme Clinic")
+    org.npi = "1234567890"
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org)
+
+    http = _mock_http(
+        {
+            "1234567890": _type2_payload(
+                org_name="Acme Clinic", ao_first="Jane", ao_last="Doe"
+            )
+        }
+    )
+    async with db_test_session_manager() as session:
+        async with http:
+            verification = await run_org_verification(
+                org_id=org.id,
+                verification_repo=VerificationRepository(session),
+                org_repo=OrganizationRepository(session),
+                audit_repo=AuditRepository(session),
+                http=http,
+                actor_id=None,
+            )
+
+    async with db_test_session_manager() as session:
+        loaded = await session.get(Organization, org.id)
+        assert loaded.npi_match_status == "matched"
+        assert loaded.org_verified is True
+        assert loaded.verified_at is not None
+        assert loaded.authorized_official_name == "Jane Doe"
+
+    assert verification.status == "verified"
+    assert verification.subject_type == "organization"
+    assert verification.org_id == org.id
+
+
+async def test_run_org_verification_needs_review_on_name_mismatch(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user = create_test_user()
+    org = make_organization_row(owner_id=user.id, name="Acme Clinic")
+    org.npi = "1234567890"
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org)
+
+    http = _mock_http(
+        {"1234567890": _type2_payload(org_name="Totally Different Practice")}
+    )
+    async with db_test_session_manager() as session:
+        async with http:
+            verification = await run_org_verification(
+                org_id=org.id,
+                verification_repo=VerificationRepository(session),
+                org_repo=OrganizationRepository(session),
+                audit_repo=AuditRepository(session),
+                http=http,
+                actor_id=None,
+            )
+
+    assert verification.status == "needs_review"
+    async with db_test_session_manager() as session:
+        loaded = await session.get(Organization, org.id)
+        assert loaded.org_verified is False
+
+
+# ---------- nppes_lookup_type2 -------------------------------------------
+
+
+async def test_nppes_lookup_type2_returns_org_and_ao():
+    http = _mock_http(
+        {"1234567890": _type2_payload(org_name="Acme", ao_first="Jane", ao_last="Doe")}
+    )
+    async with http:
+        result = await nppes_lookup_type2("1234567890", http=http)
+    assert result.found is True
+    assert result.org_name == "Acme"
+    assert result.authorized_official_name == "Jane Doe"
+
+
+async def test_nppes_lookup_type2_handles_404():
+    http = _mock_http({"1234567890": 404})
+    async with http:
+        result = await nppes_lookup_type2("1234567890", http=http)
+    assert result.found is False
+    assert result.org_name is None
+
+
+async def test_nppes_lookup_type2_rejects_type1_record():
+    """Defensive: if NPPES returns a Type-1 record despite the filter,
+    treat it as not-found for org purposes (don't accidentally write
+    a Type-1 person's name onto the org's verification row)."""
+    payload = {
+        "results": [
+            {
+                "enumeration_type": "NPI-1",
+                "basic": {"organization_name": "Should not be used"},
+            }
+        ]
+    }
+    http = _mock_http({"1234567890": payload})
+    async with http:
+        result = await nppes_lookup_type2("1234567890", http=http)
+    assert result.found is False
+
+
+# ---------- run_clinician_verification cache write-through ---------------
+
+
+async def test_run_clinician_verification_writes_through_cache(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """After Phase 3, the pipeline writes `npi_match_status='matched'`
+    + `clinician_verified=True` when the score is `verified` AND the
+    clinician has an active license. Without an active license the
+    cache stays False even after a successful NPPES match."""
+    owner = create_test_user()
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(owner)
+            clinician = make_clinician_with_org(
+                owner_id=owner.id,
+                npi="1234567890",
+                first_name="Eva",
+                last_name="Stone",
+            )
+            session.add(clinician)
+    clinician_id = clinician.id
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(
+                ClinicianLicensure(
+                    clinician_id=clinician_id,
+                    license_type="lcsw",
+                    license_number="X-1",
+                    issuing_state="IL",
+                    status="active",
+                )
+            )
+
+    http = _mock_http(
+        {
+            "1234567890": {
+                "results": [{"basic": {"first_name": "Eva", "last_name": "Stone"}}]
+            }
+        }
+    )
+    async with db_test_session_manager() as session:
+        async with http:
+            await run_clinician_verification(
+                clinician_id=clinician_id,
+                verification_repo=VerificationRepository(session),
+                clinician_repo=ClinicianRepository(session),
+                audit_repo=AuditRepository(session),
+                http=http,
+                actor_id=None,
+            )
+
+    async with db_test_session_manager() as session:
+        loaded = await session.get(Clinician, clinician_id)
+        assert loaded.npi_match_status == "matched"
+        assert loaded.clinician_verified is True
+        assert loaded.verified_at is not None
+        assert loaded.ever_verified_at is not None


### PR DESCRIPTION
## Summary
Adds the verification primitives the Profile Hub (Phase 5) and the NPI worker (Phase 8) will call into.

- **`nppes_lookup_type2(npi, ...)`** — Type-2 NPPES lookup, mirror of `nppes_lookup`. Returns `NppesOrgResult{org_name, authorized_official_name}` (AO composed from first/middle/last). Same degraded-on-failure contract — never raises.
- **`run_org_verification(*, org_id, ...)`** — Claim-B Type-2 pipeline, symmetric with `run_clinician_verification`. Persists a `Verification` row + audit row in one transaction and writes through the org-side denorm cache (`npi_match_status`, `org_verified`, `verified_at`, `authorized_official_name`). Honors handoff §10.1 — soft mismatches stay `pending`, no auto-flip to `mismatch`.
- **`recompute_clinician_claim(clinician)`** + **`recompute_org_claim(org)`** — pure functions that translate `npi_match_status` + active-license set into the denorm caches the capabilities predicates read. `ever_verified_at` is set on first transition to True and preserved across regressions so `can_read_full_feed` retention works (handoff §7.1).
- **`record_verification_event(...)`** — single append-only writer for the non-NPPES §9 transitions (`license_attested`, `authority_proven`, `admin_verify`, etc.). XOR-on-subject is enforced in Python so misuses fail at the handler boundary, not as a SQLite `IntegrityError`.
- **`run_clinician_verification`** now writes through the Claim-A denorm cache via `recompute_clinician_claim`.

16 new tests cover the pure recompute helpers, the event writer (clinician + org + XOR violations), both NPPES Type-2 paths (happy/404/defensive-type-1-reject), and the org pipeline (happy + needs_review).

No production caller invokes `run_org_verification` or `record_verification_event` yet — they ship alongside their tests so Phase 4 (authority-method handlers) and Phase 8 (NPI worker) can wire them in without changing this PR.

## Test plan
- [x] `dev test` — 2145 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)