### PR TITLE
feat: after_create hook on EntitySpec (framework)

### DIFF
--- a/src/domain/logic/org_representations/handlers.py
+++ b/src/domain/logic/org_representations/handlers.py
@@ -1,51 +1,59 @@
-"""Handlers for `OrgRepresentation` create + state-axis dispatch.
+"""Handlers for `OrgRepresentation` create dispatch + state-axis.
 
-Two bespoke handlers here:
+The create path uses the framework's generic factory plus two spec
+hooks:
 
-1. **`handle_create_org_representation`** — POST `/org_representations`.
-   Dispatches on `payload.authority_method` per handoff §6:
+1. **`validate_org_representation_payload`** — `payload_authz_path`.
+   Runs after `write_authz`, before model construction. Enforces the
+   per-`authority_method` preconditions:
 
    - ``authorized_official`` — NPPES Authorized-Official name-match.
-     Compares the org's cached `authorized_official_name` to the
-     requesting user's verified `Clinician` legal name; on match the
-     row lands at `authority_status='verified'` and a `Verification`
-     event of type `authority_proven` is recorded. No match → 400.
-   - ``rep_approval`` — invite-driven. `approved_by` must point at a
-     verified non-archived rep on the same org. Row lands at
-     `authority_status='pending'`; the approver flips it via the
-     `authority` state axis.
-   - ``domain_email`` — v1 stub: 400 "not yet enabled". The enum
-     value is shipped so the schema/UI stays coherent; full build-out
-     needs an `OrganizationDomain` table + email-at-domain
-     verification flow.
-   - ``admin_review`` — fallback. Row lands at `authority_status='pending'`.
+     The org's cached `authorized_official_name` is compared to the
+     requesting user's verified `Clinician` legal name; no match → 400.
+   - ``rep_approval`` — requires the requesting user to be an existing
+     verified rep of the org (admin bypass).
+   - ``domain_email`` — v1 stub: 400 "not yet enabled".
+   - ``admin_review`` — no precondition; passes through.
 
-2. **`handle_set_org_representation_authority`** — PUT
-   `/org_representations/{id}/authority`. Admin override (or
-   rep-approval approver, in a follow-up) flips `authority_status`.
+   Also enforces the cross-cutting "can't create for someone else"
+   rule.
 
-The generic `mount_entity` create handler is opted out
-(`routes.create=False` on the spec) so this bespoke create owns the
-post path. Update / delete continue to flow through the generic
-handlers.
+2. **`after_create_org_representation`** — `after_create_path`. Runs
+   after persistence, inside the framework's `mutate(...)` transaction
+   so its mutations land in the audit `after` snapshot. Per
+   `authority_method`:
+
+   - ``authorized_official`` / ``rep_approval`` → flip
+     `authority_status='verified'` (+ `approved_by` for rep_approval),
+     append a `Verification` event of type `authority_proven`.
+   - ``admin_review`` → leave at `pending` (default).
+
+The two-hook split keeps validation and side effects separate, and
+both run from the generic create path — no bespoke route handler
+needed.
+
+3. **`handle_set_org_representation_authority`** — PUT
+   `/org_representations/{id}/authority`. Admin override flips
+   `authority_status`. Unchanged.
 """
 
 import logging
 from uuid import UUID
+
+from pydantic import BaseModel
 
 from src.domain.logic.org_representations.repository import (
     OrgRepresentationRepository,
 )
 from src.domain.logic.org_representations.schema import (
     OrgRepresentationAuthorityUpdate,
-    OrgRepresentationCreate,
 )
 from src.domain.logic.verifications.handlers import record_verification_event
 from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.logic.verifications.scoring import _name_similarity
 from src.domain.models import Organization, OrgRepresentation, User
 from src.domain.specs.org_representation import ORG_REPRESENTATION_ENTITY
-from src.framework.audit.core import record_audit, record_audit_for
+from src.framework.audit.core import record_audit
 from src.framework.audit.repository import AuditRepository
 from src.framework.http.exceptions import (
     BadRequestError,
@@ -55,18 +63,13 @@ from src.framework.http.exceptions import (
 
 logger = logging.getLogger(__name__)
 
-# Same threshold the clinician-side NPPES name match uses. Keeping a
-# module-local constant avoids reading through `scoring._NAME_MATCH_THRESHOLD`
-# (a private symbol) at the handler boundary; if the clinician threshold
-# changes we can re-anchor here.
+# Same threshold the clinician-side NPPES name match uses.
 _AO_NAME_MATCH_THRESHOLD = 0.80
 
 
 def _verified_clinician_full_name(user: User) -> str | None:
     """First-verified Clinician's `<first> <last>` form, or None if the
-    user has no `clinician_verified=True` row with both names. The
-    `authorized_official` path matches this against the org's cached
-    `authorized_official_name`."""
+    user has no `clinician_verified=True` row with both names."""
     for c in getattr(user, "clinicians", None) or ():
         if not getattr(c, "clinician_verified", False):
             continue
@@ -77,35 +80,27 @@ def _verified_clinician_full_name(user: User) -> str | None:
     return None
 
 
