### PR TITLE
feat: pending-NPI worker job (Phase 8)

### DIFF
--- a/src/domain/logic/clinicians/repository.py
+++ b/src/domain/logic/clinicians/repository.py
@@ -28,6 +28,18 @@ class ClinicianRepository(BaseRepository):
             select(Clinician).filter(Clinician.deleted_at.is_(None))
         )
 
+    async def list_pending_npi(self) -> Sequence[Clinician]:
+        """Clinicians with `npi_match_status == 'pending'` — the work
+        queue for the NPI worker job. Picks up rows after an end-user
+        submission (`POST /clinicians/{id}/npi`) and any admin-driven
+        re-submit. Excludes soft-deleted rows."""
+        return await self._list(
+            select(Clinician).filter(
+                Clinician.npi_match_status == "pending",
+                Clinician.deleted_at.is_(None),
+            )
+        )
+
     async def list_clinicians(
         self,
         *,

--- a/src/domain/logic/organizations/repository.py
+++ b/src/domain/logic/organizations/repository.py
@@ -16,6 +16,8 @@ read the tree but won't widen the writer surface.
 import uuid
 from typing import Any, Sequence
 
+from sqlalchemy import select
+
 from src.domain.models import Organization
 from src.framework.http.exceptions import NotFoundError
 from src.framework.persistence.base_repository import BaseRepository
@@ -30,6 +32,17 @@ class OrganizationRepository(BaseRepository):
         ownership is the boundary for who may attach Clinicians, mirroring
         ``Organization.write_authz``)."""
         return await self.list_owned_by(Organization, user_id)
+
+    async def list_pending_npi(self) -> Sequence[Organization]:
+        """Orgs with `npi_match_status == 'pending'` — the work queue
+        for the NPI worker's Type-2 path. Mirror of
+        `ClinicianRepository.list_pending_npi` for Claim B."""
+        return await self._list(
+            select(Organization).filter(
+                Organization.npi_match_status == "pending",
+                Organization.deleted_at.is_(None),
+            )
+        )
 
     async def _resolve_root_id(
         self, parent_org_id: uuid.UUID | None

--- a/src/jobs/scheduler.py
+++ b/src/jobs/scheduler.py
@@ -13,6 +13,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from src.jobs.hello_world import run_hello_world
 from src.jobs.nightly_verification import run_nightly_verification
+from src.jobs.verify_pending_npis import run_verify_pending_npis
 
 
 def make_scheduler() -> AsyncIOScheduler:
@@ -38,6 +39,21 @@ def register_jobs(scheduler: AsyncIOScheduler) -> None:
         run_nightly_verification,
         trigger=CronTrigger.from_crontab(nightly_cron),
         id="nightly_verification",
+        coalesce=True,
+        max_instances=1,
+    )
+
+    # Pending-NPI drainer — runs on a short interval (default ~300s in
+    # prod, the env var lets dev dial down to 60s for a near-instant
+    # Profile Hub "Verifying…" → matched transition). Same coalesce /
+    # max_instances story as `nightly_verification`.
+    pending_interval_sec = int(
+        os.getenv("JOBS_VERIFY_PENDING_NPIS_INTERVAL_SEC", "300")
+    )
+    scheduler.add_job(
+        run_verify_pending_npis,
+        trigger=IntervalTrigger(seconds=pending_interval_sec),
+        id="verify_pending_npis",
         coalesce=True,
         max_instances=1,
     )

--- a/src/jobs/test_scheduler.py
+++ b/src/jobs/test_scheduler.py
@@ -12,6 +12,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from src.jobs.hello_world import run_hello_world
 from src.jobs.nightly_verification import run_nightly_verification
 from src.jobs.scheduler import make_scheduler, register_jobs
+from src.jobs.verify_pending_npis import run_verify_pending_npis
 
 
 def test_register_jobs_adds_hello_world_with_interval_trigger():
@@ -61,3 +62,27 @@ def test_register_jobs_respects_nightly_cron_env(monkeypatch):
     # Cheapest assertion that proves the env var threaded through:
     # the parsed cron expression includes our minute spec.
     assert "*/5" in str(nightly.trigger)
+
+
+def test_register_jobs_adds_verify_pending_npis_with_interval_trigger():
+    scheduler = make_scheduler()
+    register_jobs(scheduler)
+
+    job = scheduler.get_job("verify_pending_npis")
+    assert job is not None
+    assert job.func is run_verify_pending_npis
+    assert isinstance(job.trigger, IntervalTrigger)
+    assert job.coalesce is True
+    assert job.max_instances == 1
+    # Default cadence is 300s (prod baseline).
+    assert job.trigger.interval.total_seconds() == 300
+
+
+def test_register_jobs_respects_verify_pending_npis_interval_env(monkeypatch):
+    monkeypatch.setenv("JOBS_VERIFY_PENDING_NPIS_INTERVAL_SEC", "60")
+
+    scheduler = make_scheduler()
+    register_jobs(scheduler)
+
+    job = scheduler.get_job("verify_pending_npis")
+    assert job.trigger.interval.total_seconds() == 60

--- a/src/jobs/test_verify_pending_npis.py
+++ b/src/jobs/test_verify_pending_npis.py
@@ -1,0 +1,205 @@
+"""Pins the pending-NPI worker loop contract.
+
+Three invariants this file guards:
+
+1. The loop pulls *only* rows with `npi_match_status == 'pending'` —
+   not-yet-submitted (`'none'`) and resolved (`'matched'` / `'mismatch'`)
+   rows are skipped. Cuts the queue depth on every run.
+2. Every pending Clinician AND every pending Organization is handed to
+   the matching pipeline once with `actor_id=None`.
+3. One pipeline failure does NOT stop the rest of the batch — same per-
+   row commit + log-and-continue pattern as `nightly_verification`.
+
+The pipelines themselves are stubbed; `test_handlers_phase3.py` and
+`test_handlers.py` pin the per-row behavior.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.models import Clinician
+from src.jobs import verify_pending_npis
+from tests.helpers import (
+    create_test_user,
+    make_clinician_with_org,
+    make_organization_row,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_pending_clinicians(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    pending_count: int,
+    none_count: int,
+    matched_count: int,
+) -> tuple[list[Clinician], list[Clinician]]:
+    """Returns (pending, non_pending). Tests assert the worker visits
+    only the pending list."""
+    pending: list[Clinician] = []
+    non_pending: list[Clinician] = []
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            for i in range(pending_count):
+                user = create_test_user(username=f"pending-owner-{i}")
+                session.add(user)
+                await session.flush()
+                clinician = make_clinician_with_org(owner_id=user.id, npi="1234567890")
+                clinician.npi_match_status = "pending"
+                session.add(clinician)
+                pending.append(clinician)
+            for i in range(none_count):
+                user = create_test_user(username=f"none-owner-{i}")
+                session.add(user)
+                await session.flush()
+                clinician = make_clinician_with_org(owner_id=user.id)
+                # `npi_match_status` defaults to 'none' on insert.
+                session.add(clinician)
+                non_pending.append(clinician)
+            for i in range(matched_count):
+                user = create_test_user(username=f"matched-owner-{i}")
+                session.add(user)
+                await session.flush()
+                clinician = make_clinician_with_org(owner_id=user.id, npi="9876543210")
+                clinician.npi_match_status = "matched"
+                clinician.clinician_verified = True
+                session.add(clinician)
+                non_pending.append(clinician)
+    return pending, non_pending
+
+
+async def test_only_pending_clinicians_are_visited(
+    monkeypatch: pytest.MonkeyPatch,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    monkeypatch.setattr(
+        verify_pending_npis, "async_session_maker", db_test_session_manager
+    )
+    pending, non_pending = await _seed_pending_clinicians(
+        db_test_session_manager,
+        pending_count=2,
+        none_count=2,
+        matched_count=1,
+    )
+
+    seen: list = []
+
+    async def stub_clinician(**kwargs):
+        seen.append(kwargs["clinician_id"])
+
+    async def stub_org(**kwargs):
+        pass
+
+    monkeypatch.setattr(
+        verify_pending_npis, "run_clinician_verification", stub_clinician
+    )
+    monkeypatch.setattr(verify_pending_npis, "run_org_verification", stub_org)
+
+    await verify_pending_npis.run_verify_pending_npis()
+
+    assert set(seen) == {c.id for c in pending}
+    assert not (set(seen) & {c.id for c in non_pending})
+
+
+async def test_pending_orgs_drained(
+    monkeypatch: pytest.MonkeyPatch,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Both the Clinician and Organization queues are drained in one
+    pass."""
+    monkeypatch.setattr(
+        verify_pending_npis, "async_session_maker", db_test_session_manager
+    )
+    user = create_test_user()
+    org_pending = make_organization_row(owner_id=user.id, name="Pending Org")
+    org_pending.npi = "1234567890"
+    org_pending.npi_match_status = "pending"
+    org_resolved = make_organization_row(owner_id=user.id, name="Resolved Org")
+    org_resolved.npi = "9876543210"
+    org_resolved.npi_match_status = "matched"
+    org_resolved.org_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org_pending)
+            session.add(org_resolved)
+
+    seen_orgs: list = []
+
+    async def stub_clinician(**kwargs):
+        pass
+
+    async def stub_org(**kwargs):
+        seen_orgs.append(kwargs["org_id"])
+
+    monkeypatch.setattr(
+        verify_pending_npis, "run_clinician_verification", stub_clinician
+    )
+    monkeypatch.setattr(verify_pending_npis, "run_org_verification", stub_org)
+
+    await verify_pending_npis.run_verify_pending_npis()
+
+    assert seen_orgs == [org_pending.id]
+
+
+async def test_loop_continues_after_per_row_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """A single failing pipeline call must not stop the rest of the
+    batch. Same log-and-continue rule as `nightly_verification`."""
+    monkeypatch.setattr(
+        verify_pending_npis, "async_session_maker", db_test_session_manager
+    )
+    pending, _ = await _seed_pending_clinicians(
+        db_test_session_manager, pending_count=3, none_count=0, matched_count=0
+    )
+    failing_id = pending[1].id
+
+    seen: list = []
+
+    async def stub_clinician(**kwargs):
+        seen.append(kwargs["clinician_id"])
+        if kwargs["clinician_id"] == failing_id:
+            raise RuntimeError("simulated NPPES outage")
+
+    async def stub_org(**kwargs):
+        pass
+
+    monkeypatch.setattr(
+        verify_pending_npis, "run_clinician_verification", stub_clinician
+    )
+    monkeypatch.setattr(verify_pending_npis, "run_org_verification", stub_org)
+
+    # Must not raise.
+    await verify_pending_npis.run_verify_pending_npis()
+
+    assert set(seen) == {c.id for c in pending}
+
+
+async def test_empty_queue_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Nothing pending → no HTTP client opened, no pipeline calls."""
+    monkeypatch.setattr(
+        verify_pending_npis, "async_session_maker", db_test_session_manager
+    )
+
+    calls: list = []
+
+    async def stub_clinician(**kwargs):
+        calls.append(("clinician", kwargs["clinician_id"]))
+
+    async def stub_org(**kwargs):
+        calls.append(("org", kwargs["org_id"]))
+
+    monkeypatch.setattr(
+        verify_pending_npis, "run_clinician_verification", stub_clinician
+    )
+    monkeypatch.setattr(verify_pending_npis, "run_org_verification", stub_org)
+
+    await verify_pending_npis.run_verify_pending_npis()
+
+    assert calls == []

--- a/src/jobs/verify_pending_npis.py
+++ b/src/jobs/verify_pending_npis.py
@@ -1,0 +1,85 @@
+"""Pending-NPI verification worker.
+
+Polls `Clinician.list_pending_npi()` + `Organization.list_pending_npi()`
+on a short interval and runs the matching NPPES pipeline against each
+queued row. End-user "submit NPI" actions (Profile Hub `_claim_a_card`
+/ `_claim_b_card`) set `npi_match_status='pending'` and then return
+immediately; this job drains the queue.
+
+Sequential per pipeline (same justification as `nightly_verification`):
+NPPES has no documented rate limit and the per-call timeout bounds
+total runtime. Each per-row call owns its own transaction, so a single
+failure can't poison the queue — the loop logs and moves on.
+
+Cadence: configurable via `JOBS_VERIFY_PENDING_NPIS_INTERVAL_SEC`. In
+dev a tight ~60s loop gives a near-instant "Verifying…" → matched
+transition; production can dial back to ~300s once the queue depth is
+known.
+"""
+
+import logging
+
+import httpx
+
+from src.db import async_session_maker
+from src.domain.logic.clinicians.repository import ClinicianRepository
+from src.domain.logic.organizations.repository import OrganizationRepository
+from src.domain.logic.verifications.handlers import (
+    HTTP_TIMEOUT_SECONDS,
+    run_clinician_verification,
+    run_org_verification,
+)
+from src.domain.logic.verifications.repository import VerificationRepository
+from src.framework.audit.repository import AuditRepository
+
+logger = logging.getLogger(__name__)
+
+
+async def run_verify_pending_npis() -> None:
+    """Drain the pending-NPI queues for both Clinician (Claim A,
+    Type-1) and Organization (Claim B, Type-2)."""
+    async with async_session_maker() as session:
+        clinician_repo = ClinicianRepository(session)
+        org_repo = OrganizationRepository(session)
+        verification_repo = VerificationRepository(session)
+        audit_repo = AuditRepository(session)
+        pending_clinicians = await clinician_repo.list_pending_npi()
+        pending_orgs = await org_repo.list_pending_npi()
+
+        if not pending_clinicians and not pending_orgs:
+            logger.debug("verify_pending_npis: queue empty")
+            return
+
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT_SECONDS) as http:
+            for clinician in pending_clinicians:
+                try:
+                    await run_clinician_verification(
+                        clinician_id=clinician.id,
+                        verification_repo=verification_repo,
+                        clinician_repo=clinician_repo,
+                        audit_repo=audit_repo,
+                        http=http,
+                        actor_id=None,
+                    )
+                except Exception:
+                    logger.exception(
+                        "verify_pending_npis: clinician=%s failed", clinician.id
+                    )
+            for org in pending_orgs:
+                try:
+                    await run_org_verification(
+                        org_id=org.id,
+                        verification_repo=verification_repo,
+                        org_repo=org_repo,
+                        audit_repo=audit_repo,
+                        http=http,
+                        actor_id=None,
+                    )
+                except Exception:
+                    logger.exception("verify_pending_npis: org=%s failed", org.id)
+
+    logger.info(
+        "verify_pending_npis: drained %d clinicians + %d orgs",
+        len(pending_clinicians),
+        len(pending_orgs),
+    )


### PR DESCRIPTION
## Summary
Closes the verification automation loop. End-user "submit NPI" actions set `npi_match_status='pending'` and return immediately; this job drains the queue every ~5min (interval configurable via env), running the matching NPPES pipeline against each pending Clinician (Type-1) and Organization (Type-2).

- New `src/jobs/verify_pending_npis.py` — APScheduler job. Sequential per pipeline, log-and-continue on per-row failure, same `coalesce` + `max_instances=1` safety as `nightly_verification`. Short-circuits when both queues are empty.
- `ClinicianRepository.list_pending_npi()` + `OrganizationRepository.list_pending_npi()` — the work-queue selects.
- `src/jobs/scheduler.py` registers the new job with default interval 300s; `JOBS_VERIFY_PENDING_NPIS_INTERVAL_SEC=60` dials it down for dev (near-instant Profile Hub "Verifying…" → matched).
- 4 worker tests pin: pending-only filter, org queue drain, log-and-continue after per-row exception, empty-queue short-circuit. 2 scheduler tests pin job registration + env-var override.

Phase 8 of the verification rollout. Remaining work is the UX surface — Profile Hub (Phase 5), `/home` adaptation (Phase 6), gating-site wiring (Phase 7).

## Test plan
- [x] `dev test` — 2151 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)