### PR TITLE
feat: streamlined onboarding — minimal fast-path + deferred profile completion

### DIFF
--- a/alembic/versions/a3f1e2d4c5b6_make_clinician_affiliations_location_nullable.py
+++ b/alembic/versions/a3f1e2d4c5b6_make_clinician_affiliations_location_nullable.py
@@ -1,0 +1,78 @@
+"""make clinician_affiliations location columns nullable
+
+Revision ID: a3f1e2d4c5b6
+Revises: 9b078396f8f2
+Create Date: 2026-06-01 00:00:00.000000
+
+Location (city / state / zip) on clinician_affiliations becomes nullable
+so the onboarding wizard can collect only name + NPI on the fast path
+and let users fill in location later from the "complete your profile"
+section.  referral_details.location_* stays NOT NULL — a referral is
+always tied to a client location.
+
+The location_state CHECK constraint is dropped and re-created to allow
+NULL.  SQL NULL passes CHECK constraints by default, but we add an
+explicit ``IS NULL OR`` arm so the intent is readable and future
+contributors don't remove it thinking it's redundant.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3f1e2d4c5b6"
+down_revision: Union[str, None] = "9b078396f8f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_STATES_SQL = (
+    "location_state IS NULL OR location_state IN "
+    "('AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', "
+    "'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', "
+    "'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', "
+    "'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', "
+    "'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY')"
+)
+
+_STATES_SQL_NOT_NULL = (
+    "location_state IN "
+    "('AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', "
+    "'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', "
+    "'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', "
+    "'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', "
+    "'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY')"
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("clinician_affiliations") as batch_op:
+        batch_op.drop_constraint(
+            "ck_clinician_affiliations_location_state", type_="check"
+        )
+        batch_op.alter_column("location_city", nullable=True, type_=sa.Text())
+        batch_op.alter_column("location_state", nullable=True, type_=sa.Text())
+        batch_op.alter_column("location_zip", nullable=True, type_=sa.Text())
+        batch_op.create_check_constraint(
+            "ck_clinician_affiliations_location_state",
+            _STATES_SQL,
+        )
+
+
+def downgrade() -> None:
+    # Pre-launch: any NULL location rows would violate the restored NOT NULL
+    # constraint.  Caller must backfill or delete such rows before running
+    # downgrade in a non-empty database.
+    with op.batch_alter_table("clinician_affiliations") as batch_op:
+        batch_op.drop_constraint(
+            "ck_clinician_affiliations_location_state", type_="check"
+        )
+        batch_op.alter_column("location_city", nullable=False, type_=sa.Text())
+        batch_op.alter_column("location_state", nullable=False, type_=sa.Text())
+        batch_op.alter_column("location_zip", nullable=False, type_=sa.Text())
+        batch_op.create_check_constraint(
+            "ck_clinician_affiliations_location_state",
+            _STATES_SQL_NOT_NULL,
+        )

--- a/scripts/dev/seed/overrides/clinicians.py
+++ b/scripts/dev/seed/overrides/clinicians.py
@@ -121,7 +121,14 @@ async def generate_affiliations(
         # Primary affiliation — deterministic ID keyed (clinician, 0).
         primary_id = deterministic_uuid("ClinicianAffiliation", i, 0)
         kwargs = _affiliation_kwargs(rng, aff_index)
-        kwargs["location_city"] = _city_for_state(rng, kwargs["location_state"])
+        # ~20% of affiliations have null location — exercises the deferred
+        # "complete your profile" path where location is filled in later.
+        if rng.bool(0.2):
+            kwargs["location_city"] = None
+            kwargs["location_state"] = None
+            kwargs["location_zip"] = None
+        else:
+            kwargs["location_city"] = _city_for_state(rng, kwargs["location_state"])
         primary = ClinicianAffiliation(
             id=primary_id,
             clinician_id=clinician.id,

--- a/src/domain/logic/clinicians/schema.py
+++ b/src/domain/logic/clinicians/schema.py
@@ -215,7 +215,7 @@ class ClinicianRead(FlatLocationSchema, ReadProjection):
     # the flat input into a nested ``location`` block before validation
     # so the ``Location`` value object owns the cleaning rules; the
     # ``@model_serializer`` below unrolls it back to flat on dump.
-    location: Location
+    location: Location | None = None
     in_person_sessions: str
     virtual_sessions: str
     accepts_out_of_network: bool
@@ -266,7 +266,7 @@ class ClinicianCreate(FlatLocationSchema, WirePayload):
     # via `Clinician.__init__`'s kwarg peeling.
     first_name: StrippedOptionalText = None
     last_name: StrippedOptionalText = None
-    location: Location
+    location: Location | None = None
     in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] = "yes"
     virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] = "yes"
     # Insurance posture. `in_network_carriers` is the set the practice

--- a/src/domain/logic/profile/handlers.py
+++ b/src/domain/logic/profile/handlers.py
@@ -98,9 +98,9 @@ async def handle_clinician_create(
     first_name: str | None,
     last_name: str | None,
     npi: str | None,
-    location_city: str,
-    location_state: str,
-    location_zip: str,
+    location_city: str | None,
+    location_state: str | None,
+    location_zip: str | None,
     requesting_user: User,
     clinician_repo: Any,
     organization_repo: Any,
@@ -111,9 +111,9 @@ async def handle_clinician_create(
     NPI verification inline.
 
     Hardcodes ``solo_practice=True`` so the user doesn't need to pick
-    an org during onboarding. Session/in_person defaults to "yes" via
-    the schema. The caller returns ``HX-Redirect: /profile`` so the hub
-    re-renders with the new clinician's NPPES state already reflected.
+    an org during onboarding. Location is optional — callers that omit
+    it (the fast-path wizard) pass ``None`` for all three fields; users
+    can fill location in later from "complete your profile".
     """
     from src.domain.logic.clinicians.handlers import (
         _assert_clinician_payload_org_ownership,
@@ -152,6 +152,121 @@ async def handle_clinician_create(
         clinician_repo=clinician_repo,
         verification_audit_repo=audit_repo,
     )
+    return clinician
+
+
+async def handle_clinician_identity_update(
+    *,
+    clinician_id: UUID,
+    first_name: str | None,
+    last_name: str | None,
+    npi: str | None,
+    requesting_user: User,
+    clinician_repo: Any,
+    verification_repo: Any,
+    audit_repo: Any,
+) -> Any:
+    """Update a clinician's identity fields (name + NPI) and re-run NPI
+    verification inline.  Used by the profile hub's inline retry form
+    when the initial verification returned a mismatch — the user can
+    correct their name or NPI without leaving /profile.
+    """
+    from src.domain.logic.clinicians.handlers import after_create_clinician_verification
+    from src.domain.models import Clinician
+    from src.framework.authz import is_owner_or_admin
+    from src.framework.http.exceptions import ForbiddenError, NotFoundError
+
+    clinician = await clinician_repo.get_by_model_id(Clinician, clinician_id)
+    if clinician is None:
+        raise NotFoundError(detail="Clinician not found")
+    if not is_owner_or_admin(clinician, requesting_user):
+        raise ForbiddenError(detail="Cannot update this clinician")
+
+    fields: dict[str, Any] = {}
+    if first_name is not None:
+        fields["first_name"] = first_name or None
+    if last_name is not None:
+        fields["last_name"] = last_name or None
+    if npi is not None:
+        fields["npi"] = npi or None
+
+    if fields:
+        clinician = await clinician_repo.patch(clinician, **fields)
+
+    await after_create_clinician_verification(
+        row=clinician,
+        payload=clinician,
+        requesting_user=requesting_user,
+        verification_repo=verification_repo,
+        clinician_repo=clinician_repo,
+        verification_audit_repo=audit_repo,
+    )
+    return clinician
+
+
+async def handle_clinician_details_update(
+    *,
+    clinician_id: UUID,
+    location_city: str | None,
+    location_state: str | None,
+    location_zip: str | None,
+    in_person_sessions: str | None,
+    virtual_sessions: str | None,
+    accepts_out_of_network: bool | None,
+    sliding_scale: bool | None,
+    cost: str | None,
+    requesting_user: User,
+    clinician_repo: Any,
+    audit_repo: Any,
+) -> Any:
+    """Patch a clinician's practice details (location / availability /
+    insurance) from the profile hub's "complete your profile" section.
+    Only non-None fields are written; the call is a no-op if all args
+    are None.
+    """
+    from src.domain.models import Clinician
+    from src.domain.specs.clinician import CLINICIAN_ENTITY
+    from src.framework.audit.core import mutate
+    from src.framework.authz import is_owner_or_admin
+    from src.framework.http.exceptions import ForbiddenError, NotFoundError
+
+    clinician = await clinician_repo.get_by_model_id(Clinician, clinician_id)
+    if clinician is None:
+        raise NotFoundError(detail="Clinician not found")
+    if not is_owner_or_admin(clinician, requesting_user):
+        raise ForbiddenError(detail="Cannot update this clinician")
+
+    fields: dict[str, Any] = {}
+    # Location: patch all three or none — partial location is not useful.
+    if (
+        location_city is not None
+        and location_state is not None
+        and location_zip is not None
+    ):
+        fields["location_city"] = location_city or None
+        fields["location_state"] = location_state or None
+        fields["location_zip"] = location_zip or None
+    if in_person_sessions is not None:
+        fields["in_person_sessions"] = in_person_sessions
+    if virtual_sessions is not None:
+        fields["virtual_sessions"] = virtual_sessions
+    if accepts_out_of_network is not None:
+        fields["accepts_out_of_network"] = accepts_out_of_network
+    if sliding_scale is not None:
+        fields["sliding_scale"] = sliding_scale
+    if cost is not None:
+        fields["cost"] = cost or None
+
+    if fields:
+        async with mutate(
+            clinician_repo,
+            audit_repo,
+            actor=requesting_user,
+            target=clinician,
+            resource=CLINICIAN_ENTITY.audit,
+            verb="update",
+        ):
+            await clinician_repo.patch(clinician, **fields)
     return clinician
 
 

--- a/src/domain/logic/value_objects/location.py
+++ b/src/domain/logic/value_objects/location.py
@@ -133,8 +133,20 @@ def gather_flat_location(data: Any) -> Any:
         for sub in _LOCATION_SUBFIELDS:
             key = f"location_{sub}"
             if key in data:
-                nested[sub] = data[key]
-        out["location"] = nested
+                v = data[key]
+                # Empty string from a blank form field → treat as absent
+                if isinstance(v, str) and not v.strip():
+                    v = None
+                nested[sub] = v
+        # When every subfield is absent or None the clinician has no location
+        # yet.  Setting location=None lets schemas with `location: Location |
+        # None = None` accept the payload without 422-ing on missing required
+        # subfields.  Partial location (some fields present, some None) is
+        # forwarded as-is so LocationPartial updates work correctly.
+        if all(nested.get(sub) is None for sub in _LOCATION_SUBFIELDS):
+            out["location"] = None
+        else:
+            out["location"] = nested
         return out
     # Attribute-bag branch: SimpleNamespace (contract-test mocks),
     # SQLAlchemy rows from older code paths that didn't pick up the
@@ -149,8 +161,15 @@ def gather_flat_location(data: Any) -> Any:
     }
     if not flat_attrs:
         return data
