### PR TITLE
feat: add attestation button to licensure rows

### DIFF
--- a/src/domain/templates/clinicians/_credential_row.html
+++ b/src/domain/templates/clinicians/_credential_row.html
@@ -32,9 +32,13 @@
      delete_url, delete_confirm — optional; when both set, render an
        hx-delete confirm button on the right. Read-only callers omit
        both.
+     attest_url — optional; when set, renders an "Attest active" PUT
+       button (licensures only). Uses json-enc so the empty-body
+       payload is sent as JSON, matching the state-axis handler's
+       `_LicenseAttestationBody` expectation.
 #}
 {%- from "_shared/actions.html" import confirm_delete_button -%}
-{% macro credential_row(label, meta_parts, delete_url=None, delete_confirm=None) -%}
+{% macro credential_row(label, meta_parts, delete_url=None, delete_confirm=None, attest_url=None) -%}
   {%- set parts = meta_parts | select | list -%}
   <div class="credential-row">
     <div class="credential-row-text">
@@ -45,6 +49,14 @@
         </small>
       {%- endif %}
     </div>
+    {%- if attest_url %}
+      <button type="button"
+              class="secondary outline"
+              hx-put="{{ attest_url }}"
+              hx-ext="json-enc"
+              hx-vals='{"attested": true}'
+              hx-confirm="Attest that this license is currently active and in good standing?">Attest active</button>
+    {%- endif %}
     {%- if delete_url and delete_confirm %}{{ confirm_delete_button(delete_url, delete_confirm) }}{%- endif %}
     </div>
   {%- endmacro %}

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -101,9 +101,10 @@
     <h2>Licensures</h2>
     {% call(lic) credential_list(clinician.licensures, "No licensures yet.") %}
       {{ credential_row(LICENSE_TYPES_LABELS[lic.license_type],
-            ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None],
+            ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None, lic.status | title],
       delete_url=entity_url('clinician', id=clinician.id) ~ "/licensures/" ~ lic.id|string,
       delete_confirm="Remove this licensure?",
+      attest_url=(entity_url('clinician', id=clinician.id) ~ "/licensures/" ~ lic.id|string ~ "/attestation") if not lic.attested_active else None,
       ) }}
     {% endcall %}
     {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/licensures", "Add licensure", "Add licensure") %}


### PR DESCRIPTION
## Summary

- Adds an "Attest active" button to each unattested licensure row on the clinician edit page
- Shows license status (`Pending` / `Active` / `Expired`) in the licensure row meta line
- Wires up the existing `PUT /clinicians/{id}/licensures/{id}/attestation` endpoint so Claim A can be earned from the UI without going through the admin panel

## Why

The backend handler, state-axis spec, and route were fully implemented but there was no template affordance to reach them. Without attestation, `clinician_verified` never flips to `True` and the "Finish setting up" card never clears for any user.

## Test plan

- [ ] Add a licensure to a clinician — row shows "Pending" status and "Attest active" button
- [ ] Click "Attest active" and confirm — page refreshes, row shows "Active", button disappears
- [ ] "Finish setting up" card/banner on `/home` clears after attestation
- [ ] Already-attested licensures show no button

🤖 Generated with [Claude Code](https://claude.com/claude-code)