### PR TITLE
fix: use current= not value= in text_field macro calls in profile templates

### DIFF
--- a/src/domain/templates/profile/_manage.html
+++ b/src/domain/templates/profile/_manage.html
@@ -125,9 +125,9 @@
           </summary>
           {% call form_with_errors(action="/profile/clinician/" ~ _c.id|string ~ "/details", method="post") %}
             <div class="grid">
-              {{ text_field("location_city", "City", value=_c.location_city or "") }}
+              {{ text_field("location_city", "City", current=_c.location_city or "") }}
               {{ select_field("location_state", "State", US_STATES, current=_c.location_state, placeholder=true) }}
-              {{ text_field("location_zip", "ZIP", value=_c.location_zip or "", pattern="\\d{5}", maxlength=5) }}
+              {{ text_field("location_zip", "ZIP", current=_c.location_zip or "", pattern="\\d{5}", maxlength=5) }}
             </div>
             {{ actions("Save location") }}
           {% endcall %}
@@ -151,7 +151,7 @@
           {% call form_with_errors(action="/profile/clinician/" ~ _c.id|string ~ "/details", method="post") %}
             {{ checkbox_field("accepts_out_of_network", "Accepts out-of-network insurance", checked=_c.accepts_out_of_network) }}
             {{ checkbox_field("sliding_scale", "Sliding scale available", checked=_c.sliding_scale) }}
-            {{ text_field("cost", "Session cost (optional)", value=_c.cost or "", required=false) }}
+            {{ text_field("cost", "Session cost (optional)", current=_c.cost or "", required=false) }}
             {{ actions("Save payment info") }}
           {% endcall %}
         </details>

--- a/src/domain/templates/profile/_setup.html
+++ b/src/domain/templates/profile/_setup.html
@@ -85,20 +85,20 @@
       </p>
       {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/identity", method="post") %}
         <div class="grid">
-          {{ text_field("first_name", "First name", value=_clinician.first_name or "", required=false) }}
-          {{ text_field("last_name", "Last name", value=_clinician.last_name or "", required=false) }}
+          {{ text_field("first_name", "First name", current=_clinician.first_name or "", required=false) }}
+          {{ text_field("last_name", "Last name", current=_clinician.last_name or "", required=false) }}
         </div>
-        {{ text_field("npi", "NPI (Type-1)", value=_clinician.npi or "", required=true, pattern="\\d{10}", maxlength=10) }}
+        {{ text_field("npi", "NPI (Type-1)", current=_clinician.npi or "", required=true, pattern="\\d{10}", maxlength=10) }}
         {{ actions("Retry verification") }}
       {% endcall %}
     {% elif _clinician.npi_match_status == "none" %}
       {# NPI not submitted yet — inline form to add it. #}
       {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/identity", method="post") %}
         <div class="grid">
-          {{ text_field("first_name", "First name", value=_clinician.first_name or "", required=false) }}
-          {{ text_field("last_name", "Last name", value=_clinician.last_name or "", required=false) }}
+          {{ text_field("first_name", "First name", current=_clinician.first_name or "", required=false) }}
+          {{ text_field("last_name", "Last name", current=_clinician.last_name or "", required=false) }}
         </div>
-        {{ text_field("npi", "NPI (Type-1)", value=_clinician.npi or "", required=true, pattern="\\d{10}", maxlength=10) }}
+        {{ text_field("npi", "NPI (Type-1)", current=_clinician.npi or "", required=true, pattern="\\d{10}", maxlength=10) }}
         {{ actions("Start verification") }}
       {% endcall %}
     {% else %}


### PR DESCRIPTION
## Summary

- `text_field` macro accepts `current=` for pre-fill, not `value=` — fixes `TypeError: macro 'text_field' takes no keyword argument 'value'` thrown on the NPI mismatch and NPI-not-submitted steps of the onboarding setup page, and on the location/payment detail forms on the manage page.

## Test plan

- [ ] Hit `/profile` as a clinician with `npi_match_status == "mismatch"` — form renders without 500
- [ ] Hit `/profile` as a clinician with `npi_match_status == "none"` — form renders without 500
- [ ] Expand location / payment detail forms on the manage view — render without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)