### PR TITLE
refactor: make /profile the single onboarding home; /users/me signposts it

### DIFF
--- a/src/domain/logic/profile/view.py
+++ b/src/domain/logic/profile/view.py
@@ -2,13 +2,18 @@
 
 `onboarding_readiness(user)` collapses the two-claim verification model
 into one capability-accurate summary of "what does this user still need
-to do before they can post." It exists so any onboarding surface — the
-"Getting started" checklist on `/users/me`, the chrome nudge — reads the
-*same* readiness from the *same* predicates the server-side post gate
-uses (`capabilities.*`). That's the whole point of the capabilities
-module: the visible affordance and the gate can't disagree, so a
-checklist must never invite a user to "Post an opening" when
-`can_post_opening` would 403 them.
+to do before they can post." It exists so any surface that *reports*
+verification status — the read-only Verification card on `/users/me` —
+reads the *same* readiness from the *same* predicates the server-side
+post gate uses (`capabilities.*`). That's the whole point of the
+capabilities module: a status signpost can't disagree with the gate.
+
+The single place a user *acts* on verification is the `/profile` hub
+(handoff §8.1 — "onboarding IS the hub in setup mode; no separate
+wizard"); `/users/me` reports state and links into the hub, it does not
+re-host the onboarding wizard. So this projection drives a status line,
+not an action checklist — `next_href` is a deep-link *into the hub*, not
+a substitute for it.
 
 This is a pure projection (no I/O): it reads already-loaded relationships
 off `user` via the `capabilities` predicates and returns a frozen view

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -509,54 +509,49 @@ async def test_detail_shows_inline_create_clinician_for_self(
     assert action.attributes.get("href") == "/clinicians/form"
 
 
-async def test_users_me_onboarding_points_at_identity_when_unverified(
+async def test_users_me_verification_card_signposts_hub_when_unverified(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
     """`GET /users/me` for an email-verified user who holds no
-    posting-capable claim (no Verified Clinician, no verified org rep)
-    shows the capability-accurate "Verify your identity to start posting"
-    CTA pointing at `/profile` — never an invitation to "Post an opening"
-    that the post gate would 403. The checklist is self-only; other
-    users' profiles (/users/{id}) are unaffected."""
+    posting-capable claim shows the read-only Verification card whose
+    only CTA links into the `/profile` hub — never a "Post an opening"
+    or "Create clinician" action, which live in the hub (handoff §8.1).
+    The card is self-only; other users' profiles are unaffected."""
     response = await authenticated_client.get("/users/me")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    # The onboarding "Getting started" card must be present. Detail-page
-    # cards are `<section class="entity-card">` (article is reserved for
-    # list items); list-item cards inside still use `article` (no overlap).
     headings = [
         el.text(strip=True)
         for el in tree.css("section.entity-card header.entity-header strong")
     ]
     assert (
-        "Getting started" in headings
-    ), "/users/me is missing the 'Getting started' onboarding card"
-    # `onboarding_readiness.next_href` for an email-verified, claimless
-    # user is "/profile" with the identity-verification label. The
-    # "Post an opening" CTA must NOT render — the user can't post yet.
+        "Verification" in headings
+    ), "/users/me is missing the 'Verification' status card"
+    # The card's sole CTA signposts the hub; it carries no in-page
+    # onboarding action (no Post CTA, and the only clinician-form link on
+    # the page is the separate Clinicians-card footer, not this card).
     cta = tree.css_first("section.entity-card a[href='/profile'][role='button']")
-    assert cta is not None, "onboarding card is missing the 'Verify your identity' CTA"
-    assert "Verify your identity to start posting" in cta.text()
+    assert cta is not None, "Verification card is missing its '/profile' hub CTA"
+    assert "Set up and verify your practice" in cta.text()
     assert (
         tree.css_first(
             "section.entity-card a[href='/posts/form?kind=clinician_opening']"
         )
         is None
-    ), "claimless user must not be offered the 'Post an opening' CTA"
+    ), "Verification card must not host a 'Post an opening' action"
 
 
-async def test_users_me_onboarding_post_opening_cta_when_has_clinician(
+async def test_users_me_verification_card_manage_cta_when_can_post(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """`GET /users/me` for a user with a clinician profile renders the
-    'Post an opening' CTA pointing at `/posts/form?kind=clinician_opening`.
-    Regression for the bug where the template called
-    `entity_form_url('opening')` after the opening entity was consolidated
-    into `/posts` — the ValueError crashed the page for any user who had
-    already created a clinician profile."""
+    """`GET /users/me` for a user who can post (verified clinician) shows
+    the Verification card with a "Manage your practice" CTA into the hub
+    — not a "Post an opening" action, which lives on the hub / posts list.
+    Regression guard: the card must render without crashing for a user
+    who already has a clinician profile."""
     clinician = make_clinician_with_org(owner_id=logged_in_user.id)
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -565,22 +560,21 @@ async def test_users_me_onboarding_post_opening_cta_when_has_clinician(
     response = await authenticated_client.get("/users/me")
     assert response.status_code == 200, response.text
     tree = HTMLParser(response.text)
-    cta = tree.css_first(
-        "section.entity-card a[href='/posts/form?kind=clinician_opening'][role='button']"
-    )
+    cta = tree.css_first("section.entity-card a[href='/profile'][role='button']")
+    assert cta is not None, "Verification card is missing its '/profile' hub CTA"
+    assert "Manage your practice and verification" in cta.text()
     assert (
-        cta is not None
-    ), "onboarding card is missing 'Post an opening' CTA after having a clinician"
-    assert "Post an opening" in cta.text()
+        tree.css_first("section.entity-card a[href*='/posts/form']") is None
+    ), "Verification card must not host a 'Post an opening' action"
 
 
-async def test_users_me_onboarding_not_shown_for_other_users(
+async def test_users_me_verification_card_not_shown_for_other_users(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """The 'Getting started' onboarding card must NOT appear on
-    other users' profile pages — it is self-only."""
+    """The 'Verification' status card must NOT appear on other users'
+    profile pages — it is self-only."""
     target = create_test_user(username=f"target-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -594,8 +588,8 @@ async def test_users_me_onboarding_not_shown_for_other_users(
         for el in tree.css("section.entity-card header.entity-header strong")
     ]
     assert (
-        "Getting started" not in headings
-    ), "onboarding card unexpectedly shown on another user's profile"
+        "Verification" not in headings
+    ), "Verification card unexpectedly shown on another user's profile"
 
 
 async def test_detail_omits_inline_create_clinician_for_other_user(

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -75,50 +75,35 @@
       </footer>
     </section>
   {% endif %}
-  {# Onboarding checklist — visible only to the user viewing their own
-   profile. Driven by `onboarding_readiness(current_user)` so the CTAs
-   track the same capability gate the post route enforces: the
-   "Post an opening" button only appears once `can_post` is true, and
-   until then the checklist points at the single next verification step
-   (`next_href`) instead of inviting a 403. Other users' profiles
-   (/users/{id}) are unchanged — they keep the Clinicians card below
-   without this section. #}
+  {# Verification status — self-only, read-only. This is a *status
+   signpost*, not an onboarding wizard: the single place to verify and
+   manage claims is the /profile hub (handoff §8.1 — "onboarding IS the
+   hub in setup mode; no separate wizard"). This card reports where the
+   user stands (email + identity) and links into the hub to act; it
+   deliberately carries no "Post an opening" / "Create clinician" action
+   CTAs, which would re-create the duplicate onboarding surface the hub
+   is meant to own. Status reads from `onboarding_readiness`, the same
+   capability-accurate projection the post gate uses. Other users'
+   profiles (/users/{id}) omit this section entirely. #}
   {% if is_self %}
     {% set readiness = onboarding_readiness(current_user) %}
     <section class="entity-card">
       <header class="entity-header">
-        <strong>Getting started</strong>
+        <strong>Verification</strong>
       </header>
-      <ul>
-        <li>
-          {% if readiness.email_verified %}
-            &#10003;
-          {% else %}
-            &#9744;
-          {% endif %}
-          Verify your email
-        </li>
-        <li>
-          {% if readiness.can_post %}
-            &#10003;
-          {% else %}
-            &#9744;
-          {% endif %}
-          Verify your identity (clinician NPI or organization)
-        </li>
-        {% if clinicians %}
-          <li>
-            &#10003; <a href="{{ entity_url('clinician', id=clinicians[0].id) }}">Your clinician profile</a>
-          </li>
+      <section class="entity-facts">
+        <dl>
+          {{ fact('verify-email', 'Email', 'Verified' if readiness.email_verified else 'Not verified') }}
+          {{ fact('verify-identity', 'Identity', 'Verified' if readiness.can_post else 'Not verified') }}
+        </dl>
+      </section>
+      <footer class="entity-footer">
+        {% if readiness.can_post %}
+          <a href="/profile" role="button" class="outline">Manage your practice and verification</a>
+        {% else %}
+          <a href="{{ readiness.next_href or '/profile' }}" role="button">Set up and verify your practice</a>
         {% endif %}
-      </ul>
-      {% if readiness.can_post %}
-        <a href="{{ entity_form_url("post") }}?kind=clinician_opening"
-           role="button"
-           class="outline">Post an opening</a>
-      {% elif readiness.next_href %}
-        <a href="{{ readiness.next_href }}" role="button">{{ readiness.next_label }}</a>
-      {% endif %}
+      </footer>
     </section>
   {% endif %}
   <section class="entity-card">


### PR DESCRIPTION
## Summary
Resolves the confusing overlap between `/profile`, `/users/me`, and `/clinicians/{id}` by making `/profile` the single onboarding+verification home, per handoff §8.1 ("onboarding IS the hub in setup mode; no separate wizard").

- **`/users/me`**: the "Getting started" checklist (which duplicated the hub) is replaced with a read-only **Verification** status card — reports email + identity state and links *into* the hub. It hosts no "Post an opening" / "Create clinician" actions; those live on the hub.
- The status still reads from `onboarding_readiness`, so the signpost can't disagree with the post gate — but it's a signpost, not a second wizard.
- Division of labor: `/profile` = act (verify, manage claims), `/users/me` = account/identity + status that points at the hub, `/clinicians/{id}` = the practice record.

## Why
Two competing onboarding surfaces (the hub at `/profile` and the checklist on `/users/me`) was the root of the navigation confusion. §8.1 already designates the hub as the one home; `/users/me` should report state and defer, not re-implement onboarding.

## Test plan
- [x] `test_users_me_verification_card_signposts_hub_when_unverified` — claimless user: Verification card, sole CTA → `/profile`, no Post/clinician action.
- [x] `test_users_me_verification_card_manage_cta_when_can_post` — verified user: "Manage your practice" → `/profile`, no Post action.
- [x] `test_users_me_verification_card_not_shown_for_other_users` — self-only.
- [x] `dev test` (2287 passed), `dev lint`, `dev test contract` (40 passed, renders detail.html) green.

Note: verified via route-level rendered-HTML assertions (real route responses), not a live browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)