### PR TITLE
feat: profile hub onboarding — guided clinician setup with NPI + license flow

### DIFF
--- a/src/domain/logic/clinicians/schema.py
+++ b/src/domain/logic/clinicians/schema.py
@@ -267,8 +267,8 @@ class ClinicianCreate(FlatLocationSchema, WirePayload):
     first_name: StrippedOptionalText = None
     last_name: StrippedOptionalText = None
     location: Location
-    in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
-    virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS]
+    in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] = "yes"
+    virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] = "yes"
     # Insurance posture. `in_network_carriers` is the set the practice
     # accepts in-network (empty = no in-network); `accepts_out_of_network`
     # is independent and defaults `True` (most practices accept OON;

--- a/src/domain/logic/profile/handlers.py
+++ b/src/domain/logic/profile/handlers.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from uuid import UUID
 
 from src.domain.logic import capabilities
 from src.domain.models import User
@@ -90,3 +91,130 @@ def build_profile_context(
         "clinicians": list(getattr(user, "clinicians", None) or ()),
         "org_representations": list(getattr(user, "org_representations", None) or ()),
     }
+
+
+async def handle_clinician_create(
+    *,
+    first_name: str | None,
+    last_name: str | None,
+    npi: str | None,
+    location_city: str,
+    location_state: str,
+    location_zip: str,
+    requesting_user: User,
+    clinician_repo: Any,
+    organization_repo: Any,
+    verification_repo: Any,
+    audit_repo: Any,
+) -> Any:
+    """Create a minimal clinician profile from the profile hub and run
+    NPI verification inline.
+
+    Hardcodes ``solo_practice=True`` so the user doesn't need to pick
+    an org during onboarding. Session/in_person defaults to "yes" via
+    the schema. The caller returns ``HX-Redirect: /profile`` so the hub
+    re-renders with the new clinician's NPPES state already reflected.
+    """
+    from src.domain.logic.clinicians.handlers import (
+        _assert_clinician_payload_org_ownership,
+        after_create_clinician_verification,
+    )
+    from src.domain.logic.clinicians.schema import ClinicianCreate
+    from src.domain.models import Clinician
+
+    payload = ClinicianCreate(
+        first_name=first_name,
+        last_name=last_name,
+        npi=npi,
+        solo_practice=True,
+        location_city=location_city,
+        location_state=location_state,
+        location_zip=location_zip,
+    )
+
+    await _assert_clinician_payload_org_ownership(
+        payload=payload,
+        requesting_user=requesting_user,
+        organization_repo=organization_repo,
+    )
+
+    clinician = Clinician(
+        owner_id=requesting_user.id,
+        **payload.model_dump(),
+    )
+    clinician = await clinician_repo.create(clinician)
+
+    await after_create_clinician_verification(
+        row=clinician,
+        payload=payload,
+        requesting_user=requesting_user,
+        verification_repo=verification_repo,
+        clinician_repo=clinician_repo,
+        verification_audit_repo=audit_repo,
+    )
+    return clinician
+
+
+async def handle_clinician_license_create(
+    *,
+    clinician_id: UUID,
+    license_type: str,
+    license_number: str,
+    issuing_state: str,
+    expiration_date: str | None,
+    requesting_user: User,
+    clinician_repo: Any,
+    verification_repo: Any,
+    audit_repo: Any,
+) -> Any:
+    """Create a licensure for an onboarding clinician and immediately
+    attest it as active in one step.
+
+    Delegates attestation to ``handle_set_license_attestation`` which
+    owns the audit trail and Claim-A cache recompute. The caller returns
+    ``HX-Redirect: /profile`` so the hub re-renders with Claim A
+    potentially unlocked.
+    """
+    from datetime import date
+
+    from src.domain.logic.clinicians.handlers import handle_set_license_attestation
+    from src.domain.logic.clinicians.schema import ClinicianLicensureCreate
+    from src.domain.models import Clinician, ClinicianLicensure
+    from src.framework.authz import is_owner_or_admin
+    from src.framework.http.exceptions import ForbiddenError, NotFoundError
+
+    clinician = await clinician_repo.get_by_model_id(Clinician, clinician_id)
+    if clinician is None:
+        raise NotFoundError(detail="Clinician not found")
+    if not is_owner_or_admin(clinician, requesting_user):
+        raise ForbiddenError(detail="Cannot add licenses for this clinician")
+
+    parsed_expiry = date.fromisoformat(expiration_date) if expiration_date else None
+
+    licensure_payload = ClinicianLicensureCreate(
+        license_type=license_type,
+        license_number=license_number,
+        issuing_state=issuing_state,
+        expiration_date=parsed_expiry,
+    )
+    licensure = ClinicianLicensure(
+        clinician_id=clinician_id,
+        **licensure_payload.model_dump(),
+    )
+    licensure = await clinician_repo.create(licensure)
+
+    # Attest immediately — the form's checkbox confirms user consent.
+    from pydantic import BaseModel as _BaseModel
+
+    class _AttestPayload(_BaseModel):
+        attested: bool = True
+
+    return await handle_set_license_attestation(
+        clinician_id=clinician_id,
+        licensure_id=licensure.id,
+        payload=_AttestPayload(),
+        repo=clinician_repo,
+        verification_repo=verification_repo,
+        audit_repo=audit_repo,
+        requesting_user=requesting_user,
+    )

