### PR TITLE
feat: state-axis support on parent-owned subentities (framework)

### DIFF
--- a/src/domain/logic/clinicians/handlers.py
+++ b/src/domain/logic/clinicians/handlers.py
@@ -17,6 +17,7 @@ from src.domain.models import (
     Organization,
     User,
 )
+from src.framework.audit.repository import AuditRepository
 from src.framework.authz import assert_fk_ownership, list_visible_to
 from src.framework.dispatch.pagination import (
     DEFAULT_PAGE_SIZE,
@@ -133,3 +134,98 @@ async def handle_list_user_clinicians(
         "current_user": requesting_user,
         "pager": Pager(page=page, base_query=base_query(request)),
     }
+
+
+async def handle_set_license_attestation(
+    clinician_id: UUID,
+    licensure_id: UUID,
+    payload: BaseModel,
+    repo: ClinicianRepository,
+    verification_repo: VerificationRepository,
+    audit_repo: AuditRepository,
+    requesting_user: User,
+):
+    """State-axis handler for `PUT /clinicians/{clinician_id}/licensures/{licensure_id}/attestation`.
+
+    "I attest this license is active and in good standing." Flips
+    `attested_active=True` + `attested_at=NOW()`, recomputes the
+    licensure's `status` from `expiration_date` + the attestation, and
+    re-runs `recompute_clinician_claim` so the Claim-A denorm cache
+    reflects the new state. A `Verification` event of type
+    `license_attested` is appended.
+
+    Authz: the requesting user must own the parent Clinician (or be
+    admin). The licensure must belong to the URL-named clinician —
+    same defense-in-depth shape the framework's generic subentity
+    handlers use.
+
+    This is the canonical consumer of `mount_state_axis` with
+    `spec.parent is not None`; the path / authz / response-shape rules
+    all flow from the framework's existing state-axis machinery.
+    """
+    # Imports kept local to keep the module's top-level import surface
+    # narrow; this handler is the only caller that needs them.
+    from datetime import date, datetime, timezone
+
+    from src.domain.logic.verifications.handlers import (
+        recompute_clinician_claim,
+        record_verification_event,
+    )
+    from src.domain.models import ClinicianLicensure
+    from src.domain.specs.clinician_licensure import LICENSURE_ENTITY
+    from src.framework.audit.core import record_audit
+    from src.framework.authz import is_owner_or_admin
+
+    clinician = await repo.get_by_model_id(Clinician, clinician_id)
+    if clinician is None:
+        raise NotFoundError(detail="Clinician not found")
+    if not is_owner_or_admin(clinician, requesting_user):
+        raise ForbiddenError(detail="Cannot attest licenses for this clinician")
+
+    licensure = await repo.get_by_model_id(ClinicianLicensure, licensure_id)
+    if licensure is None or licensure.clinician_id != clinician_id:
+        raise NotFoundError(detail="Licensure not found for this clinician")
+
+    axis = LICENSURE_ENTITY.state_axis("attestation")
+    before = axis.audit_snapshot_fn(licensure)
+
+    licensure.attested_active = True
+    licensure.attested_at = datetime.now(timezone.utc)
+    if licensure.expiration_date is None or licensure.expiration_date >= date.today():
+        licensure.status = "active"
+    else:
+        licensure.status = "expired"
+
+    # Two audit surfaces here: an audit row for the licensure-level
+    # mutation (carrying `SET_LICENSE_ATTESTATION`) and a
+    # `Verification` event row in the verification cluster (carrying
+    # `event_type='license_attested'`). The audit row is what the
+    # framework's discipline guard looks for; the Verification event
+    # is the event-log entry the recompute helpers and the lapse
+    # detection read.
+    await record_audit(
+        audit_repo,
+        actor_id=requesting_user.id,
+        resource_type=LICENSURE_ENTITY.audit.type,
+        resource_id=licensure.id,
+        action=axis.action,
+        before=before,
+        after=axis.audit_snapshot_fn(licensure),
+    )
+    await record_verification_event(
+        verification_repo=verification_repo,
+        audit_repo=audit_repo,
+        subject_type="clinician",
+        clinician_id=clinician.id,
+        event_type="license_attested",
+        status="verified",
+        evidence={
+            "licensure_id": str(licensure.id),
+            "license_type": licensure.license_type,
+            "issuing_state": licensure.issuing_state,
+        },
+        actor_id=requesting_user.id,
+    )
+    recompute_clinician_claim(clinician)
+    await repo.session.commit()
+    return licensure

--- a/src/domain/routes/test_verifications.py
+++ b/src/domain/routes/test_verifications.py
@@ -388,8 +388,8 @@ async def test_license_attest_flips_to_active_and_updates_claim_cache(
         npi_match_status="matched",
         licensure_status="pending",
     )
-    response = await authenticated_client.post(
-        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attest"
+    response = await authenticated_client.put(
+        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attestation", json={}
     )
     assert response.status_code == 200
     assert response.headers.get("HX-Refresh") == "true"
@@ -423,8 +423,8 @@ async def test_license_attest_expired_keeps_status_expired(
         logged_in_user.id,
         expiration_in_past=True,
     )
-    response = await authenticated_client.post(
-        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attest"
+    response = await authenticated_client.put(
+        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attestation", json={}
     )
     assert response.status_code == 200
     async with db_test_session_manager() as session:
@@ -446,8 +446,8 @@ async def test_license_attest_records_verification_event(
     clinician_id, licensure_id = await _seed_clinician_with_licensure(
         db_test_session_manager, logged_in_user.id
     )
-    await authenticated_client.post(
-        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attest"
+    await authenticated_client.put(
+        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attestation", json={}
     )
     async with db_test_session_manager() as session:
         events = (
@@ -477,8 +477,8 @@ async def test_license_attest_non_owner_403(
     clinician_id, licensure_id = await _seed_clinician_with_licensure(
         db_test_session_manager, other_owner.id
     )
-    response = await authenticated_client.post(
-        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attest"
+    response = await authenticated_client.put(
+        f"/clinicians/{clinician_id}/licensures/{licensure_id}/attestation", json={}
     )
     assert response.status_code == 403
 
@@ -501,7 +501,7 @@ async def test_license_attest_404_when_licensure_belongs_to_other_clinician(
     _, licensure_id_b = await _seed_clinician_with_licensure(
         db_test_session_manager, other_owner.id
     )
-    response = await authenticated_client.post(
-        f"/clinicians/{clinician_id_a}/licensures/{licensure_id_b}/attest"
+    response = await authenticated_client.put(
+        f"/clinicians/{clinician_id_a}/licensures/{licensure_id_b}/attestation", json={}
     )
     assert response.status_code == 404

--- a/src/domain/routes/verifications.py
+++ b/src/domain/routes/verifications.py
@@ -37,14 +37,13 @@ from src.domain.logic.organizations.repository import (
 )
 from src.domain.logic.verifications.handlers import (
     handle_create_clinician_verification,
-    recompute_clinician_claim,
     record_verification_event,
 )
 from src.domain.logic.verifications.repository import (
     VerificationRepository,
     get_verification_repository,
 )
-from src.domain.models import Clinician, ClinicianLicensure, Organization, User
+from src.domain.models import Clinician, Organization, User
 from src.framework.audit.repository import AuditRepository
 from src.framework.authz import is_owner_or_admin
 from src.framework.http.exceptions import (
@@ -218,75 +217,9 @@ async def submit_organization_npi(
     return refreshed_response()
 
 
-@verifications_api_router.post(
-    "/clinicians/{clinician_id}/licensures/{licensure_id}/attest",
-    status_code=status.HTTP_200_OK,
-    name="verifications:license_attest",
-)
-async def attest_license(
-    clinician_id: UUID,
-    licensure_id: UUID,
-    clinician_repo: ClinicianRepository = Depends(get_clinician_repository),
-    verification_repo: VerificationRepository = Depends(get_verification_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    requesting_user: User = Depends(current_active_user),
-) -> Response:
-    """User-driven license re-attestation per handoff §10.
-
-    "I attest this license is active and in good standing." flips
-    `attested_active=True` + `attested_at=NOW()`, recomputes the
-    licensure's `status` (active if not expired, expired if past
-    `expiration_date`, pending otherwise), and re-runs
-    `recompute_clinician_claim` so the Claim-A denorm cache reflects
-    the new state. A `Verification` event of type `license_attested`
-    is appended.
-
-    Authz: the requesting user must own the parent Clinician (or be
-    admin). The licensure must belong to the URL-named clinician —
-    same defense-in-depth shape the framework's generic subentity
-    handlers use.
-    """
-    from datetime import date, datetime, timezone
-
-    clinician = await clinician_repo.get_by_model_id(Clinician, clinician_id)
-    if clinician is None:
-        raise NotFoundError(detail="Clinician not found")
-    if not is_owner_or_admin(clinician, requesting_user):
-        raise ForbiddenError(detail="Cannot attest licenses for this clinician")
-
-    licensure = await clinician_repo.get_by_model_id(ClinicianLicensure, licensure_id)
-    if licensure is None or licensure.clinician_id != clinician_id:
-        # 404 (not 403) when the licensure doesn't belong to this
-        # clinician — same info-leak shape the framework's subresource
-        # handlers use.
-        raise NotFoundError(detail="Licensure not found for this clinician")
-
-    licensure.attested_active = True
-    licensure.attested_at = datetime.now(timezone.utc)
-    if licensure.expiration_date is None or licensure.expiration_date >= date.today():
-        licensure.status = "active"
-    else:
-        licensure.status = "expired"
-
-    await record_verification_event(
-        verification_repo=verification_repo,
-        audit_repo=audit_repo,
-        subject_type="clinician",
-        clinician_id=clinician.id,
-        event_type="license_attested",
-        status="verified",
-        evidence={
-            "licensure_id": str(licensure.id),
-            "license_type": licensure.license_type,
-            "issuing_state": licensure.issuing_state,
-        },
-        actor_id=requesting_user.id,
-    )
-
-    # Recompute the Claim-A cache. Attestation may flip
-    # `clinician_verified` to True (if the NPI is already matched and
-    # this was the missing active license) or keep it as-is.
-    recompute_clinician_claim(clinician)
-
-    await clinician_repo.session.commit()
-    return refreshed_response()
+# Note on license attestation: previously a bespoke POST endpoint here;
+# now a state axis on `LICENSURE_ENTITY`
+# (`PUT /clinicians/{clinician_id}/licensures/{licensure_id}/attestation`).
+# The framework's `mount_state_axis` gained parent-owned-subentity
+# support in PR #1082 so this no longer needs to be hand-rolled. Handler
+# at `src.domain.logic.clinicians.handlers.handle_set_license_attestation`.

--- a/src/domain/specs/_credential.py
+++ b/src/domain/specs/_credential.py
@@ -20,6 +20,7 @@ from src.framework.dispatch.entity_spec import (
     OWNER_OR_ADMIN,
     EntitySpec,
     RouteSet,
+    StateAxis,
 )
 
 
@@ -33,6 +34,7 @@ def make_clinician_credential_entity(
     read_schema: type[BaseModel],
     create_adapter: type[BaseModel] | TypeAdapter,
     update_adapter: type[BaseModel] | TypeAdapter,
+    state_axes: tuple[StateAxis, ...] = (),
 ) -> EntitySpec:
     """Build a credential-subentity `EntitySpec` from its varying pieces.
 
@@ -45,6 +47,12 @@ def make_clinician_credential_entity(
     constructor synthesizes `read_to_dict` from it and defaults
     `audit_snapshot` to it as well (credential audit snapshots are
     byte-identical to their read projection).
+
+    `state_axes` is the per-credential state-axis tuple. Only
+    `LICENSURE_ENTITY` uses it today (the `attestation` axis); the
+    other two credentials pass `()`. This is the parent-owned
+    subentity surface that landed when `mount_state_axis` gained
+    `spec.parent`-aware mounting.
     """
 
     return EntitySpec(
@@ -70,4 +78,5 @@ def make_clinician_credential_entity(
         create_redirect=_clinician_form_redirect,
         update_redirect=_clinician_form_redirect,
         delete_redirect=_clinician_form_redirect,
+        state_axes=state_axes,
     )

--- a/src/domain/specs/clinician_licensure.py
+++ b/src/domain/specs/clinician_licensure.py
@@ -1,15 +1,21 @@
 """`LICENSURE_ENTITY`: clinician's licensure credential subentity.
 
 Owned subentity of `Clinician`: routes nest under
-``/clinicians/{clinician_id}/licensures/{licensure_id}``. Shape is
-identical to the other clinician credentials — see `_credential.py`
-for the shared factory.
+``/clinicians/{clinician_id}/licensures/{licensure_id}``. Base shape
+(CRUD) is identical to the other clinician credentials — see
+`_credential.py` for the shared factory. License attestation is the
+only credential-specific addition: a state axis at
+``PUT /clinicians/{clinician_id}/licensures/{licensure_id}/attestation``
+that flips `attested_active=True` + recomputes the owning clinician's
+Claim-A cache.
 
 Read by `src/domain/routes/clinicians.py` (derives `LICENSURE_SPEC` for
 the mount helpers).
 """
 
 from typing import Final
+
+from pydantic import BaseModel
 
 from src.domain.logic.clinicians.schema import (
     ClinicianLicensureCreate,
@@ -18,7 +24,29 @@ from src.domain.logic.clinicians.schema import (
 )
 from src.domain.models import ClinicianLicensure
 from src.domain.specs._credential import make_clinician_credential_entity
-from src.framework.dispatch.entity_spec import EntitySpec
+from src.framework.audit.core import AuditAction
+from src.framework.dispatch.entity_spec import EntitySpec, StateAxis
+
+
+class _LicenseAttestationBody(BaseModel):
+    """Body for the attestation axis. Empty payload — the act of
+    POSTing the URL IS the attestation. A field is reserved for future
+    refusal flows (e.g. "I attest this license is NOT active" to
+    proactively flip `status='expired'`)."""
+
+    # `attested: bool = True` keeps the shape forward-compatible while
+    # accepting an empty `{}` body (default-True). Clients that want
+    # to be explicit can POST `{"attested": true}`.
+    attested: bool = True
+
+
+def _attestation_response_to_dict(licensure: ClinicianLicensure) -> dict:
+    return {
+        "id": str(licensure.id),
+        "status": licensure.status,
+        "attested_active": licensure.attested_active,
+    }
+
 
 LICENSURE_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
     name="clinician_licensure",
@@ -29,4 +57,17 @@ LICENSURE_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
     read_schema=ClinicianLicensureRead,
     create_adapter=ClinicianLicensureCreate,
     update_adapter=ClinicianLicensureUpdate,
+    state_axes=(
+        StateAxis(
+            name="attestation",
+            body_schema=_LicenseAttestationBody,
+            action=AuditAction.SET_LICENSE_ATTESTATION,
+            response_to_dict=_attestation_response_to_dict,
+            handler_path=(
+                "src.domain.logic.clinicians.handlers" ".handle_set_license_attestation"
+            ),
+            audit_snapshot=ClinicianLicensureRead,
+            forbid_self=False,
+        ),
+    ),
 )

--- a/src/framework/audit/core.py
+++ b/src/framework/audit/core.py
@@ -85,6 +85,12 @@ class AuditAction(str, Enum):
     UPDATE_ORG_REPRESENTATION = "update_org_representation"
     DELETE_ORG_REPRESENTATION = "delete_org_representation"
     SET_ORG_REPRESENTATION_AUTHORITY = "set_org_representation_authority"
+    # State-axis action on `ClinicianLicensure` (owned subentity of
+    # `Clinician`). The first consumer of `mount_state_axis` with
+    # `spec.parent is not None` — re-attestation flips
+    # `attested_active=True` + recomputes the license `status` and the
+    # owning clinician's Claim-A cache.
+    SET_LICENSE_ATTESTATION = "set_license_attestation"
 
 
 Verb = Literal["create", "update", "delete"]

--- a/src/framework/dispatch/mounts/state_axis.py
+++ b/src/framework/dispatch/mounts/state_axis.py
@@ -14,6 +14,8 @@ from pydantic import TypeAdapter
 
 from src.framework.dispatch.mounts._common import (
     call_handler_with,
+    parent_path_param_pairs,
+    path_segments_under_router,
     resolve_handler,
 )
 from src.framework.dispatch.mounts._spec import ResourceSpec
@@ -59,6 +61,17 @@ def mount_state_axis(
     reason or a verified-by id. Single-field bodies still pay one
     declaration to keep the surface uniform.
 
+    **Parent-owned subentities** (``spec.parent is not None``) mount at
+    ``/<parent_id_param>/<collection>/<id_param>/<axis_name>`` relative
+    to the parent's router prefix — same convention the rest of the
+    sub-resource mounts (`mount_create` / `mount_update` /
+    `mount_delete`) follow. The handler receives every parent id-param
+    as a kwarg alongside ``spec.id_param``. License attestation
+    (``LICENSURE_ENTITY`` under ``CLINICIAN_ENTITY``) is the canonical
+    consumer: the axis mounts at
+    ``PUT /clinicians/{clinician_id}/licensures/{licensure_id}/attestation``
+    and the handler receives both ``clinician_id`` and ``licensure_id``.
+
     Response is ``200 OK`` with body = ``response_to_dict(updated)`` (if
     set, else ``{}``) and ``HX-Refresh: true``. The projection is
     per-mount because each axis surfaces a different field
@@ -70,14 +83,18 @@ def mount_state_axis(
         raise ValueError(
             f"mount_state_axis requires {spec.collection!r} to set write_user_dep."
         )
-    if spec.parent is not None:
-        raise NotImplementedError(
-            "mount_state_axis with spec.parent is not supported yet."
-        )
 
     id_param = spec.id_param
     body_adapter = TypeAdapter(body_schema)
-    path = f"/{{{id_param}}}/{axis_name}"
+    parent_id_names = tuple(p[0] for p in parent_path_param_pairs(spec))
+    if spec.parent is None:
+        path = f"/{{{id_param}}}/{axis_name}"
+    else:
+        # `path_segments_under_router(spec, with_id=True)` returns the
+        # `/<parent_id>/<collection>/<id_param>` prefix relative to the
+        # router (which is rooted at the topmost ancestor's collection,
+        # e.g. `/clinicians`). Append the axis name on the end.
+        path = f"{path_segments_under_router(spec, with_id=True)}/{axis_name}"
 
     async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
@@ -93,7 +110,7 @@ def mount_state_axis(
             user_dep=spec.write_user_dep,
             body_adapter=body_adapter,
             body_format="json",
-            path_param_names=(id_param,),
+            path_param_names=(*parent_id_names, id_param),
         ),
         response_builder=response_builder,
     )

--- a/src/framework/dispatch/test_resource_routes.py
+++ b/src/framework/dispatch/test_resource_routes.py
@@ -1047,6 +1047,109 @@ def test_mount_state_axis_requires_write_user_dep():
         )
 
 
+def test_mount_state_axis_parent_owned_path_includes_parent_id():
+    """A child ResourceSpec with `parent=` mounts the state-axis path
+    under the parent's id-param. Handler receives both ids by their
+    declared kwarg name. Mirrors the subresource-CRUD mounts."""
+    captured: dict = {}
+
+    async def handler(
+        parent_id: UUID,
+        widget_id: UUID,
+        payload: _AxisBody,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        captured["parent_id"] = parent_id
+        captured["widget_id"] = widget_id
+        captured["state"] = payload.state
+        return SimpleNamespace(id=widget_id)
+
+    parent_spec = ResourceSpec(
+        collection="parents",
+        id_param="parent_id",
+        repo_dep=lambda: SimpleNamespace(name="parent_repo"),
+    )
+    child_spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        parent=parent_spec,
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+
+    app = FastAPI()
+    router = APIRouter(prefix=f"/{parent_spec.collection}")
+    _override_audit(app)
+    mount_state_axis(
+        router,
+        child_spec,
+        handler=handler,
+        axis_name="toggle",
+        body_schema=_AxisBody,
+    )
+    app.include_router(router)
+
+    parent_id = uuid4()
+    widget_id = uuid4()
+    resp = TestClient(app).put(
+        f"/parents/{parent_id}/widgets/{widget_id}/toggle",
+        json={"state": "on"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["HX-Refresh"] == "true"
+    assert captured["parent_id"] == parent_id
+    assert captured["widget_id"] == widget_id
+    assert captured["state"] == "on"
+
+
+def test_mount_state_axis_parent_owned_404_when_no_parent_match():
+    """The framework's path includes `{parent_id}` so a request to the
+    wrong path entirely (no parent id) 404s. (Parent-existence + child-
+    belongs-to-parent checks are still the handler's responsibility, same
+    as the other subresource mounts.)"""
+
+    async def handler(
+        parent_id: UUID,
+        widget_id: UUID,
+        payload: _AxisBody,
+        repo: UserRepository,
+        audit_repo: AuditRepository,
+        requesting_user: User,
+    ):
+        return SimpleNamespace(id=widget_id)
+
+    parent_spec = ResourceSpec(
+        collection="parents",
+        id_param="parent_id",
+        repo_dep=lambda: SimpleNamespace(name="parent_repo"),
+    )
+    child_spec = ResourceSpec(
+        collection="widgets",
+        id_param="widget_id",
+        parent=parent_spec,
+        repo_dep=lambda: SimpleNamespace(name="repo"),
+        write_user_dep=lambda: SimpleNamespace(id=uuid4(), is_superuser=True),
+    )
+
+    app = FastAPI()
+    router = APIRouter(prefix=f"/{parent_spec.collection}")
+    _override_audit(app)
+    mount_state_axis(
+        router,
+        child_spec,
+        handler=handler,
+        axis_name="toggle",
+        body_schema=_AxisBody,
+    )
+    app.include_router(router)
+
+    # Sub-resource path without the parent prefix → 404.
+    resp = TestClient(app).put(f"/widgets/{uuid4()}/toggle", json={"state": "on"})
+    assert resp.status_code == 404
+
+
 def test_mount_state_axis_no_response_to_dict_returns_empty_body():
     """Without `response_to_dict`, the body is `{}` — handler still runs
     and the HX-Refresh header still fires."""


### PR DESCRIPTION
## Summary
Lifts the `mount_state_axis` restriction on `spec.parent is not None` and migrates the license-attestation endpoint from a bespoke POST to a proper state axis as the canonical consumer. Closes a framework gap called out in the verification-rollout retro.

- `mount_state_axis` now builds the parent-prefixed path via the same `path_segments_under_router` + `parent_path_param_pairs` helpers the existing `mount_create` / `mount_update` / `mount_delete` use. A child spec's state axis lands at `PUT /<parent_collection>/{parent_id}/<collection>/{id}/<axis_name>` and the handler receives every parent id-param as a kwarg alongside `spec.id_param`.
- `LICENSURE_ENTITY` declares the `attestation` axis. Bespoke `POST /clinicians/{id}/licensures/{id}/attest` removed; same semantics now live at `PUT /clinicians/{id}/licensures/{id}/attestation`.
- New `SET_LICENSE_ATTESTATION` AuditAction; handler emits an explicit `record_audit` row for the licensure-level action alongside the verification-cluster event.
- 2 new framework tests pin parent-owned path shape + 404 when the parent prefix is missing. The 5 existing license-attest route tests now hit the state-axis URL with `json={}` — same semantic assertions, new URL + verb.

## Test plan
- [x] `dev test` — 2203 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)