### PR TITLE
feat: show empty state in My active posts when clinician has no posts

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -77,6 +77,29 @@ async def test_profile_email_verify_shown_for_unverified_user(
     assert "Resend verification email" in response.text
 
 
+async def test_home_shows_empty_my_posts_section_when_no_active_posts(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """A verified clinician with no posts sees the 'My active posts' section
+    with an empty state message and a create CTA — not a hidden section."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    assert "My active posts" in response.text
+    assert "You have no active posts." in response.text
+    assert "Create a post" in response.text
+
+
 async def test_home_renders_post_ctas_when_claim_a_verified(
     authenticated_client: AsyncClient,
     db_test_session_manager,

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -35,16 +35,16 @@
          in `base_context()` — don't re-derive from raw `claims.*`. #}
       {% if can_post %}
         <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
-          <a href="{{ entity_form_url("post") }}?kind=referral"
+          <a href="{{ entity_form_url('post') }}?kind=referral"
              role="button"
              class="outline">+ Post a referral</a>
-          <a href="{{ entity_form_url("post") }}?kind=clinician_opening"
+          <a href="{{ entity_form_url('post') }}?kind=clinician_opening"
              role="button"
              class="outline">+ Post an opening</a>
         </section>
       {% endif %}
     {% endif %}
-    {% if my_posts %}
+    {% if can_post %}
       <section>
         <header style="display: flex;
                        justify-content: space-between;
@@ -52,7 +52,12 @@
           <h2>My active posts</h2>
           <a href="{{ entity_url('post') }}">See all</a>
         </header>
-        {{ item_list(my_posts, _no_poster_row, "my-posts-list", "post-feed-list") }}
+        {% if my_posts %}
+          {{ item_list(my_posts, _no_poster_row, "my-posts-list", "post-feed-list") }}
+        {% else %}
+          <p style="color: var(--pico-muted-color)">You have no active posts.</p>
+          <a href="{{ entity_form_url('post') }}" role="button" class="outline">Create a post</a>
+        {% endif %}
       </section>
     {% endif %}
     {% if network_posts %}


### PR DESCRIPTION
## Summary

- Previously the "My active posts" section was hidden entirely when a verified clinician had no posts
- Now it always shows for `can_post` users, with a "You have no active posts." message and a "Create a post" CTA when the list is empty
- Gate changed from `{% if my_posts %}` to `{% if can_post %}` — consistent with how the post CTAs above are gated

## Test plan

- [ ] Verified clinician with no posts sees "My active posts" header, "You have no active posts." text, and "Create a post" button on /home
- [ ] Verified clinician with active posts still sees the post list as before
- [ ] Unverified / no-claim user still sees the "Finish setting up" card, no "My active posts" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)