### PR TITLE
feat: onboarding readiness projection drives capability-accurate checklist

### DIFF
--- a/src/domain/logic/profile/test_view.py
+++ b/src/domain/logic/profile/test_view.py
@@ -1,0 +1,83 @@
+"""Tests for `onboarding_readiness` — the compact readiness projection.
+
+Pins that the summary tracks the `capabilities` predicates exactly (so a
+"Getting started" checklist can't disagree with the post gate) and that
+`next_label`/`next_href` walk the verification ladder in order: email →
+identity → done.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.domain.logic.profile.view import onboarding_readiness
+
+
+def _user(*, email=True, claim_a=False, claim_b=False, ever_verified=False):
+    """Duck-typed user matching what `capabilities.*` reads:
+    `is_verified` (email), `clinicians[*].clinician_verified` /
+    `.ever_verified_at` (Claim A / retention), `org_representations`
+    (Claim B)."""
+    clinicians = []
+    if claim_a or ever_verified:
+        clinicians = [
+            SimpleNamespace(
+                clinician_verified=claim_a,
+                ever_verified_at=("2026-01-01" if ever_verified else None),
+            )
+        ]
+    reps = (
+        [SimpleNamespace(authority_status="verified", archived_at=None)]
+        if claim_b
+        else []
+    )
+    return SimpleNamespace(
+        is_verified=email,
+        clinicians=clinicians,
+        org_representations=reps,
+    )
+
+
+def test_unverified_email_blocks_everything_and_points_at_email():
+    r = onboarding_readiness(_user(email=False, claim_a=True))
+    assert r.email_verified is False
+    # Email is the floor — Claim A reads false without it.
+    assert r.claim_a_verified is False
+    assert r.can_post is False
+    assert r.next_label == "Verify your email"
+    assert r.next_href == "/profile?focus=email"
+
+
+def test_email_verified_no_claim_points_at_identity():
+    r = onboarding_readiness(_user(email=True))
+    assert r.email_verified is True
+    assert r.can_post is False
+    assert r.next_label == "Verify your identity to start posting"
+    assert r.next_href == "/profile"
+
+
+def test_claim_a_unlocks_posting_and_clears_next_step():
+    r = onboarding_readiness(_user(claim_a=True))
+    assert r.claim_a_verified is True
+    assert r.can_post is True
+    assert r.can_read_full_feed is True
+    assert r.next_label is None
+    assert r.next_href is None
+
+
+def test_claim_b_alone_unlocks_posting():
+    r = onboarding_readiness(_user(claim_b=True))
+    assert r.claim_a_verified is False
+    assert r.claim_b_verified is True
+    assert r.can_post is True
+    assert r.next_label is None
+
+
+def test_lapsed_clinician_retains_feed_but_cannot_post():
+    """Once-verified (ever_verified_at set) but not currently verified:
+    full-feed read is retained, but posting is not — the projection
+    surfaces the identity next-step again."""
+    r = onboarding_readiness(_user(claim_a=False, ever_verified=True))
+    assert r.can_read_full_feed is True
+    assert r.can_post is False
+    assert r.next_href == "/profile"

--- a/src/domain/logic/profile/view.py
+++ b/src/domain/logic/profile/view.py
@@ -1,0 +1,94 @@
+"""Onboarding readiness projection.
+
+`onboarding_readiness(user)` collapses the two-claim verification model
+into one capability-accurate summary of "what does this user still need
+to do before they can post." It exists so any onboarding surface — the
+"Getting started" checklist on `/users/me`, the chrome nudge — reads the
+*same* readiness from the *same* predicates the server-side post gate
+uses (`capabilities.*`). That's the whole point of the capabilities
+module: the visible affordance and the gate can't disagree, so a
+checklist must never invite a user to "Post an opening" when
+`can_post_opening` would 403 them.
+
+This is a pure projection (no I/O): it reads already-loaded relationships
+off `user` via the `capabilities` predicates and returns a frozen view
+object. Mirror of `clinician_card_view` / `post_card_view`; exposed as a
+Jinja global in `template_globals.py`.
+
+The rich step-by-step setup UI (`profile/_setup.html`) is a *different*
+surface — it walks NPI-pending/mismatch sub-states the bare readiness
+summary intentionally omits. This projection is the compact "are you
+ready, and if not what's the single next click" view; `_setup.html`
+stays the detailed guided flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.domain.logic import capabilities
+
+
+@dataclass(frozen=True)
+class OnboardingReadiness:
+    """Compact readiness summary for onboarding surfaces.
+
+    - `email_verified` — the floor for every claim.
+    - `claim_a_verified` — a Verified Clinician (`clinician_verified`).
+    - `claim_b_verified` — a verified org rep for ≥1 org
+      (`any_org_rep_verified`).
+    - `can_post` — holds at least one posting-capable claim (A or B). The
+      gate a "Post an opening / referral" CTA must respect.
+    - `can_read_full_feed` — full (un-teased) feed access.
+    - `next_label` / `next_href` — the single next verification step, or
+      ``None`` when nothing remains (the user can post). Hrefs come from
+      `capabilities.fix_url_for` / `/profile` so the deep-link vocab
+      stays in one place.
+    """
+
+    email_verified: bool
+    claim_a_verified: bool
+    claim_b_verified: bool
+    can_post: bool
+    can_read_full_feed: bool
+    next_label: str | None
+    next_href: str | None
+
+
+def onboarding_readiness(user: Any) -> OnboardingReadiness:
+    """Project a user's claim state into an onboarding readiness summary.
+
+    Pure function over the `capabilities` predicates — duck-typed via
+    `getattr` like the rest of that module, so template stubs and the
+    real `User` ORM row both work. `can_post` is "holds a posting-capable
+    claim" (Claim A or any verified Claim B), matching the structure of
+    `can_read_full_feed`; the per-kind gates (`can_post_referral`,
+    `can_post_program_intake`) refine it at the actual post boundary.
+    """
+    email = capabilities.email_verified(user)
+    claim_a = capabilities.clinician_verified(user)
+    claim_b = capabilities.any_org_rep_verified(user)
+    can_post = claim_a or claim_b
+
+    next_label: str | None
+    next_href: str | None
+    if not email:
+        next_label = "Verify your email"
+        next_href = capabilities.fix_url_for(capabilities.REASON_EMAIL_UNVERIFIED)
+    elif not can_post:
+        next_label = "Verify your identity to start posting"
+        next_href = "/profile"
+    else:
+        next_label = None
+        next_href = None
+
+    return OnboardingReadiness(
+        email_verified=email,
+        claim_a_verified=claim_a,
+        claim_b_verified=claim_b,
+        can_post=can_post,
+        can_read_full_feed=capabilities.can_read_full_feed(user),
+        next_label=next_label,
+        next_href=next_href,
+    )

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -509,14 +509,16 @@ async def test_detail_shows_inline_create_clinician_for_self(
     assert action.attributes.get("href") == "/clinicians/form"
 
 
-async def test_users_me_shows_onboarding_create_clinician_cta_when_no_profile(
+async def test_users_me_onboarding_points_at_identity_when_unverified(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """`GET /users/me` for a user with no clinician profile shows a
-    'Create your clinician profile' CTA in the onboarding checklist.
-    The checklist is self-only — other users' profiles (/users/{id})
-    are unaffected."""
+    """`GET /users/me` for an email-verified user who holds no
+    posting-capable claim (no Verified Clinician, no verified org rep)
+    shows the capability-accurate "Verify your identity to start posting"
+    CTA pointing at `/profile` — never an invitation to "Post an opening"
+    that the post gate would 403. The checklist is self-only; other
+    users' profiles (/users/{id}) are unaffected."""
     response = await authenticated_client.get("/users/me")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
@@ -530,14 +532,18 @@ async def test_users_me_shows_onboarding_create_clinician_cta_when_no_profile(
     assert (
         "Getting started" in headings
     ), "/users/me is missing the 'Getting started' onboarding card"
-    # The create-clinician CTA must link to the clinician form.
-    cta = tree.css_first(
-        "section.entity-card a[href='/clinicians/form'][role='button']"
-    )
+    # `onboarding_readiness.next_href` for an email-verified, claimless
+    # user is "/profile" with the identity-verification label. The
+    # "Post an opening" CTA must NOT render — the user can't post yet.
+    cta = tree.css_first("section.entity-card a[href='/profile'][role='button']")
+    assert cta is not None, "onboarding card is missing the 'Verify your identity' CTA"
+    assert "Verify your identity to start posting" in cta.text()
     assert (
-        cta is not None
-    ), "onboarding card is missing 'Create your clinician profile' CTA"
-    assert "Create your clinician profile" in cta.text()
+        tree.css_first(
+            "section.entity-card a[href='/posts/form?kind=clinician_opening']"
+        )
+        is None
+    ), "claimless user must not be offered the 'Post an opening' CTA"
 
 
 async def test_users_me_onboarding_post_opening_cta_when_has_clinician(

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -29,6 +29,7 @@ from src.domain.logic.posts.view import (
     post_row_summary,
     referral_headline,
 )
+from src.domain.logic.profile.view import onboarding_readiness
 from src.domain.models import enums
 from src.framework.rendering.form_fields import register_choice_labels
 from src.framework.rendering.templating import register_template_globals
@@ -119,6 +120,12 @@ register_template_globals(
     # `clinicians/detail.html` reads from — see its docstring in
     # `src.domain.logic.clinicians.view`.
     clinician_card_view=clinician_card_view,
+    # `onboarding_readiness(user)` is the compact capability-accurate
+    # readiness summary the "Getting started" checklist reads — see its
+    # docstring in `src.domain.logic.profile.view`. Reuses the same
+    # `capabilities` predicates the post gate uses, so the checklist
+    # can't invite a user into an action the server would 403.
+    onboarding_readiness=onboarding_readiness,
     # `capabilities` is the single-source-of-truth predicate module
     # (`src.domain.logic.capabilities`) registered as a Jinja namespace
     # so templates can write

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -76,30 +76,49 @@
     </section>
   {% endif %}
   {# Onboarding checklist — visible only to the user viewing their own
-   profile. Shows status-based CTAs: create a clinician profile first,
-   then post an opening. Other users' profiles (/users/{id}) are
-   unchanged — they keep the Clinicians card below without this section. #}
+   profile. Driven by `onboarding_readiness(current_user)` so the CTAs
+   track the same capability gate the post route enforces: the
+   "Post an opening" button only appears once `can_post` is true, and
+   until then the checklist points at the single next verification step
+   (`next_href`) instead of inviting a 403. Other users' profiles
+   (/users/{id}) are unchanged — they keep the Clinicians card below
+   without this section. #}
   {% if is_self %}
+    {% set readiness = onboarding_readiness(current_user) %}
     <section class="entity-card">
       <header class="entity-header">
         <strong>Getting started</strong>
       </header>
       <ul>
         <li>
-          {% if clinicians %}
-            &#10003; <a href="{{ entity_url('clinician', id=clinicians[0].id) }}">Your clinician profile</a>
+          {% if readiness.email_verified %}
+            &#10003;
           {% else %}
-            <a href="{{ entity_form_url('clinician') }}" role="button">Create your clinician profile</a>
+            &#9744;
           {% endif %}
+          Verify your email
+        </li>
+        <li>
+          {% if readiness.can_post %}
+            &#10003;
+          {% else %}
+            &#9744;
+          {% endif %}
+          Verify your identity (clinician NPI or organization)
         </li>
         {% if clinicians %}
           <li>
-            <a href="{{ entity_form_url("post") }}?kind=clinician_opening"
-               role="button"
-               class="outline">Post an opening</a>
+            &#10003; <a href="{{ entity_url('clinician', id=clinicians[0].id) }}">Your clinician profile</a>
           </li>
         {% endif %}
       </ul>
+      {% if readiness.can_post %}
+        <a href="{{ entity_form_url("post") }}?kind=clinician_opening"
+           role="button"
+           class="outline">Post an opening</a>
+      {% elif readiness.next_href %}
+        <a href="{{ readiness.next_href }}" role="button">{{ readiness.next_label }}</a>
+      {% endif %}
     </section>
   {% endif %}
   <section class="entity-card">


### PR DESCRIPTION
## Summary
- Add `onboarding_readiness(user)` (`src/domain/logic/profile/view.py`) — a pure projection over the same `capabilities.*` predicates the server-side post gate uses, returning a frozen `OnboardingReadiness` (email/claim-A/claim-B state, `can_post`, `can_read_full_feed`, and the single `next_label`/`next_href` step).
- Register it as a Jinja global and rewire the "Getting started" checklist on `/users/me` to consume it. A user with no posting-capable claim now sees **"Verify your identity to start posting" → `/profile`** instead of a "Post an opening" CTA that the gate would 403.
- The "Post an opening" CTA only renders once `readiness.can_post` holds, so the visible affordance and the post gate can't disagree.

## Why
The naive checklist invited unverified users into "Post an opening", which 403s under the capabilities gate introduced earlier in this series. Routing the checklist through the same predicates closes that affordance/gate gap — the whole point of `capabilities.py`.

## Test plan
- [x] `src/domain/logic/profile/test_view.py` — 5 unit tests pinning the projection tracks the predicates (email floor, claim A/B unlock, lapsed-clinician retains feed but can't post).
- [x] `src/domain/routes/test_users.py` — onboarding route tests updated for the new capability-accurate CTA; claimless user must NOT be offered "Post an opening".
- [x] `dev test` (2285 passed), `dev lint`, `dev test contract` (40 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)