### PR TITLE
fix: gate the /posts toolbar Create CTA on a posting-capable claim

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -550,6 +550,46 @@ async def test_list_hides_verify_notice_for_verified(
     assert "posts-verify-notice" not in response.text
 
 
+# --- Toolbar Create CTA gate (posting-capable claim) -------------------------
+
+
+async def test_list_hides_create_cta_for_claimless_user(
+    authenticated_client: AsyncClient,
+    logged_in_user,
+):
+    """The `/posts` toolbar 'Create' button is hidden for a user holding
+    no posting-capable claim — clicking it would only land on a server
+    403 / degraded form. Matches the per-kind post gate's universe."""
+    response = await authenticated_client.get("/posts")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert (
+        tree.css_first("a[href='/posts/form'][role='button']") is None
+    ), "claimless user must not be offered the toolbar Create CTA"
+
+
+async def test_list_shows_create_cta_for_claim_a_user(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """A Claim-A (verified clinician) user sees the toolbar 'Create' CTA —
+    the server post gate would let them through."""
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/posts")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert (
+        tree.css_first("a[href='/posts/form'][role='button']") is not None
+    ), "Claim-A user should be offered the toolbar Create CTA"
+
+
 async def test_detail_hides_email_and_shows_cta_for_unverified(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -6,9 +6,16 @@
 {% block resource_label %}Posts{% endblock %}
 {% block toolbar %}
   {% call page_toolbar(heading="Posts") %}
-    <li>
-      <a href="{{ entity_form_url('post') }}" role="button">{{ entity_create_label("post") }}</a>
-    </li>
+    {# Create CTA is gated on a posting-capable claim — Claim A (verified
+       clinician) OR any verified Claim B (org rep). Same universe the
+       per-kind server gates accept (`capabilities.can_post_*` self path
+       OR the org-rep path), so the visible button can't invite a 403.
+       `claims.{a,b}` come from `base_context()` → `claim_state(user)`. #}
+    {% if claims.a or claims.b %}
+      <li>
+        <a href="{{ entity_form_url('post') }}" role="button">{{ entity_create_label("post") }}</a>
+      </li>
+    {% endif %}
   {% endcall %}
 {% endblock %}
 {% block actions %}{% endblock %}


### PR DESCRIPTION
## Summary
- The `/posts` toolbar "Create" button (`posts/list.html`) rendered unconditionally for every authenticated user. A claimless user could click it → `/posts/form` → server 403 / degraded form.
- Gate it on `claims.a or claims.b` — the same universe (Claim A self path **or** verified org-rep Claim B) the per-kind server post gates accept — so the visible affordance can't invite an action the server blocks.

## Why
Closes the last unwired posting affordance found auditing the onboarding surfaces after the `onboarding_readiness` projection (#1130). Every other post CTA (home, profile-manage, users/me) already gates on the capabilities predicates; this toolbar button was the outlier.

## Test plan
- [x] `test_list_hides_create_cta_for_claimless_user` — claimless user gets no toolbar Create CTA.
- [x] `test_list_shows_create_cta_for_claim_a_user` — verified clinician does.
- [x] `dev test` (2287 passed), `dev lint`, `dev test contract` (40 passed) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)