### PR TITLE
feat: profile onboarding — non-clinician org rep path + practice name + auto-OrgRepresentation

### DIFF
--- a/src/domain/logic/clinicians/handlers.py
+++ b/src/domain/logic/clinicians/handlers.py
@@ -91,26 +91,31 @@ async def _assert_clinician_payload_org_ownership(
     payload: BaseModel,
     requesting_user: User,
     organization_repo: OrganizationRepository,
-) -> None:
+) -> Organization | None:
     """Payload authz for clinician create/update.
 
     Solo-practice path: when ``payload.solo_practice`` is True,
-    auto-create a solo-practice Organization and patch ``payload.org_id``.
-    Normal path: delegate to the framework's FK-ownership guard.
+    auto-create a solo-practice Organization, patch ``payload.org_id``,
+    and return the created org so the caller can wire up an OrgRepresentation.
+    Normal path: delegate to the framework's FK-ownership guard, return None.
     """
     if getattr(payload, "solo_practice", False):
-        first = (getattr(payload, "first_name", None) or "").strip()
-        last = (getattr(payload, "last_name", None) or "").strip()
-        name_parts = [p for p in (first, last) if p]
-        org_name = " ".join(name_parts) if name_parts else requesting_user.username
+        practice_name = (getattr(payload, "practice_name", None) or "").strip()
+        if not practice_name:
+            first = (getattr(payload, "first_name", None) or "").strip()
+            last = (getattr(payload, "last_name", None) or "").strip()
+            name_parts = [p for p in (first, last) if p]
+            practice_name = (
+                " ".join(name_parts) if name_parts else requesting_user.username
+            )
         auto_org = Organization(
-            name=org_name,
+            name=practice_name,
             type="solo_practice",
             owner_id=requesting_user.id,
         )
         created_org = await organization_repo.create(auto_org)
         payload.org_id = created_org.id
