### PR TITLE
feat: nullable clinician_affiliation_id context on listing details

### DIFF
--- a/alembic/versions/c4d5e6f7a8b9_add_clinician_affiliation_context_to_listings.py
+++ b/alembic/versions/c4d5e6f7a8b9_add_clinician_affiliation_context_to_listings.py
@@ -1,0 +1,96 @@
+"""add clinician_affiliation_id context to opening_details and referral_details
+
+Revision ID: c4d5e6f7a8b9
+Revises: b9c2e1d4f6a8
+Create Date: 2026-06-02 00:00:00.000000
+
+A clinician may affiliate with several organizations
+(`clinician_affiliations` is 1:N off `clinicians`). This adds the
+"context" FK to the two clinician-authored listing kinds — which
+affiliation the opening / referral is offered under. Nullable + SET
+NULL so removing an affiliation nulls the context rather than blocking.
+
+The backfill seeds every existing row to its clinician's *primary*
+affiliation — the earliest by `created_at`, matching
+`Clinician.primary_clinician_affiliation` (which returns
+`clinician_affiliations[0]` under `order_by=created_at`). Rows whose
+clinician has no affiliation, and referral rows with a null
+`referring_clinician_id`, stay null.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: Union[str, None] = "b9c2e1d4f6a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("opening_details") as batch_op:
+        batch_op.add_column(
+            sa.Column("clinician_affiliation_id", sa.Uuid(), nullable=True)
+        )
+        batch_op.create_foreign_key(
+            "fk_opening_details_clinician_affiliation_id",
+            "clinician_affiliations",
+            ["clinician_affiliation_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    with op.batch_alter_table("referral_details") as batch_op:
+        batch_op.add_column(
+            sa.Column("clinician_affiliation_id", sa.Uuid(), nullable=True)
+        )
+        batch_op.create_foreign_key(
+            "fk_referral_details_clinician_affiliation_id",
+            "clinician_affiliations",
+            ["clinician_affiliation_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    # Backfill to each clinician's primary (earliest) affiliation.
+    op.execute("""
+        UPDATE opening_details
+        SET clinician_affiliation_id = (
+            SELECT ca.id
+            FROM clinician_affiliations ca
+            WHERE ca.clinician_id = opening_details.clinician_id
+            ORDER BY ca.created_at
+            LIMIT 1
+        )
+        WHERE clinician_id IS NOT NULL
+        """)
+    op.execute("""
+        UPDATE referral_details
+        SET clinician_affiliation_id = (
+            SELECT ca.id
+            FROM clinician_affiliations ca
+            WHERE ca.clinician_id = referral_details.referring_clinician_id
+            ORDER BY ca.created_at
+            LIMIT 1
+        )
+        WHERE referring_clinician_id IS NOT NULL
+        """)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("referral_details") as batch_op:
+        batch_op.drop_constraint(
+            "fk_referral_details_clinician_affiliation_id",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("clinician_affiliation_id")
+
+    with op.batch_alter_table("opening_details") as batch_op:
+        batch_op.drop_constraint(
+            "fk_opening_details_clinician_affiliation_id",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("clinician_affiliation_id")

--- a/src/domain/logic/posts/test_persistence.py
+++ b/src/domain/logic/posts/test_persistence.py
@@ -480,6 +480,108 @@ async def test_delete_post_cascades_opening_detail(
         assert detail_row is None
 
 
+# --- Listing context (clinician_affiliation_id) -------------------------
+
+
+async def test_opening_persists_clinician_affiliation_context(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`OpeningDetail.clinician_affiliation_id` round-trips — the FK to the
+    affiliation the opening is offered under. The clinician factory builds
+    a primary affiliation; we pin the opening to it."""
+    owner, clinician = await _seed_owner_and_clinician(db_test_session_manager)
+    affiliation_id = clinician.primary_clinician_affiliation.id
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        created = await _create_post(
+            repo,
+            Post(kind="clinician_opening", owner_id=owner.id),
+            make_opening_detail(
+                clinician_id=clinician.id, clinician_affiliation_id=affiliation_id
+            ),
+        )
+        await session.commit()
+        post_id = created.id
+
+    async with db_test_session_manager() as session:
+        detail_row = (
+            (
+                await session.execute(
+                    select(OpeningDetail).filter(OpeningDetail.post_id == post_id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert detail_row.clinician_affiliation_id == affiliation_id
+
+
+async def test_opening_affiliation_context_defaults_null(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Omitting the context FK persists NULL — additive nullable column
+    must not break a row that doesn't supply it."""
+    owner, clinician = await _seed_owner_and_clinician(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        created = await _create_post(
+            repo,
+            Post(kind="clinician_opening", owner_id=owner.id),
+            make_opening_detail(clinician_id=clinician.id),
+        )
+        await session.commit()
+        post_id = created.id
+
+    async with db_test_session_manager() as session:
+        detail_row = (
+            (
+                await session.execute(
+                    select(OpeningDetail).filter(OpeningDetail.post_id == post_id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert detail_row.clinician_affiliation_id is None
+
+
+async def test_referral_persists_clinician_affiliation_context(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`ReferralDetail.clinician_affiliation_id` round-trips — the FK to the
+    affiliation the referring clinician is acting under."""
+    owner, clinician = await _seed_owner_and_clinician(db_test_session_manager)
+    affiliation_id = clinician.primary_clinician_affiliation.id
+
+    async with db_test_session_manager() as session:
+        repo = BaseRepository(session)
+        created = await _create_post(
+            repo,
+            Post(kind="referral", owner_id=owner.id),
+            make_referral_detail(
+                description="placement",
+                referring_clinician_id=clinician.id,
+                clinician_affiliation_id=affiliation_id,
+            ),
+        )
+        await session.commit()
+        post_id = created.id
+
+    async with db_test_session_manager() as session:
+        detail_row = (
+            (
+                await session.execute(
+                    select(ReferralDetail).filter(ReferralDetail.post_id == post_id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert detail_row.clinician_affiliation_id == affiliation_id
+
+
 # --- Program availability kind ------------------------------------------
 
 

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -363,7 +363,7 @@ def test_audit_snapshot_for_referral_post():
     post = SimpleNamespace(
         kind="referral",
         owner_id=owner_id,
-        referral_detail=SimpleNamespace(**detail_attrs),
+        referral_detail=SimpleNamespace(**detail_attrs, clinician_affiliation_id=None),
     )
     snap = post_audit_snapshot(post)
     assert snap["kind"] == "referral"
@@ -657,7 +657,7 @@ def test_audit_snapshot_for_opening_post():
         kind="clinician_opening",
         owner_id=owner_id,
         referral_detail=None,
-        opening_detail=SimpleNamespace(**detail_attrs),
+        opening_detail=SimpleNamespace(**detail_attrs, clinician_affiliation_id=None),
     )
     snap = post_audit_snapshot(post)
     assert snap["kind"] == "clinician_opening"

--- a/src/domain/models/posts/README.md
+++ b/src/domain/models/posts/README.md
@@ -10,6 +10,10 @@ This subdirectory holds the SQLAlchemy models for the `posts` table and its per-
 - `opening_detail.py` — `OpeningDetail`, the detail row for `kind='clinician_opening'`. Same shape as `ReferralDetail` but tracks the clinician-availability form; adds the `settings` JSON multi-select. `services` and `settings` are required-min-1 on the wire (vs. optional/absent on Client Referral). Table name stays `opening_details` from before the kind rename (migration `9e1f7b3c4a2d`) — pure rename noise to drop it.
 - `intake_detail.py` — `IntakeDetail`, the detail row for `kind='program_intake'` (#541). Same per-announcement field set as `OpeningDetail` but points at a `Program` via `program_id` instead of a `Clinician` — the referrer is choosing an *intake door* (the Program) and trusting the owning Org to assign a clinician internally. Table name stays `intake_details` for the same reason as `opening_details`.
 
+### Listing context (`clinician_affiliation_id`)
+
+The two clinician-authored detail kinds (`OpeningDetail`, `ReferralDetail`) carry a nullable `clinician_affiliation_id` FK → `clinician_affiliations.id` (`ON DELETE SET NULL`): a clinician who affiliates with several orgs (`clinician_affiliations` is 1:N off `clinicians`) declares *which* affiliation a given opening/referral is offered under. It's nullable because the column post-dates existing rows and because not every listing has a context set. `IntakeDetail` has no such column — its context is the `Program`'s owning org, reachable via `program_id`. Migration `c4d5e6f7a8b9` added the columns and backfilled each existing row to its clinician's primary (earliest-`created_at`) affiliation, matching `Clinician.primary_clinician_affiliation`.
+
 ## Kind name history (audit-log readers)
 
 Audit-log rows persist the kind value that was current when the row was written. Two renames happened in `posts.kind`:

--- a/src/domain/models/posts/opening_detail.py
+++ b/src/domain/models/posts/opening_detail.py
@@ -50,3 +50,16 @@ class OpeningDetail(Base):
     description = Column(Text, nullable=True)
     referral_instructions = Column(Text, nullable=True)
     website = Column(Text, nullable=True)
+
+    # Context: the specific `ClinicianAffiliation` this opening is offered
+    # under. A clinician who affiliates with several orgs posts an opening
+    # under one of them; this FK names which. Nullable — null means "no
+    # context set" (the state of every row before this column existed and
+    # of rows created before a picker populates it). `SET NULL` on delete
+    # so removing an affiliation nulls the context rather than blocking.
+    clinician_affiliation_id = Column(
+        Uuid(as_uuid=True),
+        ForeignKey("clinician_affiliations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    clinician_affiliation = relationship("ClinicianAffiliation", lazy="selectin")

--- a/src/domain/models/posts/referral_detail.py
+++ b/src/domain/models/posts/referral_detail.py
@@ -94,3 +94,14 @@ class ReferralDetail(LocationMixin, Base):
         foreign_keys=[referring_clinician_id],
         lazy="selectin",
     )
+
+    # Context: the specific `ClinicianAffiliation` the referring clinician
+    # is acting under. Mirrors `OpeningDetail.clinician_affiliation_id` —
+    # a clinician with several org affiliations refers under one. Nullable
+    # (null = no context set), `SET NULL` on affiliation delete.
+    clinician_affiliation_id = Column(
+        Uuid(as_uuid=True),
+        ForeignKey("clinician_affiliations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    clinician_affiliation = relationship("ClinicianAffiliation", lazy="selectin")


### PR DESCRIPTION
## Summary
- Add a nullable `clinician_affiliation_id` FK (`ON DELETE SET NULL`) to `opening_details` and `referral_details`, so a clinician with several org affiliations can record which affiliation a given opening/referral is offered under.
- Migration `c4d5e6f7a8b9` adds the columns and backfills each existing row to its clinician's primary (earliest-`created_at`) affiliation, matching `Clinician.primary_clinician_affiliation`. `IntakeDetail` is intentionally untouched — its context comes from the Program's owning org.
- **No wire-schema or UI changes.** New rows stay NULL until a picker lands in PR 3b. This is the smallest reversible prep step before context selection + the org-rep authority chain.

## Contract surfaces
- DB: two additive nullable columns + FKs (compatible — no shrinking CHECK/UNIQUE universe).
- Wire/HTTP/persisted-JSON: unchanged — the new column is not declared on any Read/Create/Update/AuditSnapshot variant, so it's silently dropped from responses and audit snapshots until PR 3b.

## Test plan
- [x] `dev test` (2268 passed, 101 skipped)
- [x] `dev test contract` (40 passed)
- [x] `dev migrate roundtrip` (upgrade/downgrade clean)
- [x] New persistence tests pin the column round-trips + NULL default