### PR TITLE
feat: wire Claim-A capability gate into post create/update (Phase 7)

### DIFF
--- a/src/domain/logic/posts/handlers.py
+++ b/src/domain/logic/posts/handlers.py
@@ -1,28 +1,31 @@
 """Per-spec hook callables for the `Post` entity.
 
-One callable today — :func:`_assert_post_payload_target_ownership` —
-driven by ``POST_ENTITY.payload_authz_path``. The post entity has no
-bespoke CRUD handlers; this hook plus the spec declaration is the
-entire wire-side authorization surface for posts.
+`_assert_post_payload_authz` is the entry point driven by
+``POST_ENTITY.payload_authz_path``: it layers FK-ownership (the
+submitter must own the cross-entity row the post references) AND the
+capability gate from the two-claim verification model (a referral / a
+clinician-opening requires Claim A; a program-intake requires Claim B
+for the org behind the referenced Program).
 
 Why it dispatches on ``payload.kind``: all three kinds reference a
 cross-entity FK the submitting user must own.
 ``clinician_opening.clinician_id`` and ``program_intake.program_id``
 point at rows the user created; ``referral.referring_clinician_id``
-points at a Clinician the user owns (the referring clinician on a CR
-post must belong to the submitting user). The cleaner long-term shape
-is per-kind authz on :class:`PostKindSpec`; a type-switching dispatcher
-is acceptable while the kind set is small.
+points at a Clinician the user owns. The cleaner long-term shape is
+per-kind authz on :class:`PostKindSpec`; a type-switching dispatcher is
+acceptable while the kind set is small.
 """
 
 import logging
 
 from pydantic import BaseModel
 
+from src.domain.logic import capabilities
 from src.domain.logic.clinicians.repository import ClinicianRepository
 from src.domain.logic.programs.repository import ProgramRepository
 from src.domain.models import Clinician, Program, User
 from src.framework.authz import assert_fk_ownership
+from src.framework.http.exceptions import ForbiddenError
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +40,70 @@ _KIND_FK_TARGETS: tuple[tuple[str, str, str, type], ...] = (
 )
 
 
