### PR TITLE
feat: /profile renders a registry-driven setup-progress overview

### DIFF
--- a/src/domain/logic/profile/handlers.py
+++ b/src/domain/logic/profile/handlers.py
@@ -18,6 +18,7 @@ from typing import Any
 from uuid import UUID
 
 from src.domain.logic import capabilities
+from src.domain.logic.profile.onboarding import onboarding_checklist
 from src.domain.models import User
 
 logger = logging.getLogger(__name__)
@@ -88,9 +89,13 @@ def build_profile_context(
     """Compose the template context for `profile/hub.html`.
 
     Exposes the resolved mode + a snapshot of the `ClaimState` shape
-    the partials read. The chrome scalars (`is_authenticated`,
-    `claims`, `any_claim_lapsed`, etc.) are added by `base_context` at
-    render time — this context only carries the hub-specific extras.
+    the partials read, plus the `onboarding_checklist` projection that
+    drives the registry-driven progress overview (`_checklist.html`).
+    The checklist reads the same `capabilities` predicates as the post
+    gate and the global banner, so the three can't disagree. The chrome
+    scalars (`is_authenticated`, `claims`, `any_claim_lapsed`, etc.) are
+    added by `base_context` at render time — this context only carries
+    the hub-specific extras.
     """
     state = capabilities.claim_state(user)
     mode = resolve_profile_mode(user, intent=intent)
@@ -107,6 +112,7 @@ def build_profile_context(
         "mode": mode,
         "profile_modes": PROFILE_MODES,
         "claim_state": state,
+        "checklist": onboarding_checklist(user),
         "clinicians": list(getattr(user, "clinicians", None) or ()),
         "org_representations": list(getattr(user, "org_representations", None) or ()),
         "is_demo_context": is_demo_context,

--- a/src/domain/logic/profile/test_handlers.py
+++ b/src/domain/logic/profile/test_handlers.py
@@ -137,6 +137,20 @@ def test_build_profile_context_exposes_mode_and_lists():
     assert ctx["org_representations"] == user.org_representations
     assert ctx["claim_state"].a is True
     assert len(ctx["claim_state"].b) == 1
+    # A verified user has cleared the spine — the progress overview reads
+    # complete (and `_checklist.html` therefore renders nothing).
+    assert ctx["checklist"].complete is True
+
+
+def test_build_profile_context_checklist_marks_remaining_steps():
+    """A no-claim user's checklist surfaces the email-complete /
+    identity-pending split the `/profile` progress strip renders."""
+    user = _user(is_verified=True, clinicians=[], org_representations=[])
+    checklist = build_profile_context(user)["checklist"]
+    by_key = {s.step.key: s.complete for s in checklist.statuses}
+    assert by_key == {"email": True, "identity": False}
+    assert checklist.incomplete is True
+    assert checklist.next_step.key == "identity"
 
 
 # ---------------------------------------------------------------------------

--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -144,3 +144,41 @@ async def test_onboarding_banner_hidden_once_claim_verified(
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
     assert HTMLParser(response.text).css_first("#onboarding-banner") is None
+
+
+async def test_profile_checklist_shows_remaining_steps_for_incomplete_user(
+    authenticated_client: AsyncClient,
+):
+    """The registry-driven progress overview on `/profile` lists the spine
+    steps with their done/remaining state. A fresh dev user has email done
+    and identity pending."""
+    response = await authenticated_client.get("/profile")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    checklist = tree.css_first("#onboarding-checklist")
+    assert checklist is not None
+    email_row = checklist.css_first('[data-step="email"]')
+    identity_row = checklist.css_first('[data-step="identity"]')
+    assert "is-complete" in email_row.attributes["class"]
+    assert "is-pending" in identity_row.attributes["class"]
+
+
+async def test_profile_checklist_hidden_when_onboarding_complete(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """A verified clinician has nothing left to track, so the progress
+    overview is omitted (manage mode)."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/profile")
+    assert response.status_code == 200
+    assert HTMLParser(response.text).css_first("#onboarding-checklist") is None

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -235,3 +235,37 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
   border-radius: 4px;
   margin-bottom: var(--pico-spacing);
 }
+
+/* ── Onboarding progress overview ─────────────────────────────
+   Registry-driven setup-progress strip at the top of /profile
+   (profile/_checklist.html). One row per onboarding step; the mark
+   and the muted/strong treatment express completion. All state via
+   classes — no inline styles on the template. */
+.onboarding-progress {
+  list-style: none;
+  margin: 0 0 var(--pico-spacing);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.onboarding-progress-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+.onboarding-progress-mark { flex-shrink: 0; line-height: 1.4; }
+.onboarding-progress-item.is-complete .onboarding-progress-mark { color: var(--pico-color-green-600); }
+.onboarding-progress-item.is-pending .onboarding-progress-mark { color: var(--pico-color-orange-600); }
+.onboarding-progress-body { display: flex; flex-direction: column; gap: 0.1rem; flex: 1; min-width: 0; }
+.onboarding-progress-body small { color: var(--pico-muted-color); }
+.onboarding-progress-item.is-complete .onboarding-progress-body strong { color: var(--pico-muted-color); }
+.onboarding-progress-status {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.onboarding-progress-item.is-complete .onboarding-progress-status { color: var(--pico-color-green-600); }
+.onboarding-progress-item.is-pending .onboarding-progress-status { color: var(--pico-color-orange-600); }

--- a/src/domain/templates/profile/_checklist.html
+++ b/src/domain/templates/profile/_checklist.html
@@ -1,0 +1,33 @@
+{# Registry-driven setup-progress overview.
+
+   Renders the `checklist` (an `OnboardingChecklist` from
+   `build_profile_context` → `onboarding_checklist(user)`) as a single
+   completed/remaining strip covering the whole verification spine
+   (email → identity). It ties together the email step — whose actionable
+   resend lives in the `#verify-banner` aside below — and the identity
+   step — whose detailed forms live in the mode partials — into one
+   "where am I" view, the unified progress the hub otherwise lacked.
+
+   Reads the same `capabilities` predicates as the post gate and the
+   global `#onboarding-banner`, so the three can't disagree. Only shown
+   while onboarding is incomplete; a fully-verified user (manage mode)
+   has nothing left to track. #}
+{% if checklist.incomplete %}
+  <section id="onboarding-checklist" aria-label="Setup progress">
+    <ol class="onboarding-progress">
+      {% for status in checklist.statuses %}
+        <li class="onboarding-progress-item {{ 'is-complete' if status.complete else 'is-pending' }}"
+            data-step="{{ status.step.key }}">
+          <span class="onboarding-progress-mark" aria-hidden="true">
+            <i class="icon-{{ 'circle-check' if status.complete else 'circle' }}"></i>
+          </span>
+          <span class="onboarding-progress-body">
+            <strong>{{ status.step.title }}</strong>
+            <small>{{ 'Done' if status.complete else status.step.hint }}</small>
+          </span>
+          <span class="onboarding-progress-status">{{ 'Done' if status.complete else 'To do' }}</span>
+        </li>
+      {% endfor %}
+    </ol>
+  </section>
+{% endif %}

--- a/src/domain/templates/profile/hub.html
+++ b/src/domain/templates/profile/hub.html
@@ -15,6 +15,11 @@
       {% endif %}
     </p>
   </header>
+  {# Registry-driven progress overview — the unified "what's done / what
+     remains" strip, read from the `onboarding_checklist` projection. Sits
+     above the email aside and the mode partials so the user sees the whole
+     spine at a glance before acting on any one step. #}
+  {% include "profile/_checklist.html" %}
   {# Email verification step. Shown above the claim-setup content so the
      user knows to check their inbox before completing any other step.
      Uses the same HTMX target (`#verify-banner`) and swap partial as


### PR DESCRIPTION
## Summary
- Adds `profile/_checklist.html` — a registry-driven setup-progress strip at the top of `/profile` rendering each `OnboardingStep` with done/remaining state.
- `build_profile_context` now passes `checklist = onboarding_checklist(user)`; the partial is included in `hub.html` and suppressed once onboarding is complete (manage mode).
- New `.onboarding-progress` CSS expresses completion via classes (no inline styles).

This is PR3 of the "Migrate to canonical + registry" sequence: PR1 added the onboarding step registry, PR2 added the single chrome banner, and this surfaces the full checklist on `/profile`.

## Test plan
- [x] `dev test` — 54 passed across chrome banner, profile handlers, onboarding registry, base_context
- [x] `dev lint`
- [x] `dev test contract` — 40 passed
- [ ] Browser: `/profile` shows Email = Done, Identity = To do for a fresh user; checklist hidden for a verified clinician

🤖 Generated with [Claude Code](https://claude.com/claude-code)