--- a/src/domain/routes/profile.py
+++ b/src/domain/routes/profile.py
@@ -5,6 +5,15 @@ The hub is one component with four modes — setup / manage / add-a-claim
 wizard). Mode is a pure function of the requesting user's claim state;
 see `src.domain.logic.profile.handlers.resolve_profile_mode`.
 
+In addition to the hub GET, this router owns two onboarding POST
+endpoints that stay on `/profile` after completion (rather than
+redirecting to entity-specific pages):
+
+- ``POST /profile/clinician`` — create a minimal clinician + run NPI
+  verification inline, then return to the hub.
+- ``POST /profile/clinician/{clinician_id}/license`` — create a
+  licensure and attest it in one step, then return to the hub.
+
 The hub is intentionally **not** mounted as a generic EntitySpec: it's
 not a CRUD resource (no id in the URL, no list/detail surface), and
 overloading the `/users/{id}` detail page with mode-dispatch would
@@ -14,13 +23,33 @@ routes").
 """
 
 from typing import Any
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Form, Request, status
+from fastapi.responses import JSONResponse
 
 from src.auth_config import current_active_user
-from src.domain.logic.profile.handlers import build_profile_context
+from src.domain.logic.clinicians.repository import (
+    ClinicianRepository,
+    get_clinician_repository,
+)
+from src.domain.logic.organizations.repository import (
+    OrganizationRepository,
+    get_organization_repository,
+)
+from src.domain.logic.profile.handlers import (
+    build_profile_context,
+    handle_clinician_create,
+    handle_clinician_license_create,
+)
+from src.domain.logic.verifications.repository import (
+    VerificationRepository,
+    get_verification_repository,
+)
 from src.domain.models import User
+from src.framework.audit.repository import AuditRepository
 from src.framework.http.responses import APIResponse
+from src.framework.persistence.dependencies import get_audit_repository
 
 profile_pages_router = APIRouter(tags=["Profile"])
 
@@ -42,4 +71,84 @@ async def profile_hub(
         context,
         request,
         current_user=requesting_user,
+    )
+
+
+@profile_pages_router.post("/profile/clinician", name="profile:clinician_create")
+async def profile_clinician_create(
+    first_name: str | None = Form(default=None),
+    last_name: str | None = Form(default=None),
+    npi: str | None = Form(default=None),
+    location_city: str = Form(...),
+    location_state: str = Form(...),
+    location_zip: str = Form(...),
+    requesting_user: User = Depends(current_active_user),
+    clinician_repo: ClinicianRepository = Depends(get_clinician_repository),
+    organization_repo: OrganizationRepository = Depends(get_organization_repository),
+    verification_repo: VerificationRepository = Depends(get_verification_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+) -> Any:
+    """Create a minimal clinician profile from the onboarding hub.
+
+    Fires NPI verification inline (same as the generic clinician
+    create) then redirects back to /profile so the hub re-renders
+    with the NPPES result already reflected in the setup flow.
+    """
+    await handle_clinician_create(
+        first_name=first_name,
+        last_name=last_name,
+        npi=npi,
+        location_city=location_city,
+        location_state=location_state,
+        location_zip=location_zip,
+        requesting_user=requesting_user,
+        clinician_repo=clinician_repo,
+        organization_repo=organization_repo,
+        verification_repo=verification_repo,
+        audit_repo=audit_repo,
+    )
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={},
+        headers={"HX-Redirect": "/profile"},
+    )
+
+
+@profile_pages_router.post(
+    "/profile/clinician/{clinician_id}/license",
+    name="profile:clinician_license_create",
+)
+async def profile_clinician_license_create(
+    clinician_id: UUID,
+    license_type: str = Form(...),
+    license_number: str = Form(...),
+    issuing_state: str = Form(...),
+    expiration_date: str | None = Form(default=None),
+    requesting_user: User = Depends(current_active_user),
+    clinician_repo: ClinicianRepository = Depends(get_clinician_repository),
+    verification_repo: VerificationRepository = Depends(get_verification_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+) -> Any:
+    """Create a licensure and attest it in one step from the onboarding hub.
+
+    Combining create + attest removes the two-step dance (add license,
+    then separately attest) by requiring the user to check an attestation
+    checkbox on the same form. Returns to /profile so the hub shows the
+    updated Claim A state.
+    """
+    await handle_clinician_license_create(
+        clinician_id=clinician_id,
+        license_type=license_type,
+        license_number=license_number,
+        issuing_state=issuing_state,
+        expiration_date=expiration_date or None,
+        requesting_user=requesting_user,
+        clinician_repo=clinician_repo,
+        verification_repo=verification_repo,
+        audit_repo=audit_repo,
+    )
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={},
+        headers={"HX-Redirect": "/profile"},
     )

--- a/src/domain/routes/test_profile.py
+++ b/src/domain/routes/test_profile.py
@@ -8,6 +8,10 @@ to use it without holding Claim A).
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.models import Clinician, ClinicianLicensure, User
 
 pytestmark = pytest.mark.asyncio
 
@@ -16,18 +20,12 @@ async def test_profile_hub_renders_setup_for_new_user(
     authenticated_client: AsyncClient,
 ):
     """A fresh dev user (no clinician, no org representation) lands in