-async def handle_create_org_representation(
-    payload: OrgRepresentationCreate,
-    repo: OrgRepresentationRepository,
-    verification_repo: VerificationRepository,
-    audit_repo: AuditRepository,
+async def validate_org_representation_payload(
+    *,
+    payload: BaseModel,
     requesting_user: User,
-) -> OrgRepresentation:
-    """Create a new `OrgRepresentation` row. Authority-method dispatch
-    sets the initial `authority_status` + `approved_by`; the row is
-    persisted, audited, and (for the auto-verify happy path) a
-    `Verification` event is appended in the same transaction.
+    org_rep_repo: OrgRepresentationRepository,
+) -> None:
+    """`payload_authz_path` target — per-`authority_method` precondition
+    checks. Raises `ForbiddenError` / `BadRequestError` / `NotFoundError`
+    on rejection; returns `None` on success.
 
-    Authz: the requesting user must own the row they're creating
-    (`payload.user_id` == requesting_user.id) or be admin. The
-    target Organization must exist; the user must have appropriate
-    standing for the authority method.
+    Loads the target Organization here (not in `after_create`) so the
+    AO name-match runs before the row is persisted — fails fast.
     """
     if payload.user_id != requesting_user.id and not requesting_user.is_superuser:
         raise ForbiddenError(
             detail="Cannot create an org representation for another user"
         )
 
-    org = await repo.get_by_model_id(Organization, payload.org_id)
+    org = await org_rep_repo.get_by_model_id(Organization, payload.org_id)
     if org is None:
         raise NotFoundError(detail="Organization not found")
-
-    initial_status = "pending"
-    approved_by: UUID | None = None
-    verification_event: str | None = None
 
     if payload.authority_method == "authorized_official":
         if not org.authorized_official_name:
@@ -134,11 +129,8 @@ async def handle_create_org_representation(
                     "method (e.g. admin_review)."
                 )
             )
-        initial_status = "verified"
-        verification_event = "authority_proven"
 
     elif payload.authority_method == "domain_email":
-        # v1 stub — the enum value ships so the schema/UI stay coherent.
         raise BadRequestError(
             detail=(
                 "The domain_email authority path is not yet enabled. "
@@ -147,14 +139,7 @@ async def handle_create_org_representation(
         )
 
     elif payload.authority_method == "rep_approval":
-        # An existing verified rep approves the new one. The Profile Hub
-        # invite flow sets `approved_by` to the approver's user_id; the
-        # request must come FROM the approver (or admin) so an
-        # unauthorized user can't claim someone else's approval.
-        # `approved_by` is server-set here from `requesting_user.id`
-        # rather than read from the payload schema (which doesn't expose
-        # it) — the requesting user IS the approver in this flow.
-        approver_reps = await repo.list_verified_for_org(payload.org_id)
+        approver_reps = await org_rep_repo.list_verified_for_org(payload.org_id)
         if not any(r.user_id == requesting_user.id for r in approver_reps):
             if not requesting_user.is_superuser:
                 raise ForbiddenError(
@@ -164,39 +149,47 @@ async def handle_create_org_representation(
                         "new rep."
                     )
                 )
-        approved_by = requesting_user.id
-        # Approver-driven approvals land at `verified` directly — the
-        # approver IS the gate.
-        initial_status = "verified"
+
+    # `admin_review` passes through; the row will land at pending.
+
+
+async def after_create_org_representation(
+    *,
+    row: OrgRepresentation,
+    payload: BaseModel,
+    requesting_user: User,
+    verification_repo: VerificationRepository,
+    audit_repo_dep: AuditRepository,
+) -> None:
+    """`after_create_path` target — post-persist dispatch on
+    `payload.authority_method`. Mutates the row's `authority_status`
+    and (for `rep_approval`) `approved_by`; appends a `Verification`
+    event for the auto-verified paths.
+
+    Runs inside the framework's `mutate(...)` create transaction. Row
+    mutations here land in the audit `after` snapshot; the
+    `Verification` event lands in the same transaction so the audit +
+    verification rows commit atomically.
+
+    The hook DOES NOT re-run validation — that's
+    `validate_org_representation_payload`'s job. By the time we get
+    here, the payload is known-good.
+    """
+    if payload.authority_method == "authorized_official":
+        row.authority_status = "verified"
         verification_event = "authority_proven"
+    elif payload.authority_method == "rep_approval":
+        row.authority_status = "verified"
+        row.approved_by = requesting_user.id
+        verification_event = "authority_proven"
+    else:
+        # `admin_review` → leave at the default `pending`.
+        verification_event = None
 
-    elif payload.authority_method == "admin_review":
-        # Land at pending; admin closes the loop via the `authority`
-        # state axis.
-        initial_status = "pending"
-
-    new_row = OrgRepresentation(
-        user_id=payload.user_id,
-        org_id=payload.org_id,
-        role=payload.role,
-        authority_method=payload.authority_method,
-        authority_status=initial_status,
-        approved_by=approved_by,
-    )
-    new_row = await repo._persist_new(new_row)
-    await record_audit_for(
-        audit_repo,
-        resource=ORG_REPRESENTATION_ENTITY.audit,
-        verb="create",
-        actor_id=requesting_user.id,
-        target_id=new_row.id,
-        before=None,
-        after=ORG_REPRESENTATION_ENTITY.audit.snapshot(new_row),
-    )
     if verification_event is not None:
         await record_verification_event(
             verification_repo=verification_repo,
-            audit_repo=audit_repo,
+            audit_repo=audit_repo_dep,
             subject_type="organization",
             org_id=payload.org_id,
             event_type=verification_event,
@@ -207,16 +200,14 @@ async def handle_create_org_representation(
             },
             actor_id=requesting_user.id,
         )
-    await repo.session.commit()
     logger.info(
-        "org_representation.create: id=%s user=%s org=%s method=%s status=%s",
-        new_row.id,
+        "org_representation.after_create: id=%s user=%s org=%s method=%s status=%s",
+        row.id,
         payload.user_id,
         payload.org_id,
         payload.authority_method,
-        initial_status,
+        row.authority_status,
     )
-    return new_row
 
 
 async def handle_set_org_representation_authority(

--- a/src/domain/logic/org_representations/test_handlers.py
+++ b/src/domain/logic/org_representations/test_handlers.py
@@ -1,4 +1,4 @@
-"""Tests for `handle_create_org_representation` authority-method dispatch.
+"""Tests for `OrgRepresentation` create dispatch (validate + after_create).
 
 Per handoff §6 the create-time logic differs by `authority_method`:
 
@@ -10,11 +10,17 @@ Per handoff §6 the create-time logic differs by `authority_method`:
   verified rep on the same org; row lands at ``verified``.
 * ``admin_review`` — row lands at ``pending``.
 
-These tests exercise the dispatch directly (handler-level), pinning
-each branch's initial `authority_status` + `approved_by` + the
-`Verification` event side effect. The route-level happy path is
-covered separately in `routes/test_org_representations.py` (added in
-the follow-up).
+The dispatch is split across two spec hooks:
+
+* `validate_org_representation_payload` (`payload_authz_path`) runs
+  pre-persistence and raises on rejection.
+* `after_create_org_representation` (`after_create_path`) runs post-
+  persistence and mutates the row's `authority_status` + `approved_by`
+  + records the `Verification` event.
+
+These tests exercise each hook directly. The route-level happy path
+flowing through the framework's generic create handler is covered
+separately in `routes/test_org_representations.py`.
 """
 
 from __future__ import annotations
@@ -24,7 +30,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.logic.org_representations.handlers import (
-    handle_create_org_representation,
+    after_create_org_representation,
+    validate_org_representation_payload,
 )
 from src.domain.logic.org_representations.repository import (
     OrgRepresentationRepository,
@@ -32,8 +39,8 @@ from src.domain.logic.org_representations.repository import (
 from src.domain.logic.org_representations.schema import OrgRepresentationCreate
 from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.models import (
-    Clinician,
     Organization,
+    OrgRepresentation,
     User,
     Verification,
 )
@@ -74,7 +81,7 @@ async def _seed_verified_clinician(
     owner_id,
     first: str,
     last: str,
-) -> Clinician:
+):
     async with db_test_session_manager() as session:
         async with session.begin():
             clinician = make_clinician_with_org(
@@ -86,7 +93,34 @@ async def _seed_verified_clinician(
             clinician.clinician_verified = True
             clinician.npi_match_status = "matched"
             session.add(clinician)
-    return clinician
+
+
+async def _persist_and_run_after_create(
+    db_test_session_manager,
+    payload: OrgRepresentationCreate,
+    requesting_user: User,
+) -> OrgRepresentation:
+    """End-to-end runner mirroring what the framework's generic
+    create+after_create flow does, but in-process so the tests can
+    introspect the row + Verification side effects."""
+    async with db_test_session_manager() as session:
+        new_row = OrgRepresentation(
+            user_id=payload.user_id,
+            org_id=payload.org_id,
+            role=payload.role,
+            authority_method=payload.authority_method,
+        )
+        repo = OrgRepresentationRepository(session)
+        persisted = await repo._persist_new(new_row)
+        await after_create_org_representation(
+            row=persisted,
+            payload=payload,
+            requesting_user=requesting_user,
+            verification_repo=VerificationRepository(session),
+            audit_repo_dep=AuditRepository(session),
+        )
+        await session.commit()
+        return persisted
 
 
 # ---------- admin_review (the simplest, default path) -------------------
@@ -103,13 +137,14 @@ async def test_admin_review_lands_at_pending(
         authority_method="admin_review",
     )
     async with db_test_session_manager() as session:
-        new_row = await handle_create_org_representation(
+        await validate_org_representation_payload(
             payload=payload,
-            repo=OrgRepresentationRepository(session),
-            verification_repo=VerificationRepository(session),
-            audit_repo=AuditRepository(session),
             requesting_user=user,
+            org_rep_repo=OrgRepresentationRepository(session),
         )
+    new_row = await _persist_and_run_after_create(
+        db_test_session_manager, payload, user
+    )
     assert new_row.authority_status == "pending"
     assert new_row.approved_by is None
 
@@ -124,12 +159,8 @@ async def test_authorized_official_happy_path(
         db_test_session_manager, org_ao_name="Jane Doe"
     )
     await _seed_verified_clinician(
-        db_test_session_manager,
-        owner_id=user.id,
-        first="Jane",
-        last="Doe",
+        db_test_session_manager, owner_id=user.id, first="Jane", last="Doe"
     )
-    # Refresh `user.clinicians` by reloading the user from the DB.
     async with db_test_session_manager() as session:
         reloaded_user = await session.get(User, user.id)
         payload = OrgRepresentationCreate(
@@ -138,16 +169,16 @@ async def test_authorized_official_happy_path(
             role="owner",
             authority_method="authorized_official",
         )
-        new_row = await handle_create_org_representation(
+        await validate_org_representation_payload(
             payload=payload,
-            repo=OrgRepresentationRepository(session),
-            verification_repo=VerificationRepository(session),
-            audit_repo=AuditRepository(session),
             requesting_user=reloaded_user,
+            org_rep_repo=OrgRepresentationRepository(session),
         )
-        # AO name match → row lands at verified + a Verification event of
-        # type `authority_proven` is appended.
-        assert new_row.authority_status == "verified"
+    new_row = await _persist_and_run_after_create(
+        db_test_session_manager, payload, reloaded_user
+    )
+    assert new_row.authority_status == "verified"
+    async with db_test_session_manager() as session:
         events = (
             (
                 await session.execute(
@@ -184,12 +215,10 @@ async def test_authorized_official_rejects_name_mismatch(
             authority_method="authorized_official",
         )
         with pytest.raises(BadRequestError, match="Authorized Official"):
-            await handle_create_org_representation(
+            await validate_org_representation_payload(
                 payload=payload,
-                repo=OrgRepresentationRepository(session),
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
                 requesting_user=reloaded_user,
+                org_rep_repo=OrgRepresentationRepository(session),
             )
 
 
@@ -197,14 +226,10 @@ async def test_authorized_official_requires_org_ao_name_cached(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
     """The org's Type-2 NPI must have been verified first so NPPES has
-    populated `authorized_official_name`. Without it the AO path can't
-    even start."""
+    populated `authorized_official_name`."""
     user, org = await _seed_user_and_org(db_test_session_manager)  # no AO name
     await _seed_verified_clinician(
-        db_test_session_manager,
-        owner_id=user.id,
-        first="Jane",
-        last="Doe",
+        db_test_session_manager, owner_id=user.id, first="Jane", last="Doe"
     )
     async with db_test_session_manager() as session:
         reloaded_user = await session.get(User, user.id)
@@ -215,12 +240,10 @@ async def test_authorized_official_requires_org_ao_name_cached(
             authority_method="authorized_official",
         )
         with pytest.raises(BadRequestError, match="no cached Authorized Official"):
-            await handle_create_org_representation(
+            await validate_org_representation_payload(
                 payload=payload,
-                repo=OrgRepresentationRepository(session),
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
                 requesting_user=reloaded_user,
+                org_rep_repo=OrgRepresentationRepository(session),
             )
 
 
@@ -241,12 +264,10 @@ async def test_authorized_official_requires_verified_clinician(
             authority_method="authorized_official",
         )
         with pytest.raises(BadRequestError, match="verified clinician profile"):
-            await handle_create_org_representation(
+            await validate_org_representation_payload(
                 payload=payload,
-                repo=OrgRepresentationRepository(session),
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
                 requesting_user=reloaded_user,
+                org_rep_repo=OrgRepresentationRepository(session),
             )
 
 
@@ -265,12 +286,10 @@ async def test_domain_email_returns_not_yet_enabled(
     )
     async with db_test_session_manager() as session:
         with pytest.raises(BadRequestError, match="not yet enabled"):
-            await handle_create_org_representation(
+            await validate_org_representation_payload(
                 payload=payload,
-                repo=OrgRepresentationRepository(session),
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
                 requesting_user=user,
+                org_rep_repo=OrgRepresentationRepository(session),
             )
 
 
@@ -281,8 +300,7 @@ async def test_rep_approval_requires_existing_verified_rep_on_org(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
     """The requesting user must already be a verified rep on the target
-    org (or be admin). Otherwise the system would let any authed user
-    self-approve."""
+    org (or be admin)."""
     user, org = await _seed_user_and_org(db_test_session_manager)
     payload = OrgRepresentationCreate(
         user_id=user.id,
@@ -292,12 +310,10 @@ async def test_rep_approval_requires_existing_verified_rep_on_org(
     )
     async with db_test_session_manager() as session:
         with pytest.raises(ForbiddenError, match="existing verified representative"):
-            await handle_create_org_representation(
+            await validate_org_representation_payload(
                 payload=payload,
-                repo=OrgRepresentationRepository(session),
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
                 requesting_user=user,
+                org_rep_repo=OrgRepresentationRepository(session),
             )
 
 
@@ -317,14 +333,16 @@ async def test_rep_approval_admin_bypass(
         authority_method="rep_approval",
     )
     async with db_test_session_manager() as session:
-        new_row = await handle_create_org_representation(
+        await validate_org_representation_payload(
             payload=payload,
-            repo=OrgRepresentationRepository(session),
-            verification_repo=VerificationRepository(session),
-            audit_repo=AuditRepository(session),
             requesting_user=admin,
+            org_rep_repo=OrgRepresentationRepository(session),
         )
-        assert new_row.authority_status == "verified"
+    new_row = await _persist_and_run_after_create(
+        db_test_session_manager, payload, admin
+    )
+    assert new_row.authority_status == "verified"
+    assert new_row.approved_by == admin.id
 
 
 # ---------- general authz / 404 -----------------------------------------
@@ -339,19 +357,17 @@ async def test_user_cant_create_rep_for_someone_else(
         async with session.begin():
             session.add(other)
     payload = OrgRepresentationCreate(
-        user_id=other.id,  # NOT requesting_user
+        user_id=other.id,
         org_id=org.id,
         role="coordinator",
         authority_method="admin_review",
     )
     async with db_test_session_manager() as session:
         with pytest.raises(ForbiddenError, match="another user"):
-            await handle_create_org_representation(
+            await validate_org_representation_payload(
                 payload=payload,
-                repo=OrgRepresentationRepository(session),
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
                 requesting_user=user,
+                org_rep_repo=OrgRepresentationRepository(session),
             )
 
 
@@ -372,10 +388,8 @@ async def test_404_for_missing_org(
     )
     async with db_test_session_manager() as session:
         with pytest.raises(NotFoundError):
-            await handle_create_org_representation(
+            await validate_org_representation_payload(
                 payload=payload,
-                repo=OrgRepresentationRepository(session),
-                verification_repo=VerificationRepository(session),
-                audit_repo=AuditRepository(session),
                 requesting_user=user,
+                org_rep_repo=OrgRepresentationRepository(session),
             )

--- a/src/domain/routes/org_representations.py
+++ b/src/domain/routes/org_representations.py
@@ -1,69 +1,17 @@
 """Route mount for `OrgRepresentation` — User↔Org authority (Claim B).
 
-`mount_entity(ORG_REPRESENTATION_ENTITY)` mounts the framework's
-generic update / delete / state-axis handlers per the spec. POST
-`/org_representations` is bespoke (the spec opts out of the generic
-create via `routes.create=False`) so the per-authority-method dispatch
-in `handle_create_org_representation` owns row construction — every
-row gets the right initial `authority_status` instead of always
-landing at `'pending'`.
+Thin spec-driven mount. The spec declares `payload_authz_path` and
+`after_create_path` so the framework's generic create handler does the
+right per-authority-method dispatch (auto-verify, append Verification
+event) — no bespoke route handler needed. State-axis and update/delete
+flow through `mount_entity` unchanged.
 """
 
-from typing import Any
-
-from fastapi import Depends, status
-
-from src.auth_config import current_active_user
-from src.domain.logic.org_representations.handlers import (
-    handle_create_org_representation,
-)
-from src.domain.logic.org_representations.repository import (
-    OrgRepresentationRepository,
-    get_org_representation_repository,
-)
-from src.domain.logic.org_representations.schema import OrgRepresentationCreate
-from src.domain.logic.verifications.repository import (
-    VerificationRepository,
-    get_verification_repository,
-)
-from src.domain.models import User
 from src.domain.specs.org_representation import ORG_REPRESENTATION_ENTITY
 from src.framework import register_entity
-from src.framework.audit.repository import AuditRepository
 from src.framework.dispatch.resource_routes import mount_entity
-from src.framework.persistence.dependencies import get_audit_repository
 
 router = register_entity(ORG_REPRESENTATION_ENTITY)
-
-
-@router.post(
-    "/org_representations",
-    status_code=status.HTTP_201_CREATED,
-    name="org_representations:create",
-)
-async def create_org_representation(
-    payload: OrgRepresentationCreate,
-    repo: OrgRepresentationRepository = Depends(get_org_representation_repository),
-    verification_repo: VerificationRepository = Depends(get_verification_repository),
-    audit_repo: AuditRepository = Depends(get_audit_repository),
-    requesting_user: User = Depends(current_active_user),
-) -> dict[str, Any]:
-    """POST `/org_representations` — bespoke handler that dispatches on
-    `payload.authority_method`. See
-    `src.domain.logic.org_representations.handlers.handle_create_org_representation`
-    for the per-method contract.
-    """
-    new_row = await handle_create_org_representation(
-        payload=payload,
-        repo=repo,
-        verification_repo=verification_repo,
-        audit_repo=audit_repo,
-        requesting_user=requesting_user,
-    )
-    return {
-        "id": str(new_row.id),
-        "authority_status": new_row.authority_status,
-    }
 
 
 mount_entity(router, ORG_REPRESENTATION_ENTITY)

--- a/src/domain/specs/org_representation.py
+++ b/src/domain/specs/org_representation.py
@@ -12,17 +12,18 @@ the resource is User-owned, not Org-owned, so a `/orgs/{id}/reps`
 shape would be misleading). The `authority` state axis is the
 admin (or rep_approval-approver) override of `authority_status`.
 
-This Phase-1 spec lands the minimum routes the Profile Hub (Phase 5)
-needs: `create` for the goal-led setup flow, `update` for role
-changes, `delete` for hard-revoke admin paths. List/detail/form
-templates land alongside the Profile Hub partials in Phase 5; until
-then the spec opts out of `list` / `detail` / `form_new` / `form_edit`
-so no placeholder template is shipped.
+Creation uses the generic factory plus an `after_create` hook for the
+per-`authority_method` dispatch (auto-verify for `authorized_official`,
+record a `Verification` event, etc.) — see
+`src.domain.logic.org_representations.handlers.after_create_org_representation`.
+The hook runs inside the framework's `mutate(...)` create transaction so
+its mutations land in the audit `after` snapshot.
 """
 
 from typing import Final
 
 from src.domain.logic.org_representations.repository import (
+    OrgRepresentationRepository,
     get_org_representation_repository,
 )
 from src.domain.logic.org_representations.schema import (
@@ -33,8 +34,10 @@ from src.domain.logic.org_representations.schema import (
     OrgRepresentationRead,
     OrgRepresentationUpdate,
 )
+from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.models import OrgRepresentation
 from src.framework.audit.core import AuditAction
+from src.framework.audit.repository import AuditRepository
 from src.framework.dispatch.entity_spec import (
     AUTHENTICATED,
     OWNER_OR_ADMIN,
@@ -59,14 +62,40 @@ ORG_REPRESENTATION_ENTITY: Final[EntitySpec] = EntitySpec(
     update_adapter=OrgRepresentationUpdate,
     read_schema=OrgRepresentationRead,
     audit_snapshot=OrgRepresentationAuditSnapshot,
-    # Phase 1: API surface only. The Profile Hub (Phase 5) renders the
-    # list/detail/form views via its own per-mode partials — no generic
-    # collection page here yet, so we don't ship placeholder templates.
-    # `create=False` opts out of the framework's generic create so the
-    # bespoke `handle_create_org_representation` (which dispatches on
-    # `authority_method`) owns POST `/org_representations`. Update +
-    # delete still flow through the generic factories.
-    routes=RouteSet(update=True, delete=True),
+    # Generic CRUD through the factory; the per-authority_method
+    # dispatch happens in `after_create`. Update + delete are
+    # unchanged.
+    routes=RouteSet(create=True, update=True, delete=True),
+    # Precondition validation: AO name-match check, domain_email stub,
+    # rep_approval-approver check. Raises on rejection.
+    payload_authz_path=(
+        "src.domain.logic.org_representations.handlers."
+        "validate_org_representation_payload"
+    ),
+    payload_authz_repos=(
+        # `repo` is already a framework-reserved signature param on the
+        # create handler; declare under a distinct name and the hook
+        # consumes the same `OrgRepresentationRepository` instance via
+        # FastAPI's per-request injection.
+        ("org_rep_repo", OrgRepresentationRepository),
+    ),
+    # Post-persist dispatch: mutates the just-created row's
+    # `authority_status` + `approved_by` from `payload.authority_method`,
+    # and appends a `Verification` event for auto-verified paths
+    # (`authorized_official`, `rep_approval`). Lands inside the
+    # framework's create transaction so audit + verification rows
+    # commit atomically with the row itself.
+    after_create_path=(
+        "src.domain.logic.org_representations.handlers."
+        "after_create_org_representation"
+    ),
+    after_create_repos=(
+        ("verification_repo", VerificationRepository),
+        # `audit_repo` is reserved by the create-handler factory; bind
+        # under a distinct name so the hook receives its own injected
+        # instance.
+        ("audit_repo_dep", AuditRepository),
+    ),
     state_axes=(
         StateAxis(
             name="authority",

--- a/src/domain/specs/test_org_representation.py
+++ b/src/domain/specs/test_org_representation.py
@@ -24,16 +24,31 @@ def test_auth_deps_authenticated_and_policy_owner_or_admin():
     assert ORG_REPRESENTATION_ENTITY.auth_policy is OWNER_OR_ADMIN
 
 
-def test_routes_update_delete_only_no_collection_views():
-    """API-only routes. `create=False` because the bespoke handler
-    `handle_create_org_representation` (with per-authority-method
-    dispatch) owns POST `/org_representations`; the framework's
-    generic create would land every row at `authority_status='pending'`
-    and miss the `authorized_official` auto-verify happy path."""
+def test_routes_crud_only_no_collection_views():
+    """API-only routes. Generic create is back (`create=True`) — the
+    spec uses `payload_authz_path` + `after_create_path` for the per-
+    `authority_method` dispatch (auto-verify, append Verification
+    event). List/detail/form views still belong to the Profile Hub."""
     r = ORG_REPRESENTATION_ENTITY.routes
-    assert r.create is False
-    assert (r.update, r.delete) == (True, True)
+    assert (r.create, r.update, r.delete) == (True, True, True)
     assert (r.list, r.detail, r.form_new, r.form_edit) == (False, False, False, False)
+
+
+def test_create_dispatch_hooks_wired():
+    """The two spec hooks together replace the bespoke create handler.
+    `payload_authz_path` validates per-method preconditions;
+    `after_create_path` mutates the just-persisted row + records the
+    Verification event for auto-verified paths. The dotted paths are
+    pinned so a refactor that moves the callables can't silently
+    drift."""
+    assert ORG_REPRESENTATION_ENTITY.payload_authz_path == (
+        "src.domain.logic.org_representations.handlers."
+        "validate_org_representation_payload"
+    )
+    assert ORG_REPRESENTATION_ENTITY.after_create_path == (
+        "src.domain.logic.org_representations.handlers."
+        "after_create_org_representation"
+    )
 
 
 def test_authority_state_axis_wired():

--- a/src/framework/dispatch/entity_spec.py
+++ b/src/framework/dispatch/entity_spec.py
@@ -529,6 +529,37 @@ class EntitySpec:
     payload_authz_path: str | None = None
     payload_authz_repos: tuple[tuple[str, type], ...] = ()
 
+    # `after_create_path` is a dotted import path to an async callable
+    # invoked by `handle_create` AFTER the new row has been persisted
+    # (it has an id) and BEFORE the audit `after`-snapshot is taken.
+    # Use it to dispatch on payload fields and mutate the row's
+    # server-controlled columns (the mutation flushes before the audit
+    # snapshot, so the snapshot reflects the final state) OR to do
+    # side effects in the same transaction (e.g. record a `Verification`
+    # event, send an invite).
+    #
+    # Contract of the callable:
+    #
+    #   async def hook(
+    #       *,
+    #       row: <model>,                   # the just-persisted row
+    #       payload: BaseModel,             # the validated create payload
+    #       requesting_user: User,
+    #       **typed_repos,                  # one kwarg per entry in after_create_repos
+    #   ) -> None:
+    #       ...
+    #
+    # Raises propagate; the framework's `mutate(...)` context manager
+    # rolls back the transaction. The hook is for the factory-built
+    # create path — declaring `after_create_path` alongside an explicit
+    # `handlers["create"]` is rejected at mount time (same precedent as
+    # `payload_authz_path`).
+    #
+    # `after_create_repos` declares typed-repo kwargs the callable
+    # receives. Mirrors `payload_authz_repos` exactly.
+    after_create_path: str | None = None
+    after_create_repos: tuple[tuple[str, type], ...] = ()
+
     # Static context bindings -------------------------------------------
     # Constant key→value pairs that `handle_detail` / `handle_list` merge
     # into the template context after the framework's auto-injected keys
@@ -910,6 +941,19 @@ class EntitySpec:
             raise ValueError(
                 f"EntitySpec({self.name!r}) declares payload_authz_repos but "
                 "no payload_authz_path — the typed-repo kwargs would have "
+                "no consumer."
+            )
+        # `after_create` only fires from `handle_create`; declaring the
+        # path without `routes.create=True` is dead config.
+        if self.after_create_path is not None and not self.routes.create:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares after_create_path but "
+                "routes.create is False — the hook would never run."
+            )
+        if self.after_create_repos and self.after_create_path is None:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares after_create_repos but "
+                "no after_create_path — the typed-repo kwargs would have "
                 "no consumer."
             )
         if self.read_schema is not None:

--- a/src/framework/dispatch/handlers.py
+++ b/src/framework/dispatch/handlers.py
@@ -136,6 +136,8 @@ async def handle_create(
     parent_id: UUID | None = None,
     payload_authz: Callable[..., Awaitable[None]] | None = None,
     payload_authz_kwargs: dict[str, Any] | None = None,
+    after_create: Callable[..., Awaitable[None]] | None = None,
+    after_create_kwargs: dict[str, Any] | None = None,
 ) -> Any:
     """Generic create handler driven by `spec`.
 
@@ -144,7 +146,15 @@ async def handle_create(
     BEFORE the payload is used to build the model. The callable is
     expected to raise `ForbiddenError` / `NotFoundError` on rejection;
     `payload_authz_kwargs` supplies any spec-declared typed repo kwargs.
-    See `EntitySpec.payload_authz_path` for the contract."""
+    See `EntitySpec.payload_authz_path` for the contract.
+
+    `after_create` (if supplied) is invoked AFTER the row has been
+    persisted (it has an id) and BEFORE the audit `after`-snapshot is
+    taken. Use it to mutate the row's server-controlled columns based
+    on the payload, OR to do side effects in the same transaction
+    (e.g. record a `Verification` event). The hook receives `row=`,
+    `payload=`, `requesting_user=`, and `**after_create_kwargs`. See
+    `EntitySpec.after_create_path` for the contract."""
     if spec.audit is None:
         raise ValueError(
             f"handle_create: spec {spec.name!r} has no audit binding; "
@@ -235,7 +245,19 @@ async def handle_create(
         resource=spec.audit,
         verb="create",
     ):
-        pass
+        # `after_create` runs inside the `mutate(...)` block — after
+        # persistence (so the row has an id) and before the audit
+        # `after`-snapshot is taken (so any row mutations the hook
+        # makes are reflected in the snapshot). Raises propagate; the
+        # context manager rolls back the transaction without writing
+        # the audit row.
+        if after_create is not None:
+            await after_create(
+                row=created,
+                payload=payload,
+                requesting_user=requesting_user,
+                **(after_create_kwargs or {}),
+            )
     return created
 
 
@@ -375,6 +397,12 @@ class _FactoryShape:
     # for each declared typed repo, and forwards the resolved callable
     # plus the collected typed-repo dict to the underlying handler.
     payload_authz_call: bool = False
+    # Verbs that route through `after_create` (create only). Mirror of
+    # the `payload_authz_call` plumbing — `_make_factory_handler`
+    # accepts optional `after_create` + `after_create_repos`, synthesizes
+    # signature params for each declared typed repo, and forwards both
+    # to the underlying handler.
+    after_create_call: bool = False
 
 
 _DELETE_SHAPE = _FactoryShape(
@@ -389,6 +417,7 @@ _CREATE_SHAPE = _FactoryShape(
     include_parent_id=True,
     include_audit_repo=True,
     payload_authz_call=True,
+    after_create_call=True,
 )
 _UPDATE_SHAPE = _FactoryShape(
     name_template="_handle_update_{name}",
@@ -442,6 +471,8 @@ def _make_factory_handler(
     extra_repos: tuple[tuple[str, type], ...] = (),
     payload_authz: Callable[..., Awaitable[None]] | None = None,
     payload_authz_repos: tuple[tuple[str, type], ...] = (),
+    after_create: Callable[..., Awaitable[None]] | None = None,
+    after_create_repos: tuple[tuple[str, type], ...] = (),
 ):
     """Build the wrapper the mount layer introspects and calls.
 
@@ -464,7 +495,10 @@ def _make_factory_handler(
         if shape.payload_authz_call
         else ()
     )
-    if shape.payload_authz_call and payload_authz_repo_names:
+    after_create_repo_names = (
+        tuple(name for name, _ in after_create_repos) if shape.after_create_call else ()
+    )
+    if shape.payload_authz_call or shape.after_create_call:
         reserved = {
             "payload",
             "repo",
@@ -474,13 +508,29 @@ def _make_factory_handler(
         }
         if parent_id_param is not None:
             reserved.add(parent_id_param)
-        clashes = [n for n in payload_authz_repo_names if n in reserved]
+        clashes = [
+            n
+            for n in (*payload_authz_repo_names, *after_create_repo_names)
+            if n in reserved
+        ]
         if clashes:
             raise ValueError(
-                f"_make_factory_handler({spec.name!r}): payload_authz_repos "
-                f"name(s) {clashes!r} collide with the factory-generated "
-                "signature params — pick distinct names."
+                f"_make_factory_handler({spec.name!r}): payload_authz_repos / "
+                f"after_create_repos name(s) {clashes!r} collide with the "
+                "factory-generated signature params — pick distinct names."
             )
+        # Names must also not collide with each other (a single
+        # `inspect.Parameter` per name).
+        seen: set[str] = set()
+        for n in (*payload_authz_repo_names, *after_create_repo_names):
+            if n in seen:
+                raise ValueError(
+                    f"_make_factory_handler({spec.name!r}): repo name "
+                    f"{n!r} declared in both payload_authz_repos and "
+                    "after_create_repos — synthesize one slot, share it via "
+                    "a single declaration."
+                )
+            seen.add(n)
     # `spec.filters` accepts raw `QueryParam` (legacy) or `Filter`
     # subclasses (URL + UI metadata). Both expose the URL shape via the
     # same `name` / `annotation` pair — `Filter` via `to_query_param()`.
@@ -529,6 +579,14 @@ def _make_factory_handler(
     if shape.payload_authz_call:
         for name, repo_type in payload_authz_repos:
             sig_params.append(_param(name, repo_type))
+    if shape.after_create_call:
+        # Skip names already added via `payload_authz_repos` — a spec
+        # can reuse the same repo for both hooks; one slot is enough.
+        existing = set(payload_authz_repo_names) if shape.payload_authz_call else set()
+        for name, repo_type in after_create_repos:
+            if name in existing:
+                continue
+            sig_params.append(_param(name, repo_type))
 
     async def _handler(**kwargs: Any) -> Any:
         call_kwargs: dict[str, Any] = {
@@ -561,6 +619,11 @@ def _make_factory_handler(
             call_kwargs["payload_authz_kwargs"] = {
                 n: kwargs[n] for n in payload_authz_repo_names
             }
+        if shape.after_create_call and after_create is not None:
+            call_kwargs["after_create"] = after_create
+            call_kwargs["after_create_kwargs"] = {
+                n: kwargs[n] for n in after_create_repo_names
+            }
         return await handler_fn(spec, **call_kwargs)
 
     _handler.__signature__ = inspect.Signature(parameters=sig_params)  # type: ignore[attr-defined]
@@ -578,6 +641,8 @@ def make_create_handler(
     *,
     payload_authz: Callable[..., Awaitable[None]] | None = None,
     payload_authz_repos: tuple[tuple[str, type], ...] = (),
+    after_create: Callable[..., Awaitable[None]] | None = None,
+    after_create_repos: tuple[tuple[str, type], ...] = (),
 ):
     return _make_factory_handler(
         spec,
@@ -585,6 +650,8 @@ def make_create_handler(
         handle_create,
         payload_authz=payload_authz,
         payload_authz_repos=payload_authz_repos,
+        after_create=after_create,
+        after_create_repos=after_create_repos,
     )
 
 

--- a/src/framework/dispatch/mounts/entity.py
+++ b/src/framework/dispatch/mounts/entity.py
@@ -178,6 +178,13 @@ def mount_entity(
             "— pick one. The hook runs in the factory-built path; an "
             "explicit handler would silently bypass it."
         )
+    if entity.after_create_path is not None and "create" in handlers:
+        raise ValueError(
+            f"mount_entity({entity.name!r}): spec declares "
+            "after_create_path alongside an explicit handlers['create'] "
+            "— pick one. The hook runs in the factory-built create path; "
+            "an explicit create handler would silently bypass it."
+        )
 
     detail_extras = (
         resolve_dotted_path(entity, entity.detail_extras_path, "detail_extras_path")
@@ -197,6 +204,11 @@ def mount_entity(
     payload_authz = (
         resolve_dotted_path(entity, entity.payload_authz_path, "payload_authz_path")
         if entity.payload_authz_path is not None
+        else None
+    )
+    after_create = (
+        resolve_dotted_path(entity, entity.after_create_path, "after_create_path")
+        if entity.after_create_path is not None
         else None
     )
 
@@ -242,7 +254,15 @@ def mount_entity(
                 extras=form_extras,
                 extra_repos=entity.form_extras_repos,
             )
-        elif verb in ("create", "update"):
+        elif verb == "create":
+            built = maker(
+                entity,
+                payload_authz=payload_authz,
+                payload_authz_repos=entity.payload_authz_repos,
+                after_create=after_create,
+                after_create_repos=entity.after_create_repos,
+            )
+        elif verb == "update":
             built = maker(
                 entity,
                 payload_authz=payload_authz,

--- a/src/framework/dispatch/test_handlers.py
+++ b/src/framework/dispatch/test_handlers.py
@@ -3220,3 +3220,131 @@ async def test_state_axis_forbid_self_wrapper_lets_other_targets_through():
     )
     assert result == "ok"
     assert inner_called is True
+
+
+# --- after_create framework tests ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_invokes_after_create_with_row_payload_user_and_repos():
+    """Happy path: `after_create` is awaited with `row=`, `payload=`,
+    `requesting_user=`, plus the declared typed repos. Audit row is
+    written after the hook runs (so any mutations the hook makes are
+    captured in the audit `after` snapshot)."""
+    audit_used = AuditedResource(
+        type="widget",
+        # Snapshot reads `practice_name` so the test can prove the
+        # hook's mutation lands in the audit `after` row.
+        snapshot=lambda obj: {
+            "id": str(obj.id),
+            "practice_name": obj.practice_name,
+        },
+        create=AuditAction.CREATE_USER,
+        update=AuditAction.UPDATE_USER,
+        delete=AuditAction.DELETE_USER,
+    )
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_AnyRow,
+        audit=audit_used,
+    )
+    repo = _create_fake_repo()
+    audit_repo = _FakeAuditRepo()
+    user = _user()
+    extra_repo = _StubOrgRepo()
+
+    seen: list[dict[str, _Any]] = []
+
+    async def hook(*, row, payload, requesting_user, organization_repo):
+        seen.append(
+            {
+                "row": row,
+                "payload": payload,
+                "user": requesting_user,
+                "org_repo": organization_repo,
+            }
+        )
+        # Mutate the row — the audit `after` snapshot fires AFTER this,
+        # so the mutation should be captured.
+        row.practice_name = "mutated-by-hook"
+
+    payload = _StandardPayload(practice_name="P", location_city="C")
+    created = await handle_create(
+        spec,
+        payload=payload,
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=user,
+        after_create=hook,
+        after_create_kwargs={"organization_repo": extra_repo},
+    )
+
+    assert len(seen) == 1
+    assert seen[0]["row"] is created
+    assert seen[0]["payload"] is payload
+    assert seen[0]["user"] is user
+    assert seen[0]["org_repo"] is extra_repo
+    assert created.practice_name == "mutated-by-hook"
+    assert len(repo.created_rows) == 1
+    assert len(audit_repo.calls) == 1
+    assert audit_repo.calls[0]["action"] == audit_used.create
+    # The audit `after` snapshot reflects the post-hook mutation.
+    assert audit_repo.calls[0]["after"]["practice_name"] == "mutated-by-hook"
+
+
+@pytest.mark.asyncio
+async def test_create_skips_after_create_when_not_supplied():
+    """`after_create=None` is the default — the create path still works
+    end-to-end without it (no audit-row regression for entities that
+    don't declare the hook)."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_AnyRow,
+        audit=_audit(),
+    )
+    repo = _create_fake_repo()
+    audit_repo = _FakeAuditRepo()
+    payload = _StandardPayload(practice_name="P", location_city="C")
+    created = await handle_create(
+        spec, payload=payload, repo=repo, audit_repo=audit_repo, requesting_user=_user()
+    )
+    assert created.practice_name == "P"
+    assert len(audit_repo.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_after_create_exception_rolls_back_transaction():
+    """If `after_create` raises, the `mutate(...)` context manager
+    propagates the exception and the audit row is NOT written. The
+    persisted row stays in the session (the framework relies on the
+    session's exception-rollback path, but the audit row's absence is
+    the contract this test pins)."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_AnyRow,
+        audit=_audit(),
+    )
+    repo = _create_fake_repo()
+    audit_repo = _FakeAuditRepo()
+
+    async def hook(*, row, payload, requesting_user):
+        raise ValueError("after_create rejected this row")
+
+    payload = _StandardPayload(practice_name="P", location_city="C")
+    with pytest.raises(ValueError, match="after_create rejected"):
+        await handle_create(
+            spec,
+            payload=payload,
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=_user(),
+            after_create=hook,
+        )
+    # No audit row written when the hook raises.
+    assert audit_repo.calls == []


### PR DESCRIPTION
## Summary
Closes the second framework gap from the verification-rollout retro. `EntitySpec.after_create_path` runs inside the framework's generic create transaction, post-persist + pre-audit-snapshot, so entities like `OrgRepresentation` can keep the generic create path while doing per-payload dispatch + side effects.

- New `EntitySpec.after_create_path` + `after_create_repos`. Same dotted-path + typed-repos contract as `payload_authz_path`. Runs INSIDE the `mutate(...)` context manager — mutations land in the audit `after` snapshot; exceptions roll back the transaction.
- `_FactoryShape.after_create_call`, `make_create_handler`, and `handle_create` plumb the hook through. Name-collision detection with reserved factory signature params + with `payload_authz_repos`.
- `OrgRepresentation` migrates off its bespoke route. The previous monolithic `handle_create_org_representation` is split into:
  * `validate_org_representation_payload` → `payload_authz_path`
  * `after_create_org_representation` → `after_create_path`
- The bespoke POST route is removed; `routes.create=True` is back. Same semantics, no bespoke handler.
- 3 new framework tests on `handle_create` pin row/payload/user threading, default `None`, and exception → no-audit-row. 10 existing `OrgRepresentation` handler tests rewritten for the new validate/after-create split. Spec test updated.

## Test plan
- [x] `dev test` — 2206 passed, 101 skipped
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)