### PR TITLE
feat: license attestation endpoint (Phase 5 follow-up)

### DIFF
--- a/src/domain/routes/test_verifications.py
+++ b/src/domain/routes/test_verifications.py
@@ -326,3 +326,182 @@ async def test_org_npi_submit_owner_flips_to_pending(
             .all()
         )
         assert len(events) == 1
+
+
+# --- License attestation -------------------------------------------------
+
+
+async def _seed_clinician_with_licensure(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    owner_id: uuid.UUID,
+    *,
+    npi_match_status: str = "matched",
+    licensure_status: str = "pending",
+    expiration_in_past: bool = False,
+):
+    """Seed a clinician + matching licensure with the row state needed
+    to exercise the attestation flow's claim-cache recompute."""
+    from datetime import date, timedelta
+
+    from src.domain.models import ClinicianLicensure
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            clinician = make_clinician_with_org(
+                owner_id=owner_id, npi="1234567890", first_name="Jane", last_name="Doe"
+            )
+            clinician.npi_match_status = npi_match_status
+            session.add(clinician)
+        clinician_id = clinician.id
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            licensure = ClinicianLicensure(
+                clinician_id=clinician_id,
+                license_type="lcsw",
+                license_number="X-1",
+                issuing_state="IL",
+                status=licensure_status,
+                expiration_date=(
+                    date.today() - timedelta(days=30)
+                    if expiration_in_past
+                    else date.today() + timedelta(days=365)
+                ),
+            )
+            session.add(licensure)
+        licensure_id = licensure.id
+    return clinician_id, licensure_id
+
+
+async def test_license_attest_flips_to_active_and_updates_claim_cache(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Attesting a licensure on a clinician whose NPI is already matched
+    flips the Claim-A cache to True via `recompute_clinician_claim`."""
+    from src.domain.models import Clinician, ClinicianLicensure
+
+    clinician_id, licensure_id = await _seed_clinician_with_licensure(
+        db_test_session_manager,
+        logged_in_user.id,
+        npi_match_status="matched",
+        licensure_status="pending",
+    )
+    response = await authenticated_client.post(
+        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attest"
+    )
+    assert response.status_code == 200
+    assert response.headers.get("HX-Refresh") == "true"
+
+    async with db_test_session_manager() as session:
+        loaded_lic = await session.get(ClinicianLicensure, licensure_id)
+        assert loaded_lic.attested_active is True
+        assert loaded_lic.attested_at is not None
+        assert loaded_lic.status == "active"
+
+        loaded_clin = await session.get(Clinician, clinician_id)
+        # NPI matched + license active → claim flips.
+        assert loaded_clin.clinician_verified is True
+        assert loaded_clin.ever_verified_at is not None
+
+
+async def test_license_attest_expired_keeps_status_expired(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Re-attesting a licensure whose `expiration_date` is in the past
+    still sets `attested_active=True` but `status` stays `expired` —
+    the attestation flag and the date both have to be valid for an
+    "active" cache. (Future: the worker can mark these `active` once
+    the user updates the expiration_date.)"""
+    from src.domain.models import ClinicianLicensure
+
+    clinician_id, licensure_id = await _seed_clinician_with_licensure(
+        db_test_session_manager,
+        logged_in_user.id,
+        expiration_in_past=True,
+    )
+    response = await authenticated_client.post(
+        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attest"
+    )
+    assert response.status_code == 200
+    async with db_test_session_manager() as session:
+        loaded = await session.get(ClinicianLicensure, licensure_id)
+        assert loaded.attested_active is True
+        assert loaded.status == "expired"
+
+
+async def test_license_attest_records_verification_event(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A `Verification` event of type `license_attested` is appended in
+    the same transaction — the event log is the source of truth for
+    "this attestation happened at time T."""
+    from src.domain.models import Verification
+
+    clinician_id, licensure_id = await _seed_clinician_with_licensure(
+        db_test_session_manager, logged_in_user.id
+    )
+    await authenticated_client.post(
+        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attest"
+    )
+    async with db_test_session_manager() as session:
+        events = (
+            (
+                await session.execute(
+                    select(Verification).filter(
+                        Verification.clinician_id == clinician_id,
+                        Verification.event_type == "license_attested",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(events) == 1
+        assert events[0].evidence["licensure_id"] == str(licensure_id)
+
+
+async def test_license_attest_non_owner_403(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    other_owner = create_test_user(username=f"o-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other_owner)
+    clinician_id, licensure_id = await _seed_clinician_with_licensure(
+        db_test_session_manager, other_owner.id
+    )
+    response = await authenticated_client.post(
+        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attest"
+    )
+    assert response.status_code == 403
+
+
+async def test_license_attest_404_when_licensure_belongs_to_other_clinician(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """If the URL's clinician_id and licensure_id don't match (the
+    licensure belongs to someone else's clinician), respond 404 — not
+    403, to avoid leaking that the licensure exists at all."""
+    clinician_id_a, _ = await _seed_clinician_with_licensure(
+        db_test_session_manager, logged_in_user.id
+    )
+    other_owner = create_test_user(username=f"o-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other_owner)
+    _, licensure_id_b = await _seed_clinician_with_licensure(
+        db_test_session_manager, other_owner.id
+    )
+    response = await authenticated_client.post(
+        f"/clinicians/{clinician_id_a}/licensures/{licensure_id_b}/attest"
+    )
+    assert response.status_code == 404

--- a/src/domain/routes/verifications.py
+++ b/src/domain/routes/verifications.py
@@ -37,13 +37,14 @@ from src.domain.logic.organizations.repository import (
 )
 from src.domain.logic.verifications.handlers import (
     handle_create_clinician_verification,
+    recompute_clinician_claim,
     record_verification_event,
 )
 from src.domain.logic.verifications.repository import (
     VerificationRepository,
     get_verification_repository,
 )
-from src.domain.models import Clinician, Organization, User
+from src.domain.models import Clinician, ClinicianLicensure, Organization, User
 from src.framework.audit.repository import AuditRepository
 from src.framework.authz import is_owner_or_admin
 from src.framework.http.exceptions import (
@@ -214,4 +215,78 @@ async def submit_organization_npi(
         actor_id=requesting_user.id,
     )
     await org_repo.session.commit()
+    return refreshed_response()
+
+
+@verifications_api_router.post(
+    "/clinicians/{clinician_id}/licensures/{licensure_id}/attest",
+    status_code=status.HTTP_200_OK,
+    name="verifications:license_attest",
+)
+async def attest_license(
+    clinician_id: UUID,
+    licensure_id: UUID,
+    clinician_repo: ClinicianRepository = Depends(get_clinician_repository),
+    verification_repo: VerificationRepository = Depends(get_verification_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+    requesting_user: User = Depends(current_active_user),
+) -> Response:
+    """User-driven license re-attestation per handoff §10.
+
+    "I attest this license is active and in good standing." flips
+    `attested_active=True` + `attested_at=NOW()`, recomputes the
+    licensure's `status` (active if not expired, expired if past
+    `expiration_date`, pending otherwise), and re-runs
+    `recompute_clinician_claim` so the Claim-A denorm cache reflects
+    the new state. A `Verification` event of type `license_attested`
+    is appended.
+
+    Authz: the requesting user must own the parent Clinician (or be
+    admin). The licensure must belong to the URL-named clinician —
+    same defense-in-depth shape the framework's generic subentity
+    handlers use.
+    """
+    from datetime import date, datetime, timezone
+
+    clinician = await clinician_repo.get_by_model_id(Clinician, clinician_id)
+    if clinician is None:
+        raise NotFoundError(detail="Clinician not found")
+    if not is_owner_or_admin(clinician, requesting_user):
+        raise ForbiddenError(detail="Cannot attest licenses for this clinician")
+
+    licensure = await clinician_repo.get_by_model_id(ClinicianLicensure, licensure_id)
+    if licensure is None or licensure.clinician_id != clinician_id:
+        # 404 (not 403) when the licensure doesn't belong to this
+        # clinician — same info-leak shape the framework's subresource
+        # handlers use.
+        raise NotFoundError(detail="Licensure not found for this clinician")
+
+    licensure.attested_active = True
+    licensure.attested_at = datetime.now(timezone.utc)
+    if licensure.expiration_date is None or licensure.expiration_date >= date.today():
+        licensure.status = "active"
+    else:
+        licensure.status = "expired"
+
+    await record_verification_event(
+        verification_repo=verification_repo,
+        audit_repo=audit_repo,
+        subject_type="clinician",
+        clinician_id=clinician.id,
+        event_type="license_attested",
+        status="verified",
+        evidence={
+            "licensure_id": str(licensure.id),
+            "license_type": licensure.license_type,
+            "issuing_state": licensure.issuing_state,
+        },
+        actor_id=requesting_user.id,
+    )
+
+    # Recompute the Claim-A cache. Attestation may flip
+    # `clinician_verified` to True (if the NPI is already matched and
+    # this was the missing active license) or keep it as-is.
+    recompute_clinician_claim(clinician)
+
+    await clinician_repo.session.commit()
     return refreshed_response()


### PR DESCRIPTION
## Summary
Adds the user-driven license re-attestation endpoint the Profile Hub's `_claim_a_card` will POST against. "I attest this license is active and in good standing" flips `attested_active=True` + `attested_at=NOW()`, recomputes `status` from `expiration_date`, appends a `Verification` event of type `license_attested`, and re-runs `recompute_clinician_claim` so the Claim-A denorm cache reflects the new state.

- `POST /clinicians/{clinician_id}/licensures/{licensure_id}/attest`
- Owner-or-admin authz; 404 if the licensure doesn't belong to the URL-named clinician
- 5 new tests pin: happy path → Claim A flips verified; expired-date keeps `status=expired`; Verification event recorded; non-owner 403; cross-clinician 404

Lands as a bespoke endpoint rather than a state axis because the framework's `mount_state_axis` doesn't support parent-owned subentities yet. The semantic is identical — a narrow "flip a state + audit + recompute" verb — and the move to a state axis is a future no-op refactor.

## Test plan
- [x] `dev test` — 2197 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)