+async def _assert_post_payload_authz(
+    *,
+    payload: BaseModel,
+    requesting_user: User,
+    clinician_repo: ClinicianRepository,
+    program_repo: ProgramRepository,
+) -> None:
+    """`POST_ENTITY.payload_authz_path` target — runs the two
+    payload-time authorization checks in order:
+
+    1. **Ownership** — the per-kind FK on the payload must point at a
+       row the requesting user owns. (Existing rule.)
+    2. **Capability** — the submitter must hold the claim that gates
+       this post-kind:
+
+       - ``referral`` / ``clinician_opening`` → Claim A
+         (`capabilities.clinician_verified(user)`).
+       - ``program_intake`` → Claim B for the referenced Program's org
+         (deferred — the org lookup lands when the Profile Hub PR
+         (Phase 5) wires the program-intake create flow end-to-end).
+
+    Superusers bypass the capability check the same way they bypass
+    ownership — admins act on any row.
+    """
+    await _assert_post_payload_target_ownership(
+        payload=payload,
+        requesting_user=requesting_user,
+        clinician_repo=clinician_repo,
+        program_repo=program_repo,
+    )
+    _assert_post_payload_capability(payload, requesting_user)
+
+
+def _assert_post_payload_capability(payload: BaseModel, requesting_user: User) -> None:
+    """Per-kind capability gate. Skips for superusers (admin write
+    rights override the claim-based gate). For `program_intake`, the
+    Claim-B check requires the referenced Program's org id — which is
+    a DB read we don't want to add to this payload-time hook. The
+    Profile Hub PR (Phase 5) introduces the dedicated program-intake
+    create path that takes the org check; this hook stays focused on
+    Claim A."""
+    if getattr(requesting_user, "is_superuser", False):
+        return
+    kind = getattr(payload, "kind", None)
+    if kind == "referral" and not capabilities.can_post_referral(requesting_user):
+        raise ForbiddenError(
+            detail=(
+                "Posting a referral requires a verified clinician profile "
+                "(Claim A). Visit /profile to complete verification."
+            ),
+        )
+    if kind == "clinician_opening" and not capabilities.can_post_opening(
+        requesting_user
+    ):
+        raise ForbiddenError(
+            detail=(
+                "Posting a clinician opening requires a verified clinician "
+                "profile (Claim A). Visit /profile to complete verification."
+            ),
+        )
+    # `program_intake` Claim-B gate is intentionally deferred — see
+    # docstring above.
+
+
 async def _assert_post_payload_target_ownership(
     *,
     payload: BaseModel,
@@ -44,9 +111,8 @@ async def _assert_post_payload_target_ownership(
     clinician_repo: ClinicianRepository,
     program_repo: ProgramRepository,
 ) -> None:
-    """``POST_ENTITY.payload_authz_path`` target — reject a Post
-    create/update whose per-kind FK points at a row the requesting user
-    doesn't own (superusers bypass).
+    """Reject a Post create/update whose per-kind FK points at a row
+    the requesting user doesn't own (superusers bypass).
 
     Dispatches on ``payload.kind`` via :data:`_KIND_FK_TARGETS`:
 

--- a/src/domain/logic/posts/test_capability_gate.py
+++ b/src/domain/logic/posts/test_capability_gate.py
@@ -1,0 +1,96 @@
+"""Phase-7 tests: the per-kind Claim-A capability gate on post create.
+
+`_assert_post_payload_authz` runs FK-ownership AND the matching
+capability check from the two-claim verification model. Per handoff
+§4.3 + §7, `referral` and `clinician_opening` require Claim A; a user
+who owns the referenced Clinician but isn't `clinician_verified`
+should be refused at the payload-authz boundary.
+
+The existing `_assert_post_payload_target_ownership` invariant (own
+the FK target row) is exercised in higher-level integration tests;
+these tests focus narrowly on the new capability layer.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from src.domain.logic.posts.handlers import _assert_post_payload_capability
+from src.framework.http.exceptions import ForbiddenError
+
+
+def _user(
+    *,
+    is_verified: bool = True,
+    clinician_verified: bool = False,
+    is_superuser: bool = False,
+) -> SimpleNamespace:
+    """Stub that satisfies `capabilities.clinician_verified(user)` by
+    duck-typing the relevant attributes."""
+    clinicians = (
+        [SimpleNamespace(clinician_verified=True)] if clinician_verified else []
+    )
+    return SimpleNamespace(
+        id=uuid4(),
+        username="t",
+        is_superuser=is_superuser,
+        is_verified=is_verified,
+        clinicians=clinicians,
+    )
+
+
+def _payload(kind: str) -> SimpleNamespace:
+    return SimpleNamespace(kind=kind)
+
+
+def test_referral_create_requires_claim_a():
+    """A user without `clinician_verified` is rejected when posting a
+    referral — Claim A is the gate."""
+    with pytest.raises(ForbiddenError, match="Claim A"):
+        _assert_post_payload_capability(_payload("referral"), _user())
+
+
+def test_referral_create_allowed_for_verified_clinician():
+    _assert_post_payload_capability(
+        _payload("referral"), _user(clinician_verified=True)
+    )
+
+
+def test_clinician_opening_requires_claim_a():
+    with pytest.raises(ForbiddenError, match="Claim A"):
+        _assert_post_payload_capability(_payload("clinician_opening"), _user())
+
+
+def test_clinician_opening_allowed_for_verified_clinician():
+    _assert_post_payload_capability(
+        _payload("clinician_opening"), _user(clinician_verified=True)
+    )
+
+
+def test_program_intake_capability_deferred_to_phase_5():
+    """`program_intake` is intentionally not gated here — the Claim-B
+    check requires the program's org id which is a DB read we'd rather
+    not add to the payload-authz hook. The Profile Hub PR (Phase 5)
+    introduces a dedicated program-intake create path that takes the
+    org check; until then this hook lets program_intake through (the
+    FK-ownership check still runs upstream)."""
+    _assert_post_payload_capability(_payload("program_intake"), _user())
+
+
+def test_superuser_bypasses_capability_gate():
+    """Admins can post any kind regardless of claim state — same
+    discipline as the FK-ownership check (superusers bypass)."""
+    _assert_post_payload_capability(_payload("referral"), _user(is_superuser=True))
+
+
+def test_email_unverified_blocks_referral():
+    """The capability layer transitively requires `email_verified`
+    (because `clinician_verified` requires it). A user whose email is
+    unverified can't post a referral even if a stale
+    `clinician_verified=True` is on one of their clinicians."""
+    user = _user(is_verified=False, clinician_verified=True)
+    with pytest.raises(ForbiddenError, match="Claim A"):
+        _assert_post_payload_capability(_payload("referral"), user)

--- a/src/domain/specs/posts.py
+++ b/src/domain/specs/posts.py
@@ -153,13 +153,13 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
         form_edit="posts/form_edit.html",
     ),
     update_redirect=Redirects.to_detail("posts", "post_id"),
-    # Per-kind FK-ownership check. The dispatcher reads `payload.kind`
-    # and validates the kind-specific FK fields (clinician_opening's
-    # `clinician_id`, program_intake's `program_id`) against the
-    # requesting user's ownership.
-    payload_authz_path=(
-        "src.domain.logic.posts.handlers._assert_post_payload_target_ownership"
-    ),
+    # Per-kind FK-ownership check + Claim-A capability gate. The
+    # dispatcher reads `payload.kind` and validates the kind-specific FK
+    # fields (clinician_opening's `clinician_id`, program_intake's
+    # `program_id`) against the requesting user's ownership, then
+    # enforces the matching claim gate from the two-claim verification
+    # model. See `_assert_post_payload_authz` for the full contract.
+    payload_authz_path="src.domain.logic.posts.handlers._assert_post_payload_authz",
     payload_authz_repos=(
         ("clinician_repo", ClinicianRepository),
         ("program_repo", ProgramRepository),


### PR DESCRIPTION
## Summary
Adds the verification-aware gate on `POST_ENTITY` writes per handoff §4.3 + §7: a user can't post a referral or clinician-opening unless they hold Claim A (a `clinician_verified=True` Clinician).

- `_assert_post_payload_authz` wraps the existing FK-ownership check with a per-kind capability check.
- `referral` / `clinician_opening` → require `clinician_verified` (Claim A).
- `program_intake` → deferred. Claim-B requires the referenced Program's org id (an additional DB read at the payload-authz boundary). The Profile Hub PR (Phase 5) introduces the dedicated program-intake create path that takes the org check.
- Superusers bypass the capability check (same discipline as the FK-ownership bypass).
- 7 new gate tests pin the truth table: each kind × verified/unverified × superuser × email-unverified.

Existing tests stay green — they either use superuser fixtures (bypass) or trigger 422 validation errors upstream of the authz hook.

## Test plan
- [x] `dev test` — 2158 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)