### PR TITLE
refactor: split verifications/handlers → events + handlers

### DIFF
--- a/src/domain/logic/clinicians/handlers.py
+++ b/src/domain/logic/clinicians/handlers.py
@@ -167,7 +167,7 @@ async def handle_set_license_attestation(
     # narrow; this handler is the only caller that needs them.
     from datetime import date, datetime, timezone
 
-    from src.domain.logic.verifications.handlers import (
+    from src.domain.logic.verifications.events import (
         recompute_clinician_claim,
         record_verification_event,
     )

--- a/src/domain/logic/org_representations/handlers.py
+++ b/src/domain/logic/org_representations/handlers.py
@@ -40,7 +40,7 @@ from src.domain.logic.org_representations.schema import (
     OrgRepresentationAuthorityUpdate,
     OrgRepresentationCreate,
 )
-from src.domain.logic.verifications.handlers import record_verification_event
+from src.domain.logic.verifications.events import record_verification_event
 from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.logic.verifications.scoring import _name_similarity
 from src.domain.models import Organization, OrgRepresentation, User

--- a/src/domain/logic/verifications/README.md
+++ b/src/domain/logic/verifications/README.md
@@ -9,14 +9,15 @@ Persistence + pure-function primitives for the clinician verification pipeline. 
 - `nppes.py` — `nppes_lookup(npi, *, http)` against the public CMS registry. Errors / timeouts degrade to `NppesResult(found=False, raw=None)` plus a logged warning — never raises.
 - `oig.py` — `oig_check(*, first_name, last_name, npi)` against the OIG/LEIE exclusion list (loaded from a CSV on disk). Module-level cache by absolute path; missing CSV degrades to "no match" with a single startup warning.
 - `scoring.py` — `score_verification(...)` table-driven rules over `(NppesResult, OigResult, clinician name)` → `Score(status, flags, name_match_score)`. No I/O.
-- `handlers.py` — `run_clinician_verification(...)` orchestrator + `handle_create_clinician_verification(...)` admin-only retrigger. Composes the primitives with persistence + audit + an `httpx.AsyncClient`. The bespoke route lives at [`../../routes/verifications.py`](../../routes/verifications.py) and is wired into `src/main.py` next to the other hand-rolled routers.
+- `handlers.py` — NPPES pipeline: `run_clinician_verification(...)`, `run_org_verification(...)`, and their admin-only retrigger wrappers. Composes the primitives with persistence + audit + an `httpx.AsyncClient`. The bespoke route lives at [`../../routes/verifications.py`](../../routes/verifications.py) and is wired into `src/main.py` next to the other hand-rolled routers.
+- `events.py` — `recompute_clinician_claim(clinician)`, `recompute_org_claim(org)`, and `record_verification_event(...)`. These three live outside the NPPES pipeline because they are called by `clinicians/handlers.py` and `org_representations/handlers.py` without any HTTP dependency. The recompute helpers are nearly pure (no I/O; they mutate their argument in place); `record_verification_event` is the single append-only writer for the non-NPPES §9 transitions.
 
-The orchestrator has two callers:
+The pipeline orchestrators have two callers each:
 
-1. **`handle_create_clinician_verification`** in this file (admin retrigger; `actor_id=requesting_user.id`).
+1. **`handle_create_clinician_verification` / `handle_create_org_verification`** in `handlers.py` (admin retrigger; `actor_id=requesting_user.id`).
 2. **`run_nightly_verification`** in [`../../../jobs/nightly_verification.py`](../../../jobs/nightly_verification.py) (daily APScheduler job; `actor_id=None`).
 
-(`__init__.py` is intentionally empty — these are imported directly via `src.domain.logic.verifications.nppes`/`.oig`/`.scoring`/`.repository`/`.schema`/`.handlers`.)
+(`__init__.py` is intentionally empty — these are imported directly via `src.domain.logic.verifications.nppes`/`.oig`/`.scoring`/`.repository`/`.schema`/`.handlers`/`.events`.)
 
 ## Why pure functions, not classes
 

--- a/src/domain/logic/verifications/events.py
+++ b/src/domain/logic/verifications/events.py
@@ -1,0 +1,157 @@
+"""Claim-cache recompute helpers and append-only event writer.
+
+These two concerns are separated from the NPPES pipeline
+(`handlers.py`) because they are used by callers outside the pipeline:
+`clinicians/handlers.py` and `org_representations/handlers.py` both
+need `recompute_clinician_claim` / `record_verification_event` without
+pulling in the NPPES / HTTP dependencies.
+
+`recompute_clinician_claim` and `recompute_org_claim` are nearly pure
+functions (no I/O; they mutate their argument in place and the caller
+commits).  `record_verification_event` is async + DB but has no HTTP
+dependency — it is the single append-only writer for the non-NPPES §9
+transitions.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from src.domain.logic.verifications.repository import VerificationRepository
+from src.domain.logic.verifications.schema import VerificationRead
+from src.domain.models import Clinician, Organization, Verification
+from src.framework.audit.core import make_audited_resource, record_audit_for
+from src.framework.audit.repository import AuditRepository
+
+logger = logging.getLogger(__name__)
+
+VERIFICATION_RESOURCE = make_audited_resource("verification", VerificationRead)
+
+
+def _now() -> datetime:
+    """Single source of "now" so tests can patch one place if they need
+    deterministic timestamps later."""
+    return datetime.now(timezone.utc)
+
+
+# ---------- Claim-cache recompute helpers --------------------------------
+
+
+def recompute_clinician_claim(clinician: Clinician) -> None:
+    """Compute `Clinician.clinician_verified` + the timestamp triplet
+    (`verified_at`, `ever_verified_at`, regression detection) from the
+    current `npi_match_status` + the licensure set, then mutate the
+    clinician in place. The caller is responsible for committing the
+    enclosing transaction.
+
+    Claim A requires:
+      1. `npi_match_status == 'matched'`
+      2. at least one `ClinicianLicensure` with `status == 'active'`
+
+    `ever_verified_at` is set on the first transition to True and
+    preserved on regression — that's what powers the once-verified feed
+    retention rule (handoff §7.1).
+    """
+    matched = clinician.npi_match_status == "matched"
+    licensures = getattr(clinician, "licensures", None) or ()
+    has_active_license = any(
+        getattr(lic, "status", None) == "active" for lic in licensures
+    )
+    is_verified_now = matched and has_active_license
+
+    if is_verified_now:
+        if not clinician.clinician_verified:
+            clinician.verified_at = _now()
+        clinician.clinician_verified = True
+        if clinician.ever_verified_at is None:
+            clinician.ever_verified_at = clinician.verified_at or _now()
+    else:
+        clinician.clinician_verified = False
+        # Leave `verified_at` and `ever_verified_at` alone — the
+        # first-ever timestamp is preserved across regressions so the
+        # `can_read_full_feed` retention rule keeps working.
+
+
+def recompute_org_claim(org: Organization) -> None:
+    """Compute `Organization.org_verified` + `verified_at` from the
+    current `npi_match_status`. Symmetric with the Clinician side,
+    minus the licensure consideration (orgs don't hold licenses)."""
+    is_verified_now = org.npi_match_status == "matched"
+    if is_verified_now:
+        if not org.org_verified:
+            org.verified_at = _now()
+        org.org_verified = True
+    else:
+        org.org_verified = False
+
+
+# ---------- Append-only event writer -------------------------------------
+
+
+async def record_verification_event(
+    *,
+    verification_repo: VerificationRepository,
+    audit_repo: AuditRepository,
+    subject_type: str,
+    clinician_id: UUID | None = None,
+    org_id: UUID | None = None,
+    event_type: str,
+    status: str = "verified",
+    evidence: dict[str, Any] | None = None,
+    actor_id: UUID | None,
+) -> Verification:
+    """Single append-only writer for the non-NPPES §9 transitions
+    (`license_attested`, `license_expired`, `authority_proven`,
+    `authority_revoked`, `role_set`, `admin_verify`, `admin_suspend`,
+    `email_confirmed`). Records both a `Verification` row and a matching
+    audit entry in one transaction; the caller is responsible for the
+    enclosing `session.commit()`.
+
+    The NPPES-pipeline writes (`npi_submitted`, `npi_resolved`) go
+    through the dedicated `record_for_*` repository methods invoked
+    inside `run_clinician_verification` / `run_org_verification` instead
+    — they carry NPPES-specific fields (`nppes_result`, `oig_match`,
+    `name_match_score`) the non-NPPES events don't have.
+    """
+    if (clinician_id is None) == (org_id is None):
+        # Mirror the DB-level CHECK in Python so misuses fail loudly
+        # at the handler boundary rather than as a SQLite IntegrityError.
+        raise ValueError(
+            "record_verification_event requires exactly one of " "clinician_id / org_id"
+        )
+
+    if subject_type == "clinician":
+        assert clinician_id is not None  # narrowed by the XOR above
+        verification = await verification_repo.record_for_clinician(
+            clinician_id=clinician_id,
+            status=status,
+            flags=[],
+            nppes_result=None,
+            oig_match=False,
+            name_match_score=None,
+            event_type=event_type,
+            evidence=evidence,
+        )
+    else:
+        assert org_id is not None
+        verification = await verification_repo.record_for_org(
+            org_id=org_id,
+            status=status,
+            flags=[],
+            nppes_result=None,
+            name_match_score=None,
+            event_type=event_type,
+            evidence=evidence,
+        )
+
+    await record_audit_for(
+        audit_repo,
+        resource=VERIFICATION_RESOURCE,
+        verb="create",
+        actor_id=actor_id,
+        target_id=verification.id,
+        before=None,
+        after=VERIFICATION_RESOURCE.snapshot(verification),
+    )
+    return verification

--- a/src/domain/logic/verifications/handlers.py
+++ b/src/domain/logic/verifications/handlers.py
@@ -1,24 +1,25 @@
-"""Verification orchestrator + bespoke trigger endpoint handlers.
+"""NPPES verification pipeline handlers.
 
-Two pipelines + a per-claim cache recompute + an append-only event
-writer. The pipelines (`run_clinician_verification`,
-`run_org_verification`) own NPPES + scoring + persistence; the recompute
-helpers translate the latest event log + denormalized columns into the
-boolean cache the capability predicates read; `record_verification_event`
-appends the non-NPPES transitions from §9 (licensure attestation,
-authority grant/revoke, admin override) so the event history stays a
-single source of truth.
+Two pipelines that own NPPES lookup + scoring + persistence + denorm
+cache write-through.  The per-claim cache recompute helpers
+(`recompute_clinician_claim`, `recompute_org_claim`) and the append-only
+event writer (`record_verification_event`) live in `events.py` — they
+are imported from there by callers outside this pipeline.
 """
 
 import logging
-from datetime import datetime, timezone
-from typing import Any
 from uuid import UUID
 
 import httpx
 
 from src.domain.logic.clinicians.repository import ClinicianRepository
 from src.domain.logic.organizations.repository import OrganizationRepository
+from src.domain.logic.verifications.events import (
+    VERIFICATION_RESOURCE,
+    _now,
+    recompute_clinician_claim,
+    recompute_org_claim,
+)
 from src.domain.logic.verifications.nppes import (
     NppesOrgResult,
     NppesResult,
@@ -27,20 +28,17 @@ from src.domain.logic.verifications.nppes import (
 )
 from src.domain.logic.verifications.oig import oig_check
 from src.domain.logic.verifications.repository import VerificationRepository
-from src.domain.logic.verifications.schema import VerificationRead
 from src.domain.logic.verifications.scoring import (
     Score,
     _name_similarity,
     score_verification,
 )
 from src.domain.models import Clinician, Organization, User, Verification
-from src.framework.audit.core import make_audited_resource, record_audit_for
+from src.framework.audit.core import record_audit_for
 from src.framework.audit.repository import AuditRepository
 from src.framework.http.exceptions import ForbiddenError, NotFoundError
 
 logger = logging.getLogger(__name__)
-
-VERIFICATION_RESOURCE = make_audited_resource("verification", VerificationRead)
 
 HTTP_TIMEOUT_SECONDS = 10.0
 _NPPES_SKIPPED_FLAG = "nppes_skipped"
@@ -62,12 +60,6 @@ def _clinician_names(clinician: Clinician, owner: User | None) -> tuple[str, str
     if owner is None:
         return ("", "")
     return (owner.username or "", "")
-
-
-def _now() -> datetime:
-    """Single source of "now" for the orchestrator so tests can patch
-    one place if they need deterministic timestamps later."""
-    return datetime.now(timezone.utc)
 
 
 # ---------- Clinician (Claim A) pipeline ---------------------------------
@@ -308,125 +300,3 @@ async def handle_create_org_verification(
             http=http,
             actor_id=requesting_user.id,
         )
-
-
-# ---------- Claim-cache recompute helpers --------------------------------
-
-
-def recompute_clinician_claim(clinician: Clinician) -> None:
-    """Compute `Clinician.clinician_verified` + the timestamp triplet
-    (`verified_at`, `ever_verified_at`, regression detection) from the
-    current `npi_match_status` + the licensure set, then mutate the
-    clinician in place. The caller is responsible for committing the
-    enclosing transaction.
-
-    Claim A requires:
-      1. `npi_match_status == 'matched'`
-      2. at least one `ClinicianLicensure` with `status == 'active'`
-
-    `ever_verified_at` is set on the first transition to True and
-    preserved on regression — that's what powers the once-verified feed
-    retention rule (handoff §7.1).
-    """
-    matched = clinician.npi_match_status == "matched"
-    licensures = getattr(clinician, "licensures", None) or ()
-    has_active_license = any(
-        getattr(lic, "status", None) == "active" for lic in licensures
-    )
-    is_verified_now = matched and has_active_license
-
-    if is_verified_now:
-        if not clinician.clinician_verified:
-            clinician.verified_at = _now()
-        clinician.clinician_verified = True
-        if clinician.ever_verified_at is None:
-            clinician.ever_verified_at = clinician.verified_at or _now()
-    else:
-        clinician.clinician_verified = False
-        # Leave `verified_at` and `ever_verified_at` alone — the
-        # first-ever timestamp is preserved across regressions so the
-        # `can_read_full_feed` retention rule keeps working.
-
-
-def recompute_org_claim(org: Organization) -> None:
-    """Compute `Organization.org_verified` + `verified_at` from the
-    current `npi_match_status`. Symmetric with the Clinician side,
-    minus the licensure consideration (orgs don't hold licenses)."""
-    is_verified_now = org.npi_match_status == "matched"
-    if is_verified_now:
-        if not org.org_verified:
-            org.verified_at = _now()
-        org.org_verified = True
-    else:
-        org.org_verified = False
-
-
-# ---------- Append-only event writer -------------------------------------
-
-
-async def record_verification_event(
-    *,
-    verification_repo: VerificationRepository,
-    audit_repo: AuditRepository,
-    subject_type: str,
-    clinician_id: UUID | None = None,
-    org_id: UUID | None = None,
-    event_type: str,
-    status: str = "verified",
-    evidence: dict[str, Any] | None = None,
-    actor_id: UUID | None,
-) -> Verification:
-    """Single append-only writer for the non-NPPES §9 transitions
-    (`license_attested`, `license_expired`, `authority_proven`,
-    `authority_revoked`, `role_set`, `admin_verify`, `admin_suspend`,
-    `email_confirmed`). Records both a `Verification` row and a matching
-    audit entry in one transaction; the caller is responsible for the
-    enclosing `session.commit()`.
-
-    The NPPES-pipeline writes (`npi_submitted`, `npi_resolved`) go
-    through the dedicated `record_for_*` repository methods invoked
-    inside `run_clinician_verification` / `run_org_verification` instead
-    — they carry NPPES-specific fields (`nppes_result`, `oig_match`,
-    `name_match_score`) the non-NPPES events don't have.
-    """
-    if (clinician_id is None) == (org_id is None):
-        # Mirror the DB-level CHECK in Python so misuses fail loudly
-        # at the handler boundary rather than as a SQLite IntegrityError.
-        raise ValueError(
-            "record_verification_event requires exactly one of " "clinician_id / org_id"
-        )
-
-    if subject_type == "clinician":
-        assert clinician_id is not None  # narrowed by the XOR above
-        verification = await verification_repo.record_for_clinician(
-            clinician_id=clinician_id,
-            status=status,
-            flags=[],
-            nppes_result=None,
-            oig_match=False,
-            name_match_score=None,
-            event_type=event_type,
-            evidence=evidence,
-        )
-    else:
-        assert org_id is not None
-        verification = await verification_repo.record_for_org(
-            org_id=org_id,
-            status=status,
-            flags=[],
-            nppes_result=None,
-            name_match_score=None,
-            event_type=event_type,
-            evidence=evidence,
-        )
-
-    await record_audit_for(
-        audit_repo,
-        resource=VERIFICATION_RESOURCE,
-        verb="create",
-        actor_id=actor_id,
-        target_id=verification.id,
-        before=None,
-        after=VERIFICATION_RESOURCE.snapshot(verification),
-    )
-    return verification

--- a/src/domain/logic/verifications/test_events.py
+++ b/src/domain/logic/verifications/test_events.py
@@ -1,0 +1,312 @@
+"""Unit tests for `events.py`.
+
+Covers the two pure-function recompute helpers and the append-only
+event writer extracted from the pipeline module.  These tests do not
+need HTTP mocks — the NPPES pipeline is not exercised here.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.logic.verifications.events import (
+    recompute_clinician_claim,
+    recompute_org_claim,
+    record_verification_event,
+)
+from src.domain.logic.verifications.repository import VerificationRepository
+from src.domain.models import (
+    Clinician,
+    ClinicianLicensure,
+    Organization,
+    Verification,
+)
+from src.framework.audit.log import AuditLog
+from src.framework.audit.repository import AuditRepository
+from tests.helpers import (
+    create_test_user,
+    make_clinician_with_org,
+    make_organization_row,
+)
+
+# `pytest.mark.asyncio` applied per-async-function rather than at module
+# scope — the recompute_* tests are sync and would warn under a blanket
+# pytestmark.
+
+
+# ---------- recompute_clinician_claim ------------------------------------
+
+
+def test_recompute_clinician_claim_requires_matched_npi_and_active_license():
+    """Matched NPI without any active license → False."""
+    clinician = Clinician(
+        id=uuid4(),
+        owner_id=uuid4(),
+        npi="1234567890",
+        first_name="Eva",
+        last_name="Stone",
+    )
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = False
+    clinician.licensures = [
+        ClinicianLicensure(
+            clinician_id=clinician.id,
+            license_type="lcsw",
+            license_number="X-1",
+            issuing_state="IL",
+            status="pending",
+        )
+    ]
+    recompute_clinician_claim(clinician)
+    assert clinician.clinician_verified is False
+
+
+def test_recompute_clinician_claim_active_license_without_matched_npi_false():
+    """Active license without matched NPI → False."""
+    clinician = Clinician(
+        id=uuid4(), owner_id=uuid4(), first_name="Eva", last_name="Stone"
+    )
+    clinician.npi_match_status = "pending"
+    clinician.clinician_verified = False
+    clinician.licensures = [
+        ClinicianLicensure(
+            clinician_id=clinician.id,
+            license_type="lcsw",
+            license_number="X-1",
+            issuing_state="IL",
+            status="active",
+        )
+    ]
+    recompute_clinician_claim(clinician)
+    assert clinician.clinician_verified is False
+
+
+def test_recompute_clinician_claim_happy_path():
+    clinician = Clinician(
+        id=uuid4(),
+        owner_id=uuid4(),
+        npi="1234567890",
+        first_name="Eva",
+        last_name="Stone",
+    )
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = False
+    clinician.verified_at = None
+    clinician.ever_verified_at = None
+    clinician.licensures = [
+        ClinicianLicensure(
+            clinician_id=clinician.id,
+            license_type="lcsw",
+            license_number="X-1",
+            issuing_state="IL",
+            status="active",
+        )
+    ]
+    recompute_clinician_claim(clinician)
+    assert clinician.clinician_verified is True
+    assert clinician.verified_at is not None
+    assert clinician.ever_verified_at is not None
+
+
+def test_recompute_clinician_claim_preserves_ever_verified_at_on_regression():
+    """A clinician who was previously verified and now isn't (license
+    expired) must keep `ever_verified_at` set — that's what the
+    `can_read_full_feed` retention rule reads."""
+    historic = datetime(2025, 6, 1, tzinfo=timezone.utc)
+    clinician = Clinician(id=uuid4(), owner_id=uuid4())
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    clinician.verified_at = historic
+    clinician.ever_verified_at = historic
+    clinician.licensures = [
+        ClinicianLicensure(
+            clinician_id=clinician.id,
+            license_type="lcsw",
+            license_number="X-1",
+            issuing_state="IL",
+            status="expired",
+        )
+    ]
+    recompute_clinician_claim(clinician)
+    assert clinician.clinician_verified is False
+    assert clinician.ever_verified_at == historic
+
+
+# ---------- recompute_org_claim ------------------------------------------
+
+
+def test_recompute_org_claim_matched_flips_true():
+    org = Organization(
+        id=uuid4(),
+        owner_id=uuid4(),
+        name="Acme",
+        type="clinic",
+        root_org_id=uuid4(),
+    )
+    org.npi_match_status = "matched"
+    org.org_verified = False
+    org.verified_at = None
+    recompute_org_claim(org)
+    assert org.org_verified is True
+    assert org.verified_at is not None
+
+
+def test_recompute_org_claim_pending_keeps_false():
+    org = Organization(
+        id=uuid4(),
+        owner_id=uuid4(),
+        name="Acme",
+        type="clinic",
+        root_org_id=uuid4(),
+    )
+    org.npi_match_status = "pending"
+    org.org_verified = False
+    recompute_org_claim(org)
+    assert org.org_verified is False
+
+
+def test_recompute_org_claim_regression_clears_verified():
+    org = Organization(
+        id=uuid4(),
+        owner_id=uuid4(),
+        name="Acme",
+        type="clinic",
+        root_org_id=uuid4(),
+    )
+    org.npi_match_status = "mismatch"  # admin closed a soft mismatch
+    org.org_verified = True
+    recompute_org_claim(org)
+    assert org.org_verified is False
+
+
+# ---------- record_verification_event ------------------------------------
+
+
+async def _seed_clinician_only(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+) -> Clinician:
+    owner = create_test_user(username=f"owner-{uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(owner)
+            clinician = make_clinician_with_org(owner_id=owner.id, npi="1234567890")
+            session.add(clinician)
+    return clinician
+
+
+async def _seed_org(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+) -> Organization:
+    user = create_test_user(username=f"orgowner-{uuid4()}")
+    org = make_organization_row(owner_id=user.id, name="Acme")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(user)
+            session.add(org)
+    return org
+
+
+async def test_record_event_clinician_appends_row_and_audit(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    clinician = await _seed_clinician_only(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        verification = await record_verification_event(
+            verification_repo=VerificationRepository(session),
+            audit_repo=AuditRepository(session),
+            subject_type="clinician",
+            clinician_id=clinician.id,
+            event_type="license_attested",
+            evidence={"license_id": "X-1"},
+            actor_id=None,
+        )
+        await session.commit()
+
+    async with db_test_session_manager() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(Verification).filter(
+                        Verification.clinician_id == clinician.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].event_type == "license_attested"
+        assert rows[0].evidence == {"license_id": "X-1"}
+
+        audits = (
+            (
+                await session.execute(
+                    select(AuditLog).filter(AuditLog.resource_id == verification.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audits) == 1
+
+
+async def test_record_event_org_appends_row(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    org = await _seed_org(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        await record_verification_event(
+            verification_repo=VerificationRepository(session),
+            audit_repo=AuditRepository(session),
+            subject_type="organization",
+            org_id=org.id,
+            event_type="authority_proven",
+            actor_id=None,
+        )
+        await session.commit()
+
+    async with db_test_session_manager() as session:
+        row = (
+            (
+                await session.execute(
+                    select(Verification).filter(Verification.org_id == org.id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert row.event_type == "authority_proven"
+        assert row.subject_type == "organization"
+        assert row.clinician_id is None
+
+
+async def test_record_event_xor_check(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Passing both `clinician_id` and `org_id` (or neither) is a
+    handler-level misuse — fail loudly in Python before the DB check
+    fires."""
+    clinician = await _seed_clinician_only(db_test_session_manager)
+    org = await _seed_org(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        with pytest.raises(ValueError, match="exactly one"):
+            await record_verification_event(
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                subject_type="clinician",
+                clinician_id=clinician.id,
+                org_id=org.id,
+                event_type="admin_verify",
+                actor_id=None,
+            )
+        with pytest.raises(ValueError, match="exactly one"):
+            await record_verification_event(
+                verification_repo=VerificationRepository(session),
+                audit_repo=AuditRepository(session),
+                subject_type="clinician",
+                event_type="admin_verify",
+                actor_id=None,
+            )

--- a/src/domain/logic/verifications/test_handlers_phase3.py
+++ b/src/domain/logic/verifications/test_handlers_phase3.py
@@ -1,12 +1,5 @@
-"""Phase-3 tests for the verification cluster extension:
+"""Phase-3 pipeline tests for the verification cluster:
 
-- `recompute_clinician_claim(clinician)` — pure function: Claim-A cache
-  recompute from `npi_match_status` + active licensures.
-- `recompute_org_claim(org)` — pure function: Claim-B prereq cache from
-  `npi_match_status`.
-- `record_verification_event(...)` — append-only writer for the non-NPPES
-  §9 transitions (license_attested / authority_proven / admin_verify /
-  etc.) with the matching audit row.
 - `run_org_verification(...)` — Type-2 NPPES pipeline, mocked via
   `httpx.MockTransport`.
 - `nppes_lookup_type2(...)` directly — fixture-driven happy path +
@@ -16,25 +9,22 @@
 + `verified_at` + `ever_verified_at` are also pinned here (Phase 3 added
 the cache write-through; the existing handler-tests file pins the row
 shape but not the side effects).
+
+The recompute helpers and `record_verification_event` moved to
+`test_events.py` — those tests don't need HTTP mocks or LEIE fixtures.
 """
 
 import json
-from datetime import datetime, timezone
 from typing import Any
-from uuid import uuid4
 
 import httpx
 import pytest
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.logic.clinicians.repository import ClinicianRepository
 from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.verifications import oig as oig_module
 from src.domain.logic.verifications.handlers import (
-    recompute_clinician_claim,
-    recompute_org_claim,
-    record_verification_event,
     run_clinician_verification,
     run_org_verification,
 )
@@ -44,9 +34,7 @@ from src.domain.models import (
     Clinician,
     ClinicianLicensure,
     Organization,
-    Verification,
 )
-from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
 from tests.helpers import (
     create_test_user,
@@ -55,8 +43,7 @@ from tests.helpers import (
 )
 
 # `pytest.mark.asyncio` applied per-async-function rather than at module
-# scope — half the tests here are pure synchronous functions
-# (`recompute_*_claim`) and would warn under a blanket pytestmark.
+# scope — the cache write-through test seeds data synchronously first.
 
 
 @pytest.fixture(autouse=True)
@@ -109,281 +96,6 @@ def _type2_payload(
             }
         ]
     }
-
-
-# ---------- recompute_clinician_claim ------------------------------------
-
-
-def test_recompute_clinician_claim_requires_matched_npi_and_active_license():
-    """Matched NPI without any active license → False."""
-    clinician = Clinician(
-        id=uuid4(),
-        owner_id=uuid4(),
-        npi="1234567890",
-        first_name="Eva",
-        last_name="Stone",
-    )
-    clinician.npi_match_status = "matched"
-    clinician.clinician_verified = False
-    clinician.licensures = [
-        ClinicianLicensure(
-            clinician_id=clinician.id,
-            license_type="lcsw",
-            license_number="X-1",
-            issuing_state="IL",
-            status="pending",
-        )
-    ]
-    recompute_clinician_claim(clinician)
-    assert clinician.clinician_verified is False
-
-
-def test_recompute_clinician_claim_active_license_without_matched_npi_false():
-    """Active license without matched NPI → False."""
-    clinician = Clinician(
-        id=uuid4(), owner_id=uuid4(), first_name="Eva", last_name="Stone"
-    )
-    clinician.npi_match_status = "pending"
-    clinician.clinician_verified = False
-    clinician.licensures = [
-        ClinicianLicensure(
-            clinician_id=clinician.id,
-            license_type="lcsw",
-            license_number="X-1",
-            issuing_state="IL",
-            status="active",
-        )
-    ]
-    recompute_clinician_claim(clinician)
-    assert clinician.clinician_verified is False
-
-
-def test_recompute_clinician_claim_happy_path():
-    clinician = Clinician(
-        id=uuid4(),
-        owner_id=uuid4(),
-        npi="1234567890",
-        first_name="Eva",
-        last_name="Stone",
-    )
-    clinician.npi_match_status = "matched"
-    clinician.clinician_verified = False
-    clinician.verified_at = None
-    clinician.ever_verified_at = None
-    clinician.licensures = [
-        ClinicianLicensure(
-            clinician_id=clinician.id,
-            license_type="lcsw",
-            license_number="X-1",
-            issuing_state="IL",
-            status="active",
-        )
-    ]
-    recompute_clinician_claim(clinician)
-    assert clinician.clinician_verified is True
-    assert clinician.verified_at is not None
-    assert clinician.ever_verified_at is not None
-
-
-def test_recompute_clinician_claim_preserves_ever_verified_at_on_regression():
-    """A clinician who was previously verified and now isn't (license
-    expired) must keep `ever_verified_at` set — that's what the
-    `can_read_full_feed` retention rule reads."""
-    historic = datetime(2025, 6, 1, tzinfo=timezone.utc)
-    clinician = Clinician(id=uuid4(), owner_id=uuid4())
-    clinician.npi_match_status = "matched"
-    clinician.clinician_verified = True
-    clinician.verified_at = historic
-    clinician.ever_verified_at = historic
-    clinician.licensures = [
-        ClinicianLicensure(
-            clinician_id=clinician.id,
-            license_type="lcsw",
-            license_number="X-1",
-            issuing_state="IL",
-            status="expired",
-        )
-    ]
-    recompute_clinician_claim(clinician)
-    assert clinician.clinician_verified is False
-    assert clinician.ever_verified_at == historic
-
-
-# ---------- recompute_org_claim ------------------------------------------
-
-
-def test_recompute_org_claim_matched_flips_true():
-    org = Organization(
-        id=uuid4(),
-        owner_id=uuid4(),
-        name="Acme",
-        type="clinic",
-        root_org_id=uuid4(),
-    )
-    org.npi_match_status = "matched"
-    org.org_verified = False
-    org.verified_at = None
-    recompute_org_claim(org)
-    assert org.org_verified is True
-    assert org.verified_at is not None
-
-
-def test_recompute_org_claim_pending_keeps_false():
-    org = Organization(
-        id=uuid4(),
-        owner_id=uuid4(),
-        name="Acme",
-        type="clinic",
-        root_org_id=uuid4(),
-    )
-    org.npi_match_status = "pending"
-    org.org_verified = False
-    recompute_org_claim(org)
-    assert org.org_verified is False
-
-
-def test_recompute_org_claim_regression_clears_verified():
-    org = Organization(
-        id=uuid4(),
-        owner_id=uuid4(),
-        name="Acme",
-        type="clinic",
-        root_org_id=uuid4(),
-    )
-    org.npi_match_status = "mismatch"  # admin closed a soft mismatch
-    org.org_verified = True
-    recompute_org_claim(org)
-    assert org.org_verified is False
-
-
-# ---------- record_verification_event ------------------------------------
-
-
-async def _seed_clinician_only(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-) -> Clinician:
-    owner = create_test_user(username=f"owner-{uuid4()}")
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(owner)
-            clinician = make_clinician_with_org(owner_id=owner.id, npi="1234567890")
-            session.add(clinician)
-    return clinician
-
-
-async def _seed_org(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-) -> Organization:
-    user = create_test_user(username=f"orgowner-{uuid4()}")
-    org = make_organization_row(owner_id=user.id, name="Acme")
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(user)
-            session.add(org)
-    return org
-
-
-async def test_record_event_clinician_appends_row_and_audit(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-):
-    clinician = await _seed_clinician_only(db_test_session_manager)
-    async with db_test_session_manager() as session:
-        verification = await record_verification_event(
-            verification_repo=VerificationRepository(session),
-            audit_repo=AuditRepository(session),
-            subject_type="clinician",
-            clinician_id=clinician.id,
-            event_type="license_attested",
-            evidence={"license_id": "X-1"},
-            actor_id=None,
-        )
-        await session.commit()
-
-    async with db_test_session_manager() as session:
-        rows = (
-            (
-                await session.execute(
-                    select(Verification).filter(
-                        Verification.clinician_id == clinician.id
-                    )
-                )
-            )
-            .scalars()
-            .all()
-        )
-        assert len(rows) == 1
-        assert rows[0].event_type == "license_attested"
-        assert rows[0].evidence == {"license_id": "X-1"}
-
-        audits = (
-            (
-                await session.execute(
-                    select(AuditLog).filter(AuditLog.resource_id == verification.id)
-                )
-            )
-            .scalars()
-            .all()
-        )
-        assert len(audits) == 1
-
-
-async def test_record_event_org_appends_row(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-):
-    org = await _seed_org(db_test_session_manager)
-    async with db_test_session_manager() as session:
-        await record_verification_event(
-            verification_repo=VerificationRepository(session),
-            audit_repo=AuditRepository(session),
-            subject_type="organization",
-            org_id=org.id,
-            event_type="authority_proven",
-            actor_id=None,
-        )
-        await session.commit()
-
-    async with db_test_session_manager() as session:
-        row = (
-            (
-                await session.execute(
-                    select(Verification).filter(Verification.org_id == org.id)
-                )
-            )
-            .scalars()
-            .first()
-        )
-        assert row.event_type == "authority_proven"
-        assert row.subject_type == "organization"
-        assert row.clinician_id is None
-
-
-async def test_record_event_xor_check(
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-):
-    """Passing both `clinician_id` and `org_id` (or neither) is a
-    handler-level misuse — fail loudly in Python before the DB check
-    fires."""
-    clinician = await _seed_clinician_only(db_test_session_manager)
-    org = await _seed_org(db_test_session_manager)
-    async with db_test_session_manager() as session:
-        with pytest.raises(ValueError, match="exactly one"):
-            await record_verification_event(
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
-                subject_type="clinician",
-                clinician_id=clinician.id,
-                org_id=org.id,
-                event_type="admin_verify",
-                actor_id=None,
-            )
-        with pytest.raises(ValueError, match="exactly one"):
-            await record_verification_event(
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
-                subject_type="clinician",
-                event_type="admin_verify",
-                actor_id=None,
-            )
 
 
 # ---------- run_org_verification -----------------------------------------

--- a/src/domain/routes/verifications.py
+++ b/src/domain/routes/verifications.py
@@ -35,10 +35,8 @@ from src.domain.logic.organizations.repository import (
     OrganizationRepository,
     get_organization_repository,
 )
-from src.domain.logic.verifications.handlers import (
-    handle_create_clinician_verification,
-    record_verification_event,
-)
+from src.domain.logic.verifications.events import record_verification_event
+from src.domain.logic.verifications.handlers import handle_create_clinician_verification
 from src.domain.logic.verifications.repository import (
     VerificationRepository,
     get_verification_repository,


### PR DESCRIPTION
## What was mixed together

`verifications/handlers.py` contained three distinct concerns:

1. **NPPES pipeline** (`run_clinician_verification`, `run_org_verification`, and their admin-retrigger wrappers) — async, HTTP, full DB transaction.
2. **Claim-cache recompute helpers** (`recompute_clinician_claim`, `recompute_org_claim`) — nearly pure functions (no I/O; mutate their argument in place, caller commits).
3. **Append-only event writer** (`record_verification_event`) — async DB writes for the non-NPPES §9 transitions (licensure attestation, authority grant/revoke, admin override).

## The new boundary

- `handlers.py` — NPPES pipeline only. Imports the recompute helpers from `events.py` to keep the denorm cache write-through in one place.
- `events.py` (new) — `recompute_clinician_claim`, `recompute_org_claim`, `record_verification_event`.

## Why `recompute_*` and `record_verification_event` belong in `events.py`

Both are called by callers **outside** the NPPES pipeline:

- `clinicians/handlers.py` calls `recompute_clinician_claim` + `record_verification_event` when a licensure state changes.
- `org_representations/handlers.py` calls `record_verification_event` when an authority method resolves.

Having those callers import from `handlers.py` forced them to pull in the NPPES / httpx dependency chain unnecessarily. `events.py` has no HTTP imports — only `VerificationRepository`, `AuditRepository`, and the domain models.

## Changes

- New `src/domain/logic/verifications/events.py` — extracted functions + their private `_now()` helper.
- Slimmed `handlers.py` — imports `recompute_*` / `VERIFICATION_RESOURCE` from `events.py`.
- Updated callers: `clinicians/handlers.py`, `org_representations/handlers.py`, `domain/routes/verifications.py`.
- New `test_events.py` — the 7 pure-function / event-writer tests that don't need HTTP mocks or LEIE fixtures.
- `test_handlers_phase3.py` — stripped to the pipeline tests (NPPES mock transport, cache write-through).
- `verifications/README.md` — updated file list to document both modules.

No function signatures, logic, or behavior changed.

## Test plan

- [x] `dev test src/domain/logic/verifications/ src/domain/logic/clinicians/ src/domain/logic/org_representations/` — 191 passed
- [x] `dev lint` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)