### PR TITLE
fix: correct checkbox_field kwarg from checked= to current= in profile manage template

### DIFF
--- a/src/domain/templates/profile/_manage.html
+++ b/src/domain/templates/profile/_manage.html
@@ -126,8 +126,8 @@
             <strong>Insurance &amp; payment</strong>
           </summary>
           {% call form_with_errors(action="/profile/clinician/" ~ _c.id|string ~ "/details", method="post") %}
-            {{ checkbox_field("accepts_out_of_network", "Accepts out-of-network insurance", checked=_c.accepts_out_of_network) }}
-            {{ checkbox_field("sliding_scale", "Sliding scale available", checked=_c.sliding_scale) }}
+            {{ checkbox_field("accepts_out_of_network", "Accepts out-of-network insurance", current=_c.accepts_out_of_network) }}
+            {{ checkbox_field("sliding_scale", "Sliding scale available", current=_c.sliding_scale) }}
             {{ text_field("cost", "Session cost (optional)", current=_c.cost or "", required=false) }}
             {{ actions("Save payment info") }}
           {% endcall %}


### PR DESCRIPTION
## Summary

- Fixes prod 500 on `GET /profile` — the `checkbox_field` macro signature uses `current=` not `checked=`, causing a `TypeError` for any clinician in manage mode
- Introduced in #1105; the wrong kwarg name was used when wiring up `accepts_out_of_network` and `sliding_scale` checkboxes

Sentry: https://will-moritz.sentry.io/issues/7520147573/

## Test plan

- [ ] `GET /profile` as a clinician with a manage-mode hub renders without error
- [ ] Checkbox checked state reflects the clinician's stored values

🤖 Generated with [Claude Code](https://claude.com/claude-code)