### PR TITLE
feat: Profile Hub add-claim + reverify partials (Phase 5 follow-up)

### DIFF
--- a/scripts/dev/contract_form_coverage_check.py
+++ b/scripts/dev/contract_form_coverage_check.py
@@ -81,6 +81,14 @@ FORMS_WITHOUT_PAIRS: dict[str, str] = {
         "Empty-body endpoint that reads the user from the session and "
         "re-mints a verify token. Nothing to pin beyond the path."
     ),
+    "POST /org_representations": (
+        "The Profile Hub's `_add_claim.html` submits to the bespoke "
+        "create handler that dispatches on authority_method. Body shape "
+        "is pinned by `OrgRepresentationCreate` (Pydantic) and the "
+        "in-process handler tests in "
+        "`src/domain/logic/org_representations/test_handlers.py`. A Pact "
+        "pair would only re-verify what those tests already cover."
+    ),
 }
 
 

--- a/src/domain/routes/test_profile.py
+++ b/src/domain/routes/test_profile.py
@@ -47,3 +47,27 @@ async def test_profile_hub_in_navigation(authenticated_client: AsyncClient):
     assert response.status_code == 200
     # The Profile link target should be the bespoke hub.
     assert 'href="/profile"' in response.text
+
+
+async def test_profile_hub_add_claim_mode_renders_unlocks_unchanged(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """A verified user with `?intent=add_claim` lands in `add-a-claim`
+    mode — wireframe-L6 "Unlocks / Unchanged" framing."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    # `make_clinician_with_org` defaults to clinician_verified=True; that's
+    # exactly what the test needs here.
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/profile?intent=add_claim")
+    assert response.status_code == 200
+    # Distinctive copy from `_add_claim.html`.
+    assert "Add a capability" in response.text
+    assert "Unlocks" in response.text
+    assert "Unchanged" in response.text

--- a/src/domain/templates/profile/_add_claim.html
+++ b/src/domain/templates/profile/_add_claim.html
@@ -1,0 +1,101 @@
+{# Add-a-claim mode — wireframe L6.
+
+   Two-column "Unlocks / Unchanged" framing. The user already holds at
+   least one verified claim and is adding the other one. The framing
+   is deliberately additive — never re-gates the existing claim per
+   acceptance criterion "Adding a claim is a pure unlock".
+
+   The form below targets `POST /org_representations`, which dispatches
+   on `authority_method`. The `authorized_official` happy path is the
+   wireframe-L6 "Solo shortcut: you're the Authorized Official on this
+   NPI — representation added automatically" — when the user's verified
+   Clinician name matches the org's cached AO name the row lands at
+   `verified` in one round-trip.
+#}
+<header>
+  <nav aria-label="Breadcrumb">
+    <a href="/profile">← Profile</a>
+  </nav>
+  <hgroup>
+    <h2>Add a capability</h2>
+    {% if claim_state.a %}
+      <p>
+        {# title-case-ignore: "Claim B" is a user-facing label #}
+        You're a verified clinician. Adding Claim B lets you also post on behalf of an organization. Your existing clinician verification is unchanged.
+      </p>
+    {% elif claim_state.b %}
+      <p>
+        {# title-case-ignore: "Claim A" is a user-facing label #}
+        You represent an organization. Adding Claim A lets you also post referrals and openings as a clinician. Your existing representation is unchanged.
+      </p>
+    {% endif %}
+  </hgroup>
+</header>
+<section style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem">
+  <article>
+    <header>
+      <strong><i class="icon-plus"></i> Unlocks</strong>
+    </header>
+    {% if not claim_state.a %}
+      <ul>
+        <li>Posting referrals as a clinician</li>
+        <li>Posting clinician openings</li>
+        <li>Appearing in the public directory as a bookable clinician</li>
+      </ul>
+    {% elif not claim_state.b %}
+      <ul>
+        <li>Posting program intakes on behalf of an organization</li>
+        <li>Posting org-attributed referrals (for affiliated clinicians)</li>
+      </ul>
+    {% endif %}
+  </article>
+  <article>
+    <header>
+      <strong><i class="icon-check"></i> Unchanged</strong>
+    </header>
+    {% if claim_state.a %}
+      <ul>
+        <li>Your clinician identity</li>
+        <li>Your existing posts</li>
+        <li>Your directory listing</li>
+      </ul>
+    {% elif claim_state.b %}
+      <ul>
+        <li>Your existing organization representations</li>
+        <li>Your existing posts on their behalf</li>
+      </ul>
+    {% endif %}
+  </article>
+</section>
+{# Form: pick org + role + authority method. The handler dispatches.
+   Coordinator path uses admin_review since rep_approval requires
+   another verified rep to invite. #}
+{%- set _rep_create_url = entity_url('org_representation') -%}
+<form method="post"
+      action="{{ _rep_create_url }}"
+      hx-post="{{ _rep_create_url }}"
+      hx-ext="json-enc"
+      hx-target="body"
+      hx-swap="outerHTML"
+      style="margin-top: 1rem">
+  <input type="hidden" name="user_id" value="{{ current_user_id }}" />
+  <label for="org_id">Organization</label>
+  <input type="text"
+         id="org_id"
+         name="org_id"
+         placeholder="Organization UUID"
+         required />
+  <small>Paste the Organization's id (a future PR will replace this with a typeahead).</small>
+  <label for="role">Role</label>
+  <select id="role" name="role" required>
+    <option value="coordinator">Coordinator</option>
+    <option value="admin">Admin</option>
+    <option value="owner">Owner</option>
+  </select>
+  <label for="authority_method">Authority method</label>
+  <select id="authority_method" name="authority_method" required>
+    <option value="authorized_official">NPPES Authorized Official match (auto-verify)</option>
+    <option value="admin_review">Admin review</option>
+  </select>
+  <button type="submit">Add representation</button>
+</form>

--- a/src/domain/templates/profile/_reverify.html
+++ b/src/domain/templates/profile/_reverify.html
@@ -1,0 +1,77 @@
+{# Re-verify mode — wireframe L7.
+
+   At least one of the user's claims has lapsed (a license expired, an
+   authority was revoked, an NPPES re-check failed). Per handoff §7,
+   capabilities gated on the lapsed claim pause; capabilities gated on
+   other claims keep working; the user's feed read-access is retained
+   via `ever_verified_at`.
+
+   The page header names the lapse + offers a one-tap Fix CTA — no dead
+   ends. The detail of WHICH claim has lapsed comes from
+   `claim_state.lapsed` (a tuple of reason codes); we render one card
+   per reason and a "still active" reassurance line for the unaffected
+   claim.
+
+   Phase-5 ships the dispatch + this template; the `claim_state.lapsed`
+   detection itself is populated by Phase-3's recompute helpers when
+   they detect a regression (currently stubbed empty in `claim_state`).
+   This template renders correctly the moment `lapsed` becomes
+   non-empty.
+#}
+<header>
+  <hgroup>
+    <h2>
+      <i class="icon-alert-triangle"></i> Action needed
+    </h2>
+    <p>
+      One of your verification claims has lapsed. The affected capabilities are paused until you re-attest; everything else keeps working.
+    </p>
+  </hgroup>
+</header>
+{% for reason in claim_state.lapsed %}
+  <article style="border-left: 4px solid var(--pico-color-yellow-600);">
+    <header>
+      {% if reason == "claim_a_lapsed" %}
+        {# title-case-ignore: "Claim A" is a user-facing label #}
+        <strong>Clinician identity (Claim A) lapsed</strong>
+        <p style="margin-bottom: 0;">
+          <small>Re-attest your license to resume posting referrals and openings.</small>
+        </p>
+      {% elif reason == "claim_b_lapsed" %}
+        {# title-case-ignore: "Claim B" is a user-facing label #}
+        <strong>Organization representation (Claim B) lapsed</strong>
+        <p style="margin-bottom: 0;">
+          <small>Re-verify your authority for the affected organization to resume posting on its behalf.</small>
+        </p>
+      {% else %}
+        <strong>{{ reason }}</strong>
+      {% endif %}
+    </header>
+    <a href="/profile" role="button">Fix</a>
+  </article>
+{% endfor %}
+{# Reassurance section — the unaffected claim(s) keep working. Per
+   wireframe L7 the lapsed-claim banner is paired with a "still
+   working" line so the user knows what's paused vs not. #}
+<section style="margin-top: 1rem;">
+  <header>
+    <strong>Still working</strong>
+  </header>
+  <ul>
+    {% if claim_state.a and "claim_a_lapsed" not in claim_state.lapsed %}
+      <li>
+        {# title-case-ignore: "Claim A" is a user-facing label #}
+        <i class="icon-check"></i> Clinician identity (Claim A) — verified
+      </li>
+    {% endif %}
+    {% if claim_state.b and "claim_b_lapsed" not in claim_state.lapsed %}
+      <li>
+        {# title-case-ignore: "Claim B" is a user-facing label #}
+        <i class="icon-check"></i> Organization representation (Claim B) — verified for {{ claim_state.b|length }} organization(s)
+      </li>
+    {% endif %}
+    <li>
+      <i class="icon-check"></i> Feed browsing — retained
+    </li>
+  </ul>
+</section>

--- a/src/domain/templates/profile/hub.html
+++ b/src/domain/templates/profile/hub.html
@@ -15,17 +15,18 @@
       {% endif %}
     </p>
   </header>
-  {# Mode dispatch. Phase 5 skeleton ships `setup` and `manage`
-     partials; the `add-a-claim` and `re-verify` partials are wired up
-     in follow-up PRs (the route handler already resolves into them so
-     the dispatch is a one-line add). #}
+  {# Mode dispatch. All four modes have dedicated partials:
+     * `_setup.html`     — wireframe L1, no-claim goal picker.
+     * `_manage.html`    — wireframe L4, ≥1 claim verified.
+     * `_add_claim.html` — wireframe L6, additive unlock framing.
+     * `_reverify.html`  — wireframe L7, lapsed-claim Fix CTA. #}
   {% if mode == "setup" %}
     {% include "profile/_setup.html" %}
   {% elif mode == "manage" %}
     {% include "profile/_manage.html" %}
   {% elif mode == "add-a-claim" %}
-    {% include "profile/_manage.html" %}
+    {% include "profile/_add_claim.html" %}
   {% elif mode == "re-verify" %}
-    {% include "profile/_manage.html" %}
+    {% include "profile/_reverify.html" %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
Adds the two remaining Profile Hub partials. The hub dispatcher already routed into them but fell through to `_manage.html`; now each mode has its own template per wireframe.

- **`_add_claim.html`** — wireframe L6. Two-column "Unlocks / Unchanged" framing per acceptance criterion "Adding a claim is a pure unlock". Includes the org-representation create form pointing at `POST /org_representations` (the bespoke authority-method dispatch handler from Phase 4); the `authorized_official` happy path lands the row at `verified` in one round-trip when the user's verified Clinician name matches the org's NPPES AO.
- **`_reverify.html`** — wireframe L7. Per-reason cards from `claim_state.lapsed` + a "still working" reassurance section. Renders correctly the moment `claim_state.lapsed` becomes non-empty; the populator lands in a follow-up.
- `hub.html` updated to dispatch directly (no more fall-through).
- New `FORMS_WITHOUT_PAIRS` entry for `POST /org_representations` (body shape pinned by `OrgRepresentationCreate` + handler tests).
- `_add_claim.html` form uses `entity_url('org_representation')` per template-route-check.
- 1 new route test pins add-claim rendering.

## Test plan
- [x] `dev test` — 2200 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)