### PR TITLE
feat: org-rep authority chain for post create (Claim B path)

### DIFF
--- a/src/domain/logic/posts/handlers.py
+++ b/src/domain/logic/posts/handlers.py
@@ -66,14 +66,29 @@ async def _assert_post_payload_authz(
     requesting_user: User,
     clinician_repo: ClinicianRepository,
     program_repo: ProgramRepository,
+    organization_repo: OrganizationRepository,
 ) -> None:
-    """`POST_ENTITY.payload_authz_path` target — runs the two
-    payload-time authorization checks in order:
+    """`POST_ENTITY.payload_authz_path` target — authorizes a post
+    create payload via one of two authority paths.
 
-    1. **Ownership** — the per-kind FK on the payload must point at a
-       row the requesting user owns. (Existing rule.)
-    2. **Capability** — the submitter must hold the claim that gates
-       this post-kind:
+    First ``_resolve_affiliation_context`` derives the listing's
+    clinician FK from the picker-submitted ``clinician_affiliation_id``
+    (clinician-authored kinds only) and returns the resolved
+    affiliation. Authority then resolves as:
+
+    1. **Org-rep (Claim B) path** — if the payload carries an
+       affiliation and the requesting user is a *verified org rep*
+       (`capabilities.org_rep_verified`) for that affiliation's org,
+       the write is authorized. This lets a group-practice coordinator
+       post a referral/opening under an affiliated clinician they don't
+       *own*, without holding Claim A themselves — the org-rep authority
+       chain (`OrgRepresentation` → org → affiliation → clinician).
+
+    2. **Self (owner + Claim A) path** — otherwise the per-kind FK on
+       the payload must point at a row the requesting user owns
+       (:func:`_assert_post_payload_target_ownership`) AND the user must
+       hold the claim that gates this post-kind
+       (:func:`_assert_post_payload_capability`):
 
        - ``referral`` / ``clinician_opening`` → Claim A
          (`capabilities.clinician_verified(user)`).
