### PR TITLE
feat: run NPI verification inline on clinician create

### DIFF
--- a/src/domain/logic/clinicians/handlers.py
+++ b/src/domain/logic/clinicians/handlers.py
@@ -33,6 +33,43 @@ from src.framework.rendering.templating import set_viewer
 logger = logging.getLogger(__name__)
 
 
+async def after_create_clinician_verification(
+    *,
+    row: Clinician,
+    payload: BaseModel,
+    requesting_user: User,
+    verification_repo: VerificationRepository,
+    clinician_repo: ClinicianRepository,
+    verification_audit_repo: AuditRepository,
+) -> None:
+    """Run the NPI verification pipeline immediately after a clinician row
+    is created. Produces one Verification row + audit row and writes through
+    the Claim-A denorm cache, all within the same request transaction.
+
+    `run_clinician_verification` commits internally. After that commit the
+    session expires `row`'s attributes, so a `refresh` follows to keep the
+    object usable for the `mutate` context manager's after-snapshot (which
+    runs synchronously via Pydantic's `model_validate`).
+    """
+    import httpx
+
+    from src.domain.logic.verifications.handlers import (
+        HTTP_TIMEOUT_SECONDS,
+        run_clinician_verification,
+    )
+
+    async with httpx.AsyncClient(timeout=HTTP_TIMEOUT_SECONDS) as http:
+        await run_clinician_verification(
+            clinician_id=row.id,
+            verification_repo=verification_repo,
+            clinician_repo=clinician_repo,
+            audit_repo=verification_audit_repo,
+            http=http,
+            actor_id=requesting_user.id,
+        )
+    await clinician_repo.session.refresh(row)
+
+
 async def _assert_clinician_payload_org_ownership(
     *,
     payload: BaseModel,

--- a/src/domain/logic/clinicians/test_handlers.py
+++ b/src/domain/logic/clinicians/test_handlers.py
@@ -855,3 +855,186 @@ async def test_set_clinician_verification_state_404_for_missing(
                 audit_repo=AuditRepository(session),
                 requesting_user=admin,
             )
+
+
+# --- after_create_clinician_verification (post-create hook) ---------------
+
+
+async def test_after_create_clinician_verification_creates_verification_row(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Happy path: the hook produces one Verification row for the just-
+    created clinician and updates the Claim-A denorm cache.
+
+    `nppes_lookup` is patched so no real HTTP call is made; the OIG module
+    is pointed at the fixture CSV so it loads correctly.
+    """
+    from pathlib import Path
+    from unittest.mock import AsyncMock, patch
+
+    from src.domain.logic.clinicians.handlers import after_create_clinician_verification
+    from src.domain.logic.verifications import oig as oig_module
+    from src.domain.logic.verifications.nppes import NppesResult
+
+    leie_fixture = (
+        Path(__file__).parent.parent / "verifications" / "test_data" / "leie_sample.csv"
+    )
+    oig_module._reset_cache_for_tests()
+
+    import os
+
+    old_path = os.environ.get("LEIE_CSV_PATH")
+    os.environ["LEIE_CSV_PATH"] = str(leie_fixture)
+    try:
+        user = await _seed_user(db_test_session_manager)
+        org_id = await _seed_org(db_test_session_manager, owner_id=user.id)
+
+        nppes_match = NppesResult(
+            found=True, first_name="Jane", last_name="Smith", raw={}
+        )
+
+        async with db_test_session_manager() as session:
+            repo = ClinicianRepository(session)
+            audit_repo = AuditRepository(session)
+            verification_repo = VerificationRepository(session)
+
+            clinician = Clinician(
+                owner_id=user.id,
+                org_id=org_id,
+                location_city="Springfield",
+                location_state="IL",
+                location_zip="62701",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+                first_name="Jane",
+                last_name="Smith",
+                npi="9999999999",
+            )
+            created = await repo.create(clinician)
+
+            with patch(
+                "src.domain.logic.verifications.handlers.nppes_lookup",
+                new=AsyncMock(return_value=nppes_match),
+            ):
+                await after_create_clinician_verification(
+                    row=created,
+                    payload=_clinician_create_payload(org_id=org_id),
+                    requesting_user=user,
+                    verification_repo=verification_repo,
+                    clinician_repo=repo,
+                    verification_audit_repo=audit_repo,
+                )
+
+        async with db_test_session_manager() as session:
+            from src.domain.models import Verification
+
+            rows = (
+                (
+                    await session.execute(
+                        select(Verification).filter(
+                            Verification.clinician_id == created.id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].status == "verified"
+            assert rows[0].event_type == "npi_resolved"
+
+            loaded = await session.get(Clinician, created.id)
+            assert loaded.npi_match_status == "matched"
+    finally:
+        if old_path is None:
+            os.environ.pop("LEIE_CSV_PATH", None)
+        else:
+            os.environ["LEIE_CSV_PATH"] = old_path
+        oig_module._reset_cache_for_tests()
+
+
+async def test_after_create_clinician_verification_no_npi_records_skipped(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """A clinician without an NPI still gets a Verification row (status=failed,
+    nppes_skipped flag) and npi_match_status stays 'none'. nppes_lookup is never called.
+    """
+    from pathlib import Path
+    from unittest.mock import AsyncMock, patch
+
+    from src.domain.logic.clinicians.handlers import after_create_clinician_verification
+    from src.domain.logic.verifications import oig as oig_module
+
+    leie_fixture = (
+        Path(__file__).parent.parent / "verifications" / "test_data" / "leie_sample.csv"
+    )
+    oig_module._reset_cache_for_tests()
+
+    import os
+
+    old_path = os.environ.get("LEIE_CSV_PATH")
+    os.environ["LEIE_CSV_PATH"] = str(leie_fixture)
+    try:
+        user = await _seed_user(db_test_session_manager)
+        org_id = await _seed_org(db_test_session_manager, owner_id=user.id)
+
+        async with db_test_session_manager() as session:
+            repo = ClinicianRepository(session)
+            audit_repo = AuditRepository(session)
+            verification_repo = VerificationRepository(session)
+
+            clinician = Clinician(
+                owner_id=user.id,
+                org_id=org_id,
+                location_city="Springfield",
+                location_state="IL",
+                location_zip="62701",
+                in_person_sessions="yes",
+                virtual_sessions="no",
+                npi=None,
+            )
+            created = await repo.create(clinician)
+
+            nppes_stub = AsyncMock(
+                side_effect=AssertionError("nppes_lookup called unexpectedly")
+            )
+            with patch(
+                "src.domain.logic.verifications.handlers.nppes_lookup",
+                new=nppes_stub,
+            ):
+                await after_create_clinician_verification(
+                    row=created,
+                    payload=_clinician_create_payload(org_id=org_id),
+                    requesting_user=user,
+                    verification_repo=verification_repo,
+                    clinician_repo=repo,
+                    verification_audit_repo=audit_repo,
+                )
+            nppes_stub.assert_not_called()
+
+        async with db_test_session_manager() as session:
+            from src.domain.models import Verification
+
+            rows = (
+                (
+                    await session.execute(
+                        select(Verification).filter(
+                            Verification.clinician_id == created.id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].status == "failed"
+            assert "nppes_skipped" in rows[0].flags
+
+            loaded = await session.get(Clinician, created.id)
+            assert loaded.npi_match_status == "none"
+    finally:
+        if old_path is None:
+            os.environ.pop("LEIE_CSV_PATH", None)
+        else:
+            os.environ["LEIE_CSV_PATH"] = old_path
+        oig_module._reset_cache_for_tests()

--- a/src/domain/logic/verifications/README.md
+++ b/src/domain/logic/verifications/README.md
@@ -12,10 +12,11 @@ Persistence + pure-function primitives for the clinician verification pipeline. 
 - `handlers.py` — NPPES pipeline: `run_clinician_verification(...)`, `run_org_verification(...)`, and their admin-only retrigger wrappers. Composes the primitives with persistence + audit + an `httpx.AsyncClient`. The bespoke route lives at [`../../routes/verifications.py`](../../routes/verifications.py) and is wired into `src/main.py` next to the other hand-rolled routers.
 - `events.py` — `recompute_clinician_claim(clinician)`, `recompute_org_claim(org)`, and `record_verification_event(...)`. These three live outside the NPPES pipeline because they are called by `clinicians/handlers.py` and `org_representations/handlers.py` without any HTTP dependency. The recompute helpers are nearly pure (no I/O; they mutate their argument in place); `record_verification_event` is the single append-only writer for the non-NPPES §9 transitions.
 
-The pipeline orchestrators have two callers each:
+The pipeline orchestrators have three callers each:
 
-1. **`submit_clinician_npi` / `submit_organization_npi`** in [`../../routes/verifications.py`](../../routes/verifications.py) (end-user NPI submission; the route runs the pipeline inline so the response carries the resolved state — see that file's docstring).
-2. **`handle_create_clinician_verification` / `handle_create_org_verification`** in `handlers.py` (admin retrigger; `actor_id=requesting_user.id`).
+1. **`after_create_clinician_verification`** in [`../clinicians/handlers.py`](../clinicians/handlers.py) (post-create hook wired to `CLINICIAN_ENTITY.after_create_path`; runs inline on `POST /clinicians` so the first Verification row lands in the same request as the row itself).
+2. **`submit_clinician_npi` / `submit_organization_npi`** in [`../../routes/verifications.py`](../../routes/verifications.py) (end-user NPI submission; the route runs the pipeline inline so the response carries the resolved state — see that file's docstring).
+3. **`handle_create_clinician_verification` / `handle_create_org_verification`** in `handlers.py` (admin retrigger; `actor_id=requesting_user.id`).
 
 There is no scheduled job — see [`../../../jobs/README.md`](../../../jobs/README.md) for the rationale (NPPES is fast enough to run inline; a worker buys polling and pending-state complexity in exchange for no real latency win).
 
@@ -53,4 +54,4 @@ The `mutate(...)` context manager is a snapshot-before / mutate / record_audit /
 
 ### Post-create hook
 
-Triggering verification automatically after `POST /clinicians` succeeds was scoped out of this PR per #528 — the framework's CRUD handler doesn't have a `post_create_hook`. Track as a follow-up issue.
+`CLINICIAN_ENTITY.after_create_path` is wired to `after_create_clinician_verification` in `src/domain/logic/clinicians/handlers.py`. The hook calls `run_clinician_verification` inline — the NPPES pipeline runs in the same request as `POST /clinicians`, and the Verification row + denorm cache update are committed before the clinician's own audit row is written. An `await session.refresh(row)` follows the internal commit so the `mutate` context manager's after-snapshot can read the updated column values synchronously via Pydantic.

--- a/src/domain/specs/clinician.py
+++ b/src/domain/specs/clinician.py
@@ -16,7 +16,10 @@ Read by:
 
 from typing import Final
 
-from src.domain.logic.clinicians.repository import get_clinician_repository
+from src.domain.logic.clinicians.repository import (
+    ClinicianRepository,
+    get_clinician_repository,
+)
 from src.domain.logic.clinicians.schema import (
     ClinicianCreate,
     ClinicianRead,
@@ -38,6 +41,7 @@ from src.domain.models.enums import (
     US_STATES,
 )
 from src.framework.audit.core import AuditAction
+from src.framework.audit.repository import AuditRepository
 from src.framework.dispatch.entity_spec import (
     AUTHENTICATED,
     OWNER_OR_ADMIN,
@@ -125,6 +129,18 @@ CLINICIAN_ENTITY: Final[EntitySpec] = EntitySpec(
         "src.domain.logic.clinicians.handlers._assert_clinician_payload_org_ownership"
     ),
     payload_authz_repos=(("organization_repo", OrganizationRepository),),
+    # Run NPI verification immediately after a clinician row is persisted.
+    # `verification_audit_repo` is the AuditRepository under a distinct
+    # name because `audit_repo` is a reserved factory-handler kwarg and
+    # cannot appear in `after_create_repos`.
+    after_create_path=(
+        "src.domain.logic.clinicians.handlers.after_create_clinician_verification"
+    ),
+    after_create_repos=(
+        ("verification_repo", VerificationRepository),
+        ("clinician_repo", ClinicianRepository),
+        ("verification_audit_repo", AuditRepository),
+    ),
     # Clinician templates render credential-type display labels and the
     # tuples behind the filter/select dropdowns. Tying them to the spec
     # (instead of Jinja globals) means a new credential-type tuple


### PR DESCRIPTION
## Summary

- Wires `CLINICIAN_ENTITY.after_create_path` to a new `after_create_clinician_verification` hook in `clinicians/handlers.py`
- The hook calls `run_clinician_verification` synchronously in the same request as `POST /clinicians`, so a `Verification` row and Claim-A denorm cache update land automatically at creation time
- Follows `session.refresh(row)` after the pipeline's internal commit so the `mutate` context manager's after-snapshot reads fresh column values synchronously via Pydantic
- `AuditRepository` injected under the alias `verification_audit_repo` to avoid collision with the factory-reserved `audit_repo` kwarg name
- Updates `verifications/README.md` to remove the now-resolved "scoped out" note and document the three callers of the pipeline

## Test plan

- [ ] `test_after_create_clinician_verification_creates_verification_row` — happy path: NPI present, NPPES match, `npi_match_status` → `matched`
- [ ] `test_after_create_clinician_verification_no_npi_records_skipped` — no NPI: `Verification` row created with `nppes_skipped` flag, `npi_match_status` stays `none`, `nppes_lookup` never called
- [ ] Full suite: `dev test` → 2213 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)