### PR TITLE
feat: directory listing filter on clinician_verified (Phase 7 follow-up)

### DIFF
--- a/src/domain/logic/clinicians/repository.py
+++ b/src/domain/logic/clinicians/repository.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 from uuid import UUID
 
+import sqlalchemy as sa
 from sqlalchemy import select
 
 from src.domain.models import Clinician, ClinicianLicensure
@@ -50,8 +51,29 @@ class ClinicianRepository(BaseRepository):
     ) -> Sequence[Clinician]:
         """List directory entries newest first. Both filters are multi-select;
         when set, joins through `clinician_licensures` (SQL table) and distincts so a
-        clinician with multiple matching licensures appears once."""
-        stmt = select(Clinician)
+        clinician with multiple matching licensures appears once.
+
+        Per handoff §4.3 + §10.6, the directory only surfaces clinicians
+        with `clinician_verified=True` OR `ever_verified_at IS NOT NULL`:
+
+        * `clinician_verified=True` — actively verified Claim A.
+        * `ever_verified_at IS NOT NULL` — once-verified clinician
+          whose claim has lapsed (per §10.6 they "stay listed but hide
+          open posts" — listing them keeps the directory page useful,
+          their post visibility is gated separately by the capability
+          predicates).
+
+        Never-verified clinicians are filtered out so the directory
+        stays a curated index of verified providers — the chrome's
+        capability gates already prevent them from posting, and listing
+        them would surface noise.
+        """
+        stmt = select(Clinician).filter(
+            sa.or_(
+                Clinician.clinician_verified.is_(True),
+                Clinician.ever_verified_at.is_not(None),
+            )
+        )
         if license_type or issuing_state:
             stmt = stmt.join(
                 ClinicianLicensure,

--- a/src/domain/logic/clinicians/test_repository.py
+++ b/src/domain/logic/clinicians/test_repository.py
@@ -346,6 +346,16 @@ async def test_delete_clinician_cascades_to_credentials(
 # --- list_clinicians -----------------------------------------------------------------------------------------------------
 
 
+def _verified(clinician):
+    """Per Phase-7 the directory filter only surfaces clinicians with
+    `clinician_verified=True` OR `ever_verified_at IS NOT NULL` (per
+    handoff §4.3 + §10.6). These tests pre-date that rule; flip the
+    flag here so they exercise the filter's success path."""
+    clinician.clinician_verified = True
+    clinician.npi_match_status = "matched"
+    return clinician
+
+
 async def test_list_clinicians_no_filters_returns_all(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
@@ -354,15 +364,66 @@ async def test_list_clinicians_no_filters_returns_all(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            session.add(make_clinician_with_org(owner_id=user_a.id))
+            session.add(_verified(make_clinician_with_org(owner_id=user_a.id)))
             session.add(
-                make_clinician_with_org(owner_id=user_b.id, practice_name="Other")
+                _verified(
+                    make_clinician_with_org(owner_id=user_b.id, practice_name="Other")
+                )
             )
 
     async with db_test_session_manager() as session:
         repo = ClinicianRepository(session)
         clinicians = await repo.list_clinicians()
         assert len(clinicians) == 2
+
+
+async def test_list_clinicians_filters_out_never_verified(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """A clinician with `clinician_verified=False` AND
+    `ever_verified_at IS NULL` is filtered out of the directory per
+    handoff §4.3. The chrome's capability gate already prevents them
+    from posting; listing them would surface noise."""
+    user = await _seed_user(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            # `make_clinician_with_org` defaults to verified; override
+            # explicitly to None-out the "other" clinician's claim.
+            session.add(make_clinician_with_org(owner_id=user.id))
+            other = make_clinician_with_org(
+                owner_id=user.id,
+                practice_name="Other",
+                clinician_verified=False,
+                npi_match_status="none",
+            )
+            session.add(other)
+
+    async with db_test_session_manager() as session:
+        repo = ClinicianRepository(session)
+        clinicians = await repo.list_clinicians()
+        assert len(clinicians) == 1
+
+
+async def test_list_clinicians_includes_once_verified_clinicians(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Per handoff §10.6 a clinician whose claim has lapsed stays
+    visible in the directory (their open posts are gated separately).
+    `ever_verified_at IS NOT NULL` is the retention signal."""
+    import datetime as _dt
+
+    user = await _seed_user(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            lapsed = make_clinician_with_org(owner_id=user.id)
+            lapsed.clinician_verified = False
+            lapsed.ever_verified_at = _dt.datetime(2025, 6, 1)
+            session.add(lapsed)
+
+    async with db_test_session_manager() as session:
+        repo = ClinicianRepository(session)
+        clinicians = await repo.list_clinicians()
+        assert len(clinicians) == 1
 
 
 async def test_list_clinicians_filtered_by_license_type(
@@ -373,9 +434,9 @@ async def test_list_clinicians_filtered_by_license_type(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            clinician_a = make_clinician_with_org(owner_id=user_a.id)
-            clinician_b = make_clinician_with_org(
-                owner_id=user_b.id, practice_name="Other"
+            clinician_a = _verified(make_clinician_with_org(owner_id=user_a.id))
+            clinician_b = _verified(
+                make_clinician_with_org(owner_id=user_b.id, practice_name="Other")
             )
             session.add_all([clinician_a, clinician_b])
             await session.flush()
@@ -409,9 +470,9 @@ async def test_list_clinicians_filtered_by_issuing_state(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            clinician_a = make_clinician_with_org(owner_id=user_a.id)
-            clinician_b = make_clinician_with_org(
-                owner_id=user_b.id, practice_name="Other"
+            clinician_a = _verified(make_clinician_with_org(owner_id=user_a.id))
+            clinician_b = _verified(
+                make_clinician_with_org(owner_id=user_b.id, practice_name="Other")
             )
             session.add_all([clinician_a, clinician_b])
             await session.flush()
@@ -447,12 +508,12 @@ async def test_list_clinicians_combined_filter_is_anded(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            clinician_a = make_clinician_with_org(owner_id=user_a.id)
-            clinician_b = make_clinician_with_org(
-                owner_id=user_b.id, practice_name="Two"
+            clinician_a = _verified(make_clinician_with_org(owner_id=user_a.id))
+            clinician_b = _verified(
+                make_clinician_with_org(owner_id=user_b.id, practice_name="Two")
             )
-            clinician_c = make_clinician_with_org(
-                owner_id=user_c.id, practice_name="Three"
+            clinician_c = _verified(
+                make_clinician_with_org(owner_id=user_c.id, practice_name="Three")
             )
             session.add_all([clinician_a, clinician_b, clinician_c])
             await session.flush()
@@ -529,7 +590,7 @@ async def test_list_clinicians_distinct_when_multiple_licensures_match(
 
     async with db_test_session_manager() as session:
         async with session.begin():
-            clinician_row = make_clinician_with_org(owner_id=user.id)
+            clinician_row = _verified(make_clinician_with_org(owner_id=user.id))
             session.add(clinician_row)
             await session.flush()
             session.add(

--- a/src/domain/logic/verifications/test_handlers_phase3.py
+++ b/src/domain/logic/verifications/test_handlers_phase3.py
@@ -518,11 +518,16 @@ async def test_run_clinician_verification_writes_through_cache(
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(owner)
+            # Seed unverified so the pipeline exercises the
+            # `False → True` transition. The helper defaults to
+            # verified, so override here.
             clinician = make_clinician_with_org(
                 owner_id=owner.id,
                 npi="1234567890",
                 first_name="Eva",
                 last_name="Stone",
+                clinician_verified=False,
+                npi_match_status="none",
             )
             session.add(clinician)
     clinician_id = clinician.id

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -292,6 +292,13 @@ def certification_payload(**overrides: Any) -> dict[str, Any]:
 def make_clinician(*, owner_id: UUID, **overrides: Any) -> Clinician:
     """Build a `Clinician` ORM row with CHECK-valid defaults.
 
+    Defaults `clinician_verified=True` + `npi_match_status='matched'` so
+    rows are directory-visible by default — handoff §4.3 / §10.6 filter
+    the directory on `clinician_verified OR ever_verified_at`. Tests that
+    specifically exercise unverified-clinician paths pass
+    `clinician_verified=False` (and `npi_match_status='none'` if they
+    want the column to read as "never submitted").
+
     ``Clinician.org_id`` is NOT NULL. Callers persisting the returned row
     must pass ``org_id=<existing-org.id>`` in ``overrides`` (Org persisted
     separately via ``make_organization_row`` + ``session.add``), or use
@@ -299,7 +306,14 @@ def make_clinician(*, owner_id: UUID, **overrides: Any) -> Clinician:
     one call. Bare ORM constructors without an ``org_id`` will trip the
     NOT NULL constraint at flush time.
     """
-    return Clinician(owner_id=owner_id, **{**_CLINICIAN_DEFAULTS, **overrides})
+    verified_defaults = {
+        "clinician_verified": True,
+        "npi_match_status": "matched",
+    }
+    return Clinician(
+        owner_id=owner_id,
+        **{**_CLINICIAN_DEFAULTS, **verified_defaults, **overrides},
+    )
 
 
 def make_organization_row(


### PR DESCRIPTION
## Summary
Per handoff §4.3 + §10.6, `directory.listed = clinician_verified`. The `/clinicians` directory now only surfaces:

- `clinician_verified=True` — actively verified Claim A, OR
- `ever_verified_at IS NOT NULL` — once-verified clinician whose claim has lapsed (per §10.6 they "stay listed but hide open posts" — listing them keeps the directory useful; post visibility is gated separately).

Never-verified clinicians fall out of the directory.

`tests/helpers.py::make_clinician` defaults to `clinician_verified=True` + `npi_match_status='matched'` so existing test fixtures stay visible. Tests that specifically exercise unverified paths pass `clinician_verified=False` explicitly.

2 new repo tests pin the filter; 1 verification handler test updated to seed unverified so it exercises the `False → True` transition.

## Test plan
- [x] `dev test` — 2199 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)