### PR TITLE
fix: redirect to /profile after account creation

### DIFF
--- a/src/domain/routes/auth_routes.py
+++ b/src/domain/routes/auth_routes.py
@@ -110,7 +110,7 @@ async def register_request_handler(
         # Mirrors the pattern in src/domain/routes/dev_auth.py.
         login_response = await auth_backend.login(get_strategy(), created_user)
         login_response.status_code = 200
-        login_response.headers["HX-Redirect"] = "/users/me"
+        login_response.headers["HX-Redirect"] = "/profile"
         return login_response
 
     return created_user

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -95,7 +95,7 @@ async def test_register_via_htmx_sets_cookie_and_redirects(test_client: AsyncCli
         headers={"HX-Request": "true", "Content-Type": "application/json"},
     )
     assert response.status_code == 200
-    assert response.headers.get("HX-Redirect") == "/users/me"
+    assert response.headers.get("HX-Redirect") == "/profile"
     # A session cookie must be set so the redirect lands authenticated.
     assert (
         "fastapiusersauth" in response.cookies


### PR DESCRIPTION
## Summary
- Changes `HX-Redirect` after HTMX register from `/users/me` to `/profile`
- Updates the corresponding test assertion

## Test plan
- [ ] `dev test src/domain/routes/test_auth_routes.py` — all 43 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)