@@ -81,17 +96,28 @@ async def _assert_post_payload_authz(
          (deferred — the org lookup lands when the Profile Hub PR
          (Phase 5) wires the program-intake create flow end-to-end).
 
-    Superusers bypass the capability check the same way they bypass
-    ownership — admins act on any row.
+    Superusers fall through to the self path, where both the ownership
+    and capability checks bypass for admins — so an admin still writes
+    any row. ``program_intake`` carries no affiliation, so it always
+    takes the self path (its org authority is the Program's owning org,
+    handled there).
 
-    Before ownership runs, ``_resolve_affiliation_context`` derives the
-    listing's clinician FK from the picker-submitted
-    ``clinician_affiliation_id`` (clinician-authored kinds only). The
-    ownership check then validates that *resolved* clinician, so a
-    picker pointing at an affiliation whose clinician the user doesn't
-    own is rejected here.
+    **Create-only.** The org-rep path is wired on create
+    (`mount_create` runs only ``payload_authz`` on the not-yet-existing
+    post). Editing a post one doesn't own is still gated by the
+    object-level ``write_authz`` (owner-or-admin) that runs before this
+    hook on PATCH — expanding *that* to the org-rep chain needs an async
+    object-level policy and is a separate change.
     """
-    await _resolve_affiliation_context(payload=payload, clinician_repo=clinician_repo)
+    affiliation = await _resolve_affiliation_context(
+        payload=payload, clinician_repo=clinician_repo
+    )
+    if affiliation is not None and await _is_verified_org_rep_for_affiliation(
+        affiliation=affiliation,
+        requesting_user=requesting_user,
+        organization_repo=organization_repo,
+    ):
+        return
     await _assert_post_payload_target_ownership(
         payload=payload,
         requesting_user=requesting_user,
@@ -101,9 +127,31 @@ async def _assert_post_payload_authz(
     _assert_post_payload_capability(payload, requesting_user)
 
 
+async def _is_verified_org_rep_for_affiliation(
+    *,
+    affiliation: ClinicianAffiliation,
+    requesting_user: User,
+    organization_repo: OrganizationRepository,
+) -> bool:
+    """True iff ``requesting_user`` holds verified Claim B for the org
+    the affiliation points at.
+
+    The affiliation *is* the clinician↔org link, so resolving its
+    ``org_id`` and checking `capabilities.org_rep_verified(user, org)`
+    fully captures the org-rep authority chain — the
+    "clinician affiliated to org" leg of `can_post_org_referral` is
+    tautological when the affiliation is the source of truth. Returns
+    False (rather than raising) on any miss so the caller falls through
+    to the self/owner authority path."""
+    org = await organization_repo.get_by_model_id(Organization, affiliation.org_id)
+    if org is None:
+        return False
+    return capabilities.org_rep_verified(requesting_user, org)
+
+
 async def _resolve_affiliation_context(
     *, payload: BaseModel, clinician_repo: ClinicianRepository
-) -> None:
+) -> ClinicianAffiliation | None:
     """Derive the listing's clinician FK from the picker's affiliation.
 
     The opening / referral create+edit forms expose a single practice
@@ -120,13 +168,15 @@ async def _resolve_affiliation_context(
     it into the update path too). Runs before the ownership check, which
     then validates the resolved clinician.
 
-    No-op when the payload carries no ``clinician_affiliation_id`` — a
-    ``program_intake`` payload (no such field) or a referral/opening
-    PATCH that leaves context unchanged. 404 when the id doesn't resolve.
+    Returns the loaded ``ClinicianAffiliation`` (so the caller can reach
+    its ``org_id`` for the org-rep authority path), or ``None`` when the
+    payload carries no ``clinician_affiliation_id`` — a ``program_intake``
+    payload (no such field) or a referral/opening PATCH that leaves
+    context unchanged. 404 when the id doesn't resolve.
     """
     aff_id = getattr(payload, "clinician_affiliation_id", None)
     if aff_id is None:
-        return
+        return None
     affiliation = await clinician_repo.get_by_model_id(ClinicianAffiliation, aff_id)
     if affiliation is None:
         raise NotFoundError(detail=f"Clinician affiliation {aff_id} not found")
@@ -136,6 +186,7 @@ async def _resolve_affiliation_context(
         else "clinician_id"
     )
     setattr(payload, derived_attr, affiliation.clinician_id)
+    return affiliation
 
 
 def _assert_post_payload_capability(payload: BaseModel, requesting_user: User) -> None:

--- a/src/domain/logic/posts/test_org_rep_authority.py
+++ b/src/domain/logic/posts/test_org_rep_authority.py
@@ -1,0 +1,198 @@
+"""Org-rep authority path on post create (`_assert_post_payload_authz`).
+
+PR 3c wires the **org-rep (Claim B) authority chain**: a user who is a
+verified `OrgRepresentation` for an org may create a referral/opening
+whose `clinician_affiliation_id` points at a clinician affiliated with
+that org — without owning the clinician or holding Claim A. The
+affiliation *is* the clinician↔org link, so the org rep's authority
+flows `OrgRepresentation → org → affiliation → clinician`.
+
+These tests pin the create-path orchestrator end-to-end with stubbed
+repos: the rep path authorizes (early return, no ownership/Claim-A
+check), and every miss in the chain falls through to the existing
+self/owner authority path. Edit-by-non-owner-rep is *not* covered —
+that path is gated by the object-level `write_authz` (owner-or-admin)
+that runs before this hook on PATCH, and is a separate change.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from src.domain.logic.posts.handlers import (
+    _assert_post_payload_authz,
+    _is_verified_org_rep_for_affiliation,
+)
+from src.domain.models import Clinician, ClinicianAffiliation, Organization
+from src.framework.http.exceptions import ForbiddenError
+
+
+class _Repo:
+    """`get_by_model_id` stub that dispatches on the requested model
+    class to a per-type lookup dict, mirroring the real repos closely
+    enough for the authz orchestrator."""
+
+    def __init__(self, by_model: dict):
+        self._by_model = by_model
+        self.calls: list = []
+
+    async def get_by_model_id(self, model, model_id):
+        self.calls.append((model.__name__, model_id))
+        return self._by_model.get(model.__name__, {}).get(model_id)
+
+
+def _user(
+    *,
+    user_id=None,
+    is_superuser=False,
+    verified_rep_org_id=None,
+    clinician_verified=False,
+):
+    user_id = user_id or uuid4()
+    reps = (
+        [
+            SimpleNamespace(
+                org_id=verified_rep_org_id,
+                authority_status="verified",
+                archived_at=None,
+            )
+        ]
+        if verified_rep_org_id is not None
+        else []
+    )
+    clinicians = (
+        [SimpleNamespace(clinician_verified=True)] if clinician_verified else []
+    )
+    return SimpleNamespace(
+        id=user_id,
+        is_superuser=is_superuser,
+        is_verified=True,
+        org_representations=reps,
+        clinicians=clinicians,
+    )
+
+
+def _referral_payload(*, aff_id):
+    return SimpleNamespace(
+        kind="referral",
+        clinician_affiliation_id=aff_id,
+        referring_clinician_id=None,
+    )
+
+
+def _opening_payload(*, aff_id):
+    return SimpleNamespace(
+        kind="clinician_opening",
+        clinician_affiliation_id=aff_id,
+        clinician_id=None,
+    )
+
+
+def _setup(*, owner_id, org_verified=True):
+    """Build coherent affiliation/clinician/org rows: an affiliation of
+    `clinician` (owned by `owner_id`) at `org`. Returns ids + repos."""
+    aff_id, clin_id, org_id = uuid4(), uuid4(), uuid4()
+    affiliation = SimpleNamespace(id=aff_id, clinician_id=clin_id, org_id=org_id)
+    clinician = SimpleNamespace(id=clin_id, owner_id=owner_id)
+    org = SimpleNamespace(id=org_id, org_verified=org_verified)
+    clinician_repo = _Repo(
+        {
+            ClinicianAffiliation.__name__: {aff_id: affiliation},
+            Clinician.__name__: {clin_id: clinician},
+        }
+    )
+    organization_repo = _Repo({Organization.__name__: {org_id: org}})
+    return SimpleNamespace(
+        aff_id=aff_id,
+        clin_id=clin_id,
+        org_id=org_id,
+        clinician_repo=clinician_repo,
+        organization_repo=organization_repo,
+    )
+
+
+async def _run(payload, user, fx):
+    await _assert_post_payload_authz(
+        payload=payload,
+        requesting_user=user,
+        clinician_repo=fx.clinician_repo,
+        program_repo=_Repo({}),
+        organization_repo=fx.organization_repo,
+    )
+
+
+async def test_org_rep_authorizes_referral_without_owning_clinician():
+    """A verified rep of the affiliation's org may post a referral under
+    that affiliation's clinician even though someone else owns the
+    clinician and the rep holds no Claim A."""
+    fx = _setup(owner_id=uuid4())  # clinician owned by a *different* user
+    rep = _user(verified_rep_org_id=fx.org_id, clinician_verified=False)
+
+    await _run(_referral_payload(aff_id=fx.aff_id), rep, fx)
+
+    # Early return on the rep path: the ownership check (which would load
+    # the Clinician and 403) never ran.
+    assert (Clinician.__name__, fx.clin_id) not in fx.clinician_repo.calls
+
+
+async def test_org_rep_authorizes_opening():
+    fx = _setup(owner_id=uuid4())
+    rep = _user(verified_rep_org_id=fx.org_id)
+
+    await _run(_opening_payload(aff_id=fx.aff_id), rep, fx)
+
+    assert (Clinician.__name__, fx.clin_id) not in fx.clinician_repo.calls
+
+
+async def test_unverified_org_falls_through_to_self_path_and_403s():
+    """If the org's Type-2 NPI isn't verified, `org_rep_verified` is
+    False — the rep path is skipped and the non-owner is rejected by the
+    self/ownership path."""
+    fx = _setup(owner_id=uuid4(), org_verified=False)
+    rep = _user(verified_rep_org_id=fx.org_id)
+
+    with pytest.raises(ForbiddenError):
+        await _run(_referral_payload(aff_id=fx.aff_id), rep, fx)
+
+
+async def test_non_rep_non_owner_is_rejected():
+    """A user who is neither a rep of the org nor the clinician's owner
+    falls through to the self path and is rejected."""
+    fx = _setup(owner_id=uuid4())
+    stranger = _user()  # no rep, owns nothing
+
+    with pytest.raises(ForbiddenError):
+        await _run(_referral_payload(aff_id=fx.aff_id), stranger, fx)
+
+
+async def test_owner_with_claim_a_takes_self_path():
+    """The owner path still works: owning the clinician + Claim A
+    authorizes even with no org-rep status."""
+    owner_id = uuid4()
+    fx = _setup(owner_id=owner_id)
+    owner = _user(user_id=owner_id, clinician_verified=True)
+
+    await _run(_referral_payload(aff_id=fx.aff_id), owner, fx)
+
+
+async def test_superuser_falls_through_and_is_authorized():
+    """A superuser who isn't a rep falls through to the self path, where
+    ownership + capability both bypass for admins."""
+    fx = _setup(owner_id=uuid4())
+    admin = _user(is_superuser=True)
+
+    await _run(_referral_payload(aff_id=fx.aff_id), admin, fx)
+
+
+async def test_is_verified_org_rep_false_when_org_missing():
+    aff = SimpleNamespace(org_id=uuid4(), clinician_id=uuid4())
+    organization_repo = _Repo({})  # org not found
+    result = await _is_verified_org_rep_for_affiliation(
+        affiliation=aff,
+        requesting_user=_user(verified_rep_org_id=aff.org_id),
+        organization_repo=organization_repo,
+    )
+    assert result is False

--- a/src/domain/models/posts/README.md
+++ b/src/domain/models/posts/README.md
@@ -16,6 +16,8 @@ The two clinician-authored detail kinds (`OpeningDetail`, `ReferralDetail`) carr
 
 On the create/edit forms this column is the **only** clinician selector the user touches: the practice picker submits `clinician_affiliation_id`, and the listing's clinician FK (`referring_clinician_id` for referrals, `clinician_id` for openings) is *derived* from that affiliation server-side — so the two can never disagree, and a clinician affiliated with two orgs no longer collapses both options onto one value. The derivation runs in `_resolve_affiliation_context` ([`../../logic/posts/handlers.py`](../../logic/posts/handlers.py)) before the FK-ownership check, which then validates the resolved clinician.
 
+Because the affiliation *is* the clinician↔org link, it also carries the **org-rep authority chain** on create: `_assert_post_payload_authz` authorizes a referral/opening either via the **self** path (own the resolved clinician + hold Claim A) or the **org-rep** path (be a verified `OrgRepresentation` — Claim B — for the affiliation's org, per `capabilities.org_rep_verified`). The org-rep path lets a group-practice coordinator post under an affiliated clinician they don't own without holding Claim A. It's wired on **create only**: editing a post one doesn't own is still gated by the object-level owner-or-admin `write_authz` that runs before the payload hook on PATCH (expanding that to the org-rep chain needs an async object-level policy — a separate change).
+
 ## Kind name history (audit-log readers)
 
 Audit-log rows persist the kind value that was current when the row was written. Two renames happened in `posts.kind`:

--- a/src/domain/specs/posts.py
+++ b/src/domain/specs/posts.py
@@ -17,6 +17,7 @@ for the full polymorphic-face contract.
 from typing import Final
 
 from src.domain.logic.clinicians.repository import ClinicianRepository
+from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.posts.repository import get_post_repository
 from src.domain.logic.posts.schema import (
     post_audit_snapshot,
@@ -153,16 +154,17 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
         form_edit="posts/form_edit.html",
     ),
     update_redirect=Redirects.to_detail("posts", "post_id"),
-    # Per-kind FK-ownership check + Claim-A capability gate. The
-    # dispatcher reads `payload.kind` and validates the kind-specific FK
-    # fields (clinician_opening's `clinician_id`, program_intake's
-    # `program_id`) against the requesting user's ownership, then
-    # enforces the matching claim gate from the two-claim verification
-    # model. See `_assert_post_payload_authz` for the full contract.
+    # Two authority paths on create (see `_assert_post_payload_authz`):
+    # the **self** path (own the per-kind FK row + hold the matching
+    # claim) or the **org-rep** path (be a verified rep of the org the
+    # listing's `clinician_affiliation_id` points at). The org lookup for
+    # the rep path needs `organization_repo`; the self path needs the
+    # clinician/program repos for the FK-ownership check.
     payload_authz_path="src.domain.logic.posts.handlers._assert_post_payload_authz",
     payload_authz_repos=(
         ("clinician_repo", ClinicianRepository),
         ("program_repo", ProgramRepository),
+        ("organization_repo", OrganizationRepository),
     ),
     discriminator=POST_KINDS,
     # Whole-supertype: no `discriminator_value` or `discriminator_values`.


### PR DESCRIPTION
## Summary
- `_assert_post_payload_authz` now authorizes a referral/opening **create** via one of two paths:
  - **Self path** (unchanged): own the resolved clinician + hold Claim A.
  - **Org-rep path** (new): be a verified `OrgRepresentation` (Claim B) for the org the listing's `clinician_affiliation_id` points at. This lets a group-practice coordinator post under an affiliated clinician they don't own, without holding Claim A.
- The affiliation **is** the clinician↔org link, so the authority flows `OrgRepresentation → org → affiliation → clinician` — the "clinician affiliated to org" leg is tautological when the affiliation is the source. The check reuses `capabilities.org_rep_verified` (which enforces email-verified + `Organization.org_verified` + a verified non-archived rep).
- Wires the previously-defined-but-unused org-rep capability into the post write gate.

## Scope / contract surface
- **Create only.** `mount_create` runs only `payload_authz` on the not-yet-existing post, so this is a surgical, self-contained change. **Authorization expansion (additive):** no existing client breaks — it only grants new permission to verified reps.
- **Edit deferred.** Editing a post one doesn't own is still gated by the object-level owner-or-admin `write_authz` that runs *before* the payload hook on PATCH. Expanding that to the org-rep chain needs an async object-level policy — a separate, framework-touching PR.
- Adds `organization_repo` to `POST_ENTITY.payload_authz_repos` for the org lookup.

## Test plan
- [x] `test_org_rep_authority.py` — rep authorizes referral + opening without owning the clinician; unverified org / non-rep / stranger fall through to the self path and 403; owner+Claim A still works; superuser bypasses; org-missing returns False
- [x] Existing `_resolve_affiliation_context` + capability-gate tests still green
- [x] `dev test` (2280 passed) + `dev lint`
- [x] `dev test contract` (40 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)