+    # Mirrors the dict branch: all-None subfields mean "no location yet"
+    # (deferred onboarding path) — set location=None so Location | None
+    # schemas accept the payload without 422-ing on missing required subfields.
+    if all(v is None for v in flat_attrs.values()):
+        location_value: dict | None = None
+    else:
+        location_value = flat_attrs
     try:
-        setattr(data, "location", flat_attrs)
+        setattr(data, "location", location_value)
     except (AttributeError, TypeError):
         # Immutable / slot-bound bags can't take new attrs; downstream
         # validation will surface a helpful error.
@@ -177,8 +196,17 @@ def flatten_location_on_dump(model: BaseModel, data: dict[str, Any]) -> dict[str
     touched ``location.city`` produces ``{"location_city": ...}`` and
     not ``{"location_city": ..., "location_state": None, "location_zip": None}``.
     """
-    nested = data.pop("location", None)
+    _absent = object()
+    nested = data.pop("location", _absent)
+    if nested is _absent:
+        # `location` key was absent (e.g. model_dump(exclude_unset=True) on an
+        # Update that didn't touch location) — leave the dict untouched.
+        return data
     if nested is None:
+        # location was explicitly None — write explicit nulls so the wire shape
+        # is stable (consumers always see location_city / _state / _zip, just null).
+        for sub in _LOCATION_SUBFIELDS:
+            data[f"location_{sub}"] = None
         return data
     if not isinstance(nested, dict):
         # Shouldn't happen in practice, but be defensive — restore the

--- a/src/domain/models/clinician_affiliations/clinician_affiliation.py
+++ b/src/domain/models/clinician_affiliations/clinician_affiliation.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import ClassVar
 
 from sqlalchemy import JSON, Boolean, Column, ForeignKey, Text, text
 from sqlalchemy.orm import relationship
@@ -14,6 +15,9 @@ _ck = partial(named_check_in, _TABLE)
 
 
 class ClinicianAffiliation(LocationMixin, BaseModel):
+    # Location is deferred during onboarding — users fill it in from the
+    # "complete your profile" section after NPI verification.
+    _location_nullable: ClassVar[bool] = True
     """The clinician's role at one organization.
 
     Holds the practice-role attributes that vary per (clinician × org):

--- a/src/domain/routes/profile.py
+++ b/src/domain/routes/profile.py
@@ -40,6 +40,8 @@ from src.domain.logic.organizations.repository import (
 from src.domain.logic.profile.handlers import (
     build_profile_context,
     handle_clinician_create,
+    handle_clinician_details_update,
+    handle_clinician_identity_update,
     handle_clinician_license_create,
 )
 from src.domain.logic.verifications.repository import (
@@ -79,9 +81,9 @@ async def profile_clinician_create(
     first_name: str | None = Form(default=None),
     last_name: str | None = Form(default=None),
     npi: str | None = Form(default=None),
-    location_city: str = Form(...),
-    location_state: str = Form(...),
-    location_zip: str = Form(...),
+    location_city: str | None = Form(default=None),
+    location_state: str | None = Form(default=None),
+    location_zip: str | None = Form(default=None),
     requesting_user: User = Depends(current_active_user),
     clinician_repo: ClinicianRepository = Depends(get_clinician_repository),
     organization_repo: OrganizationRepository = Depends(get_organization_repository),
@@ -149,6 +151,85 @@ async def profile_clinician_license_create(
     )
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,
+        content={},
+        headers={"HX-Redirect": "/profile"},
+    )
+
+
+@profile_pages_router.post(
+    "/profile/clinician/{clinician_id}/identity",
+    name="profile:clinician_identity_update",
+)
+async def profile_clinician_identity_update(
+    clinician_id: UUID,
+    first_name: str | None = Form(default=None),
+    last_name: str | None = Form(default=None),
+    npi: str | None = Form(default=None),
+    requesting_user: User = Depends(current_active_user),
+    clinician_repo: ClinicianRepository = Depends(get_clinician_repository),
+    verification_repo: VerificationRepository = Depends(get_verification_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+) -> Any:
+    """Update a clinician's name + NPI and immediately re-run NPI
+    verification.  Presented as an inline form on /profile when the
+    initial verification returned a mismatch — keeps the user on /profile
+    rather than bouncing them to the full clinician-edit page.
+    """
+    await handle_clinician_identity_update(
+        clinician_id=clinician_id,
+        first_name=first_name,
+        last_name=last_name,
+        npi=npi,
+        requesting_user=requesting_user,
+        clinician_repo=clinician_repo,
+        verification_repo=verification_repo,
+        audit_repo=audit_repo,
+    )
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={},
+        headers={"HX-Redirect": "/profile"},
+    )
+
+
+@profile_pages_router.post(
+    "/profile/clinician/{clinician_id}/details",
+    name="profile:clinician_details_update",
+)
+async def profile_clinician_details_update(
+    clinician_id: UUID,
+    location_city: str | None = Form(default=None),
+    location_state: str | None = Form(default=None),
+    location_zip: str | None = Form(default=None),
+    in_person_sessions: str | None = Form(default=None),
+    virtual_sessions: str | None = Form(default=None),
+    accepts_out_of_network: bool | None = Form(default=None),
+    sliding_scale: bool | None = Form(default=None),
+    cost: str | None = Form(default=None),
+    requesting_user: User = Depends(current_active_user),
+    clinician_repo: ClinicianRepository = Depends(get_clinician_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+) -> Any:
+    """Patch a clinician's location / availability / insurance from the
+    profile hub's "complete your profile" section.  Returns the user to
+    /profile after saving so the hub reflects the updated state.
+    """
+    await handle_clinician_details_update(
+        clinician_id=clinician_id,
+        location_city=location_city,
+        location_state=location_state,
+        location_zip=location_zip,
+        in_person_sessions=in_person_sessions,
+        virtual_sessions=virtual_sessions,
+        accepts_out_of_network=accepts_out_of_network,
+        sliding_scale=sliding_scale,
+        cost=cost,
+        requesting_user=requesting_user,
+        clinician_repo=clinician_repo,
+        audit_repo=audit_repo,
+    )
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
         content={},
         headers={"HX-Redirect": "/profile"},
     )

--- a/src/domain/routes/test_profile.py
+++ b/src/domain/routes/test_profile.py
@@ -103,6 +103,37 @@ async def test_post_profile_clinician_creates_and_redirects(
         assert clinician.org_id is not None
 
 
+async def test_post_profile_clinician_without_location(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """POST /profile/clinician works without location fields — the fast
+    path only needs name + NPI.  Location columns stay NULL on the
+    affiliation row and can be filled in later via the details endpoint."""
+    response = await authenticated_client.post(
+        "/profile/clinician",
+        data={
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "npi": "1234567890",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.headers.get("HX-Redirect") == "/profile"
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(Clinician).where(Clinician.owner_id == logged_in_user.id)
+        )
+        clinician = result.scalars().first()
+        assert clinician is not None
+        assert clinician.npi == "1234567890"
+        assert clinician.location_city is None
+        assert clinician.location_state is None
+
+
 async def test_post_profile_clinician_requires_authentication(
     test_client: AsyncClient,
 ):
@@ -163,6 +194,136 @@ async def test_post_profile_clinician_license_creates_attests_and_redirects(
         assert licensure is not None
         assert licensure.attested_active is True
         assert licensure.status == "active"
+
+
+async def test_post_profile_clinician_identity_update_retries_verification(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """POST /profile/clinician/{id}/identity updates name + NPI and
+    re-runs verification inline, returning HX-Redirect: /profile."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(
+        owner_id=logged_in_user.id,
+        npi="1111111111",
+        npi_match_status="mismatch",
+    )
+    clinician.clinician_verified = False
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+    clinician_id = clinician.id
+
+    response = await authenticated_client.post(
+        f"/profile/clinician/{clinician_id}/identity",
+        data={
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "npi": "9999999999",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("HX-Redirect") == "/profile"
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(Clinician).where(Clinician.id == clinician_id)
+        )
+        updated = result.scalars().first()
+        assert updated.npi == "9999999999"
+        assert updated.first_name == "Jane"
+
+
+async def test_post_profile_clinician_identity_update_rejects_wrong_owner(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A user cannot update another user's clinician identity."""
+    from tests.helpers import create_test_user, make_clinician_with_org
+
+    other = create_test_user(username="other-identity")
+    clinician = make_clinician_with_org(owner_id=other.id, npi="2222222222")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(clinician)
+
+    response = await authenticated_client.post(
+        f"/profile/clinician/{clinician.id}/identity",
+        data={"first_name": "Evil", "last_name": "Hacker", "npi": "3333333333"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 403
+
+
+async def test_post_profile_clinician_details_update_saves_location(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """POST /profile/clinician/{id}/details patches location fields and
+    returns HX-Redirect: /profile."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(
+        owner_id=logged_in_user.id,
+        npi="1234567890",
+        location_city=None,
+        location_state=None,
+        location_zip=None,
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+    clinician_id = clinician.id
+
+    response = await authenticated_client.post(
+        f"/profile/clinician/{clinician_id}/details",
+        data={
+            "location_city": "Portland",
+            "location_state": "OR",
+            "location_zip": "97201",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("HX-Redirect") == "/profile"
+
+    async with db_test_session_manager() as session:
+        result = await session.execute(
+            select(Clinician).where(Clinician.id == clinician_id)
+        )
+        updated = result.scalars().first()
+        assert updated.location_city == "Portland"
+        assert updated.location_state == "OR"
+        assert updated.location_zip == "97201"
+
+
+async def test_post_profile_clinician_details_update_rejects_wrong_owner(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A user cannot update another user's clinician details."""
+    from tests.helpers import create_test_user, make_clinician_with_org
+
+    other = create_test_user(username="other-details")
+    clinician = make_clinician_with_org(owner_id=other.id, npi="5555555555")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+            session.add(clinician)
+
+    response = await authenticated_client.post(
+        f"/profile/clinician/{clinician.id}/details",
+        data={"location_city": "Evil", "location_state": "CA", "location_zip": "90210"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 403
 
 
 async def test_post_profile_clinician_license_requires_authentication(

--- a/src/domain/templates/profile/_manage.html
+++ b/src/domain/templates/profile/_manage.html
@@ -2,7 +2,14 @@
    profile header with claim badges, status rows for clinician identity
    and org representation with direct "Manage →" edit links, and a
    "+ New post" CTA when verified.
+
+   Also renders a "Complete your profile" section when optional practice
+   details (location, availability, insurance) have not been filled in
+   yet — deferred from the fast-path onboarding wizard.
 #}
+{%- from "_shared/form_fields.html" import text_field, select_field, checkbox_field -%}
+{%- from "_shared/form_meta.html" import form_with_errors with context -%}
+{%- from "_shared/actions.html" import actions -%}
 <section>
   <header>
     <hgroup>
@@ -96,5 +103,59 @@
          role="button"
          class="outline">+ Post an opening</a>
     </section>
+  {% endif %}
+  {# ------------------------------------------------------------------ #}
+  {# Complete your profile — deferred practice details                   #}
+  {# ------------------------------------------------------------------ #}
+  {% if clinicians %}
+    {% set _c = clinicians[0] %}
+    {% set _missing_location = not _c.location_city or not _c.location_state %}
+    {% if _missing_location %}
+      <article id="complete-profile">
+        <header>
+          <strong>Complete your profile</strong>
+          <small style="display: block; color: var(--pico-muted-color);">
+            Add practice details to help clients find you — fill in what you like, whenever you like.
+          </small>
+        </header>
+        {# Location ---------------------------------------------------- #}
+        <details {% if _missing_location %}open{% endif %}>
+          <summary>
+            <strong>Location</strong>
+          </summary>
+          {% call form_with_errors(action="/profile/clinician/" ~ _c.id|string ~ "/details", method="post") %}
+            <div class="grid">
+              {{ text_field("location_city", "City", value=_c.location_city or "") }}
+              {{ select_field("location_state", "State", US_STATES, current=_c.location_state, placeholder=true) }}
+              {{ text_field("location_zip", "ZIP", value=_c.location_zip or "", pattern="\\d{5}", maxlength=5) }}
+            </div>
+            {{ actions("Save location") }}
+          {% endcall %}
+        </details>
+        {# Availability ------------------------------------------------ #}
+        <details>
+          <summary>
+            <strong>Session availability</strong>
+          </summary>
+          {% call form_with_errors(action="/profile/clinician/" ~ _c.id|string ~ "/details", method="post") %}
+            {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=_c.in_person_sessions) }}
+            {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=_c.virtual_sessions) }}
+            {{ actions("Save availability") }}
+          {% endcall %}
+        </details>
+        {# Insurance / payment ----------------------------------------- #}
+        <details>
+          <summary>
+            <strong>Insurance &amp; payment</strong>
+          </summary>
+          {% call form_with_errors(action="/profile/clinician/" ~ _c.id|string ~ "/details", method="post") %}
+            {{ checkbox_field("accepts_out_of_network", "Accepts out-of-network insurance", checked=_c.accepts_out_of_network) }}
+            {{ checkbox_field("sliding_scale", "Sliding scale available", checked=_c.sliding_scale) }}
+            {{ text_field("cost", "Session cost (optional)", value=_c.cost or "", required=false) }}
+            {{ actions("Save payment info") }}
+          {% endcall %}
+        </details>
+      </article>
+    {% endif %}
   {% endif %}
 </section>

--- a/src/domain/templates/profile/_setup.html
+++ b/src/domain/templates/profile/_setup.html
@@ -2,26 +2,28 @@
    Renders a progressive step-by-step flow based on the user's
    clinicians' current state:
 
-   Step 0 — no clinician yet: minimal create form (name + NPI +
-     location). Posts to POST /profile/clinician, which fires NPI
-     verification inline and redirects back here.
+   Step 0 — no clinician yet: minimal fast-path form (name + NPI only;
+     location is deferred to "complete your profile"). Posts to
+     POST /profile/clinician, which fires NPI verification inline and
+     redirects back here.
 
    Step 1 — clinician exists, NPI matched but no active license:
      inline license + attestation form. Posts to
      POST /profile/clinician/{id}/license.
 
-   Step 2 — clinician exists, NPI mismatch: error copy + link to
-     the clinician edit page to correct the NPI.
+   Step 2 — clinician exists, NPI mismatch: inline name + NPI retry
+     form so the user can correct without leaving /profile. Posts to
+     POST /profile/clinician/{id}/identity.
 
-   Step 2b — clinician exists, NPI not yet submitted: prompt to edit
-     and add NPI.
+   Step 2b — clinician exists, NPI not yet submitted: inline NPI
+     submit form.
 
    Claim B ("Post on behalf of an organization") card stays visible
    per handoff §8.1 / wireframe L5 — always shown, never hidden.
 
    Uses `form_with_errors` from `_shared/form_meta.html` so validation
-   failures (e.g. invalid NPI, bad ZIP) re-render the form in-place
-   via HTMX with per-field error copy.
+   failures (e.g. invalid NPI format) re-render the form in-place via
+   HTMX with per-field error copy.
 #}
 {%- from "_shared/form_fields.html" import text_field, select_field, checkbox_field -%}
 {%- from "_shared/form_meta.html" import form_with_errors with context -%}
@@ -40,18 +42,13 @@
     {%- set _clinician = clinicians[0] if clinicians else none -%}
     {%- set _active_licenses = (_clinician.licensures | selectattr('status', 'equalto', 'active') | list) if _clinician else [] -%}
     {% if not _clinician %}
-      {# Step 0: no clinician yet — minimal create form. #}
+      {# Step 0: no clinician yet — name + NPI only; location deferred. #}
       {% call form_with_errors(action="/profile/clinician", method="post") %}
         <div class="grid">
           {{ text_field("first_name", "First name", required=false) }}
           {{ text_field("last_name", "Last name", required=false) }}
         </div>
         {{ text_field("npi", "NPI (Type-1)", required=true, pattern="\\d{10}", maxlength=10) }}
-        <div class="grid">
-          {{ text_field('location_city', 'City') }}
-          {{ select_field("location_state", "State", US_STATES, placeholder=true) }}
-          {{ text_field("location_zip", "ZIP", pattern="\\d{5}", maxlength=5) }}
-        </div>
         {{ actions("Start verification") }}
       {% endcall %}
     {% elif _clinician.npi_match_status == "matched" and not _active_licenses %}
@@ -76,7 +73,7 @@
         {{ actions("Add license") }}
       {% endcall %}
     {% elif _clinician.npi_match_status == "mismatch" %}
-      {# Step 2: NPI mismatch — guide user to correct it. #}
+      {# Step 2: NPI mismatch — inline retry form, no redirect away. #}
       <p style="color: var(--pico-color-orange-600);">
         <i class="icon-shield-alert"></i>
         <strong>NPI not matched</strong>
@@ -84,18 +81,26 @@
       </p>
       <p style="color: var(--pico-muted-color);">
         {# title-case-ignore #}
-        Check that your first name, last name, and NPI match your NPPES record exactly.
+        Correct your name or NPI below to match your NPPES record exactly, then retry.
       </p>
-      <a href="{{ entity_url('clinician', id=_clinician.id) }}/form"
-         role="button"
-         class="outline">Edit clinician profile</a>
+      {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/identity", method="post") %}
+        <div class="grid">
+          {{ text_field("first_name", "First name", value=_clinician.first_name or "", required=false) }}
+          {{ text_field("last_name", "Last name", value=_clinician.last_name or "", required=false) }}
+        </div>
+        {{ text_field("npi", "NPI (Type-1)", value=_clinician.npi or "", required=true, pattern="\\d{10}", maxlength=10) }}
+        {{ actions("Retry verification") }}
+      {% endcall %}
     {% elif _clinician.npi_match_status == "none" %}
-      {# NPI not submitted yet — prompt to add it. #}
-      <p style="color: var(--pico-muted-color);">
-        No NPI on file yet.
-        <a href="{{ entity_url('clinician', id=_clinician.id) }}/form">Add your NPI</a>
-        to start verification.
-      </p>
+      {# NPI not submitted yet — inline form to add it. #}
+      {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/identity", method="post") %}
+        <div class="grid">
+          {{ text_field("first_name", "First name", value=_clinician.first_name or "", required=false) }}
+          {{ text_field("last_name", "Last name", value=_clinician.last_name or "", required=false) }}
+        </div>
+        {{ text_field("npi", "NPI (Type-1)", value=_clinician.npi or "", required=true, pattern="\\d{10}", maxlength=10) }}
+        {{ actions("Start verification") }}
+      {% endcall %}
     {% else %}
       {# Pending / any other transient state. #}
       <p style="color: var(--pico-muted-color);">

--- a/src/framework/persistence/mixins.py
+++ b/src/framework/persistence/mixins.py
@@ -24,53 +24,58 @@ from sqlalchemy.orm import declared_attr
 class LocationMixin:
     """``(city, state, zip)`` postal-address column group.
 
-    Mixed into :class:`~src.domain.models.clinicians.Clinician` and
-    :class:`~src.domain.models.posts.referral_detail.ReferralDetail`.
-    Both consumers want ``nullable=False`` on all three columns and a
-    ``location_state`` CHECK constraint against ``US_STATES``; the
-    constraint stays on the consuming table (CHECK names are table-
-    prefixed, see module docstring).
+    Mixed into ORM models that carry a location triple.
+    ``ReferralDetail`` keeps ``nullable=False`` (a referral is always
+    location-specific).  ``ClinicianAffiliation`` sets
+    ``_location_nullable = True`` so location can be deferred during
+    onboarding and filled in later.
 
     Each column is declared via :func:`declared_attr` so SQLAlchemy
     builds a fresh :class:`Column` per subclass (a bare ``Column(...)``
     on a mixin would be shared across every consumer and only attach to
     the first table that imports it).
 
-    The mixin also exposes a Python-side :attr:`location` property that
-    returns a ``{"city": ..., "state": ..., "zip": ...}`` dict view of
-    the three columns. The Read wire schema's nested ``location: Location``
-    field consumes this property via Pydantic's ``from_attributes=True``;
-    embedding schemas don't need to know about the underlying column
-    layout.
+    The mixin exposes a Python-side :attr:`location` property that
+    returns a ``{"city": ..., "state": ..., "zip": ...}`` dict when the
+    columns are populated, or ``None`` when all three are ``NULL``.  The
+    Read wire schema's nested ``location: Location | None`` field consumes
+    this via Pydantic's ``from_attributes=True``.
 
     The wire/audit-layer counterpart is
     :class:`src.domain.logic.value_objects.location.Location`.
     """
 
+    # Subclasses that allow NULL location (e.g. ClinicianAffiliation where
+    # location is optional during onboarding) set this to True.  The
+    # declared_attr methods read this at mapper-configuration time so
+    # SQLAlchemy emits the right column definition per table.
+    _location_nullable: bool = False
+
     @declared_attr
     def location_city(cls):
-        return Column(Text, nullable=False)
+        return Column(Text, nullable=getattr(cls, "_location_nullable", False))
 
     @declared_attr
     def location_state(cls):
-        return Column(Text, nullable=False)
+        return Column(Text, nullable=getattr(cls, "_location_nullable", False))
 
     @declared_attr
     def location_zip(cls):
-        return Column(Text, nullable=False)
+        return Column(Text, nullable=getattr(cls, "_location_nullable", False))
 
     @property
-    def location(self) -> dict[str, str]:
+    def location(self) -> dict[str, str | None] | None:
         """Python-side dict view of the ``(city, state, zip)`` columns.
 
-        Consumed by the Read wire schema (``location: Location`` field
-        with ``from_attributes=True``). The wire layer's
-        ``model_serializer`` flattens this back to top-level
-        ``location_<sub>`` keys on dump, so JSON/audit shape stays
-        unchanged from pre-#451.
+        Returns ``None`` when all three columns are ``NULL`` — this lets
+        the Read wire schema declare ``location: Location | None`` and
+        correctly represent clinicians whose location has not been filled
+        in yet.  When at least one column is non-NULL the full dict is
+        returned so ``Location`` validation succeeds.
         """
-        return {
-            "city": self.location_city,
-            "state": self.location_state,
-            "zip": self.location_zip,
-        }
+        city = self.location_city
+        state = self.location_state
+        zip_ = self.location_zip
+        if city is None and state is None and zip_ is None:
+            return None
+        return {"city": city, "state": state, "zip": zip_}

--- a/src/framework/persistence/test_mixins.py
+++ b/src/framework/persistence/test_mixins.py
@@ -20,15 +20,15 @@ def test_both_consumer_tables_carry_the_three_location_columns():
 
 
 def test_location_columns_are_not_null_on_each_table():
-    """Both consumers want ``NOT NULL`` on the three columns at the
-    ORM layer. A bare ``Column(...)`` on a mixin is shared across
-    subclasses and the nullability silently inverts on the second
-    consumer — keep the invariant pinned here so a regression surfaces
-    immediately."""
-    for cls in (ClinicianAffiliation, ReferralDetail):
-        for name in ("location_city", "location_state", "location_zip"):
-            col = cls.__table__.c[name]
-            assert col.nullable is False, f"{cls.__name__}.{name} is nullable"
+    """ReferralDetail keeps ``NOT NULL`` on the three location columns.
+    ClinicianAffiliation allows ``NULL`` (location is deferred in the
+    fast-path onboarding wizard; users fill it in via "Complete your profile").
+    Pin both explicitly so a regression in either direction surfaces immediately."""
+    for name in ("location_city", "location_state", "location_zip"):
+        ref_col = ReferralDetail.__table__.c[name]
+        assert ref_col.nullable is False, f"ReferralDetail.{name} must be NOT NULL"
+        aff_col = ClinicianAffiliation.__table__.c[name]
+        assert aff_col.nullable is True, f"ClinicianAffiliation.{name} must be nullable"
 
 
 def test_check_constraint_is_table_prefixed_per_consumer():


### PR DESCRIPTION
## Summary

- **Remove friction from new-account onboarding**: the clinician create form now requires only first name, last name, and NPI. Location, session availability, and insurance move to a "Complete your profile" section shown after the user is verified.
- **Make `ClinicianAffiliation` location nullable** (`location_city/state/zip`): migration `a3f1e2d4c5b6` drops the `NOT NULL` constraint and relaxes the state CHECK to allow `NULL`. `ReferralDetail` keeps `NOT NULL`.
- **Inline step-by-step wizard on `/profile` setup mode**: the template now shows the right form for the user's current state (create clinician → add license → retry NPI if mismatch), with no redirects away from `/profile`.
- **Two new POST endpoints**: `POST /profile/clinician/{id}/identity` (inline NPI retry) and `POST /profile/clinician/{id}/details` (deferred practice details).
- **`gather_flat_location` attribute-bag fix**: when all three location subfields are `None`, the helper now sets `location=None` (not `{"city": None, ...}`) so `ClinicianRead` validates cleanly. Fixes `Location | None` schemas round-tripping null-location clinicians.
- **`flatten_location_on_dump` sentinel fix**: use `_absent = object()` sentinel to distinguish "key was absent" from "key was explicitly `None`", so `model_dump(exclude_unset=True)` on an unrelated Update doesn't inject null location keys.

## Test plan

- [ ] Full suite: 2227 passed, 0 failures (`dev test`)
- [ ] Lint: all checks passed (`dev lint`)
- [ ] `test_post_profile_clinician_without_location` — fast path (name + NPI only)
- [ ] `test_post_profile_clinician_identity_update_retries_verification` — inline NPI retry
- [ ] `test_post_profile_clinician_identity_update_rejects_wrong_owner` — ownership guard
- [ ] `test_post_profile_clinician_details_update_saves_location` — deferred details save
- [ ] `test_post_profile_clinician_details_update_rejects_wrong_owner` — ownership guard
- [ ] Audit discipline check passes for `handle_clinician_details_update`
- [ ] Seed test `test_nullable_columns_have_both_null_and_populated` passes (seed produces ~20% null-location affiliations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)