### PR TITLE
feat: locked-affordance primitive for capability-gated UI

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -33,21 +33,73 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
 
-# Reason codes used by `_locked.html` partials and `fix_url_for(...)`.
-# Closed vocab: any new reason must be added here and mapped below.
+# Reason codes used by the `_shared/_locked.html` macros and
+# `fix_url_for(...)`. Closed vocab: any new reason must be added here and
+# given a `ReasonMeta` entry in `_REASON_META` below.
 REASON_EMAIL_UNVERIFIED = "email_unverified"
 REASON_CLAIM_A_UNVERIFIED = "claim_a_unverified"
 REASON_CLAIM_B_UNVERIFIED = "claim_b_unverified"
 REASON_CLAIM_A_LAPSED = "claim_a_lapsed"
 REASON_AFFILIATION_MISSING = "affiliation_missing"
 
-_FIX_URLS = {
-    REASON_EMAIL_UNVERIFIED: "/profile?focus=email",
-    REASON_CLAIM_A_UNVERIFIED: "/profile?focus=claim_a",
-    REASON_CLAIM_A_LAPSED: "/profile?focus=claim_a",
-    REASON_CLAIM_B_UNVERIFIED: "/profile?focus=claim_b",
-    REASON_AFFILIATION_MISSING: "/profile?focus=claim_b",
+
+@dataclass(frozen=True)
+class ReasonMeta:
+    """The human-facing half of a gating reason: everything a locked
+    affordance needs to render, in one place.
+
+    - `unlock`: imperative sentence shown under a disabled action or in
+      place of a withheld field ("Add a verified clinician profile to
+      unlock this.").
+    - `fix_label`: CTA link text ("Complete clinician setup").
+    - `fix_url`: deep-link into the relevant `/profile` section.
+
+    Templates read this via the `capabilities.reason_meta(reason)` Jinja
+    global so a given reason reads identically on every surface — the
+    copy lives here, never inline in a template. Adding a reason without
+    a `ReasonMeta` entry falls back to the generic hub pointer.
+    """
+
+    unlock: str
+    fix_label: str
+    fix_url: str
+
+
+_REASON_META = {
+    REASON_EMAIL_UNVERIFIED: ReasonMeta(
+        unlock="Verify your email to unlock this.",
+        fix_label="Verify email",
+        fix_url="/profile?focus=email",
+    ),
+    REASON_CLAIM_A_UNVERIFIED: ReasonMeta(
+        unlock="Add a verified clinician profile to unlock this.",
+        fix_label="Complete clinician setup",
+        fix_url="/profile?focus=claim_a",
+    ),
+    REASON_CLAIM_A_LAPSED: ReasonMeta(
+        unlock="Re-attest your license to resume this.",
+        fix_label="Re-verify license",
+        fix_url="/profile?focus=claim_a",
+    ),
+    REASON_CLAIM_B_UNVERIFIED: ReasonMeta(
+        unlock="Become a verified organization representative to unlock this.",
+        fix_label="Complete organization setup",
+        fix_url="/profile?focus=claim_b",
+    ),
+    REASON_AFFILIATION_MISSING: ReasonMeta(
+        unlock="Add a clinician affiliation to unlock this.",
+        fix_label="Manage affiliations",
+        fix_url="/profile?focus=claim_b",
+    ),
 }
+
+# Unknown reasons land here: a generic nudge into the hub root. Keeps a
+# caller that passes an unmapped code from rendering an empty affordance.
+_FALLBACK_META = ReasonMeta(
+    unlock="Finish setting up your profile to unlock this.",
+    fix_label="Open profile",
+    fix_url="/profile",
+)
 
 
 @dataclass(frozen=True)
@@ -218,8 +270,20 @@ def claim_state(user: Any) -> ClaimState:
     )
 
 
+def reason_meta(reason: str) -> ReasonMeta:
+    """Resolve a `REASON_*` code to its human-facing copy + fix link.
+
+    Single source for the text a locked affordance shows. Templates call
+    this as a Jinja global (`capabilities.reason_meta(reason)`); routes /
+    banners that only need the URL call `fix_url_for` (a thin accessor over
+    this). Unknown reasons return `_FALLBACK_META` so a stray code renders
+    a sane nudge rather than blank chrome."""
+    return _REASON_META.get(reason, _FALLBACK_META)
+
+
 def fix_url_for(reason: str) -> str:
-    """Deep-link a "blocked action" partial into the relevant section of
-    `/profile`. The closed reason vocab keeps the partial / route / banner
-    from drifting. Unknown reasons fall back to the hub root."""
-    return _FIX_URLS.get(reason, "/profile")
+    """Deep-link a gated affordance into the relevant section of `/profile`.
+    Thin accessor over `reason_meta(reason).fix_url`, kept as a named
+    function because routes/banners reference the URL without the rest of
+    the metadata. Unknown reasons fall back to the hub root."""
+    return reason_meta(reason).fix_url

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -488,18 +488,56 @@ def test_fix_url_for_unknown_reason_falls_back_to_hub_root():
     assert capabilities.fix_url_for("totally-not-a-reason") == "/profile"
 
 
-def test_fix_url_table_covers_every_reason_constant():
-    """Guardrail: every REASON_* constant must have a fix URL mapping —
-    otherwise an unknown-reason fallback masks the missing entry."""
-    declared_reasons = {
+def _declared_reasons() -> set[str]:
+    reasons = {
         value
         for name, value in vars(capabilities).items()
         if name.startswith("REASON_") and isinstance(value, str)
     }
-    assert declared_reasons, "no REASON_* constants found"
-    for reason in declared_reasons:
+    assert reasons, "no REASON_* constants found"
+    return reasons
+
+
+def test_fix_url_table_covers_every_reason_constant():
+    """Guardrail: every REASON_* constant must have a `_REASON_META` entry —
+    otherwise an unknown-reason fallback masks the missing entry."""
+    for reason in _declared_reasons():
         url = capabilities.fix_url_for(reason)
-        assert url != "/profile", f"REASON {reason!r} has no entry in _FIX_URLS"
+        assert url != "/profile", f"REASON {reason!r} has no entry in _REASON_META"
+
+
+# ---------- reason_meta ---------------------------------------------------
+
+
+def test_reason_meta_known_reason_carries_full_copy():
+    """A known reason resolves to non-empty unlock copy, a fix label, and
+    the same deep-link `fix_url_for` returns — one source for both."""
+    meta = capabilities.reason_meta(capabilities.REASON_CLAIM_A_UNVERIFIED)
+    assert meta.unlock
+    assert meta.fix_label
+    assert meta.fix_url == "/profile?focus=claim_a"
+    assert meta.fix_url == capabilities.fix_url_for(
+        capabilities.REASON_CLAIM_A_UNVERIFIED
+    )
+
+
+def test_reason_meta_unknown_reason_falls_back():
+    """An unmapped code returns the generic hub pointer, never raises —
+    a stray reason renders a sane nudge rather than blank chrome."""
+    meta = capabilities.reason_meta("totally-not-a-reason")
+    assert meta.fix_url == "/profile"
+    assert meta.unlock
+    assert meta.fix_label
+
+
+def test_reason_meta_covers_every_reason_constant_with_nonempty_copy():
+    """Guardrail mirroring the fix-URL one, for the human copy: every
+    REASON_* must resolve to non-empty unlock + fix_label text so no
+    surface renders an empty locked affordance."""
+    for reason in _declared_reasons():
+        meta = capabilities.reason_meta(reason)
+        assert meta.unlock, f"REASON {reason!r} has empty unlock copy"
+        assert meta.fix_label, f"REASON {reason!r} has empty fix_label"
 
 
 # ---------- UUID type sanity for claim_state.b ----------------------------

--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -124,6 +124,62 @@ async def test_home_renders_post_ctas_when_claim_a_verified(
     assert "+ Post an opening" in response.text
 
 
+async def test_home_shows_locked_post_actions_for_claim_b_only_org_rep(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """A Claim-B-only org rep (verified org representative, no Claim A)
+    can't post as themselves, but the chrome no longer hides the actions —
+    it renders them DISABLED with the unlock path (`locked_action` →
+    `_shared/_locked.html`). Pins: the buttons render disabled (not as
+    active create links), and the unlock copy comes from
+    `capabilities.reason_meta`, not inline text."""
+    from src.domain.logic import capabilities
+    from src.domain.models.org_representations.org_representation import (
+        OrgRepresentation,
+    )
+    from tests.helpers import make_organization_row
+
+    org = make_organization_row(owner_id=logged_in_user.id)
+    rep = OrgRepresentation(
+        user_id=logged_in_user.id,
+        org_id=org.id,
+        role="coordinator",
+        authority_method="admin_review",
+        authority_status="verified",
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(org)
+            session.add(rep)
+
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    # Claim-B-only → has a claim, so NOT the no-claim finish-setup card.
+    assert "Finish setting up" not in response.text
+
+    # Both post actions render as DISABLED buttons, not active create links.
+    disabled_labels = {
+        b.text(strip=True)
+        for b in tree.css("button[disabled]")
+        if b.text(strip=True).startswith("+ Post")
+    }
+    assert "+ Post a referral" in disabled_labels
+    assert "+ Post an opening" in disabled_labels
+    assert (
+        tree.css_first("a[href*='kind=referral']") is None
+    ), "Claim-B-only rep must not get an active post-create link"
+
+    # Unlock copy is the single-source string, not inline-authored here.
+    assert (
+        capabilities.reason_meta(capabilities.REASON_CLAIM_A_UNVERIFIED).unlock
+        in response.text
+    )
+
+
 async def test_onboarding_banner_shown_off_profile_for_incomplete_user(
     authenticated_client: AsyncClient,
 ):

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {%- from "_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {%- from "_shared/_item_list.html" import item_list -%}
+{%- from "_shared/_locked.html" import locked_action -%}
 {%- macro _no_poster_row(post) %}{{ post_feed_row(post, show_poster=False) }}{%- endmacro -%}
   {% block title %}Home{% endblock %}
   {% block content %}
@@ -28,21 +29,26 @@
         <a href="/profile" role="button">Open Profile</a>
       </article>
     {% else %}
-      {# Post CTAs gate on `can_post` (Claim A only). The server's
-         `_assert_post_payload_authz` also accepts verified org reps
-         (Claim B), but the chrome deliberately omits that path — org
-         reps have no chrome CTA by design. `can_post` is derived once
-         in `base_context()` — don't re-derive from raw `claims.*`. #}
-      {% if can_post %}
-        <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
+      {# Post CTAs gate on `can_post` (Claim A only). A Claim-B-only org
+         rep can't post as themselves, but rather than hide the actions we
+         render them DISABLED with the unlock path (`locked_action`), so
+         the user sees the capability exists and how to reach it. The
+         server's `_assert_post_payload_authz` is the real gate; a disabled
+         button leaks nothing. `can_post` is derived once in
+         `base_context()` — don't re-derive from raw `claims.*`. #}
+      <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
+        {% if can_post %}
           <a href="{{ entity_form_url('post') }}?kind=referral"
              role="button"
              class="outline">+ Post a referral</a>
           <a href="{{ entity_form_url('post') }}?kind=clinician_opening"
              role="button"
              class="outline">+ Post an opening</a>
-        </section>
-      {% endif %}
+        {% else %}
+          {{ locked_action(capabilities.REASON_CLAIM_A_UNVERIFIED, "+ Post a referral") }}
+          {{ locked_action(capabilities.REASON_CLAIM_A_UNVERIFIED, "+ Post an opening") }}
+        {% endif %}
+      </section>
     {% endif %}
     {% if can_post %}
       <section>

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -562,3 +562,26 @@ body {
   display: grid;
   grid-template-rows: auto 1fr auto;
 }
+/* Locked affordances rendered by `_shared/_locked.html`. A gated *action*
+   stays visible but disabled, stacked above a muted unlock line; a gated
+   *field* renders a muted italic placeholder where the withheld value
+   would be. Both carry an `icon-lock` glyph and a deep-link to the fix.
+   See the macro header for the action-vs-field contract. */
+.locked-action {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.locked-action button[disabled] {
+  width: auto;
+  margin: 0;
+  cursor: not-allowed;
+}
+.locked-reason {
+  color: var(--pico-muted-color);
+  font-size: 0.875rem;
+}
+.locked-field {
+  color: var(--pico-muted-color);
+  font-style: italic;
+}

--- a/src/framework/templates/_shared/_locked.html
+++ b/src/framework/templates/_shared/_locked.html
@@ -1,0 +1,40 @@
+{# Consistent "you can't do/see this yet" affordances, driven by the
+   closed `capabilities.REASON_*` vocab. Two treatments, picked by the
+   *type* of thing being gated:
+
+   - `locked_action(reason, label)` — for write affordances (buttons,
+     create links). Renders the control DISABLED and visible, with the
+     reason + fix link beneath. The user sees the action exists and what
+     unlocks it. Safe to render: the server re-checks authz on submit
+     (e.g. `_assert_post_payload_authz`), so a disabled control leaks no
+     data.
+
+   - `locked_field(reason, label)` — for withheld DATA values (practice
+     name, description, full address). Renders a placeholder that names
+     the field in place of its value. The caller passes the field's NAME,
+     never its value — so this macro CANNOT leak the data. Withholding the
+     real value is the VIEW layer's job (null it server-side); this macro
+     only renders the gap and the path to unlock it.
+
+   Copy + fix link both come from `capabilities.reason_meta(reason)` so a
+   given reason reads identically everywhere. `capabilities` is a Jinja
+   global (registered in `src/domain/template_globals.py`), so these
+   macros need no `with context` on import. Add or change reason copy in
+`src/domain/logic/capabilities.py` — never inline here. #}
+{% macro locked_action(reason, label) -%}
+  {%- set meta = capabilities.reason_meta(reason) -%}
+  <div class="locked-action">
+    <button type="button" class="outline" disabled aria-disabled="true">{{ label }}</button>
+    <small class="locked-reason">
+      <i class="icon-lock" aria-hidden="true"></i>{{ meta.unlock }}
+      <a href="{{ meta.fix_url }}">{{ meta.fix_label }} →</a>
+    </small>
+  </div>
+{%- endmacro %}
+{% macro locked_field(reason, label) -%}
+  {%- set meta = capabilities.reason_meta(reason) -%}
+  <span class="locked-field" title="{{ meta.unlock }}">
+    <i class="icon-lock" aria-hidden="true"></i>{{ label }} hidden —
+    <a href="{{ meta.fix_url }}">{{ meta.fix_label }} →</a>
+  </span>
+{%- endmacro %}

--- a/src/framework/templates/_shared/test_locked.py
+++ b/src/framework/templates/_shared/test_locked.py
@@ -1,0 +1,105 @@
+"""Tests for the locked-affordance macros in ``_shared/_locked.html``.
+
+The two macros render the consistent "you can't do/see this yet" chrome
+driven by the closed ``capabilities.REASON_*`` vocab:
+
+- ``locked_action`` — a *disabled, visible* control plus an unlock line.
+  Pins that the control is non-submittable (``disabled``) and that the
+  reason copy + fix link come from ``capabilities.reason_meta`` (not
+  inline), so a refactor can't silently drop the disabled attribute or
+  hard-code copy that drifts from the single source.
+- ``locked_field`` — a placeholder that names a *withheld* value. Pins
+  that the caller-supplied field NAME renders while no value is emitted
+  (the macro is handed a label, never data — it cannot leak).
+
+The real ``capabilities`` module is registered as the ``capabilities``
+Jinja global so the assertions exercise the actual copy wiring, exactly
+as a page render would.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from jinja2 import ChoiceLoader, DictLoader, Environment, FileSystemLoader
+from selectolax.parser import HTMLParser
+
+from src.domain.logic import capabilities
+
+
+def _make_env() -> Environment:
+    stub = DictLoader({})
+    framework = FileSystemLoader(
+        str(Path(__file__).resolve().parents[1])
+    )  # src/framework/templates
+    env = Environment(loader=ChoiceLoader([stub, framework]))
+    env.globals["capabilities"] = capabilities
+    return env
+
+
+def _render(macro: str, reason: str, label: str) -> str:
+    template = textwrap.dedent(f"""\
+        {{%- from "_shared/_locked.html" import {macro} -%}}
+        {{{{ {macro}(capabilities.{reason}, {label!r}) }}}}
+        """)
+    return _make_env().from_string(template).render()
+
+
+# ---------------------------------------------------------------------------
+# locked_action — disabled control + unlock line
+# ---------------------------------------------------------------------------
+
+
+def test_locked_action_renders_disabled_button_with_label() -> None:
+    html = _render("locked_action", "REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None, "expected a <button> for the gated action"
+    assert "disabled" in button.attributes, "gated action must be disabled"
+    assert button.text(strip=True) == "+ Post a referral"
+
+
+def test_locked_action_shows_reason_copy_and_fix_link_from_capabilities() -> None:
+    """Copy + link come from `reason_meta`, not inline — assert the exact
+    strings the single source returns so drift is caught here."""
+    meta = capabilities.reason_meta(capabilities.REASON_CLAIM_A_UNVERIFIED)
+    html = _render("locked_action", "REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
+    tree = HTMLParser(html)
+    assert meta.unlock in html
+    link = tree.css_first("a")
+    assert link is not None
+    assert link.attributes.get("href") == meta.fix_url
+    assert meta.fix_label in link.text()
+
+
+# ---------------------------------------------------------------------------
+# locked_field — placeholder naming a withheld value
+# ---------------------------------------------------------------------------
+
+
+def test_locked_field_names_the_field_without_emitting_a_value() -> None:
+    """The macro is handed the field NAME, never its value — it renders
+    the name + unlock path and nothing resembling live data."""
+    html = _render("locked_field", "REASON_EMAIL_UNVERIFIED", "Practice name")
+    tree = HTMLParser(html)
+    assert "Practice name" in html
+    link = tree.css_first("a.locked-field a, .locked-field a")
+    assert link is not None
+    assert link.attributes.get("href") == capabilities.fix_url_for(
+        capabilities.REASON_EMAIL_UNVERIFIED
+    )
+    # No interactive control: a field placeholder is read-only chrome.
+    assert tree.css_first("button") is None
+
+
+def test_locked_field_unknown_reason_falls_back_not_raises() -> None:
+    """A stray reason renders the generic hub nudge instead of raising."""
+    env = _make_env()
+    template = (
+        '{%- from "_shared/_locked.html" import locked_field -%}'
+        '{{ locked_field("totally-not-a-reason", "Some field") }}'
+    )
+    html = env.from_string(template).render()
+    link = HTMLParser(html).css_first(".locked-field a")
+    assert link is not None
+    assert link.attributes.get("href") == "/profile"


### PR DESCRIPTION
## Summary

A reusable pattern for **"this is gated because you still need to do X"**, replacing today's ad-hoc mix of hide-entirely CTAs and reason copy retyped per template. Two treatments, chosen by element type:

| Element type | Treatment | Macro |
|---|---|---|
| **Actions** (buttons, create links) | rendered **disabled + visible**, with the unlock path beneath — user sees the capability exists | `locked_action(reason, label)` |
| **Data values** (practice name, description, address) | **withheld server-side**, placeholder names the field | `locked_field(reason, label)` |

`locked_field` receives the field **name**, never its value, so the macro *cannot* leak — withholding the real value stays the view layer's job. `locked_action` is safe to render because the server re-checks authz on submit (`_assert_post_payload_authz`).

**The consistency win:** a single `REASON_* → ReasonMeta` map (copy + fix link) in `capabilities.py`, read via the `capabilities.reason_meta` Jinja global, so a reason reads identically on every surface. `fix_url_for` now reads the same map — one home for the URL.

## Pilot migration

The `/home` post CTAs for a **Claim-B-only org rep** flip from hidden → disabled-with-reason. A real first call site, so the macro ships proven rather than aspirational.

![locked treatment: disabled "+ Post a referral / + Post an opening" buttons with "Add a verified clinician profile to unlock this. Complete clinician setup →" beneath; data field shows "Practice name hidden — Verify email →"]

## Files

| File | Change |
|---|---|
| `src/domain/logic/capabilities.py` | `ReasonMeta` dataclass + `_REASON_META` map + `reason_meta()`; `fix_url_for` rewired onto it |
| `src/framework/templates/_shared/_locked.html` | new — `locked_action` / `locked_field` macros |
| `src/framework/static/css/framework.css` | `.locked-action` / `.locked-reason` / `.locked-field` styles |
| `src/domain/templates/home.html` | pilot: Claim-B-only post CTAs → `locked_action` |
| `*/test_*.py` | `reason_meta` unit tests, macro render tests, `/home` Claim-B integration test |

## Follow-up PRs (this is PR 1 of a sequence)

2. Route the `_facts_block` `redacted=` omissions through `locked_field` (feed/detail data placeholders).
3. Converge profile cards (`_manage.html`, `_reverify.html`) + remaining CTAs onto the shared copy.

## Test plan

- [x] `reason_meta` known/unknown/coverage-guardrail unit tests
- [x] `locked_action` / `locked_field` render tests (disabled attr, copy-from-source, no-value-leak)
- [x] `/home` Claim-B-only org rep sees disabled buttons + unlock copy, no active create link
- [x] Visually verified the treatment renders correctly (screenshot above)
- [x] Full suite: 2316 passed, 0 failed; `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)