-        return
+        return created_org
     await assert_fk_ownership(
         payload=payload,
         attr="org_id",
@@ -120,6 +125,7 @@ async def _assert_clinician_payload_org_ownership(
         parent_noun="Organization",
         child_noun="Clinician",
     )
+    return None
 
 
 async def clinician_form_extras(

--- a/src/domain/logic/clinicians/schema.py
+++ b/src/domain/logic/clinicians/schema.py
@@ -247,6 +247,10 @@ class ClinicianCreate(FlatLocationSchema, WirePayload):
     # patches `org_id` before persisting the Clinician (#699). Excluded
     # from model_dump() so the field never leaks into the ORM constructor.
     solo_practice: bool = Field(default=False, exclude=True)
+    # Display name for the auto-created solo-practice org. Falls back to
+    # "first last" (then username) when absent. Excluded from model_dump()
+    # — used only by the org-creation step, never written to Clinician.
+    practice_name: StrippedOptionalText = Field(default=None, exclude=True)
     # Required when `solo_practice=False`; the handler fills it in for
     # the solo path. The `@model_validator` below enforces the invariant.
     org_id: uuid.UUID | None = None

--- a/src/domain/logic/profile/handlers.py
+++ b/src/domain/logic/profile/handlers.py
@@ -118,12 +118,14 @@ async def handle_clinician_create(
     first_name: str | None,
     last_name: str | None,
     npi: str | None,
+    practice_name: str | None = None,
     location_city: str | None,
     location_state: str | None,
     location_zip: str | None,
     requesting_user: User,
     clinician_repo: Any,
     organization_repo: Any,
+    org_rep_repo: Any,
     verification_repo: Any,
     audit_repo: Any,
     demo_outcome: str | None = None,
@@ -132,36 +134,51 @@ async def handle_clinician_create(
     NPI verification inline.
 
     Hardcodes ``solo_practice=True`` so the user doesn't need to pick
-    an org during onboarding. Location is optional — callers that omit
-    it (the fast-path wizard) pass ``None`` for all three fields; users
-    can fill location in later from "complete your profile".
+    an org during onboarding. Also auto-creates an ``OrgRepresentation``
+    so the user has owner authority over their solo-practice org from day
+    one (Claim B pending org NPI verification).
+
+    `practice_name` names the auto-org; falls back to "first last" then
+    username when absent. Location is optional — callers pass ``None``
+    for all three fields and users fill it in later from "complete your
+    profile".
 
     `demo_outcome` is only honored when the requesting user is in a demo
-    org context (checked here via `_user_is_demo_context`). If passed by
-    a non-demo user it is ignored and NPPES runs normally.
+    org context.
     """
     from src.domain.logic.clinicians.handlers import (
         _assert_clinician_payload_org_ownership,
         after_create_clinician_verification,
     )
     from src.domain.logic.clinicians.schema import ClinicianCreate
-    from src.domain.models import Clinician
+    from src.domain.models import Clinician, OrgRepresentation
 
     payload = ClinicianCreate(
         first_name=first_name,
         last_name=last_name,
         npi=npi,
+        practice_name=practice_name,
         solo_practice=True,
         location_city=location_city,
         location_state=location_state,
         location_zip=location_zip,
     )
 
-    await _assert_clinician_payload_org_ownership(
+    auto_org = await _assert_clinician_payload_org_ownership(
         payload=payload,
         requesting_user=requesting_user,
         organization_repo=organization_repo,
     )
+
+    if auto_org is not None:
+        auto_rep = OrgRepresentation(
+            user_id=requesting_user.id,
+            org_id=auto_org.id,
+            role="owner",
+            authority_method="admin_review",
+            authority_status="verified",
+        )
+        await org_rep_repo.create(auto_rep)
 
     clinician = Clinician(
         owner_id=requesting_user.id,
@@ -180,6 +197,65 @@ async def handle_clinician_create(
         demo_outcome=effective_demo,
     )
     return clinician
+
+
+async def handle_org_create(
+    *,
+    org_name: str,
+    org_type: str,
+    org_npi: str | None,
+    requesting_user: User,
+    organization_repo: Any,
+    org_rep_repo: Any,
+    verification_repo: Any,
+    audit_repo: Any,
+) -> Any:
+    """Create an org + auto-grant owner OrgRepresentation for non-clinician
+    onboarding (and any user who wants to register a named practice).
+
+    The user becomes the org owner with ``authority_status='verified'``
+    immediately — no external proof required because they are creating the
+    org themselves.  ``org_verified`` stays ``False`` until an org-side NPI
+    verification passes; if ``org_npi`` is supplied the NPPES lookup runs
+    inline exactly as it does for clinician NPI verification.
+    """
+    import httpx
+
+    from src.domain.logic.verifications.handlers import (
+        HTTP_TIMEOUT_SECONDS,
+        run_org_verification,
+    )
+    from src.domain.models import Organization, OrgRepresentation
+
+    org = Organization(
+        name=org_name,
+        type=org_type,
+        owner_id=requesting_user.id,
+        npi=org_npi or None,
+    )
+    created_org = await organization_repo.create(org)
+
+    auto_rep = OrgRepresentation(
+        user_id=requesting_user.id,
+        org_id=created_org.id,
+        role="owner",
+        authority_method="admin_review",
+        authority_status="verified",
+    )
+    await org_rep_repo.create(auto_rep)
+
+    if org_npi:
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT_SECONDS) as http:
+            await run_org_verification(
+                org_id=created_org.id,
+                verification_repo=verification_repo,
+                org_repo=organization_repo,
+                audit_repo=audit_repo,
+                http=http,
+                actor_id=requesting_user.id,
+            )
+
+    return created_org
 
 
 async def handle_clinician_identity_update(

--- a/src/domain/logic/profile/test_handlers.py
+++ b/src/domain/logic/profile/test_handlers.py
@@ -137,3 +137,129 @@ def test_build_profile_context_exposes_mode_and_lists():
     assert ctx["org_representations"] == user.org_representations
     assert ctx["claim_state"].a is True
     assert len(ctx["claim_state"].b) == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-clinician org-rep onboarding path
+# ---------------------------------------------------------------------------
+
+
+def test_non_clinician_org_rep_only_exits_setup():
+    """A user with a verified OrgRepresentation but no clinician exits setup
+    into manage mode — the two-claim model allows Claim B without Claim A."""
+    user = _user(org_representations=[_rep(authority_status="verified")])
+    assert resolve_profile_mode(user) == MODE_MANAGE
+
+
+def test_pending_org_rep_stays_in_setup():
+    """An OrgRepresentation that is still `pending` does not contribute to
+    `claim_state.b`, so the user stays in setup mode."""
+    user = _user(org_representations=[_rep(authority_status="pending")])
+    assert resolve_profile_mode(user) == MODE_SETUP
+
+
+def test_archived_org_rep_stays_in_setup():
+    """An archived OrgRepresentation (revoked) is excluded from the active rep
+    set, so the user falls back to setup mode if they have no other claims."""
+    from datetime import datetime
+    from types import SimpleNamespace
+
+    archived_rep = SimpleNamespace(
+        org_id=uuid4(),
+        authority_status="verified",
+        archived_at=datetime.now(),
+    )
+    user = _user(org_representations=[archived_rep])
+    assert resolve_profile_mode(user) == MODE_SETUP
+
+
+# ---------------------------------------------------------------------------
+# _assert_clinician_payload_org_ownership return value
+# ---------------------------------------------------------------------------
+
+
+def test_clinician_create_handler_uses_practice_name():
+    """_assert_clinician_payload_org_ownership should use practice_name over
+    first+last when it is provided, so the auto-org gets the right display name."""
+    from src.domain.logic.clinicians.handlers import (
+        _assert_clinician_payload_org_ownership,
+    )
+
+    class _MockOrg:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            self.id = uuid4()
+
+    class _MockRepo:
+        last_created = None
+
+        async def create(self, obj):
+            self.__class__.last_created = obj
+            obj.id = uuid4()
+            return obj
+
+        async def get_by_model_id(self, *a, **kw):
+            return None
+
+    import asyncio
+    from types import SimpleNamespace
+
+    user = SimpleNamespace(
+        id=uuid4(), username="alice", is_superuser=False, is_verified=True
+    )
+
+    class _Payload:
+        solo_practice = True
+        practice_name = "Single Thread Psychiatry"
+        first_name = "Katie"
+        last_name = "Reeves"
+        org_id = None
+
+    repo = _MockRepo()
+    result = asyncio.get_event_loop().run_until_complete(
+        _assert_clinician_payload_org_ownership(
+            payload=_Payload(),
+            requesting_user=user,
+            organization_repo=repo,
+        )
+    )
+    assert result is not None
+    assert _MockRepo.last_created.name == "Single Thread Psychiatry"
+
+
+def test_clinician_create_handler_falls_back_to_name():
+    """When practice_name is absent, the org name falls back to first+last."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from src.domain.logic.clinicians.handlers import (
+        _assert_clinician_payload_org_ownership,
+    )
+
+    class _MockRepo:
+        last_created = None
+
+        async def create(self, obj):
+            self.__class__.last_created = obj
+            obj.id = uuid4()
+            return obj
+
+    user = SimpleNamespace(
+        id=uuid4(), username="alice", is_superuser=False, is_verified=True
+    )
+
+    class _Payload:
+        solo_practice = True
+        practice_name = None
+        first_name = "Katie"
+        last_name = "Reeves"
+        org_id = None
+
+    asyncio.get_event_loop().run_until_complete(
+        _assert_clinician_payload_org_ownership(
+            payload=_Payload(),
+            requesting_user=user,
+            organization_repo=_MockRepo(),
+        )
+    )
+    assert _MockRepo.last_created.name == "Katie Reeves"

--- a/src/domain/logic/profile/test_handlers.py
+++ b/src/domain/logic/profile/test_handlers.py
@@ -216,7 +216,7 @@ def test_clinician_create_handler_uses_practice_name():
         org_id = None
 
     repo = _MockRepo()
-    result = asyncio.get_event_loop().run_until_complete(
+    result = asyncio.run(
         _assert_clinician_payload_org_ownership(
             payload=_Payload(),
             requesting_user=user,
@@ -255,7 +255,7 @@ def test_clinician_create_handler_falls_back_to_name():
         last_name = "Reeves"
         org_id = None
 
-    asyncio.get_event_loop().run_until_complete(
+    asyncio.run(
         _assert_clinician_payload_org_ownership(
             payload=_Payload(),
             requesting_user=user,

--- a/src/domain/routes/profile.py
+++ b/src/domain/routes/profile.py
@@ -33,6 +33,10 @@ from src.domain.logic.clinicians.repository import (
     ClinicianRepository,
     get_clinician_repository,
 )
+from src.domain.logic.org_representations.repository import (
+    OrgRepresentationRepository,
+    get_org_representation_repository,
+)
 from src.domain.logic.organizations.repository import (
     OrganizationRepository,
     get_organization_repository,
@@ -43,6 +47,7 @@ from src.domain.logic.profile.handlers import (
     handle_clinician_details_update,
     handle_clinician_identity_update,
     handle_clinician_license_create,
+    handle_org_create,
 )
 from src.domain.logic.verifications.repository import (
     VerificationRepository,
@@ -81,6 +86,7 @@ async def profile_clinician_create(
     first_name: str | None = Form(default=None),
     last_name: str | None = Form(default=None),
     npi: str | None = Form(default=None),
+    practice_name: str | None = Form(default=None),
     location_city: str | None = Form(default=None),
     location_state: str | None = Form(default=None),
     location_zip: str | None = Form(default=None),
@@ -88,31 +94,80 @@ async def profile_clinician_create(
     requesting_user: User = Depends(current_active_user),
     clinician_repo: ClinicianRepository = Depends(get_clinician_repository),
     organization_repo: OrganizationRepository = Depends(get_organization_repository),
+    org_rep_repo: OrgRepresentationRepository = Depends(
+        get_org_representation_repository
+    ),
     verification_repo: VerificationRepository = Depends(get_verification_repository),
     audit_repo: AuditRepository = Depends(get_audit_repository),
 ) -> Any:
     """Create a minimal clinician profile from the onboarding hub.
 
-    Fires NPI verification inline (same as the generic clinician
-    create) then redirects back to /profile so the hub re-renders
-    with the NPPES result already reflected in the setup flow.
+    Fires NPI verification inline then redirects back to /profile so the
+    hub re-renders with the NPPES result already reflected in the setup
+    flow. Also auto-creates an OrgRepresentation for the solo-practice org
+    so the user has owner authority over their practice immediately.
 
-    `demo_outcome` is only honored when the requesting user is in a demo
-    org context — the handler ignores it for regular users.
+    `practice_name` names the auto-created org (falls back to "first last"
+    then username). `demo_outcome` is only honored in demo org context.
     """
     await handle_clinician_create(
         first_name=first_name,
         last_name=last_name,
         npi=npi,
+        practice_name=practice_name,
         location_city=location_city,
         location_state=location_state,
         location_zip=location_zip,
         requesting_user=requesting_user,
         clinician_repo=clinician_repo,
         organization_repo=organization_repo,
+        org_rep_repo=org_rep_repo,
         verification_repo=verification_repo,
         audit_repo=audit_repo,
         demo_outcome=demo_outcome,
+    )
+    return JSONResponse(
+        status_code=status.HTTP_201_CREATED,
+        content={},
+        headers={"HX-Redirect": "/profile"},
+    )
+
+
+@profile_pages_router.post("/profile/org", name="profile:org_create")
+async def profile_org_create(
+    org_name: str = Form(...),
+    org_type: str = Form(...),
+    org_npi: str | None = Form(default=None),
+    requesting_user: User = Depends(current_active_user),
+    organization_repo: OrganizationRepository = Depends(get_organization_repository),
+    org_rep_repo: OrgRepresentationRepository = Depends(
+        get_org_representation_repository
+    ),
+    verification_repo: VerificationRepository = Depends(get_verification_repository),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+) -> Any:
+    """Register an organization and auto-grant the submitting user owner
+    authority over it.
+
+    For non-clinician org reps this is the primary onboarding path — they
+    skip the NPI / license steps and land here directly. Clinicians can
+    also use this to register a named practice separate from their
+    solo-practice auto-org (e.g. after joining a group practice).
+
+    If ``org_npi`` is provided the org NPPES verification runs inline,
+    exactly as clinician NPI verification does. ``org_verified`` stays
+    ``False`` if no NPI is given; the user can add one later from the
+    manage view.
+    """
+    await handle_org_create(
+        org_name=org_name,
+        org_type=org_type,
+        org_npi=org_npi or None,
+        requesting_user=requesting_user,
+        organization_repo=organization_repo,
+        org_rep_repo=org_rep_repo,
+        verification_repo=verification_repo,
+        audit_repo=audit_repo,
     )
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,

--- a/src/domain/routes/test_profile.py
+++ b/src/domain/routes/test_profile.py
@@ -25,8 +25,8 @@ async def test_profile_hub_renders_setup_for_new_user(
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     # Setup mode's distinctive copy from `_setup.html`.
-    assert "Add a clinician profile" in response.text
-    assert "Post on behalf of an organization" in response.text
+    assert "Verify your NPI" in response.text
+    assert "Register an organization" in response.text
 
 
 async def test_profile_hub_requires_authentication(test_client: AsyncClient):

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -187,3 +187,51 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
   .posts-filter-sidebar { flex: unset; width: 100%; }
   .posts-filter-form { display: none; }
 }
+
+/* ── Profile step cards ───────────────────────────────────────
+   Each verification requirement on /profile renders as a step card.
+   Status badges surface completion state; border-left accents mark
+   cards that need action. All state is expressed via classes — no
+   inline styles on the profile templates. */
+.step-card > header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+.step-card > header > a {
+  font-size: 0.875rem;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+.step-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  flex: 1;
+}
+.step-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 0.1rem;
+}
+.step-status--complete { color: var(--pico-color-green-600); }
+.step-status--action   { color: var(--pico-color-orange-600); }
+.step-status--error    { color: var(--pico-color-red-600); }
+.step-status--pending  { color: var(--pico-muted-color); }
+.step-card--action { border-left: 3px solid var(--pico-color-orange-400); }
+.step-card--error  { border-left: 3px solid var(--pico-color-red-400); }
+.step-summary-list { margin: 0.5rem 0 0; padding-left: 1.25rem; }
+.step-cta-row { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.step-banner--warn {
+  color: var(--pico-color-yellow-600);
+  background: var(--pico-color-yellow-100);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  margin-bottom: var(--pico-spacing);
+}

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -73,13 +73,23 @@ register_template_globals(
     GENDER_LABELS=enums.GENDER_LABELS,
     INSURANCE_POSTURES=enums.INSURANCE_POSTURES,
     INSURANCE_POSTURE_LABELS=enums.INSURANCE_POSTURE_LABELS,
+    # Org types exposed as a Jinja global so the profile-hub setup template
+    # (and any other bespoke template that isn't rendered via an EntitySpec)
+    # can render the org-type select without per-route context injection.
+    ORGANIZATION_TYPES=enums.ORGANIZATION_TYPES,
+    ORGANIZATION_TYPES_LABELS=enums.ORGANIZATION_TYPES_LABELS,
+    # LICENSE_TYPES and EDUCATION/CERTIFICATION equivalents are exposed here
+    # as globals so bespoke templates (like the profile hub's license step)
+    # can reference them without relying on CLINICIAN_ENTITY.static_context,
+    # which only runs through the framework's generic entity handlers.
+    LICENSE_TYPES=enums.LICENSE_TYPES,
+    LICENSE_TYPES_LABELS=enums.LICENSE_TYPES_LABELS,
     # `LICENSE_TYPES`, `EDUCATION_TYPES`, `CERTIFICATION_TYPES` and
-    # their `_LABELS` are clinician-only — they flow into the context
-    # via `CLINICIAN_ENTITY.static_context` (merged by `handle_detail` /
-    # `handle_list` / `handle_get_edit_form`) so the spec is the single
-    # binding site. `register_choice_labels(...)` for those tuples
-    # stays below (the form-rendering macro looks up labels by tuple
-    # identity, not by Jinja global).
+    # their `_LABELS` also flow into the context via
+    # `CLINICIAN_ENTITY.static_context` (merged by `handle_detail` /
+    # `handle_list` / `handle_get_edit_form`) so the spec remains the
+    # single binding site for generic entity pages. `register_choice_labels`
+    # below covers the form-field macro label lookup for both paths.
     #
     # Polymorphic posts have no single create-schema (the top-level
     # adapter is a discriminated union); the per-kind route handler
@@ -135,6 +145,7 @@ register_choice_labels(enums.REFERRAL_SERVICES, enums.REFERRAL_SERVICE_LABELS)
 register_choice_labels(enums.TREATMENT_SETTINGS, enums.TREATMENT_SETTINGS_LABELS)
 register_choice_labels(enums.TREATMENT_MODALITIES, enums.TREATMENT_MODALITY_LABELS)
 register_choice_labels(enums.GENDERS, enums.GENDER_LABELS)
+register_choice_labels(enums.ORGANIZATION_TYPES, enums.ORGANIZATION_TYPES_LABELS)
 register_choice_labels(enums.LICENSE_TYPES, enums.LICENSE_TYPES_LABELS)
 register_choice_labels(enums.EDUCATION_TYPES, enums.EDUCATION_TYPES_LABELS)
 register_choice_labels(enums.CERTIFICATION_TYPES, enums.CERTIFICATION_TYPES_LABELS)

--- a/src/domain/templates/profile/_manage.html
+++ b/src/domain/templates/profile/_manage.html
@@ -1,60 +1,38 @@
-{# Manage mode — user holds ≥1 verified claim. Per wireframe L4:
-   profile header with claim badges, status rows for clinician identity
-   and org representation with direct "Manage →" edit links, and a
-   "+ New post" CTA when verified.
-
-   Also renders a "Complete your profile" section when optional practice
-   details (location, availability, insurance) have not been filled in
-   yet — deferred from the fast-path onboarding wizard.
-#}
+{# Manage mode — user holds ≥1 verified claim. Step cards for clinician
+   identity and org representation show verified state with a "Manage →"
+   link; a CTA row links to new-post forms when claim A is active; an
+   optional "Complete your profile" step card surfaces deferred practice
+   details when location is still missing. #}
 {%- from "_shared/form_fields.html" import text_field, select_field, checkbox_field -%}
 {%- from "_shared/form_meta.html" import form_with_errors with context -%}
 {%- from "_shared/actions.html" import actions -%}
 <section>
   <header>
     <hgroup>
-      <h2>
-        {{ current_username }}
-        {% if claim_state.a %}
-          <span style="font-size: 0.875rem;
-                       color: var(--pico-primary);
-                       margin-left: 0.5rem">
-            <i class="icon-shield-check"></i> Verified clinician
-          </span>
-        {% endif %}
-        {% if claim_state.b %}
-          <span style="font-size: 0.875rem;
-                       color: var(--pico-primary);
-                       margin-left: 0.5rem">
-            <i class="icon-building"></i> Represents {{ claim_state.b|length }} org(s)
-          </span>
-        {% endif %}
-      </h2>
+      <h2>{{ current_username }}</h2>
     </hgroup>
-    {% if any_claim_lapsed %}
-      <p style="color: var(--pico-color-yellow-600);
-                background: var(--pico-color-yellow-100);
-                padding: 0.5rem 1rem;
-                border-radius: 4px">
-        <i class="icon-alert-triangle"></i> Action needed — one of your claims has lapsed.
-      </p>
-    {% endif %}
   </header>
-  <article>
-    <header style="display: flex;
-                   justify-content: space-between;
-                   align-items: baseline">
-      <strong>Clinician identity</strong>
-      {% if clinicians %}
-        <a href="{{ entity_url('clinician', id=clinicians[0].id) }}/form"
-           style="font-size: 0.875rem">Manage →</a>
-      {% endif %}
+  {% if any_claim_lapsed %}
+    <p class="step-banner--warn">
+      <i class="icon-alert-triangle"></i> Action needed — one of your claims has lapsed.
+    </p>
+  {% endif %}
+  {# ── Clinician identity ─────────────────────────────────────────────── #}
+  <article class="step-card{% if not claim_state.a %} step-card--action{% endif %}">
+    <header>
+      <div class="step-card-meta">
+        {% if claim_state.a %}
+          <span class="step-status step-status--complete"><i class="icon-shield-check"></i> Verified</span>
+        {% else %}
+          <span class="step-status step-status--action"><i class="icon-alert-triangle"></i> Incomplete</span>
+        {% endif %}
+        <strong>Clinician identity</strong>
+        <small>NPI + active license — required to post referrals and openings</small>
+      </div>
+      {% if clinicians %}<a href="{{ entity_url('clinician', id=clinicians[0].id) }}/form">Manage →</a>{% endif %}
     </header>
     {% if claim_state.a %}
-      <p>
-        <i class="icon-check"></i> Verified
-      </p>
-      <ul style="margin: 0; padding-left: 1.25rem;">
+      <ul class="step-summary-list">
         {% for c in clinicians %}
           <li>
             {{ c.first_name or "" }} {{ c.last_name or "" }}
@@ -65,9 +43,7 @@
         {% endfor %}
       </ul>
     {% else %}
-      <p style="color: var(--pico-muted-color);">
-        Not yet verified. Add a clinician profile and active license to unlock posting.
-      </p>
+      <p>Add an active license to unlock posting.</p>
       {% if clinicians %}
         <a href="{{ entity_url('clinician', id=clinicians[0].id) }}/form"
            role="button"
@@ -75,17 +51,21 @@
       {% endif %}
     {% endif %}
   </article>
-  <article>
-    <header style="display: flex;
-                   justify-content: space-between;
-                   align-items: baseline">
-      <strong>Organization representation</strong>
+  {# ── Organization representation ────────────────────────────────────── #}
+  <article class="step-card">
+    <header>
+      <div class="step-card-meta">
+        {% if claim_state.b %}
+          <span class="step-status step-status--complete"><i class="icon-check"></i> Verified</span>
+        {% else %}
+          <span class="step-status step-status--pending">Coming soon</span>
+        {% endif %}
+        <strong>Organization representation</strong>
+        <small>Post on behalf of a practice or facility with a Type-2 NPI</small>
+      </div>
     </header>
     {% if claim_state.b %}
-      <p>
-        <i class="icon-check"></i> Representing {{ claim_state.b|length }} organization(s)
-      </p>
-      <ul style="margin: 0; padding-left: 1.25rem;">
+      <ul class="step-summary-list">
         {% for rep in org_representations %}
           {% if rep.authority_status == "verified" and rep.archived_at is none %}
             <li>{{ rep.org.name if rep.org else rep.org_id }} — {{ rep.role }}</li>
@@ -93,32 +73,31 @@
         {% endfor %}
       </ul>
     {% else %}
-      <p style="color: var(--pico-muted-color);">Not currently representing any organization.</p>
+      <p>Coming soon — represent an organization via NPI Authorized-Official match, domain email, or admin review.</p>
     {% endif %}
   </article>
+  {# ── Post CTAs ──────────────────────────────────────────────────────── #}
   {% if claim_state.a %}
-    <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
+    <div class="step-cta-row">
       <a href="{{ entity_form_url("post") }}?kind=referral" role="button">+ Post a referral</a>
       <a href="{{ entity_form_url("post") }}?kind=clinician_opening"
          role="button"
          class="outline">+ Post an opening</a>
-    </section>
+    </div>
   {% endif %}
-  {# ------------------------------------------------------------------ #}
-  {# Complete your profile — deferred practice details                   #}
-  {# ------------------------------------------------------------------ #}
+  {# ── Complete your profile — deferred practice details ─────────────── #}
   {% if clinicians %}
     {% set _c = clinicians[0] %}
     {% set _missing_location = not _c.location_city or not _c.location_state %}
     {% if _missing_location %}
-      <article id="complete-profile">
+      <article class="step-card" id="complete-profile">
         <header>
-          <strong>Complete your profile</strong>
-          <small style="display: block; color: var(--pico-muted-color);">
-            Add practice details to help clients find you — fill in what you like, whenever you like.
-          </small>
+          <div class="step-card-meta">
+            <span class="step-status step-status--pending">Optional</span>
+            <strong>Complete your profile</strong>
+            <small>Helps clients find you — fill in what you like, whenever you like</small>
+          </div>
         </header>
-        {# Location ---------------------------------------------------- #}
         <details {% if _missing_location %}open{% endif %}>
           <summary>
             <strong>Location</strong>
@@ -132,7 +111,6 @@
             {{ actions("Save location") }}
           {% endcall %}
         </details>
-        {# Availability ------------------------------------------------ #}
         <details>
           <summary>
             <strong>Session availability</strong>
@@ -143,7 +121,6 @@
             {{ actions("Save availability") }}
           {% endcall %}
         </details>
-        {# Insurance / payment ----------------------------------------- #}
         <details>
           <summary>
             <strong>Insurance &amp; payment</strong>

--- a/src/domain/templates/profile/_reverify.html
+++ b/src/domain/templates/profile/_reverify.html
@@ -1,22 +1,8 @@
-{# Re-verify mode — wireframe L7.
-
-   At least one of the user's claims has lapsed (a license expired, an
-   authority was revoked, an NPPES re-check failed). Per handoff §7,
-   capabilities gated on the lapsed claim pause; capabilities gated on
-   other claims keep working; the user's feed read-access is retained
-   via `ever_verified_at`.
-
-   The page header names the lapse + offers a one-tap Fix CTA — no dead
-   ends. The detail of WHICH claim has lapsed comes from
-   `claim_state.lapsed` (a tuple of reason codes); we render one card
-   per reason and a "still active" reassurance line for the unaffected
-   claim.
-
-   Phase-5 ships the dispatch + this template; the `claim_state.lapsed`
-   detection itself is populated by Phase-3's recompute helpers when
-   they detect a regression (currently stubbed empty in `claim_state`).
-   This template renders correctly the moment `lapsed` becomes
-   non-empty.
+{# Re-verify mode — ≥1 claim has lapsed. Step cards name each lapsed
+   claim with a "Fix now" CTA; a "Still active" card reassures the user
+   about what keeps working. Populated once claim_state.lapsed is
+   non-empty (currently stubbed; renders correctly when Phase-3 recompute
+   helpers detect a regression).
 #}
 <header>
   <hgroup>
@@ -24,54 +10,43 @@
       <i class="icon-alert-triangle"></i> Action needed
     </h2>
     <p>
-      One of your verification claims has lapsed. The affected capabilities are paused until you re-attest; everything else keeps working.
+      One of your verification claims has lapsed. Affected capabilities are paused until you re-attest; everything else keeps working.
     </p>
   </hgroup>
 </header>
 {% for reason in claim_state.lapsed %}
-  <article style="border-left: 4px solid var(--pico-color-yellow-600);">
+  <article class="step-card step-card--error">
     <header>
-      {% if reason == "claim_a_lapsed" %}
-        {# title-case-ignore: "Claim A" is a user-facing label #}
-        <strong>Clinician identity (Claim A) lapsed</strong>
-        <p style="margin-bottom: 0;">
-          <small>Re-attest your license to resume posting referrals and openings.</small>
-        </p>
-      {% elif reason == "claim_b_lapsed" %}
-        {# title-case-ignore: "Claim B" is a user-facing label #}
-        <strong>Organization representation (Claim B) lapsed</strong>
-        <p style="margin-bottom: 0;">
-          <small>Re-verify your authority for the affected organization to resume posting on its behalf.</small>
-        </p>
-      {% else %}
-        <strong>{{ reason }}</strong>
-      {% endif %}
+      <div class="step-card-meta">
+        <span class="step-status step-status--error"><i class="icon-shield-x"></i> Lapsed</span>
+        {% if reason == "claim_a_lapsed" %}
+          {# title-case-ignore: "Claim A" is a user-facing label #}
+          <strong>Clinician identity</strong>
+          <small>Re-attest your license to resume posting referrals and openings</small>
+        {% elif reason == "claim_b_lapsed" %}
+          {# title-case-ignore: "Claim B" is a user-facing label #}
+          <strong>Organization representation</strong>
+          <small>Re-verify your authority for the affected organization to resume posting on its behalf</small>
+        {% else %}
+          <strong>{{ reason }}</strong>
+        {% endif %}
+      </div>
     </header>
-    <a href="/profile" role="button">Fix</a>
+    <a href="/profile" role="button">Fix now</a>
   </article>
 {% endfor %}
-{# Reassurance section — the unaffected claim(s) keep working. Per
-   wireframe L7 the lapsed-claim banner is paired with a "still
-   working" line so the user knows what's paused vs not. #}
-<section style="margin-top: 1rem;">
+<article class="step-card">
   <header>
-    <strong>Still working</strong>
+    <div class="step-card-meta">
+      <span class="step-status step-status--complete"><i class="icon-check"></i> Still active</span>
+      <strong>What's still working</strong>
+    </div>
   </header>
-  <ul>
-    {% if claim_state.a and "claim_a_lapsed" not in claim_state.lapsed %}
-      <li>
-        {# title-case-ignore: "Claim A" is a user-facing label #}
-        <i class="icon-check"></i> Clinician identity (Claim A) — verified
-      </li>
-    {% endif %}
+  <ul class="step-summary-list">
+    {% if claim_state.a and "claim_a_lapsed" not in claim_state.lapsed %}<li>Clinician identity — verified</li>{% endif %}
     {% if claim_state.b and "claim_b_lapsed" not in claim_state.lapsed %}
-      <li>
-        {# title-case-ignore: "Claim B" is a user-facing label #}
-        <i class="icon-check"></i> Organization representation (Claim B) — verified for {{ claim_state.b|length }} organization(s)
-      </li>
+      <li>Organization representation — {{ claim_state.b|length }} organization(s)</li>
     {% endif %}
-    <li>
-      <i class="icon-check"></i> Feed browsing — retained
-    </li>
+    <li>Feed browsing — retained</li>
   </ul>
-</section>
+</article>

--- a/src/domain/templates/profile/_setup.html
+++ b/src/domain/templates/profile/_setup.html
@@ -1,29 +1,10 @@
 {# Setup mode — guided onboarding for users with no verified claims.
-   Renders a progressive step-by-step flow based on the user's
-   clinicians' current state:
+   Progressive step cards surface each requirement clearly:
+     Card 1: Verify NPI — clinicians only; non-clinicians skip to Card 3
+     Card 2: Add license — shown only after NPI matched
+     Card 3: Register an organization — real form; non-clinicians start here
 
-   Step 0 — no clinician yet: minimal fast-path form (name + NPI only;
-     location is deferred to "complete your profile"). Posts to
-     POST /profile/clinician, which fires NPI verification inline and
-     redirects back here.
-
-   Step 1 — clinician exists, NPI matched but no active license:
-     inline license + attestation form. Posts to
-     POST /profile/clinician/{id}/license.
-
-   Step 2 — clinician exists, NPI mismatch: inline name + NPI retry
-     form so the user can correct without leaving /profile. Posts to
-     POST /profile/clinician/{id}/identity.
-
-   Step 2b — clinician exists, NPI not yet submitted: inline NPI
-     submit form.
-
-   Claim B ("Post on behalf of an organization") card stays visible
-   per handoff §8.1 / wireframe L5 — always shown, never hidden.
-
-   Uses `form_with_errors` from `_shared/form_meta.html` so validation
-   failures (e.g. invalid NPI format) re-render the form in-place via
-   HTMX with per-field error copy.
+   Each card carries a status badge and a border accent when action is needed.
 
    `is_demo_context` (bool, from build_profile_context): when True the
    user is associated with a demo org and NPI verification forms show a
@@ -76,61 +57,42 @@
     </fieldset>
   {% endif %}
 {%- endmacro -%}
+{%- set _clinician = clinicians[0] if clinicians else none -%}
+{%- set _active_licenses = (_clinician.licensures | selectattr('status', 'equalto', 'active') | list) if _clinician else [] -%}
+{%- set _npi_ok = _clinician and _clinician.npi_match_status == "matched" -%}
 <section>
-  {# ------------------------------------------------------------------ #}
-  {# Clinician identity                                                   #}
-  {# ------------------------------------------------------------------ #}
-  <article id="claim-a-card">
+  {# ── Step 1: Verify your NPI (clinicians only) ────────────────────── #}
+  <article class="step-card{% if not _npi_ok and not org_representations %} step-card--action{% endif %}"
+           id="claim-a-card">
     <header>
-      <strong>Add a clinician profile</strong>
-      <small style="display: block; color: var(--pico-muted-color);">
-        Verify your individual NPI and license to post referrals or openings
-      </small>
-    </header>
-    {%- set _clinician = clinicians[0] if clinicians else none -%}
-    {%- set _active_licenses = (_clinician.licensures | selectattr('status', 'equalto', 'active') | list) if _clinician else [] -%}
-    {% if not _clinician %}
-      {# Step 0: no clinician yet — name + NPI only; location deferred. #}
-      {% call form_with_errors(action="/profile/clinician", method="post") %}
-        <div class="grid">
-          {{ text_field("first_name", "First name", required=false) }}
-          {{ text_field("last_name", "Last name", required=false) }}
-        </div>
-        {{ text_field("npi", "NPI (Type-1)", required=true, pattern="\\d{10}", maxlength=10) }}
-        {{ _demo_outcome_picker() }}
-        {{ actions("Start verification") }}
-      {% endcall %}
-    {% elif _clinician.npi_match_status == "matched" and not _active_licenses %}
-      {# Step 1: NPI matched — add license and attest in one step. #}
-      <p style="color: var(--pico-color-green-600);">
-        <i class="icon-shield-check"></i>
-        {# title-case-ignore #}
-        <strong>Matched in NPPES</strong>
-        {% if _clinician.first_name or _clinician.last_name %}
-          — resolves to {{ _clinician.first_name or "" }} {{ _clinician.last_name or "" }}
+      <div class="step-card-meta">
+        {% if _npi_ok %}
+          <span class="step-status step-status--complete"><i class="icon-shield-check"></i> NPI verified</span>
+        {% elif _clinician and _clinician.npi_match_status == "mismatch" %}
+          <span class="step-status step-status--error"><i class="icon-shield-x"></i> Verification failed</span>
+        {% elif _clinician and _clinician.npi_match_status == "pending" %}
+          <span class="step-status step-status--pending"><i class="icon-loader"></i> Verifying…</span>
+        {% elif org_representations %}
+          <span class="step-status"><i class="icon-minus"></i> Skipped</span>
+        {% else %}
+          <span class="step-status step-status--action"><i class="icon-alert-triangle"></i> Required (clinicians)</span>
         {% endif %}
-      </p>
-      <p>Now add your license:</p>
-      {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/license", method="post") %}
-        {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
-        <div class="grid">
-          {{ select_field("issuing_state", "Issuing state", US_STATES, placeholder=true) }}
-          {{ text_field('license_number', 'License number') }}
-        </div>
-        {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
-        {{ checkbox_field("_attest_confirm", "I attest this license is active and in good standing.", required=true) }}
-        {{ actions("Add license") }}
-      {% endcall %}
-    {% elif _clinician.npi_match_status == "mismatch" %}
-      {# Step 2: NPI mismatch — inline retry form, no redirect away. #}
-      <p style="color: var(--pico-color-orange-600);">
-        <i class="icon-shield-alert"></i>
-        <strong>NPI not matched</strong>
-        {% if _clinician.npi %}— NPI {{ _clinician.npi }} did not resolve to your name in NPPES.{% endif %}
-      </p>
-      <p style="color: var(--pico-muted-color);">
+        <strong>Verify your NPI</strong>
+        <small>Confirms your identity in NPPES — required to post and see full referral details</small>
+      </div>
+    </header>
+    {% if _npi_ok %}
+      <p>
+        NPI {{ _clinician.npi }}
+        {% if _clinician.first_name or _clinician.last_name %}
+          — {{ _clinician.first_name or "" }} {{ _clinician.last_name or "" }}
+        {% endif %}
         {# title-case-ignore #}
-        Correct your name or NPI below to match your NPPES record exactly, then retry.
+        resolves in NPPES.
+      </p>
+    {% elif _clinician and _clinician.npi_match_status == "mismatch" %}
+      <p>
+        NPI {{ _clinician.npi }} did not match your name in NPPES. Correct your name or NPI to match your NPPES record exactly, then retry.
       </p>
       {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/identity", method="post") %}
         <div class="grid">
@@ -141,8 +103,13 @@
         {{ _demo_outcome_picker() }}
         {{ actions("Retry verification") }}
       {% endcall %}
-    {% elif _clinician.npi_match_status == "none" %}
-      {# NPI not submitted yet — inline form to add it. #}
+    {% elif _clinician and _clinician.npi_match_status == "pending" %}
+      <p>
+        {# title-case-ignore #}
+        Checking NPPES… <a href="/profile">Refresh</a>
+      </p>
+    {% elif _clinician %}
+      {# Clinician exists but NPI not submitted yet #}
       {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/identity", method="post") %}
         <div class="grid">
           {{ text_field("first_name", "First name", current=_clinician.first_name or "", required=false) }}
@@ -152,38 +119,101 @@
         {{ _demo_outcome_picker() }}
         {{ actions("Start verification") }}
       {% endcall %}
+    {% elif not org_representations %}
+      {# No clinician record yet and no org rep — show the create form #}
+      {% call form_with_errors(action="/profile/clinician", method="post") %}
+        <div class="grid">
+          {{ text_field("first_name", "First name", required=false) }}
+          {{ text_field("last_name", "Last name", required=false) }}
+        </div>
+        {{ text_field("npi", "NPI (Type-1)", required=true, pattern="\\d{10}", maxlength=10) }}
+        {{ text_field("practice_name", "Practice name (optional)", required=false,
+                help="e.g. Single Thread Psychiatry — leave blank to use your name") }}
+        {{ _demo_outcome_picker() }}
+        {{ actions("Start verification") }}
+      {% endcall %}
+      <p style="margin-top: 0.75rem;
+                font-size: 0.9em;
+                color: var(--pico-muted-color)">
+        Not a clinician? <a href="#claim-b-card">Skip to register your organization below.</a>
+      </p>
     {% else %}
-      {# Pending / any other transient state. #}
-      <p style="color: var(--pico-muted-color);">
-        <i class="icon-loader"></i> Verification in progress…
-        <a href="{{ entity_url('clinician', id=_clinician.id) }}/form">View clinician</a>
+      {# Has org reps but no clinician — skipped #}
+      <p style="color: var(--pico-muted-color); font-size: 0.9em">
+        Skipped — you registered as an organization representative.
+        <a href="#claim-a-card"
+           onclick="this.closest('article').querySelector('form') && this.closest('article').querySelector('form').style.display !== 'none'">Add your NPI</a> any time to also enable clinician capabilities.
       </p>
     {% endif %}
   </article>
-  {# ------------------------------------------------------------------ #}
-  {# Organization representation                                          #}
-  {# ------------------------------------------------------------------ #}
-  <article id="claim-b-card">
+  {# ── Step 2: Add a license — only shown after NPI matches ─────────── #}
+  {% if _npi_ok %}
+    <article class="step-card step-card--action">
+      <header>
+        <div class="step-card-meta">
+          <span class="step-status step-status--action"><i class="icon-alert-triangle"></i> Required</span>
+          <strong>Add an active license</strong>
+          <small>Attests a valid state license — required to post referrals and openings</small>
+        </div>
+      </header>
+      {% call form_with_errors(action="/profile/clinician/" ~ _clinician.id|string ~ "/license", method="post") %}
+        {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
+        <div class="grid">
+          {{ select_field("issuing_state", "Issuing state", US_STATES, placeholder=true) }}
+          {{ text_field('license_number', 'License number') }}
+        </div>
+        {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
+        {{ checkbox_field("_attest_confirm", "I attest this license is active and in good standing.", required=true) }}
+        {{ actions("Add license") }}
+      {% endcall %}
+    </article>
+  {% endif %}
+  {# ── Step 3: Register an organization ─────────────────────────────── #}
+  <article class="step-card{% if not org_representations and not _npi_ok %} step-card--action{% endif %}"
+           id="claim-b-card">
     <header>
-      <strong>Post on behalf of an organization</strong>
-      <small style="display: block; color: var(--pico-muted-color);">Represent an organization with a Type-2 NPI</small>
+      <div class="step-card-meta">
+        {% if org_representations %}
+          <span class="step-status step-status--complete"><i class="icon-shield-check"></i> Organization registered</span>
+        {% else %}
+          <span class="step-status{% if not _npi_ok %} step-status--action{% endif %}">
+            <i class="icon-building"></i>
+            {% if not _npi_ok %}
+              Required (org reps)
+            {% else %}
+              Optional
+            {% endif %}
+          </span>
+        {% endif %}
+        <strong>Register an organization</strong>
+        <small>Post program intakes on behalf of a practice or facility — requires a Type-2 NPI for full verification</small>
+      </div>
     </header>
-    <p>
-      To post program intakes or org-attributed referrals, become a verified
-      representative of an organization.
-    </p>
     {% if org_representations %}
-      <p>
-        <small>You have {{ org_representations|length }} representation(s) on file.</small>
-      </p>
+      <ul style="margin: 0; padding-left: 1.25rem;">
+        {% for rep in org_representations %}
+          {% if rep.authority_status == "verified" and rep.archived_at is none %}
+            <li>
+              {{ rep.org.name if rep.org else rep.org_id }}
+              {% if rep.org and rep.org.org_verified %}
+                <span style="color: var(--pico-ins-color); font-size: 0.85em">— verified</span>
+              {% else %}
+                <span style="color: var(--pico-muted-color); font-size: 0.85em">— NPI verification pending</span>
+              {% endif %}
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
     {% else %}
-      <p style="color: var(--pico-muted-color);">
-        <small>
-          The org's NPI is verified once; you prove you're authorized to speak
-          for it via Authorized-Official match, domain email, or admin review.
-          Coming soon.
-        </small>
-      </p>
+      {% call form_with_errors(action="/profile/org", method="post") %}
+        {{ text_field("org_name", "Organization name", required=true) }}
+        {{ select_field("org_type", "Organization type", ORGANIZATION_TYPES,
+                labels=ORGANIZATION_TYPES_LABELS, placeholder=true) }}
+        {{ text_field("org_npi", "Type-2 NPI (optional)", required=false,
+                pattern="\\d{10}", maxlength=10,
+                help="10-digit organizational NPI — enables program intake posting") }}
+        {{ actions("Register organization") }}
+      {% endcall %}
     {% endif %}
   </article>
 </section>

--- a/src/domain/templates/profile/hub.html
+++ b/src/domain/templates/profile/hub.html
@@ -5,7 +5,7 @@
     <h1>Profile</h1>
     <p style="color: var(--pico-muted-color); margin-top: -0.25rem;">
       {% if mode == "setup" %}
-        Setting up — tell us what you want to do.
+        Verify your identity to post and see full referral details.
       {% elif mode == "manage" %}
         Manage your verification claims and profile.
       {% elif mode == "add-a-claim" %}


### PR DESCRIPTION
## Summary

- **Auto-OrgRepresentation for solo practitioners**: when a clinician is created with `solo_practice=True`, an `OrgRepresentation(role=owner, authority_status=verified)` is now auto-created for the resulting org. Previously the org existed but the user had no authority token over it.
- **Practice name field**: `ClinicianCreate` now accepts an optional `practice_name` that names the auto-org (e.g. "Single Thread Psychiatry") instead of defaulting to "First Last".
- **Non-clinician org rep path**: new `POST /profile/org` route backed by `handle_org_create` — creates an org + auto-rep in one request. If a Type-2 NPI is provided, NPPES org verification runs inline. Non-clinicians (coordinators, program reps) now have a clear onboarding path.
- **Card 3 activated**: setup template's "Coming soon" org card is replaced with a real form. Card 1 adds a "Not a clinician? Skip to register your organization" escape hatch.
- **Jinja globals fix**: `ORGANIZATION_TYPES` and `LICENSE_TYPES` are now registered as Jinja globals so bespoke templates (profile hub) can render those selects without relying on `EntitySpec.static_context`, which only runs via the generic entity framework.
- Profile step card CSS (`domain.css`) and manage/reverify template polish.

## Test plan

- [ ] New user (clinician) creates profile: practice name field appears; auto-org gets the provided name; OrgRepresentation exists immediately after submit
- [ ] New user (non-clinician): skip Card 1 via anchor link, fill Card 3 with org name + type; confirms landing in manage mode after submit
- [ ] Non-clinician with Type-2 NPI: org NPPES verification runs inline; `org_verified` reflects NPPES result
- [ ] `dev test` passes
- [ ] `dev lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)