-    setup mode — the wireframe-L1 goal picker."""
+    setup mode — the minimal clinician create form."""
     response = await authenticated_client.get("/profile")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     # Setup mode's distinctive copy from `_setup.html`.
-    assert "What do you want to do on Bedlam Connect" in response.text
-    # Both cards render (Claim A + Claim B); the Claim A card has
-    # the "+ Add a clinician profile" CTA when none exists yet.
-    assert (
-        "Refer &amp; take clients" in response.text
-        or "Refer & take clients" in response.text
-    )
+    assert "Add a clinician profile" in response.text
     assert "Post on behalf of an organization" in response.text
 
 
@@ -71,3 +69,143 @@ async def test_profile_hub_add_claim_mode_renders_unlocks_unchanged(
     assert "Add a capability" in response.text
     assert "Unlocks" in response.text
     assert "Unchanged" in response.text
+
+
+async def test_post_profile_clinician_creates_and_redirects(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """POST /profile/clinician creates a minimal clinician + fires NPI
+    verification inline, then returns HX-Redirect: /profile."""
+    response = await authenticated_client.post(
+        "/profile/clinician",
+        data={
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "npi": "1234567890",
+            "location_city": "Portland",
+            "location_state": "OR",
+            "location_zip": "97201",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.headers.get("HX-Redirect") == "/profile"
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(Clinician).where(Clinician.owner_id == logged_in_user.id)
+        )
+        clinician = result.scalars().first()
+        assert clinician is not None
+        assert clinician.npi == "1234567890"
+        assert clinician.org_id is not None
+
+
+async def test_post_profile_clinician_requires_authentication(
+    test_client: AsyncClient,
+):
+    """Unauthenticated POST to /profile/clinician is rejected."""
+    response = await test_client.post(
+        "/profile/clinician",
+        data={
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "npi": "1234567890",
+            "location_city": "Portland",
+            "location_state": "OR",
+            "location_zip": "97201",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code != 201
+
+
+async def test_post_profile_clinician_license_creates_attests_and_redirects(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """POST /profile/clinician/{id}/license creates a licensure, attests
+    it active in one step, and returns HX-Redirect: /profile."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(
+        owner_id=logged_in_user.id,
+        npi="1234567890",
+        npi_match_status="matched",
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+    clinician_id = clinician.id
+
+    response = await authenticated_client.post(
+        f"/profile/clinician/{clinician_id}/license",
+        data={
+            "license_type": "lcsw",
+            "license_number": "LCS-99999",
+            "issuing_state": "OR",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.headers.get("HX-Redirect") == "/profile"
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(ClinicianLicensure).where(
+                ClinicianLicensure.clinician_id == clinician_id
+            )
+        )
+        licensure = result.scalars().first()
+        assert licensure is not None
+        assert licensure.attested_active is True
+        assert licensure.status == "active"
+
+
+async def test_post_profile_clinician_license_requires_authentication(
+    test_client: AsyncClient,
+):
+    """Unauthenticated POST to /profile/clinician/{id}/license is rejected."""
+    import uuid
+
+    response = await test_client.post(
+        f"/profile/clinician/{uuid.uuid4()}/license",
+        data={
+            "license_type": "lcsw",
+            "license_number": "LCS-99999",
+            "issuing_state": "OR",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code != 201
+
+
+async def test_post_profile_clinician_license_rejects_wrong_owner(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A user cannot add a license to another user's clinician."""
+    from tests.helpers import create_test_user, make_clinician_with_org
+
+    other = create_test_user(username="other-owner")
+    clinician = make_clinician_with_org(owner_id=other.id, npi="9999999999")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(clinician)
+    clinician_id = clinician.id
+
+    response = await authenticated_client.post(
+        f"/profile/clinician/{clinician_id}/license",
+        data={
+            "license_type": "lcsw",
+            "license_number": "LCS-STOLEN",
+            "issuing_state": "CA",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 403

--- a/src/domain/templates/profile/_manage.html
+++ b/src/domain/templates/profile/_manage.html
@@ -1,11 +1,7 @@
 {# Manage mode — user holds ≥1 verified claim. Per wireframe L4:
-   profile header with claim badges, three editable rows (Clinician
-   identity / Org representation / Specialties·insurance·ages), and a
-   `+ New post` CTA when Claim A is verified.
-
-   Phase 5 skeleton renders the claim badges + verification status rows;
-   inline edit forms and the profile-strength meter land in the follow-
-   up PR alongside the NPI submit endpoints.
+   profile header with claim badges, status rows for clinician identity
+   and org representation with direct "Manage →" edit links, and a
+   "+ New post" CTA when verified.
 #}
 <section>
   <header>
@@ -15,83 +11,90 @@
         {% if claim_state.a %}
           <span style="font-size: 0.875rem;
                        color: var(--pico-primary);
-                       margin-left: 0.5rem"><i class="icon-shield-check"></i> Verified clinician</span>
+                       margin-left: 0.5rem">
+            <i class="icon-shield-check"></i> Verified clinician
+          </span>
         {% endif %}
         {% if claim_state.b %}
-        <span style="font-size: 0.875rem;
-                     color: var(--pico-primary);
-                     margin-left: 0.5rem"><i class="icon-building"></i>
-      Represents {{ claim_state.b|length }} org(s)</span>
-    {% endif %}
-  </h2>
-</hgroup>
-{% if any_claim_lapsed %}
-  <p style="color: var(--pico-color-yellow-600);
-            background: var(--pico-color-yellow-100);
-            padding: 0.5rem 1rem;
-            border-radius: 4px">
-    <i class="icon-alert-triangle"></i> Action needed — one of your claims has lapsed.
-  </p>
-{% endif %}
-</header>
-<article>
-  <header>
-    {# title-case-ignore: "Claim A" is a user-facing label for the two-claim model #}
-    <strong>Clinician identity (Claim A)</strong>
-  </header>
-  {% if claim_state.a %}
-    <p>
-      <i class="icon-check"></i> Verified
-    </p>
-    <ul>
-      {% for c in clinicians %}
-        <li>
-          {{ c.first_name or "" }} {{ c.last_name or "" }} —
-          {% if c.npi %}
-            NPI {{ c.npi }}
-          {% else %}
-            no NPI
-          {% endif %}
-          ·
-          <a href="{{ entity_url('clinician', id=c.id) }}">View</a>
-        </li>
-      {% endfor %}
-    </ul>
-  {% else %}
-    {# title-case-ignore: "Clinician" is the entity name, kept capitalized #}
-    <p>Not verified. Add a Clinician profile + license to claim this.</p>
-    <a href="{{ entity_url('user', id='me') }}"
-       role="button"
-       class="outline">Manage clinicians</a>
-  {% endif %}
-</article>
-<article>
-  <header>
-    {# title-case-ignore: "Claim B" is a user-facing label for the two-claim model #}
-    <strong>Organization representation (Claim B)</strong>
-  </header>
-  {% if claim_state.b %}
-    <p>
-      <i class="icon-check"></i> Representing
-      {{ claim_state.b|length }} organization(s)
-    </p>
-    <ul>
-      {% for rep in org_representations %}
-        {% if rep.authority_status == "verified" and rep.archived_at is none %}
-          <li>{{ rep.org.name if rep.org else rep.org_id }} — {{ rep.role }}</li>
+          <span style="font-size: 0.875rem;
+                       color: var(--pico-primary);
+                       margin-left: 0.5rem">
+            <i class="icon-building"></i> Represents {{ claim_state.b|length }} org(s)
+          </span>
         {% endif %}
-      {% endfor %}
-    </ul>
-  {% else %}
-    <p style="color: var(--pico-muted-color);">Not currently representing any organization.</p>
+      </h2>
+    </hgroup>
+    {% if any_claim_lapsed %}
+      <p style="color: var(--pico-color-yellow-600);
+                background: var(--pico-color-yellow-100);
+                padding: 0.5rem 1rem;
+                border-radius: 4px">
+        <i class="icon-alert-triangle"></i> Action needed — one of your claims has lapsed.
+      </p>
+    {% endif %}
+  </header>
+  <article>
+    <header style="display: flex;
+                   justify-content: space-between;
+                   align-items: baseline">
+      <strong>Clinician identity</strong>
+      {% if clinicians %}
+        <a href="{{ entity_url('clinician', id=clinicians[0].id) }}/form"
+           style="font-size: 0.875rem">Manage →</a>
+      {% endif %}
+    </header>
+    {% if claim_state.a %}
+      <p>
+        <i class="icon-check"></i> Verified
+      </p>
+      <ul style="margin: 0; padding-left: 1.25rem;">
+        {% for c in clinicians %}
+          <li>
+            {{ c.first_name or "" }} {{ c.last_name or "" }}
+            {%- if c.npi %}· NPI {{ c.npi }}{% endif %}
+            {%- set _active = c.licensures | selectattr('status', 'equalto', 'active') | list -%}
+            {%- if _active %}· {{ _active|length }} active license(s){% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p style="color: var(--pico-muted-color);">
+        Not yet verified. Add a clinician profile and active license to unlock posting.
+      </p>
+      {% if clinicians %}
+        <a href="{{ entity_url('clinician', id=clinicians[0].id) }}/form"
+           role="button"
+           class="outline">Continue setup</a>
+      {% endif %}
+    {% endif %}
+  </article>
+  <article>
+    <header style="display: flex;
+                   justify-content: space-between;
+                   align-items: baseline">
+      <strong>Organization representation</strong>
+    </header>
+    {% if claim_state.b %}
+      <p>
+        <i class="icon-check"></i> Representing {{ claim_state.b|length }} organization(s)
+      </p>
+      <ul style="margin: 0; padding-left: 1.25rem;">
+        {% for rep in org_representations %}
+          {% if rep.authority_status == "verified" and rep.archived_at is none %}
+            <li>{{ rep.org.name if rep.org else rep.org_id }} — {{ rep.role }}</li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p style="color: var(--pico-muted-color);">Not currently representing any organization.</p>
+    {% endif %}
+  </article>
+  {% if claim_state.a %}
+    <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
+      <a href="{{ entity_form_url("post") }}?kind=referral" role="button">+ Post a referral</a>
+      <a href="{{ entity_form_url("post") }}?kind=clinician_opening"
+         role="button"
+         class="outline">+ Post an opening</a>
+    </section>
   {% endif %}
-</article>
-{% if claim_state.a %}
-  <section style="display: flex; gap: 1rem;">
-    <a href="{{ entity_form_url("post") }}?kind=referral" role="button">+ Post a referral</a>
-    <a href="{{ entity_form_url("post") }}?kind=clinician_opening"
-       role="button"
-       class="outline">+ Post an opening</a>
-  </section>
-{% endif %}
 </section>

--- a/src/domain/templates/profile/_setup.html
+++ b/src/domain/templates/profile/_setup.html
@@ -1,54 +1,132 @@
-{# Setup mode — first-run goal picker per wireframe L1.
+{# Setup mode — guided onboarding for users with no verified claims.
+   Renders a progressive step-by-step flow based on the user's
+   clinicians' current state:
 
-   Renders two cards (Claim A / Claim B). In Phase-5-skeleton these are
-   informational + a link to the existing user-detail page where NPI /
-   license / org-representation rows can be created via the framework's
-   generic CRUD. The follow-up PR introduces inline POST endpoints
-   (`POST /clinicians/{id}/npi`, `POST /organizations/{id}/npi`) that
-   land the row, flip `npi_match_status='pending'`, and swap the card
-   into a "Verifying…" pill via HTMX.
+   Step 0 — no clinician yet: minimal create form (name + NPI +
+     location). Posts to POST /profile/clinician, which fires NPI
+     verification inline and redirects back here.
 
-   Per handoff §8.1 / wireframe L5: when a user only wants Claim B,
-   the Claim A card stays visible but in a disabled / "not needed"
-   state — never hidden. The card IS the affordance; inputs simply
-   aren't there until the user opts in.
+   Step 1 — clinician exists, NPI matched but no active license:
+     inline license + attestation form. Posts to
+     POST /profile/clinician/{id}/license.
+
+   Step 2 — clinician exists, NPI mismatch: error copy + link to
+     the clinician edit page to correct the NPI.
+
+   Step 2b — clinician exists, NPI not yet submitted: prompt to edit
+     and add NPI.
+
+   Claim B ("Post on behalf of an organization") card stays visible
+   per handoff §8.1 / wireframe L5 — always shown, never hidden.
+
+   Uses `form_with_errors` from `_shared/form_meta.html` so validation
+   failures (e.g. invalid NPI, bad ZIP) re-render the form in-place
+   via HTMX with per-field error copy.
 #}
+{%- from "_shared/form_fields.html" import text_field, select_field, checkbox_field -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{%- from "_shared/actions.html" import actions -%}
 <section>
-  <p>
-    <strong>What do you want to do on Bedlam Connect?</strong>
-  </p>
+  {# ------------------------------------------------------------------ #}
+  {# Clinician identity                                                   #}
+  {# ------------------------------------------------------------------ #}
   <article id="claim-a-card">
     <header>
-      <strong>Refer &amp; take clients as a clinician</strong>
-      <small style="display: block; color: var(--pico-muted-color);">Claim A — verify your individual NPI and license</small>
+      <strong>Add a clinician profile</strong>
+      <small style="display: block; color: var(--pico-muted-color);">
+        Verify your individual NPI and license to post referrals or openings
+      </small>
     </header>
-    <p>To list clinicians under your account and post referrals or openings, add a verified clinician profile.</p>
-    {% if clinicians %}
-      <p>
-        <small>You have {{ clinicians|length }} clinician profile(s) on file.
-          <a href="{{ entity_url('user', id='me') }}">Manage</a></small>
+    {%- set _clinician = clinicians[0] if clinicians else none -%}
+    {%- set _active_licenses = (_clinician.licensures | selectattr('status', 'equalto', 'active') | list) if _clinician else [] -%}
+    {% if not _clinician %}
+      {# Step 0: no clinician yet — minimal create form. #}
+      {% call form_with_errors(action="/profile/clinician", method="post") %}
+        <div class="grid">
+          {{ text_field("first_name", "First name", required=false) }}
+          {{ text_field("last_name", "Last name", required=false) }}
+        </div>
+        {{ text_field("npi", "NPI (Type-1)", required=true, pattern="\\d{10}", maxlength=10) }}
+        <div class="grid">
+          {{ text_field('location_city', 'City') }}
+          {{ select_field("location_state", "State", US_STATES, placeholder=true) }}
+          {{ text_field("location_zip", "ZIP", pattern="\\d{5}", maxlength=5) }}
+        </div>
+        {{ actions("Start verification") }}
+      {% endcall %}
+    {% elif _clinician.npi_match_status == "matched" and not _active_licenses %}
+      {# Step 1: NPI matched — add license and attest in one step. #}
+      <p style="color: var(--pico-color-green-600);">
+        <i class="icon-shield-check"></i>
+        {# title-case-ignore #}
+        <strong>Matched in NPPES</strong>
+        {% if _clinician.first_name or _clinician.last_name %}
+          — resolves to {{ _clinician.first_name or "" }} {{ _clinician.last_name or "" }}
+        {% endif %}
+      </p>
+      <p>Now add your license:</p>
+      {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/license", method="post") %}
+        {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
+        <div class="grid">
+          {{ select_field("issuing_state", "Issuing state", US_STATES, placeholder=true) }}
+          {{ text_field('license_number', 'License number') }}
+        </div>
+        {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
+        {{ checkbox_field("_attest_confirm", "I attest this license is active and in good standing.", required=true) }}
+        {{ actions("Add license") }}
+      {% endcall %}
+    {% elif _clinician.npi_match_status == "mismatch" %}
+      {# Step 2: NPI mismatch — guide user to correct it. #}
+      <p style="color: var(--pico-color-orange-600);">
+        <i class="icon-shield-alert"></i>
+        <strong>NPI not matched</strong>
+        {% if _clinician.npi %}— NPI {{ _clinician.npi }} did not resolve to your name in NPPES.{% endif %}
+      </p>
+      <p style="color: var(--pico-muted-color);">
+        {# title-case-ignore #}
+        Check that your first name, last name, and NPI match your NPPES record exactly.
+      </p>
+      <a href="{{ entity_url('clinician', id=_clinician.id) }}/form"
+         role="button"
+         class="outline">Edit clinician profile</a>
+    {% elif _clinician.npi_match_status == "none" %}
+      {# NPI not submitted yet — prompt to add it. #}
+      <p style="color: var(--pico-muted-color);">
+        No NPI on file yet.
+        <a href="{{ entity_url('clinician', id=_clinician.id) }}/form">Add your NPI</a>
+        to start verification.
       </p>
     {% else %}
-      <a href="{{ entity_url('user', id='me') }}"
-         role="button"
-         class="outline">+ Add a clinician profile</a>
+      {# Pending / any other transient state. #}
+      <p style="color: var(--pico-muted-color);">
+        <i class="icon-loader"></i> Verification in progress…
+        <a href="{{ entity_url('clinician', id=_clinician.id) }}/form">View clinician</a>
+      </p>
     {% endif %}
   </article>
+  {# ------------------------------------------------------------------ #}
+  {# Organization representation                                          #}
+  {# ------------------------------------------------------------------ #}
   <article id="claim-b-card">
     <header>
       <strong>Post on behalf of an organization</strong>
-      <small style="display: block; color: var(--pico-muted-color);">
-        Claim B — represent an organization with a Type-2 NPI
-      </small>
+      <small style="display: block; color: var(--pico-muted-color);">Represent an organization with a Type-2 NPI</small>
     </header>
-    <p>To post program intakes or org-attributed referrals, become a verified representative of an organization.</p>
+    <p>
+      To post program intakes or org-attributed referrals, become a verified
+      representative of an organization.
+    </p>
     {% if org_representations %}
       <p>
         <small>You have {{ org_representations|length }} representation(s) on file.</small>
       </p>
     {% else %}
       <p style="color: var(--pico-muted-color);">
-        <small>Coordinator path — coming soon. The org's NPI is verified once; you prove you're authorized to speak for it via Authorized-Official match, domain email, or admin review.</small>
+        <small>
+          The org's NPI is verified once; you prove you're authorized to speak
+          for it via Authorized-Official match, domain email, or admin review.
+          Coming soon.
+        </small>
       </p>
     {% endif %}
   </article>


### PR DESCRIPTION
## Summary

- **`POST /profile/clinician`**: creates a minimal clinician (name + NPI + location) and fires NPI verification inline, then redirects back to `/profile`. No 15-field form — just the fields required for verification.
- **`POST /profile/clinician/{id}/license`**: creates a licensure and immediately attests it active in one step via a required attestation checkbox, then redirects to `/profile`. Eliminates the two-step create-then-attest dance.
- **`_setup.html` rewrite**: progressive 5-state flow driven by `npi_match_status` — no clinician yet → NPI matched (add license) → mismatch → NPI not submitted → verification pending. Claim B card remains visible per §8.1.
- **`_manage.html` polish**: direct "Manage →" links to the clinician edit form, per-clinician active license count, removed stale `/users/me` CTA.
- **`ClinicianCreate` schema**: added `= "yes"` defaults to `in_person_sessions` / `virtual_sessions` so the profile endpoints don't need to send those fields.

## Test plan

- [ ] `dev test src/domain/routes/test_profile.py` — 9 tests, all pass (happy path create + license, auth required, ownership enforcement)
- [ ] `dev lint` — all checks pass
- [ ] Manual: new user → `/profile` shows minimal form → submit NPI + name + location → page shows NPPES match status → add license + attest → `/home` "Finish setting up" card disappears
- [ ] Existing `/clinicians/form` create flow unaffected (forms POST session values explicitly; schema defaults are additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)