### PR TITLE
feat: single registry-driven incomplete-profile banner

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -1,14 +1,21 @@
 """Pins the profile-as-verification-state-view contract.
 
 `/profile` is the single place where all verification state lives:
-email confirmation, NPI, license. The global chrome no longer carries
-a nag banner — `_verify_banner.html` was removed. These tests assert:
+email confirmation, NPI, license. The global chrome carries one
+registry-driven incomplete-profile banner (`#onboarding-banner`, copy in
+`base.html`, gated on `onboarding_incomplete` from `base_context` →
+`onboarding_checklist`); it is suppressed on `/profile` itself, where the
+full checklist is already on screen. The old `_verify_banner.html`
+remains removed — this banner is the single consolidated signal, not its
+return. These tests assert:
 
 1. `/home` still shows the "Finish setting up" card for a no-claim user
    (that copy lives in `home.html`, not in the old banner).
 2. `/profile` shows the email-verify section for unverified users and
    hides it for verified users (dev users are auto-verified).
 3. Post CTAs on `/home` are gated on `claims.a` being populated.
+4. The global `#onboarding-banner` shows for an incomplete authed user
+   off `/profile`, hides on `/profile`, and hides once a claim verifies.
 """
 
 import pytest
@@ -92,3 +99,48 @@ async def test_home_renders_post_ctas_when_claim_a_verified(
     assert response.status_code == 200
     assert "+ Post a referral" in response.text
     assert "+ Post an opening" in response.text
+
+
+async def test_onboarding_banner_shown_off_profile_for_incomplete_user(
+    authenticated_client: AsyncClient,
+):
+    """A fresh dev user (email auto-verified, no claim) is onboarding-
+    incomplete, so the global banner shows on a non-`/profile` page and
+    links into the hub."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    banner = tree.css_first("#onboarding-banner")
+    assert banner is not None
+    assert banner.css_first("a").attributes["href"].startswith("/profile")
+
+
+async def test_onboarding_banner_suppressed_on_profile(
+    authenticated_client: AsyncClient,
+):
+    """The banner never renders on `/profile` itself — the full checklist
+    is already on screen there."""
+    response = await authenticated_client.get("/profile")
+    assert response.status_code == 200
+    assert HTMLParser(response.text).css_first("#onboarding-banner") is None
+
+
+async def test_onboarding_banner_hidden_once_claim_verified(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """A verified clinician has completed onboarding, so the global banner
+    is silent even off `/profile`."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    assert HTMLParser(response.text).css_first("#onboarding-banner") is None

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -51,10 +51,25 @@ def base_context(user: Actor | None) -> dict:
     which also accepts verified org reps (Claim B). Org-rep posting has no
     chrome entry point by design; templates gate on `can_post` so they all
     use the same definition instead of re-deriving `claims.a`.
+
+    `onboarding_incomplete` / `onboarding_next_href` drive the single
+    global incomplete-profile banner in `base.html`. They read the same
+    `onboarding_checklist(user)` registry every other onboarding surface
+    reads, so the chrome signal can't disagree with the `/profile`
+    checklist. Both default to the silent state (`False` / `None`) for
+    anonymous viewers — the checklist is only computed for an authed user.
     """
     from src.domain.logic.capabilities import can_read_full_feed, claim_state
+    from src.domain.logic.profile.onboarding import onboarding_checklist
 
     state = claim_state(user)
+    checklist = onboarding_checklist(user) if user is not None else None
+    onboarding_incomplete = checklist is not None and checklist.incomplete
+    onboarding_next_href = (
+        checklist.next_step.action_href
+        if checklist is not None and checklist.next_step is not None
+        else None
+    )
     return {
         "is_authenticated": user is not None,
         "is_admin": is_admin(user),
@@ -74,6 +89,8 @@ def base_context(user: Actor | None) -> dict:
         # via `ever_verified_at`). Anonymous viewers always see the
         # teaser (predicate returns False for `user=None`).
         "can_read_full_feed": can_read_full_feed(user),
+        "onboarding_incomplete": onboarding_incomplete,
+        "onboarding_next_href": onboarding_next_href or "/profile",
     }
 
 

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -36,6 +36,10 @@ def test_base_context_anonymous():
         "any_claim_lapsed": False,
         "can_read_full_feed": False,
         "can_post": False,
+        # Anonymous viewers never see the incomplete-profile banner; the
+        # checklist is only computed for an authed user.
+        "onboarding_incomplete": False,
+        "onboarding_next_href": "/profile",
     }
 
 
@@ -59,6 +63,10 @@ def test_base_context_regular_user():
         "any_claim_lapsed": False,
         "can_read_full_feed": False,
         "can_post": False,
+        # Email verified but no claim → identity step incomplete, so the
+        # banner shows and points at the claim-A focus deep-link.
+        "onboarding_incomplete": True,
+        "onboarding_next_href": "/profile?focus=claim_a",
     }
 
 
@@ -165,6 +173,41 @@ def test_base_context_can_post_false_for_claim_b_only():
     ctx = base_context(user)
     assert ctx["can_post"] is False
     assert ctx["claims"]["b"] == [org_id]
+
+
+def test_base_context_onboarding_complete_silences_banner():
+    """A verified clinician has cleared the spine, so `onboarding_incomplete`
+    is False and the global banner stays silent."""
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        username="alice",
+        is_superuser=False,
+        is_verified=True,
+        clinicians=[
+            SimpleNamespace(
+                npi="1234567890", clinician_verified=True, ever_verified_at=None
+            )
+        ],
+        org_representations=[],
+    )
+    ctx = base_context(user)
+    assert ctx["onboarding_incomplete"] is False
+
+
+def test_base_context_unverified_email_points_banner_at_email():
+    """An unverified-email user's first incomplete step is email, so the
+    banner deep-links to the email focus."""
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        username="alice",
+        is_superuser=False,
+        is_verified=False,
+        clinicians=[],
+        org_representations=[],
+    )
+    ctx = base_context(user)
+    assert ctx["onboarding_incomplete"] is True
+    assert ctx["onboarding_next_href"] == "/profile?focus=email"
 
 
 def test_base_context_unverified_user_surfaces_for_nag_banner():

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -178,6 +178,22 @@
         {# Anonymous visitors get only the brand link. #}
       </nav>
     </header>
+    {# Single global incomplete-profile banner. One chrome signal that
+       reads `onboarding_incomplete` from `base_context` — itself the
+       `onboarding_checklist` registry projection — so it can't disagree
+       with the itemized steps on `/profile`. Explains *why* content is
+       gated and links to the next actionable step (a `/profile?focus=…`
+       deep-link). Suppressed on `/profile` itself, where the full
+       checklist is already on screen — a banner there would just point
+       at the page you're on. #}
+    {% if is_authenticated and onboarding_incomplete and not _on_profile %}
+      <aside role="status" id="onboarding-banner" class="container">
+        <strong>Finish setting up your profile.</strong>
+        Clinician names and contact details stay hidden, and you can't post,
+        until you verify.
+        <a href="{{ onboarding_next_href }}">Continue setup →</a>
+      </aside>
+    {% endif %}
     <main class="container">
       {# Breadcrumb zone bar — `{% block breadcrumb %}` accepts the
          `breadcrumb(items)` macro from `_shared/_breadcrumb.html`.


### PR DESCRIPTION
## Summary
- Reintroduces one consolidated global chrome banner (`#onboarding-banner` in `base.html`) for incomplete profiles, replacing the per-state nag that was removed earlier.
- Reads `onboarding_incomplete` / `onboarding_next_href` from `base_context`, which is the `onboarding_checklist` registry projection (PR #1136) — so the chrome signal can't disagree with the `/profile` checklist.
- Explains *why* content is gated ("names/contact hidden, can't post until you verify") and deep-links to the next actionable step (`/profile?focus=…`).
- Suppressed on `/profile` itself, where the full checklist is already on screen.

Stacked on #1136 (now merged); this branch is rebased onto `main` and contains only the banner changes.

## Test plan
- [x] `dev test` — 2300 passed, 101 skipped.
- [x] `dev test contract` — 40 passed (touched `base.html`).
- [x] `dev lint` — clean.
- [x] New tests: `#onboarding-banner` shows off `/profile` for an incomplete user, hides on `/profile`, hides once a claim verifies; `base_context` scalars pinned for anon / email-only / unverified-email / complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)