### PR TITLE
feat: practice picker sets affiliation context; derive clinician server-side

### DIFF
--- a/scripts/dev/seed/overrides/posts.py
+++ b/scripts/dev/seed/overrides/posts.py
@@ -63,6 +63,17 @@ async def generate_posts(
     clinicians: list[Clinician] = pool.all("clinicians")
     programs: list[Program] = pool.all("programs")
 
+    # Clinician → primary affiliation id. The generic `build_row` would
+    # resolve the listing's `clinician_affiliation_id` FK to a *random*
+    # affiliation; under the picker-derives-clinician model that must
+    # instead be one of the listing clinician's own affiliations. First
+    # affiliation seen per clinician is its primary (generate_affiliations
+    # appends primary before any secondary), matching
+    # `Clinician.primary_clinician_affiliation`.
+    primary_aff_by_clinician: dict = {}
+    for aff in pool.all("clinician_affiliations"):
+        primary_aff_by_clinician.setdefault(aff.clinician_id, aff.id)
+
     out: list[Post] = []
 
     # --- Referral posts ---
@@ -73,6 +84,12 @@ async def generate_posts(
         detail = build_row(ReferralDetail, i, rng, pool)
         # FK + description: generic builder can't infer either.
         detail.post_id = post_id
+        # Referring clinician + its context affiliation, kept coherent:
+        # the affiliation must belong to the referring clinician (the
+        # picker-derives-clinician invariant).
+        ref_clin = clinicians[i % len(clinicians)]
+        detail.referring_clinician_id = ref_clin.id
+        detail.clinician_affiliation_id = primary_aff_by_clinician.get(ref_clin.id)
         detail.subject = None if rng.bool(0.2) else referral_subject(rng, i)
         detail.description = render_referral_description(rng, i)
         # Sidecar PK isn't an FK-pool target; just give it a stable
@@ -90,7 +107,10 @@ async def generate_posts(
         _shift_created_at(post, days_ago=i % 180)
         detail = build_row(OpeningDetail, i, rng, pool)
         detail.post_id = post_id
-        detail.clinician_id = clinicians[i % len(clinicians)].id
+        opening_clin = clinicians[i % len(clinicians)]
+        detail.clinician_id = opening_clin.id
+        # Context affiliation must belong to this opening's clinician.
+        detail.clinician_affiliation_id = primary_aff_by_clinician.get(opening_clin.id)
         detail.subject = None if rng.bool(0.2) else opening_subject(rng, i)
         # `description` is nullable — populate most rows for narrative,
         # leave a slice NULL so the empty-state card renders too.

--- a/src/domain/logic/posts/handlers.py
+++ b/src/domain/logic/posts/handlers.py
@@ -28,7 +28,13 @@ from src.domain.logic.clinicians.repository import ClinicianRepository
 from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.posts.repository import PostRepository
 from src.domain.logic.programs.repository import ProgramRepository
-from src.domain.models import Clinician, Organization, Program, User
+from src.domain.models import (
+    Clinician,
+    ClinicianAffiliation,
+    Organization,
+    Program,
+    User,
+)
 from src.framework.authz import assert_fk_ownership
 from src.framework.dispatch.pagination import (
     DEFAULT_PAGE_SIZE,
@@ -77,7 +83,15 @@ async def _assert_post_payload_authz(
 
     Superusers bypass the capability check the same way they bypass
     ownership — admins act on any row.
+
+    Before ownership runs, ``_resolve_affiliation_context`` derives the
+    listing's clinician FK from the picker-submitted
+    ``clinician_affiliation_id`` (clinician-authored kinds only). The
+    ownership check then validates that *resolved* clinician, so a
+    picker pointing at an affiliation whose clinician the user doesn't
+    own is rejected here.
     """
+    await _resolve_affiliation_context(payload=payload, clinician_repo=clinician_repo)
     await _assert_post_payload_target_ownership(
         payload=payload,
         requesting_user=requesting_user,
@@ -85,6 +99,43 @@ async def _assert_post_payload_authz(
         program_repo=program_repo,
     )
     _assert_post_payload_capability(payload, requesting_user)
+
+
+async def _resolve_affiliation_context(
+    *, payload: BaseModel, clinician_repo: ClinicianRepository
+) -> None:
+    """Derive the listing's clinician FK from the picker's affiliation.
+
+    The opening / referral create+edit forms expose a single practice
+    picker whose options are the acting user's ``ClinicianAffiliation``
+    rows (one per clinician×org). The picker submits
+    ``clinician_affiliation_id``; the listing's persisted clinician FK
+    (``clinician_id`` for openings, ``referring_clinician_id`` for
+    referrals) is *derived* from that affiliation's ``clinician_id`` so
+    the two can never disagree — and so a clinician affiliated with two
+    orgs no longer collapses both options onto the same value.
+
+    Sets the derived FK on ``payload`` in place (Pydantic v2 marks it in
+    ``model_fields_set``, so ``model_dump(exclude_unset=True)`` carries
+    it into the update path too). Runs before the ownership check, which
+    then validates the resolved clinician.
+
+    No-op when the payload carries no ``clinician_affiliation_id`` — a
+    ``program_intake`` payload (no such field) or a referral/opening
+    PATCH that leaves context unchanged. 404 when the id doesn't resolve.
+    """
+    aff_id = getattr(payload, "clinician_affiliation_id", None)
+    if aff_id is None:
+        return
+    affiliation = await clinician_repo.get_by_model_id(ClinicianAffiliation, aff_id)
+    if affiliation is None:
+        raise NotFoundError(detail=f"Clinician affiliation {aff_id} not found")
+    derived_attr = (
+        "referring_clinician_id"
+        if getattr(payload, "kind", None) == "referral"
+        else "clinician_id"
+    )
+    setattr(payload, derived_attr, affiliation.clinician_id)
 
 
 def _assert_post_payload_capability(payload: BaseModel, requesting_user: User) -> None:

--- a/src/domain/logic/posts/schema.py
+++ b/src/domain/logic/posts/schema.py
@@ -220,6 +220,10 @@ class ReferralRead(_PostReadBase):
     # Nullable on the read side — rows created before this field existed
     # will have None here.
     referring_clinician_id: uuid.UUID | None = None
+    # Context affiliation this referral was offered under. Nullable —
+    # rows predating the column (and rows whose affiliation was later
+    # deleted, `SET NULL`) read as None.
+    clinician_affiliation_id: uuid.UUID | None = None
 
     # Flat-on-dump: keep ``location_city`` / ``location_state`` /
     # ``location_zip`` at the top level of JSON responses. The parent's
@@ -240,6 +244,9 @@ class ClinicianOpeningRead(_PostReadBase):
     # FK; templates dereference via
     # `post.opening_detail.clinician.<field>`.
     clinician_id: uuid.UUID
+    # Context affiliation this opening is offered under. Nullable — see
+    # `ReferralRead.clinician_affiliation_id`.
+    clinician_affiliation_id: uuid.UUID | None = None
     desired_times: DesiredTimesField = []
     schedule_text: str | None = None
     services: ServicesField = []
@@ -327,11 +334,19 @@ class ReferralCreate(FlatLocationSchema, WirePayload):
     # decision.
     network_preference: Literal[*NETWORK_PREFERENCES]
     insurance_carrier: OptionalInsuranceCarrier = None
+    # Context: which ClinicianAffiliation the referring clinician acts
+    # under. This is what the form's practice picker submits (one option
+    # per affiliation). Required on new referrals. The server resolves
+    # `referring_clinician_id` from this affiliation in
+    # `_assert_post_payload_authz` — see `referring_clinician_id` below.
+    clinician_affiliation_id: uuid.UUID
     # FK to the Clinician the submitting user designates as referrer.
-    # Required on new referrals; the ownership check in
-    # `_assert_post_payload_target_ownership` verifies the user owns
-    # the clinician before persisting.
-    referring_clinician_id: uuid.UUID
+    # NOT a form input — the picker submits `clinician_affiliation_id`
+    # and the server derives this from `affiliation.clinician_id`
+    # (`_assert_post_payload_authz`), then re-checks ownership of the
+    # resolved clinician. Optional/None on the wire; any client-sent
+    # value is overwritten by the resolved one.
+    referring_clinician_id: uuid.UUID | None = None
 
 
 class ClinicianOpeningCreate(WirePayload):
@@ -345,11 +360,18 @@ class ClinicianOpeningCreate(WirePayload):
     description: TextareaOptional = None
     referral_instructions: TextareaOptional = None
     website: UrlOptional = None
-    # FK to one of the requesting user's Clinician profiles. The form
-    # restricts the dropdown to clinicians owned by the user; the route
-    # handler also verifies ownership at write time so a wire-level
-    # attacker can't reference another user's clinician.
-    clinician_id: uuid.UUID
+    # Context: which ClinicianAffiliation this opening is offered under.
+    # This is what the form's practice picker submits (one option per
+    # affiliation). Required on new openings. The server resolves
+    # `clinician_id` from `affiliation.clinician_id` in
+    # `_assert_post_payload_authz`.
+    clinician_affiliation_id: uuid.UUID
+    # FK to the Clinician whose practice this announcement describes. NOT
+    # a form input — the picker submits `clinician_affiliation_id` and
+    # the server derives this from `affiliation.clinician_id`
+    # (`_assert_post_payload_authz`), then re-checks ownership. Optional/
+    # None on the wire; any client-sent value is overwritten.
+    clinician_id: uuid.UUID | None = None
     desired_times: DesiredTimesField = []
     # Free-text companion to `desired_times` for cohort dates / fixed
     # program hours. Single-line input; not a textarea.
@@ -452,8 +474,14 @@ class ReferralUpdate(FlatLocationSchema, PartialUpdate):
     # repo's "None means leave unchanged" semantic for optional fields).
     network_preference: Literal[*NETWORK_PREFERENCES] | None = None
     insurance_carrier: OptionalInsuranceCarrier = None
-    # `None` = leave unchanged. Ownership re-checked on update — a PATCH
-    # that repoints to a clinician the user doesn't own is 403.
+    # `None` = leave unchanged. The form picker submits this; the server
+    # re-derives `referring_clinician_id` from it (and re-checks
+    # ownership of the resolved clinician) in `_assert_post_payload_authz`.
+    clinician_affiliation_id: uuid.UUID | None = None
+    # `None` = leave unchanged. Server-derived from
+    # `clinician_affiliation_id` when the picker changes context;
+    # ownership re-checked on update — repointing to a clinician the user
+    # doesn't own is 403.
     referring_clinician_id: uuid.UUID | None = None
 
 
@@ -465,8 +493,13 @@ class ClinicianOpeningUpdate(PartialUpdate):
     description: TextareaOptional = None
     referral_instructions: TextareaOptional = None
     website: UrlOptional = None
+    # `None` = leave unchanged. The form picker submits this; the server
+    # re-derives `clinician_id` from it (and re-checks ownership of the
+    # resolved clinician) in `_assert_post_payload_authz`.
+    clinician_affiliation_id: uuid.UUID | None = None
     # FK to a Clinician profile owned by the requesting user. `None` =
-    # leave unchanged. The route handler verifies ownership on update.
+    # leave unchanged. Server-derived from `clinician_affiliation_id`
+    # when the picker changes context; ownership verified on update.
     clinician_id: uuid.UUID | None = None
     desired_times: DesiredTimesField | None = None
     schedule_text: StrippedOptionalText = None
@@ -549,6 +582,7 @@ class ReferralAuditSnapshot(_PostAuditSnapshotBase):
     network_preference: Literal[*NETWORK_PREFERENCES]
     insurance_carrier: OptionalInsuranceCarrier = None
     referring_clinician_id: uuid.UUID | None = None
+    clinician_affiliation_id: uuid.UUID | None = None
 
     # Flat-on-dump — see :class:`ReferralRead`.
     @model_serializer(mode="wrap")
@@ -565,6 +599,7 @@ class ClinicianOpeningAuditSnapshot(_PostAuditSnapshotBase):
     # Audit row records the FK, not the dereferenced practice fields —
     # standard pattern for relational audit snapshots.
     clinician_id: uuid.UUID
+    clinician_affiliation_id: uuid.UUID | None = None
     desired_times: DesiredTimesField = []
     schedule_text: str | None = None
     services: ServicesField = []

--- a/src/domain/logic/posts/test_affiliation_context.py
+++ b/src/domain/logic/posts/test_affiliation_context.py
@@ -1,0 +1,111 @@
+"""Unit tests for `_resolve_affiliation_context` — the picker-derives-
+clinician step that runs before FK-ownership on post create/update.
+
+The opening / referral forms submit a single `clinician_affiliation_id`
+(the practice picker). The server derives the listing's clinician FK
+from that affiliation's `clinician_id`:
+
+  - `kind='referral'`          → `referring_clinician_id`
+  - `kind='clinician_opening'` → `clinician_id`
+
+The derived value is set on the payload in place so it flows through
+both `model_dump()` (create) and `model_dump(exclude_unset=True)`
+(update). These tests pin the per-kind target, the missing-affiliation
+404, and the no-op when no `clinician_affiliation_id` is present.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from src.domain.logic.posts.handlers import _resolve_affiliation_context
+from src.framework.http.exceptions import NotFoundError
+
+
+class _StubClinicianRepo:
+    """Returns `affiliation` for any `get_by_model_id` call, or None to
+    simulate a missing row."""
+
+    def __init__(self, affiliation):
+        self._affiliation = affiliation
+        self.calls: list = []
+
+    async def get_by_model_id(self, model, model_id):
+        self.calls.append((model, model_id))
+        return self._affiliation
+
+
+async def test_referral_derives_referring_clinician_id():
+    clinician_id = uuid4()
+    aff_id = uuid4()
+    affiliation = SimpleNamespace(id=aff_id, clinician_id=clinician_id)
+    payload = SimpleNamespace(
+        kind="referral",
+        clinician_affiliation_id=aff_id,
+        referring_clinician_id=None,
+    )
+    repo = _StubClinicianRepo(affiliation)
+
+    await _resolve_affiliation_context(payload=payload, clinician_repo=repo)
+
+    assert payload.referring_clinician_id == clinician_id
+
+
+async def test_opening_derives_clinician_id():
+    clinician_id = uuid4()
+    aff_id = uuid4()
+    affiliation = SimpleNamespace(id=aff_id, clinician_id=clinician_id)
+    payload = SimpleNamespace(
+        kind="clinician_opening",
+        clinician_affiliation_id=aff_id,
+        clinician_id=None,
+    )
+    repo = _StubClinicianRepo(affiliation)
+
+    await _resolve_affiliation_context(payload=payload, clinician_repo=repo)
+
+    assert payload.clinician_id == clinician_id
+
+
+async def test_missing_affiliation_raises_not_found():
+    aff_id = uuid4()
+    payload = SimpleNamespace(
+        kind="referral",
+        clinician_affiliation_id=aff_id,
+        referring_clinician_id=None,
+    )
+    repo = _StubClinicianRepo(None)
+
+    with pytest.raises(NotFoundError, match=str(aff_id)):
+        await _resolve_affiliation_context(payload=payload, clinician_repo=repo)
+
+
+async def test_no_affiliation_id_is_noop():
+    """A `program_intake` payload (no picker) or a PATCH that doesn't
+    touch context carries no `clinician_affiliation_id` — the repo is
+    never hit and nothing is derived."""
+    payload = SimpleNamespace(kind="program_intake", program_id=uuid4())
+    repo = _StubClinicianRepo(SimpleNamespace(clinician_id=uuid4()))
+
+    await _resolve_affiliation_context(payload=payload, clinician_repo=repo)
+
+    assert repo.calls == []
+
+
+async def test_none_affiliation_id_is_noop():
+    """An opening/referral PATCH that leaves the picker untouched has
+    `clinician_affiliation_id=None` — also a no-op, no derivation."""
+    payload = SimpleNamespace(
+        kind="referral",
+        clinician_affiliation_id=None,
+        referring_clinician_id=None,
+    )
+    repo = _StubClinicianRepo(SimpleNamespace(clinician_id=uuid4()))
+
+    await _resolve_affiliation_context(payload=payload, clinician_repo=repo)
+
+    assert repo.calls == []
+    assert payload.referring_clinician_id is None

--- a/src/domain/logic/posts/test_schema.py
+++ b/src/domain/logic/posts/test_schema.py
@@ -104,7 +104,10 @@ def test_post_create_referral_rejects_empty_description():
         "age_groups",
         "description",
         "network_preference",
-        "referring_clinician_id",
+        # The picker submits this; `referring_clinician_id` is now
+        # server-derived from it, so the affiliation id is the required
+        # wire field, not the clinician id.
+        "clinician_affiliation_id",
     ],
 )
 def test_post_create_referral_requires_all_required_fields(missing_field):
@@ -363,7 +366,7 @@ def test_audit_snapshot_for_referral_post():
     post = SimpleNamespace(
         kind="referral",
         owner_id=owner_id,
-        referral_detail=SimpleNamespace(**detail_attrs, clinician_affiliation_id=None),
+        referral_detail=SimpleNamespace(**detail_attrs),
     )
     snap = post_audit_snapshot(post)
     assert snap["kind"] == "referral"
@@ -536,7 +539,9 @@ def test_post_update_opening_accepts_age_groups_only():
 @pytest.mark.parametrize(
     "missing_field",
     [
-        "clinician_id",
+        # The picker submits this; `clinician_id` is now server-derived
+        # from it, so the affiliation id is the required wire field.
+        "clinician_affiliation_id",
         "age_groups",
     ],
 )
@@ -657,7 +662,7 @@ def test_audit_snapshot_for_opening_post():
         kind="clinician_opening",
         owner_id=owner_id,
         referral_detail=None,
-        opening_detail=SimpleNamespace(**detail_attrs, clinician_affiliation_id=None),
+        opening_detail=SimpleNamespace(**detail_attrs),
     )
     snap = post_audit_snapshot(post)
     assert snap["kind"] == "clinician_opening"

--- a/src/domain/models/posts/README.md
+++ b/src/domain/models/posts/README.md
@@ -14,6 +14,8 @@ This subdirectory holds the SQLAlchemy models for the `posts` table and its per-
 
 The two clinician-authored detail kinds (`OpeningDetail`, `ReferralDetail`) carry a nullable `clinician_affiliation_id` FK → `clinician_affiliations.id` (`ON DELETE SET NULL`): a clinician who affiliates with several orgs (`clinician_affiliations` is 1:N off `clinicians`) declares *which* affiliation a given opening/referral is offered under. It's nullable because the column post-dates existing rows and because not every listing has a context set. `IntakeDetail` has no such column — its context is the `Program`'s owning org, reachable via `program_id`. Migration `c4d5e6f7a8b9` added the columns and backfilled each existing row to its clinician's primary (earliest-`created_at`) affiliation, matching `Clinician.primary_clinician_affiliation`.
 
+On the create/edit forms this column is the **only** clinician selector the user touches: the practice picker submits `clinician_affiliation_id`, and the listing's clinician FK (`referring_clinician_id` for referrals, `clinician_id` for openings) is *derived* from that affiliation server-side — so the two can never disagree, and a clinician affiliated with two orgs no longer collapses both options onto one value. The derivation runs in `_resolve_affiliation_context` ([`../../logic/posts/handlers.py`](../../logic/posts/handlers.py)) before the FK-ownership check, which then validates the resolved clinician.
+
 ## Kind name history (audit-log readers)
 
 Audit-log rows persist the kind value that was current when the row was written. Two renames happened in `posts.kind`:

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -463,9 +463,12 @@ async def test_create_form_shown_when_clinician_profile_exists(
     assert "Create your clinician profile" not in response.text
 
 
+# Both clinician-authored kinds now expose a single practice picker named
+# `clinician_affiliation_id` (one option per affiliation); the server
+# derives the clinician FK from the chosen affiliation.
 _CLINICIAN_FIELD = {
-    "referral": "referring_clinician_id",
-    "clinician_opening": "clinician_id",
+    "referral": "clinician_affiliation_id",
+    "clinician_opening": "clinician_affiliation_id",
 }
 
 
@@ -476,14 +479,15 @@ async def test_create_form_preselects_first_clinician(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """The clinician picker on new-post forms defaults to the user's first
-    clinician — no placeholder '-- ' option is rendered."""
+    """The practice picker on new-post forms defaults to the user's first
+    affiliation — no placeholder '-- ' option is rendered."""
     clinician = make_clinician_with_org(
         owner_id=logged_in_user.id, practice_name="First Practice"
     )
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(clinician)
+    affiliation_id = clinician.clinician_affiliations[0].id
 
     response = await authenticated_client.get(f"/posts/form?kind={kind}")
     assert response.status_code == 200
@@ -494,7 +498,7 @@ async def test_create_form_preselects_first_clinician(
     assert select is not None, f"no <select name={field_name!r}> in response"
 
     options = select.css("option")
-    assert options, "clinician select rendered no options"
+    assert options, "practice select rendered no options"
 
     # No disabled placeholder.
     assert not any(
@@ -507,10 +511,10 @@ async def test_create_form_preselects_first_clinician(
     # key presence — not a non-None value — is the correct sentinel.
     assert (
         "selected" in options[0].attributes
-    ), "first clinician option should carry the 'selected' attribute"
-    assert str(clinician.id) in (
+    ), "first affiliation option should carry the 'selected' attribute"
+    assert str(affiliation_id) in (
         options[0].attributes.get("value") or ""
-    ), "selected option value should be the first clinician's id"
+    ), "selected option value should be the first affiliation's id"
 
 
 # --- Anonymization gate (can_read_full_feed) ---------------------------------

--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -51,18 +51,19 @@ Field order:
     {# Practice picker. A Clinician may carry multiple Affiliations
      (clinician × org practice-role rows); the dropdown labels each
      option by the affiliation's org name so a clinician who works at
-     two practices sees both options. Each option's value is the
-     clinician id; the label comes from the affiliation's org. Uses
-     `composite_select_field` because the label is sourced from a
-     nested `affiliations` loop, not a flat attribute on the clinician
-     — mirrors `_form_referral.html`'s referring_clinician_id picker. #}
+     two practices sees both. Each option's value is the *affiliation*
+     id — the server derives the opening's `clinician_id` from it
+     (`_resolve_affiliation_context`), so a two-affiliation clinician's
+     options no longer collapse onto one value. Uses
+     `composite_select_field` because the label is sourced from a nested
+     `affiliations` loop — mirrors `_form_referral.html`'s picker. #}
     {%- set _practices = namespace(opts=[]) -%}
     {%- for c in current_user.clinicians -%}
       {%- for aff in c.clinician_affiliations -%}
-        {%- set _practices.opts = _practices.opts + [(c.id, aff.org.name)] -%}
+        {%- set _practices.opts = _practices.opts + [(aff.id, aff.org.name)] -%}
       {%- endfor -%}
     {%- endfor -%}
-    {{ composite_select_field("clinician_id", "Which practice?", _practices.opts, current=d.clinician_id if d else None, default_first=true) }}
+    {{ composite_select_field("clinician_affiliation_id", "Which practice?", _practices.opts, current=d.clinician_affiliation_id if d else None, default_first=true) }}
     {# About: free-text core fields — description / referral / website. #}
     {% call form_section("About") %}
       {{ field_for(schema, "description", "Description", current=d.description if d else None) }}

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -45,20 +45,20 @@ which FastAPI/Pydantic parses as a list.
   {%- set _hx_attrs = "hx-target=\"this\" hx-swap=\"outerHTML\" hx-target-4xx=\"this\" hx-swap-4xx=\"outerHTML\"" -%}
   <form hx-{{ hx_method }}="{{ action }}" {{ _hx_attrs|safe }}>
     <input type="hidden" name="kind" value="referral" />
-    {# Referring clinician picker — required; populated from the
-       current user's owned clinicians. Each option value is the
-       clinician id; the label is the affiliated org name, mirroring
-       the PA form's practice-picker pattern. Multi-affiliation
-       clinicians produce one option per affiliation; the macro's
-       first-match-wins prefill keeps the `selected` on the first
-       occurrence so the dropdown's displayed selection is stable. #}
+    {# Referring clinician picker — required; populated from the current
+       user's owned clinicians' affiliations. Each option value is the
+       *affiliation* id; the label is the affiliated org name. The server
+       derives `referring_clinician_id` from the chosen affiliation
+       (`_resolve_affiliation_context`), so a clinician affiliated with
+       two orgs produces two distinct options instead of collapsing both
+       onto the same clinician id. Mirrors the PA form's practice picker. #}
     {%- set _practices = namespace(opts=[]) -%}
     {%- for c in current_user.clinicians -%}
       {%- for aff in c.clinician_affiliations -%}
-        {%- set _practices.opts = _practices.opts + [(c.id, aff.org.name)] -%}
+        {%- set _practices.opts = _practices.opts + [(aff.id, aff.org.name)] -%}
       {%- endfor -%}
     {%- endfor -%}
-    {{ composite_select_field("referring_clinician_id", "Referring clinician", _practices.opts, current=d.referring_clinician_id if d else None, default_first=true) }}
+    {{ composite_select_field("clinician_affiliation_id", "Referring clinician", _practices.opts, current=d.clinician_affiliation_id if d else None, default_first=true) }}
     {{ textarea_field("description", "About the client", current=d.description if d else None, help="Anything else a clinician needs to know. Please don't include identifying details.") }}
     {% call form_section("Client demographics") %}
       {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help() ) }}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -59,6 +59,12 @@ def create_test_user(
 # hit the DB. Real round-trip tests pass an actual Clinician's id.
 _STUB_REFERRING_CLINICIAN_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
 
+# Stub clinician_affiliation_id — the field the form practice-picker
+# submits and from which the server derives the listing's clinician FK.
+# Required on the wire Create for both clinician-authored kinds. Schema
+# tests use the stub; route/persistence tests pass a real affiliation id.
+_STUB_CLINICIAN_AFFILIATION_ID = uuid.UUID("00000000-0000-0000-0000-000000000003")
+
 # ORM factory defaults: FK fields must be None (nullable columns).
 # SQLAlchemy's UUID column type calls .hex on the value — plain strings blow up.
 _REFERRAL_ORM_DEFAULTS: dict[str, Any] = {
@@ -84,9 +90,13 @@ _REFERRAL_ORM_DEFAULTS: dict[str, Any] = {
 
 # Wire-payload defaults: FK fields as stub string UUIDs for Pydantic validation.
 # Tests that actually persist must override with a real DB-resident ID.
+# `clinician_affiliation_id` is the required picker field; `referring_clinician_id`
+# is now optional on the wire (server-derived from the affiliation) but kept
+# here as a stub so schema round-trip tests still exercise it.
 _REFERRAL_WIRE_DEFAULTS: dict[str, Any] = {
     **_REFERRAL_ORM_DEFAULTS,
     "referring_clinician_id": str(_STUB_REFERRING_CLINICIAN_ID),
+    "clinician_affiliation_id": str(_STUB_CLINICIAN_AFFILIATION_ID),
 }
 
 _OPENING_DEFAULTS: dict[str, Any] = {
@@ -133,6 +143,7 @@ def opening_payload(**overrides: Any) -> dict[str, Any]:
     return {
         "kind": "clinician_opening",
         "clinician_id": str(_STUB_CLINICIAN_ID),
+        "clinician_affiliation_id": str(_STUB_CLINICIAN_AFFILIATION_ID),
         **_OPENING_DEFAULTS,
         **overrides,
     }


### PR DESCRIPTION
## Summary
- The opening/referral create+edit forms now expose a single **practice picker** that submits `clinician_affiliation_id` (one option per clinician×org affiliation).
- The listing's clinician FK (`referring_clinician_id` for referrals, `clinician_id` for openings) is **derived server-side** from the chosen affiliation in `_resolve_affiliation_context`, which runs before FK-ownership so the check validates the *resolved* clinician.
- Fixes a latent bug: a clinician affiliated with two orgs previously produced two picker options carrying the **same** clinician id, silently discarding which org was selected. The affiliation id is now the natural discriminator.

## Contract surface
- **Request body (breaking, internal-only):** `clinician_affiliation_id` is now required on `ReferralCreate`/`ClinicianOpeningCreate`; `referring_clinician_id`/`clinician_id` relaxed to optional (server-derived). Only our own forms + tests produce these payloads.
- Builds on PR 3a (#1124), which added the nullable `clinician_affiliation_id` column + backfill.

## Test plan
- [x] `_resolve_affiliation_context` unit tests (per-kind derivation, 404 on missing affiliation, no-op when absent/None) — `test_affiliation_context.py`
- [x] Schema required-field tests updated to assert the picker field
- [x] Route test asserts the picker option value is the affiliation id
- [x] Seed override keeps affiliation↔clinician coherent
- [x] `dev test` (2273 passed) + `dev lint` green
- [x] `dev test contract` (40 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)