### PR TITLE
fix: embed onboarding actions into checklist rows on /profile setup

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -82,6 +82,11 @@ async def test_profile_email_verify_shown_for_unverified_user(
     classes = resend.attributes.get("class", "")
     assert "outline" in classes
     assert "verify-resend" in classes
+    # The resend is embedded *inside* the email spine row, not a standalone
+    # aside above it — the row owns its own action (no duplicate email block).
+    email_row = tree.css_first('#onboarding-checklist [data-step="email"]')
+    assert email_row is not None
+    assert email_row.css_first("#verify-banner") is not None
 
 
 async def test_home_shows_empty_my_posts_section_when_no_active_posts(

--- a/src/domain/routes/test_profile.py
+++ b/src/domain/routes/test_profile.py
@@ -8,6 +8,7 @@ to use it without holding Claim A).
 
 import pytest
 from httpx import AsyncClient
+from selectolax.parser import HTMLParser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -31,6 +32,13 @@ async def test_profile_hub_renders_persona_chooser_for_new_user(
     assert "I represent an organization" in response.text
     assert "?path=clinician" in response.text
     assert "?path=org" in response.text
+    # The setup flow is embedded *inside* the identity spine row, not a
+    # separate section below the checklist — the row owns its own action.
+    identity_row = HTMLParser(response.text).css_first(
+        '#onboarding-checklist [data-step="identity"]'
+    )
+    assert identity_row is not None
+    assert identity_row.css_first(".picker") is not None
     # The chooser renders as the shared picker card grid — each option is a
     # bordered `.picker-option` card, not a bare underlined link. This is the
     # primary action on the setup page, so it must read as a card.

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -245,20 +245,28 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
   margin-bottom: var(--pico-spacing);
 }
 
-/* ── Onboarding progress overview ─────────────────────────────
-   Registry-driven setup-progress strip at the top of /profile
-   (profile/_checklist.html). One row per onboarding step; the mark
-   and the muted/strong treatment express completion. All state via
-   classes — no inline styles on the template. */
+/* ── Onboarding setup spine ───────────────────────────────────
+   Registry-driven spine at the top of /profile (profile/_checklist.html).
+   One row per onboarding step. Each row is a vertical stack: a `head`
+   (mark · title/hint · optional Done tag) over an optional embedded
+   `action` — the incomplete row that owns it carries its satisfying
+   control inline (email → resend, identity → the setup flow). The mark
+   and muted/strong treatment express completion. All state via classes —
+   no inline styles on the template. */
 .onboarding-progress {
   list-style: none;
   margin: 0 0 var(--pico-spacing);
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
 }
 .onboarding-progress-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.onboarding-progress-head {
   display: flex;
   align-items: flex-start;
   gap: 0.6rem;
@@ -275,6 +283,9 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
+  color: var(--pico-color-green-600);
 }
-.onboarding-progress-item.is-complete .onboarding-progress-status { color: var(--pico-color-green-600); }
-.onboarding-progress-item.is-pending .onboarding-progress-status { color: var(--pico-color-orange-600); }
+/* The embedded action sits under the row head, indented past the mark so
+   it lines up with the step title. */
+.onboarding-progress-action { margin-left: 1.6rem; }
+.onboarding-progress-action > form { margin-bottom: 0; }

--- a/src/domain/templates/profile/_checklist.html
+++ b/src/domain/templates/profile/_checklist.html
@@ -1,12 +1,21 @@
-{# Registry-driven setup-progress overview.
+{# Registry-driven setup spine — one row per onboarding step, each row
+   owning its own action inline.
 
    Renders the `checklist` (an `OnboardingChecklist` from
-   `build_profile_context` → `onboarding_checklist(user)`) as a single
-   completed/remaining strip covering the whole verification spine
-   (email → identity). It ties together the email step — whose actionable
-   resend lives in the `#verify-banner` aside below — and the identity
-   step — whose detailed forms live in the mode partials — into one
-   "where am I" view, the unified progress the hub otherwise lacked.
+   `build_profile_context` → `onboarding_checklist(user)`) as the
+   verification spine (email → identity). Each incomplete row *embeds the
+   action that satisfies it* rather than pointing at a separate block
+   elsewhere on the page — the email row carries the resend control, the
+   identity row carries the full setup flow (`_setup.html`). This is what
+   the registry's `OnboardingStep.embed` hint is for, and it's why the hub
+   no longer renders a standalone email aside or a separate setup section:
+   the spine is the page in setup mode.
+
+   Per-key dispatch (email → resend, identity → `_setup.html`) is
+   unavoidable because the satisfying action is inherently step-specific;
+   the registry can't hold Jinja markup. The identity embed is gated on
+   `mode == "setup"` so re-verify/add-claim modes — which can also leave
+   identity incomplete — keep their own mode partials below instead.
 
    Reads the same `capabilities` predicates as the post gate and the
    global `#onboarding-banner`, so the three can't disagree. Only shown
@@ -18,14 +27,37 @@
       {% for status in checklist.statuses %}
         <li class="onboarding-progress-item {{ 'is-complete' if status.complete else 'is-pending' }}"
             data-step="{{ status.step.key }}">
-          <span class="onboarding-progress-mark" aria-hidden="true">
-            <i class="icon-{{ 'circle-check' if status.complete else 'circle' }}"></i>
-          </span>
-          <span class="onboarding-progress-body">
-            <strong>{{ status.step.title }}</strong>
-            <small>{{ 'Done' if status.complete else status.step.hint }}</small>
-          </span>
-          <span class="onboarding-progress-status">{{ 'Done' if status.complete else 'To do' }}</span>
+          <div class="onboarding-progress-head">
+            <span class="onboarding-progress-mark" aria-hidden="true">
+              <i class="icon-{{ 'circle-check' if status.complete else 'circle' }}"></i>
+            </span>
+            <span class="onboarding-progress-body">
+              <strong>{{ status.step.title }}</strong>
+              <small>{{ 'Done' if status.complete else status.step.hint }}</small>
+            </span>
+            {% if status.complete %}<span class="onboarding-progress-status">Done</span>{% endif %}
+          </div>
+          {# Embedded action — only on the incomplete row that owns it. The
+             status tag is dropped here on purpose: the action below makes
+             "to do" self-evident, so the tag would just be inert chrome. #}
+          {%- if not status.complete -%}
+            {%- if status.step.key == "email" -%}
+              {# The resend form keeps the `#verify-banner` id + swap target
+                 the old aside used, so `POST /auth/resend-verify` still
+                 swaps its confirmation partial in place. #}
+              <div id="verify-banner" class="onboarding-progress-action">
+                <form method="post"
+                      action="/auth/resend-verify"
+                      hx-post="/auth/resend-verify"
+                      hx-target="#verify-banner"
+                      hx-swap="outerHTML">
+                  <button type="submit" class="outline secondary verify-resend">Resend verification email</button>
+                </form>
+              </div>
+            {%- elif status.step.embed and mode == "setup" -%}
+              <div class="onboarding-progress-action">{% include "profile/_setup.html" %}</div>
+            {%- endif -%}
+          {%- endif -%}
         </li>
       {% endfor %}
     </ol>

--- a/src/domain/templates/profile/_setup.html
+++ b/src/domain/templates/profile/_setup.html
@@ -77,7 +77,7 @@
       {
         "href": "/profile?path=clinician",
         "heading": "I'm a clinician",
-        "description": "A solo or group practitioner — verify your NPI and license to post and see full referral details."
+        "description": "A solo or group practitioner — verify your NPI and license."
       },
       {
         "href": "/profile?path=org",

--- a/src/domain/templates/profile/hub.html
+++ b/src/domain/templates/profile/hub.html
@@ -5,7 +5,7 @@
     <h1>Profile</h1>
     <p style="color: var(--pico-muted-color); margin-top: -0.25rem;">
       {% if mode == "setup" %}
-        Verify your identity to post and see full referral details.
+        Complete these steps to start posting and see full referral details.
       {% elif mode == "manage" %}
         Manage your verification claims and profile.
       {% elif mode == "add-a-claim" %}
@@ -15,36 +15,20 @@
       {% endif %}
     </p>
   </header>
-  {# Registry-driven progress overview — the unified "what's done / what
-     remains" strip, read from the `onboarding_checklist` projection. Sits
-     above the email aside and the mode partials so the user sees the whole
-     spine at a glance before acting on any one step. #}
+  {# Registry-driven setup spine. In setup mode this *is* the page: each
+     incomplete step row embeds its own action — the email row carries the
+     resend control (with the `#verify-banner` swap target), the identity
+     row embeds `_setup.html`. So there is no standalone email aside or
+     separate setup section here; see `_checklist.html`. The spine is
+     suppressed once onboarding is complete (manage mode). #}
   {% include "profile/_checklist.html" %}
-  {# Email verification step. Shown above the claim-setup content so the
-     user knows to check their inbox before completing any other step.
-     Uses the same HTMX target (`#verify-banner`) and swap partial as
-     the old global banner so `POST /auth/resend-verify` keeps working. #}
-  {%- if not current_user_is_verified -%}
-    <aside role="status" id="verify-banner" style="margin-bottom: 1rem;">
-      <strong>Verify your email.</strong>
-      Check your inbox for a link to confirm your account.
-      <form method="post"
-            action="/auth/resend-verify"
-            hx-post="/auth/resend-verify"
-            hx-target="#verify-banner"
-            hx-swap="outerHTML">
-        <button type="submit" class="outline secondary verify-resend">Resend verification email</button>
-      </form>
-    </aside>
-  {%- endif -%}
-  {# Mode dispatch. All four modes have dedicated partials:
-     * `_setup.html`     — wireframe L1, no-claim goal picker.
+  {# Mode dispatch for the post-onboarding modes. Setup-mode content lives
+     inside the spine above (the identity row), so it is not dispatched
+     here:
      * `_manage.html`    — wireframe L4, ≥1 claim verified.
      * `_add_claim.html` — wireframe L6, additive unlock framing.
      * `_reverify.html`  — wireframe L7, lapsed-claim Fix CTA. #}
-  {% if mode == "setup" %}
-    {% include "profile/_setup.html" %}
-  {% elif mode == "manage" %}
+  {% if mode == "manage" %}
     {% include "profile/_manage.html" %}
   {% elif mode == "add-a-claim" %}
     {% include "profile/_add_claim.html" %}


### PR DESCRIPTION
## Summary
- In setup mode, each incomplete onboarding-spine row now embeds its own satisfying action inline: the **email** row carries the resend control (preserving the `#verify-banner` HTMX swap target), the **identity** row embeds `_setup.html` (persona chooser / NPI / license).
- Removes the standalone email `<aside>` and the separate setup-section include from `hub.html` — in setup mode the spine *is* the page. Mode dispatch now only covers manage / add-a-claim / re-verify.
- CSS: rows become a vertical stack (`head` over embedded `action`), action indented to line up under the step title.
- Identity embed is gated on `mode == "setup"` so re-verify / add-claim modes keep their own partials.

## Test plan
- [x] `test_chrome_banner.py` — resend button renders `outline`/`verify-resend` and `#verify-banner` lives inside `[data-step="email"]`; banner suppression/visibility contract unchanged.
- [x] `test_profile.py` — persona chooser (`.picker`) renders inside `[data-step="identity"]`.
- [x] `dev test` (full), `dev test contract` (40 passed), `dev lint` all green.
- [x] Browser-verified at 390px: verified user (chooser embedded in identity row, email "Done") and unverified user (resend embedded in email row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)