### PR TITLE
feat: anonymize identifying info server-side for unverified users

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -511,3 +511,88 @@ async def test_create_form_preselects_first_clinician(
     assert str(clinician.id) in (
         options[0].attributes.get("value") or ""
     ), "selected option value should be the first clinician's id"
+
+
+# --- Anonymization gate (can_read_full_feed) ---------------------------------
+
+
+async def test_list_shows_verify_notice_for_unverified(
+    authenticated_client: AsyncClient,
+    logged_in_user,
+):
+    """Unverified users see a CTA on /posts directing them to complete
+    verification, since poster names and contact info are hidden."""
+    response = await authenticated_client.get("/posts")
+    assert response.status_code == 200
+    assert "posts-verify-notice" in response.text
+    assert "Complete verification" in response.text
+
+
+async def test_list_hides_verify_notice_for_verified(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """Verified users (Claim A active) see no verify-notice on /posts."""
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/posts")
+    assert response.status_code == 200
+    assert "posts-verify-notice" not in response.text
+
+
+async def test_detail_hides_email_and_shows_cta_for_unverified(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """Unverified users see a 'Verify to contact' CTA on post detail instead
+    of the poster's email address — contact info is not sent to the browser."""
+    author = create_test_user(
+        username=f"detail-author-{uuid.uuid4()}",
+        email=f"detail-author-{uuid.uuid4()}@example.com",
+    )
+    post = _referral_post(owner_id=author.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    assert f"mailto:{author.email}" not in response.text
+    assert author.email not in response.text
+    assert "Verify to contact" in response.text
+
+
+async def test_detail_shows_email_for_verified(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """Verified users (Claim A active) see the poster's email button on the
+    post detail page."""
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    author_email = f"detail-author-{uuid.uuid4()}@example.com"
+    author = create_test_user(
+        username=f"detail-author-{uuid.uuid4()}",
+        email=author_email,
+    )
+    post = _referral_post(owner_id=author.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    assert f"mailto:{author_email}" in response.text
+    assert "Verify to contact" not in response.text

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -5,7 +5,7 @@
   {% block title %}Home{% endblock %}
   {% block content %}
     {# Three-branch home per handoff §8.2:
-       1. No claim → "Finish setting up" card + blurred teaser feed.
+       1. No claim → "Finish setting up" card + anonymized teaser feed.
        2. ≥1 claim → existing body (my posts + network feed).
        3. Any claim lapsed → yellow banner above the existing body
           naming the lapsed claim. The banner copy is owned by
@@ -71,22 +71,20 @@
         <a href="{{ entity_url('post') }}">Adjust filters</a>
           {# djlint:on #}
         </p>
-        {# When the user hasn't verified yet (no claim AND no
-           ever_verified_at), blur the network feed so the teaser
-           conveys "there's content here once you verify". Drives the
-           handoff-§7.1 feed-teaser rule via the same single-source
-           capability predicate, exposed as a `base_context()` scalar
-           so this template stays chrome-dumb. #}
+        {# Identifying info (poster name, practice, contact) is
+           anonymized server-side via `can_read_full_feed`. Show a
+           CTA so unverified users know verification unlocks the full
+           view. Verified users see nothing extra here. #}
         {% if not can_read_full_feed %}
-          <div id="feed-teaser-blur"
-               style="filter: blur(4px);
-                      user-select: none;
-                      pointer-events: none">
-            {{ item_list(network_posts, post_feed_row, "network-posts-list", "post-feed-list") }}
-          </div>
-        {% else %}
-          {{ item_list(network_posts, post_feed_row, "network-posts-list", "post-feed-list") }}
+          <p id="feed-verify-notice"
+             style="font-size: 0.875rem;
+                    color: var(--pico-muted-color);
+                    margin-bottom: 1rem">
+            Clinician names and contact details are hidden until you verify.
+            <a href="/profile">Complete verification →</a>
+          </p>
         {% endif %}
+        {{ item_list(network_posts, post_feed_row, "network-posts-list", "post-feed-list") }}
       </section>
     {% endif %}
   {% endblock %}

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -47,7 +47,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
 `DESIRED_TIME_SLOT_LABELS`, `REFERRAL_SERVICE_LABELS`,
 `TREATMENT_SETTINGS_LABELS`) are Jinja globals. #}
 {%- from "_shared/sections.html" import fact -%}
-{% macro facts_block(view, expanded=False) -%}
+{% macro facts_block(view, expanded=False, redacted=False) -%}
   <section class="entity-facts">
     <dl>
       {%- if view.services or view.settings %}
@@ -123,19 +123,19 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
                       {{ fact('age', 'Age', ages | join(", ") , icon='users') }}
                     {%- endif %}
-                    {%- if view.practice_link %}
+                    {%- if view.practice_link and not redacted %}
                       {%- call fact('practice', 'Practice') %}<a href="{{ entity_url('clinician', id=view.practice_link.id) }}">{{ view.practice_link.name }}</a>
                     {% endcall %}
                   {%- endif %}
-                  {%- if view.program_link %}
+                  {%- if view.program_link and not redacted %}
                     {%- call fact('program', 'Program') %}<a href="{{ entity_url('program', id=view.program_link.id) }}">{{ view.program_link.name }}</a>
                   {% endcall %}
                 {%- endif %}
-                {%- if view.organization_link %}
+                {%- if view.organization_link and not redacted %}
                   {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a>
                 {% endcall %}
               {%- endif %}
-              {%- if view.full_address %}{{ fact('address', 'Address', view.full_address, icon='map-pin') }}{%- endif %}
+              {%- if view.full_address and not redacted %}{{ fact('address', 'Address', view.full_address, icon='map-pin') }}{%- endif %}
                 {%- if view.in_person is not none %}
                   {{ fact('in_person_sessions', 'In-person sessions', LOCATION_AVAILABILITY_LABELS[view.in_person], icon='monitor') }}
                 {%- endif %}

--- a/src/domain/templates/posts/_shared/_feed_row.html
+++ b/src/domain/templates/posts/_shared/_feed_row.html
@@ -35,6 +35,7 @@ under the "Feed rows" section. #}
 <span class="post-feed-type-tag post-feed-type-tag--{{ kind_class }}">{{ kind_label }}</span>
 <span class="post-feed-byline">
 {%- if show_poster and post.owner -%}
+{%- if can_read_full_feed -%}
 {%- set _fn = post.owner.first_name -%}
 {%- set _ln = post.owner.last_name -%}
 {%- set _poster_name -%}
@@ -45,6 +46,9 @@ under the "Feed rows" section. #}
 {%- endif %}
 {%- endset -%}
 <small>{{ _poster_name | trim }}</small>
+{%- else -%}
+<small>Clinician</small>
+{%- endif -%}
 {%- endif -%}
 <small>{{ post.created_at | days_ago }}</small>
 </span>

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -25,14 +25,18 @@
 {% block content %}
   <section class="entity-card" data-kind="{{ post.kind }}">
     {%- if view.description %}<p>{{ view.description }}</p>{%- endif %}
-    {{ facts_block(view, expanded=True) }}
+    {{ facts_block(view, expanded=True, redacted=not can_read_full_feed) }}
     {%- if view.referral %}{{ how_to_refer(view) }}{%- endif %}
       <footer>
-        <a href="mailto:{{ post.owner.email }}"
-           target="_blank"
-           rel="noopener noreferrer"
-           role="button"
-           class="secondary outline">Email</a>
+        {% if can_read_full_feed %}
+          <a href="mailto:{{ post.owner.email }}"
+             target="_blank"
+             rel="noopener noreferrer"
+             role="button"
+             class="secondary outline">Email</a>
+        {% else %}
+          <a href="/profile" role="button" class="secondary outline">Verify to contact →</a>
+        {% endif %}
       </footer>
     </section>
   {% endblock %}

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -17,6 +17,15 @@
   {%- set _empty %}{{ post_feed_empty("No posts match these filters." if active_filter_count else "No posts found.",
     link_href=entity_url("post") if active_filter_count else none
     ) }}{%- endset %}
+    {% if not can_read_full_feed %}
+      <p id="posts-verify-notice"
+         style="font-size: 0.875rem;
+                color: var(--pico-muted-color);
+                margin-bottom: 1rem">
+        Clinician names and contact details are hidden until you verify.
+        <a href="/profile">Complete verification →</a>
+      </p>
+    {% endif %}
     <div class="posts-browse-layout">
       <aside class="posts-filter-sidebar">
         <hgroup>

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient
 from selectolax.parser import HTMLParser
 
+from src.domain.models import Post
 from src.main import lifespan
 
 pytestmark = pytest.mark.asyncio
@@ -71,6 +72,67 @@ async def test_home_page_hides_post_buttons_without_claim_a(
     tree = HTMLParser(response.text)
     assert tree.css_first('a[href="/posts/form?kind=referral"]') is None
     assert "Finish setting up" in response.text
+
+
+async def test_home_page_no_blur_element(authenticated_client: AsyncClient):
+    """The blur wrapper (`feed-teaser-blur`) is removed regardless of
+    verification state — anonymization is now server-side via `can_read_full_feed`,
+    not a CSS filter on the client."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    assert "feed-teaser-blur" not in response.text
+
+
+async def test_home_page_verify_notice_for_unverified_with_network_posts(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """When the viewer can't read the full feed and there are network posts,
+    the home page shows a CTA directing them to complete verification."""
+    from tests.helpers import create_test_user, make_referral_detail
+
+    author = create_test_user(username="net-poster")
+    post = Post(kind="referral", owner_id=author.id)
+    post.referral_detail = make_referral_detail()
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    assert "feed-verify-notice" in response.text
+    assert "Complete verification" in response.text
+
+
+async def test_home_page_no_verify_notice_for_verified_user(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """A verified user (Claim A active) sees no verify-notice on /home."""
+    from tests.helpers import (
+        create_test_user,
+        make_clinician_with_org,
+        make_referral_detail,
+    )
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    author = create_test_user(username="net-poster-v")
+    post = Post(kind="referral", owner_id=author.id)
+    post.referral_detail = make_referral_detail()
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    assert "feed-verify-notice" not in response.text
 
 
 async def test_home_page_shows_primary_nav(authenticated_client: AsyncClient):


### PR DESCRIPTION
## Summary

- Removes the CSS blur on `/home` that exposed data client-side — identifying info is now stripped server-side before it reaches the browser
- Feed rows show `"Clinician"` instead of poster name when viewer hasn't verified
- Post detail hides practice link, organization link, and full address for unverified viewers; replaces the email button with a `"Verify to contact →"` CTA
- Tasteful one-line notices on `/home` network feed and `/posts` list link unverified users to `/profile` to complete verification
- Uses the existing `can_read_full_feed` predicate from `base_context()` as the single gate — same truth as the feed-teaser rule, now enforced at render time

## Test plan

- [ ] Visit `/posts` as an unverified user — verify notice appears, no personal names visible in rows
- [ ] Visit `/posts/{id}` as an unverified user — no email link, no practice/org/address rows, CTA button links to `/profile`
- [ ] Visit `/posts/{id}` as a verified user (Claim A) — email link present, practice/org/address rows visible
- [ ] Visit `/home` as an unverified user with network posts — verify notice appears, no blur
- [ ] Inspect page source in all three cases — confirming no mailto: or practice name in raw HTML for unverified

🤖 Generated with [Claude Code](https://claude.com/claude-code)