### PR TITLE
feat: OrgRepresentation authority-method dispatch (Phase 4)

### DIFF
--- a/src/domain/logic/org_representations/handlers.py
+++ b/src/domain/logic/org_representations/handlers.py
@@ -1,18 +1,33 @@
-"""Handlers for the `OrgRepresentation` state-axis subresource.
+"""Handlers for `OrgRepresentation` create + state-axis dispatch.
 
-Generic CRUD is provided by `mount_entity` via the framework's
-`handle_create` / `handle_update` / `handle_delete` factories. The one
-bespoke piece this cluster needs today is the **authority state axis** —
-admin (or `rep_approval` approver) flipping `authority_status` without
-re-PUTing the whole row, with a fresh audit entry and a Verification
-event each transition.
+Two bespoke handlers here:
 
-Phase-4 extension PRs will add the per-method authority dispatch
-(`authorized_official` auto-match, `rep_approval` invite/approve, etc.)
-on top of the generic create path. For now `mount_entity` accepts
-create payloads with any authority_method and inserts at
-`authority_status='pending'` — the state axis here is the only path to
-flip to `verified` / `rejected`.
+1. **`handle_create_org_representation`** — POST `/org_representations`.
+   Dispatches on `payload.authority_method` per handoff §6:
+
+   - ``authorized_official`` — NPPES Authorized-Official name-match.
+     Compares the org's cached `authorized_official_name` to the
+     requesting user's verified `Clinician` legal name; on match the
+     row lands at `authority_status='verified'` and a `Verification`
+     event of type `authority_proven` is recorded. No match → 400.
+   - ``rep_approval`` — invite-driven. `approved_by` must point at a
+     verified non-archived rep on the same org. Row lands at
+     `authority_status='pending'`; the approver flips it via the
+     `authority` state axis.
+   - ``domain_email`` — v1 stub: 400 "not yet enabled". The enum
+     value is shipped so the schema/UI stays coherent; full build-out
+     needs an `OrganizationDomain` table + email-at-domain
+     verification flow.
+   - ``admin_review`` — fallback. Row lands at `authority_status='pending'`.
+
+2. **`handle_set_org_representation_authority`** — PUT
+   `/org_representations/{id}/authority`. Admin override (or
+   rep-approval approver, in a follow-up) flips `authority_status`.
+
+The generic `mount_entity` create handler is opted out
+(`routes.create=False` on the spec) so this bespoke create owns the
+post path. Update / delete continue to flow through the generic
+handlers.
 """
 
 import logging
@@ -23,14 +38,185 @@ from src.domain.logic.org_representations.repository import (
 )
 from src.domain.logic.org_representations.schema import (
     OrgRepresentationAuthorityUpdate,
+    OrgRepresentationCreate,
 )
-from src.domain.models import OrgRepresentation, User
+from src.domain.logic.verifications.handlers import record_verification_event
+from src.domain.logic.verifications.repository import VerificationRepository
+from src.domain.logic.verifications.scoring import _name_similarity
+from src.domain.models import Organization, OrgRepresentation, User
 from src.domain.specs.org_representation import ORG_REPRESENTATION_ENTITY
-from src.framework.audit.core import record_audit
+from src.framework.audit.core import record_audit, record_audit_for
 from src.framework.audit.repository import AuditRepository
-from src.framework.http.exceptions import ForbiddenError, NotFoundError
+from src.framework.http.exceptions import (
+    BadRequestError,
+    ForbiddenError,
+    NotFoundError,
+)
 
 logger = logging.getLogger(__name__)
+
+# Same threshold the clinician-side NPPES name match uses. Keeping a
+# module-local constant avoids reading through `scoring._NAME_MATCH_THRESHOLD`
+# (a private symbol) at the handler boundary; if the clinician threshold
+# changes we can re-anchor here.
+_AO_NAME_MATCH_THRESHOLD = 0.80
+
+
+def _verified_clinician_full_name(user: User) -> str | None:
+    """First-verified Clinician's `<first> <last>` form, or None if the
+    user has no `clinician_verified=True` row with both names. The
+    `authorized_official` path matches this against the org's cached
+    `authorized_official_name`."""
+    for c in getattr(user, "clinicians", None) or ():
+        if not getattr(c, "clinician_verified", False):
+            continue
+        first = (c.first_name or "").strip()
+        last = (c.last_name or "").strip()
+        if first and last:
+            return f"{first} {last}"
+    return None
+
+
+async def handle_create_org_representation(
+    payload: OrgRepresentationCreate,
+    repo: OrgRepresentationRepository,
+    verification_repo: VerificationRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+) -> OrgRepresentation:
+    """Create a new `OrgRepresentation` row. Authority-method dispatch
+    sets the initial `authority_status` + `approved_by`; the row is
+    persisted, audited, and (for the auto-verify happy path) a
+    `Verification` event is appended in the same transaction.
+
+    Authz: the requesting user must own the row they're creating
+    (`payload.user_id` == requesting_user.id) or be admin. The
+    target Organization must exist; the user must have appropriate
+    standing for the authority method.
+    """
+    if payload.user_id != requesting_user.id and not requesting_user.is_superuser:
+        raise ForbiddenError(
+            detail="Cannot create an org representation for another user"
+        )
+
+    org = await repo.get_by_model_id(Organization, payload.org_id)
+    if org is None:
+        raise NotFoundError(detail="Organization not found")
+
+    initial_status = "pending"
+    approved_by: UUID | None = None
+    verification_event: str | None = None
+
+    if payload.authority_method == "authorized_official":
+        if not org.authorized_official_name:
+            raise BadRequestError(
+                detail=(
+                    "This organization has no cached Authorized Official "
+                    "name. Submit the org's Type-2 NPI first so NPPES "
+                    "can populate it."
+                )
+            )
+        clinician_name = _verified_clinician_full_name(requesting_user)
+        if clinician_name is None:
+            raise BadRequestError(
+                detail=(
+                    "The Authorized-Official path requires a verified "
+                    "clinician profile with first + last name. Visit "
+                    "/profile to complete Claim A first."
+                )
+            )
+        similarity = _name_similarity(clinician_name, org.authorized_official_name)
+        if similarity < _AO_NAME_MATCH_THRESHOLD:
+            raise BadRequestError(
+                detail=(
+                    "Your clinician name doesn't match this organization's "
+                    "NPPES Authorized Official. Try a different authority "
+                    "method (e.g. admin_review)."
+                )
+            )
+        initial_status = "verified"
+        verification_event = "authority_proven"
+
+    elif payload.authority_method == "domain_email":
+        # v1 stub — the enum value ships so the schema/UI stay coherent.
+        raise BadRequestError(
+            detail=(
+                "The domain_email authority path is not yet enabled. "
+                "Use authorized_official, rep_approval, or admin_review."
+            )
+        )
+
+    elif payload.authority_method == "rep_approval":
+        # An existing verified rep approves the new one. The Profile Hub
+        # invite flow sets `approved_by` to the approver's user_id; the
+        # request must come FROM the approver (or admin) so an
+        # unauthorized user can't claim someone else's approval.
+        # `approved_by` is server-set here from `requesting_user.id`
+        # rather than read from the payload schema (which doesn't expose
+        # it) — the requesting user IS the approver in this flow.
+        approver_reps = await repo.list_verified_for_org(payload.org_id)
+        if not any(r.user_id == requesting_user.id for r in approver_reps):
+            if not requesting_user.is_superuser:
+                raise ForbiddenError(
+                    detail=(
+                        "The rep_approval path requires an existing verified "
+                        "representative of this organization to approve the "
+                        "new rep."
+                    )
+                )
+        approved_by = requesting_user.id
+        # Approver-driven approvals land at `verified` directly — the
+        # approver IS the gate.
+        initial_status = "verified"
+        verification_event = "authority_proven"
+
+    elif payload.authority_method == "admin_review":
+        # Land at pending; admin closes the loop via the `authority`
+        # state axis.
+        initial_status = "pending"
+
+    new_row = OrgRepresentation(
+        user_id=payload.user_id,
+        org_id=payload.org_id,
+        role=payload.role,
+        authority_method=payload.authority_method,
+        authority_status=initial_status,
+        approved_by=approved_by,
+    )
+    new_row = await repo._persist_new(new_row)
+    await record_audit_for(
+        audit_repo,
+        resource=ORG_REPRESENTATION_ENTITY.audit,
+        verb="create",
+        actor_id=requesting_user.id,
+        target_id=new_row.id,
+        before=None,
+        after=ORG_REPRESENTATION_ENTITY.audit.snapshot(new_row),
+    )
+    if verification_event is not None:
+        await record_verification_event(
+            verification_repo=verification_repo,
+            audit_repo=audit_repo,
+            subject_type="organization",
+            org_id=payload.org_id,
+            event_type=verification_event,
+            status="verified",
+            evidence={
+                "user_id": str(payload.user_id),
+                "authority_method": payload.authority_method,
+            },
+            actor_id=requesting_user.id,
+        )
+    await repo.session.commit()
+    logger.info(
+        "org_representation.create: id=%s user=%s org=%s method=%s status=%s",
+        new_row.id,
+        payload.user_id,
+        payload.org_id,
+        payload.authority_method,
+        initial_status,
+    )
+    return new_row
 
 
 async def handle_set_org_representation_authority(

--- a/src/domain/logic/org_representations/test_handlers.py
+++ b/src/domain/logic/org_representations/test_handlers.py
@@ -1,0 +1,381 @@
+"""Tests for `handle_create_org_representation` authority-method dispatch.
+
+Per handoff §6 the create-time logic differs by `authority_method`:
+
+* ``authorized_official`` — auto-verify when the user's verified
+  Clinician name clears the NPPES AO similarity threshold; reject on
+  no match.
+* ``domain_email`` — v1 stub; 400.
+* ``rep_approval`` — requires the requesting user to be an existing
+  verified rep on the same org; row lands at ``verified``.
+* ``admin_review`` — row lands at ``pending``.
+
+These tests exercise the dispatch directly (handler-level), pinning
+each branch's initial `authority_status` + `approved_by` + the
+`Verification` event side effect. The route-level happy path is
+covered separately in `routes/test_org_representations.py` (added in
+the follow-up).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.logic.org_representations.handlers import (
+    handle_create_org_representation,
+)
+from src.domain.logic.org_representations.repository import (
+    OrgRepresentationRepository,
+)
+from src.domain.logic.org_representations.schema import OrgRepresentationCreate
+from src.domain.logic.verifications.repository import VerificationRepository
+from src.domain.models import (
+    Clinician,
+    Organization,
+    User,
+    Verification,
+)
+from src.framework.audit.repository import AuditRepository
+from src.framework.http.exceptions import BadRequestError, ForbiddenError, NotFoundError
+from tests.helpers import (
+    create_test_user,
+    make_clinician_with_org,
+    make_organization_row,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_user_and_org(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    username: str = "actor",
+    org_name: str = "Acme Health",
+    org_ao_name: str | None = None,
+) -> tuple[User, Organization]:
+    user = create_test_user(username=username)
+    org = make_organization_row(owner_id=user.id, name=org_name)
+    if org_ao_name is not None:
+        org.authorized_official_name = org_ao_name
+        org.npi_match_status = "matched"
+        org.org_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org)
+    return user, org
+
+
+async def _seed_verified_clinician(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    owner_id,
+    first: str,
+    last: str,
+) -> Clinician:
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            clinician = make_clinician_with_org(
+                owner_id=owner_id,
+                first_name=first,
+                last_name=last,
+                npi="1234567890",
+            )
+            clinician.clinician_verified = True
+            clinician.npi_match_status = "matched"
+            session.add(clinician)
+    return clinician
+
+
+# ---------- admin_review (the simplest, default path) -------------------
+
+
+async def test_admin_review_lands_at_pending(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user, org = await _seed_user_and_org(db_test_session_manager)
+    payload = OrgRepresentationCreate(
+        user_id=user.id,
+        org_id=org.id,
+        role="coordinator",
+        authority_method="admin_review",
+    )
+    async with db_test_session_manager() as session:
+        new_row = await handle_create_org_representation(
+            payload=payload,
+            repo=OrgRepresentationRepository(session),
+            verification_repo=VerificationRepository(session),
+            audit_repo=AuditRepository(session),
+            requesting_user=user,
+        )
+    assert new_row.authority_status == "pending"
+    assert new_row.approved_by is None
+
+
+# ---------- authorized_official -----------------------------------------
+
+
+async def test_authorized_official_happy_path(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user, org = await _seed_user_and_org(
+        db_test_session_manager, org_ao_name="Jane Doe"
+    )
+    await _seed_verified_clinician(
+        db_test_session_manager,
+        owner_id=user.id,
+        first="Jane",
+        last="Doe",
+    )
+    # Refresh `user.clinicians` by reloading the user from the DB.
+    async with db_test_session_manager() as session:
+        reloaded_user = await session.get(User, user.id)
+        payload = OrgRepresentationCreate(
+            user_id=reloaded_user.id,
+            org_id=org.id,
+            role="owner",
+            authority_method="authorized_official",
+        )
+        new_row = await handle_create_org_representation(
+            payload=payload,
+            repo=OrgRepresentationRepository(session),
+            verification_repo=VerificationRepository(session),
+            audit_repo=AuditRepository(session),
+            requesting_user=reloaded_user,
+        )
+        # AO name match → row lands at verified + a Verification event of
+        # type `authority_proven` is appended.
+        assert new_row.authority_status == "verified"
+        events = (
+            (
+                await session.execute(
+                    select(Verification).filter(
+                        Verification.org_id == org.id,
+                        Verification.event_type == "authority_proven",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(events) == 1
+
+
+async def test_authorized_official_rejects_name_mismatch(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user, org = await _seed_user_and_org(
+        db_test_session_manager, org_ao_name="Jane Doe"
+    )
+    await _seed_verified_clinician(
+        db_test_session_manager,
+        owner_id=user.id,
+        first="Bartholomew",
+        last="Jenkins",
+    )
+    async with db_test_session_manager() as session:
+        reloaded_user = await session.get(User, user.id)
+        payload = OrgRepresentationCreate(
+            user_id=reloaded_user.id,
+            org_id=org.id,
+            role="owner",
+            authority_method="authorized_official",
+        )
+        with pytest.raises(BadRequestError, match="Authorized Official"):
+            await handle_create_org_representation(
+                payload=payload,
+                repo=OrgRepresentationRepository(session),
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                requesting_user=reloaded_user,
+            )
+
+
+async def test_authorized_official_requires_org_ao_name_cached(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """The org's Type-2 NPI must have been verified first so NPPES has
+    populated `authorized_official_name`. Without it the AO path can't
+    even start."""
+    user, org = await _seed_user_and_org(db_test_session_manager)  # no AO name
+    await _seed_verified_clinician(
+        db_test_session_manager,
+        owner_id=user.id,
+        first="Jane",
+        last="Doe",
+    )
+    async with db_test_session_manager() as session:
+        reloaded_user = await session.get(User, user.id)
+        payload = OrgRepresentationCreate(
+            user_id=reloaded_user.id,
+            org_id=org.id,
+            role="owner",
+            authority_method="authorized_official",
+        )
+        with pytest.raises(BadRequestError, match="no cached Authorized Official"):
+            await handle_create_org_representation(
+                payload=payload,
+                repo=OrgRepresentationRepository(session),
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                requesting_user=reloaded_user,
+            )
+
+
+async def test_authorized_official_requires_verified_clinician(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """A user with no `clinician_verified=True` clinician can't take
+    the AO path — there's no name to match against."""
+    user, org = await _seed_user_and_org(
+        db_test_session_manager, org_ao_name="Jane Doe"
+    )
+    async with db_test_session_manager() as session:
+        reloaded_user = await session.get(User, user.id)
+        payload = OrgRepresentationCreate(
+            user_id=reloaded_user.id,
+            org_id=org.id,
+            role="owner",
+            authority_method="authorized_official",
+        )
+        with pytest.raises(BadRequestError, match="verified clinician profile"):
+            await handle_create_org_representation(
+                payload=payload,
+                repo=OrgRepresentationRepository(session),
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                requesting_user=reloaded_user,
+            )
+
+
+# ---------- domain_email v1 stub ----------------------------------------
+
+
+async def test_domain_email_returns_not_yet_enabled(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user, org = await _seed_user_and_org(db_test_session_manager)
+    payload = OrgRepresentationCreate(
+        user_id=user.id,
+        org_id=org.id,
+        role="coordinator",
+        authority_method="domain_email",
+    )
+    async with db_test_session_manager() as session:
+        with pytest.raises(BadRequestError, match="not yet enabled"):
+            await handle_create_org_representation(
+                payload=payload,
+                repo=OrgRepresentationRepository(session),
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                requesting_user=user,
+            )
+
+
+# ---------- rep_approval ------------------------------------------------
+
+
+async def test_rep_approval_requires_existing_verified_rep_on_org(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """The requesting user must already be a verified rep on the target
+    org (or be admin). Otherwise the system would let any authed user
+    self-approve."""
+    user, org = await _seed_user_and_org(db_test_session_manager)
+    payload = OrgRepresentationCreate(
+        user_id=user.id,
+        org_id=org.id,
+        role="coordinator",
+        authority_method="rep_approval",
+    )
+    async with db_test_session_manager() as session:
+        with pytest.raises(ForbiddenError, match="existing verified representative"):
+            await handle_create_org_representation(
+                payload=payload,
+                repo=OrgRepresentationRepository(session),
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                requesting_user=user,
+            )
+
+
+async def test_rep_approval_admin_bypass(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Admins bypass the verified-rep-on-org check."""
+    user, org = await _seed_user_and_org(db_test_session_manager)
+    admin = create_test_user(username=f"admin-{user.id}", is_superuser=True)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(admin)
+    payload = OrgRepresentationCreate(
+        user_id=user.id,
+        org_id=org.id,
+        role="coordinator",
+        authority_method="rep_approval",
+    )
+    async with db_test_session_manager() as session:
+        new_row = await handle_create_org_representation(
+            payload=payload,
+            repo=OrgRepresentationRepository(session),
+            verification_repo=VerificationRepository(session),
+            audit_repo=AuditRepository(session),
+            requesting_user=admin,
+        )
+        assert new_row.authority_status == "verified"
+
+
+# ---------- general authz / 404 -----------------------------------------
+
+
+async def test_user_cant_create_rep_for_someone_else(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    user, org = await _seed_user_and_org(db_test_session_manager)
+    other = create_test_user(username="other")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+    payload = OrgRepresentationCreate(
+        user_id=other.id,  # NOT requesting_user
+        org_id=org.id,
+        role="coordinator",
+        authority_method="admin_review",
+    )
+    async with db_test_session_manager() as session:
+        with pytest.raises(ForbiddenError, match="another user"):
+            await handle_create_org_representation(
+                payload=payload,
+                repo=OrgRepresentationRepository(session),
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                requesting_user=user,
+            )
+
+
+async def test_404_for_missing_org(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    import uuid
+
+    user = create_test_user(username="actor")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+    payload = OrgRepresentationCreate(
+        user_id=user.id,
+        org_id=uuid.uuid4(),
+        role="coordinator",
+        authority_method="admin_review",
+    )
+    async with db_test_session_manager() as session:
+        with pytest.raises(NotFoundError):
+            await handle_create_org_representation(
+                payload=payload,
+                repo=OrgRepresentationRepository(session),
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                requesting_user=user,
+            )

--- a/src/domain/routes/org_representations.py
+++ b/src/domain/routes/org_representations.py
@@ -1,16 +1,69 @@
 """Route mount for `OrgRepresentation` — User↔Org authority (Claim B).
 
-Thin: spec-driven. `mount_entity` reads `ORG_REPRESENTATION_ENTITY` and
-binds the framework's `make_create_handler` / `make_update_handler` /
-`make_delete_handler` factories, plus the `authority` state-axis
-(resolved lazily via the spec's `handler_path`).
+`mount_entity(ORG_REPRESENTATION_ENTITY)` mounts the framework's
+generic update / delete / state-axis handlers per the spec. POST
+`/org_representations` is bespoke (the spec opts out of the generic
+create via `routes.create=False`) so the per-authority-method dispatch
+in `handle_create_org_representation` owns row construction — every
+row gets the right initial `authority_status` instead of always
+landing at `'pending'`.
 """
 
+from typing import Any
+
+from fastapi import Depends, status
+
+from src.auth_config import current_active_user
+from src.domain.logic.org_representations.handlers import (
+    handle_create_org_representation,
+)
+from src.domain.logic.org_representations.repository import (
+    OrgRepresentationRepository,
+    get_org_representation_repository,
+)
+from src.domain.logic.org_representations.schema import OrgRepresentationCreate
+from src.domain.logic.verifications.repository import (
+    VerificationRepository,
+    get_verification_repository,
+)
+from src.domain.models import User
 from src.domain.specs.org_representation import ORG_REPRESENTATION_ENTITY
 from src.framework import register_entity
+from src.framework.audit.repository import AuditRepository
 from src.framework.dispatch.resource_routes import mount_entity
+from src.framework.persistence.dependencies import get_audit_repository
 
 router = register_entity(ORG_REPRESENTATION_ENTITY)
+
+
+@router.post(
+    "/org_representations",
+    status_code=status.HTTP_201_CREATED,
+    name="org_representations:create",
+)
+async def create_org_representation(
+    payload: OrgRepresentationCreate,
+    repo: OrgRepresentationRepository = Depends(get_org_representation_repository),
+    verification_repo: VerificationRepository = Depends(get_verification_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+    requesting_user: User = Depends(current_active_user),
+) -> dict[str, Any]:
+    """POST `/org_representations` — bespoke handler that dispatches on
+    `payload.authority_method`. See
+    `src.domain.logic.org_representations.handlers.handle_create_org_representation`
+    for the per-method contract.
+    """
+    new_row = await handle_create_org_representation(
+        payload=payload,
+        repo=repo,
+        verification_repo=verification_repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+    )
+    return {
+        "id": str(new_row.id),
+        "authority_status": new_row.authority_status,
+    }
 
 
 mount_entity(router, ORG_REPRESENTATION_ENTITY)

--- a/src/domain/specs/org_representation.py
+++ b/src/domain/specs/org_representation.py
@@ -62,7 +62,11 @@ ORG_REPRESENTATION_ENTITY: Final[EntitySpec] = EntitySpec(
     # Phase 1: API surface only. The Profile Hub (Phase 5) renders the
     # list/detail/form views via its own per-mode partials — no generic
     # collection page here yet, so we don't ship placeholder templates.
-    routes=RouteSet(create=True, update=True, delete=True),
+    # `create=False` opts out of the framework's generic create so the
+    # bespoke `handle_create_org_representation` (which dispatches on
+    # `authority_method`) owns POST `/org_representations`. Update +
+    # delete still flow through the generic factories.
+    routes=RouteSet(update=True, delete=True),
     state_axes=(
         StateAxis(
             name="authority",

--- a/src/domain/specs/test_org_representation.py
+++ b/src/domain/specs/test_org_representation.py
@@ -24,11 +24,15 @@ def test_auth_deps_authenticated_and_policy_owner_or_admin():
     assert ORG_REPRESENTATION_ENTITY.auth_policy is OWNER_OR_ADMIN
 
 
-def test_routes_crud_only_no_collection_views():
-    """Phase 1: API-only. The Profile Hub (Phase 5) owns rendering;
-    no generic list/detail/form pages ship here yet."""
+def test_routes_update_delete_only_no_collection_views():
+    """API-only routes. `create=False` because the bespoke handler
+    `handle_create_org_representation` (with per-authority-method
+    dispatch) owns POST `/org_representations`; the framework's
+    generic create would land every row at `authority_status='pending'`
+    and miss the `authorized_official` auto-verify happy path."""
     r = ORG_REPRESENTATION_ENTITY.routes
-    assert (r.create, r.update, r.delete) == (True, True, True)
+    assert r.create is False
+    assert (r.update, r.delete) == (True, True)
     assert (r.list, r.detail, r.form_new, r.form_edit) == (False, False, False, False)
 
 


### PR DESCRIPTION
## Summary
Closes Phase 4. Bespoke `handle_create_org_representation` dispatches POST `/org_representations` by `payload.authority_method` per handoff §6.

- **`authorized_official`** — NPPES AO name-match (≥0.80) against the requesting user's verified Clinician. Match → row at `authority_status='verified'` + a `Verification` event of type `authority_proven`. No match → 400.
- **`domain_email`** — v1 stub: 400 "not yet enabled".
- **`rep_approval`** — requires the requesting user to be an existing verified rep on the same org (admin bypass). Row at `verified`; `approved_by` set to the approver.
- **`admin_review`** — fallback. Row at `pending`; admin closes via the `authority` state axis.

`ORG_REPRESENTATION_ENTITY.routes.create=False` opts out of the framework's generic create. The bespoke `POST /org_representations` wires onto the existing router and is the only post path.

10 new handler tests pin every method branch (admin_review default, AO happy path + 3 reject conditions, domain_email stub, rep_approval verified-rep gate + admin bypass, can't-create-for-other-user, 404 missing org).

## Test plan
- [x] `dev test` — 2192 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)