### PR TITLE
feat: path switcher in setup sub-flows using picker selected state

### DIFF
--- a/src/domain/routes/test_profile.py
+++ b/src/domain/routes/test_profile.py
@@ -107,7 +107,9 @@ async def test_profile_identity_step_started_clinician_ignores_path_hint(
     response = await authenticated_client.get("/profile/identity?path=org")
     assert response.status_code == 200
     assert "Verify your NPI" in response.text
-    assert "I represent an organization" not in response.text
+    # The org registration form should not appear; the path switcher picker
+    # still shows "I represent an organization" as a non-selected link option.
+    assert "Register an organization" not in response.text
 
 
 async def test_profile_step_unknown_key_returns_404(

--- a/src/domain/templates/profile/_setup.html
+++ b/src/domain/templates/profile/_setup.html
@@ -75,18 +75,30 @@
     <p>How will you use Bedlam Connect? Pick the option that fits — you can add the other later.</p>
     {{ picker([
       {
-        "href": "/profile?path=clinician",
+        "href": "/profile/identity?path=clinician",
         "heading": "I'm a clinician",
         "description": "A solo or group practitioner — verify your NPI and license."
       },
       {
-        "href": "/profile?path=org",
+        "href": "/profile/identity?path=org",
         "heading": "I represent an organization",
         "description": "Register your practice, clinic, or facility to post program intakes and on behalf of its clinicians."
       }
     ]) }}
   {% elif setup_path == "clinician" %}
     {# ── Clinician path: verify NPI, then attest a license ──────────── #}
+    {{ picker([
+      {
+        "selected": true,
+        "heading": "I'm a clinician",
+        "description": "A solo or group practitioner — verify your NPI and license."
+      },
+      {
+        "href": "/profile/identity?path=org",
+        "heading": "I represent an organization",
+        "description": "Register your practice, clinic, or facility to post program intakes."
+      }
+    ]) }}
     <article class="step-card{% if not _npi_ok %} step-card--action{% endif %}"
              id="claim-a-card">
       <header>
@@ -179,13 +191,20 @@
         {% endcall %}
       </article>
     {% endif %}
-    <p style="margin-top: 0.75rem;
-              font-size: 0.9em;
-              color: var(--pico-muted-color)">
-      Representing an organization instead? <a href="/profile?path=org">Register your organization.</a>
-    </p>
   {% elif setup_path == "org" %}
     {# ── Org path: register the organization + its Type-2 NPI ───────── #}
+    {{ picker([
+      {
+        "href": "/profile/identity?path=clinician",
+        "heading": "I'm a clinician",
+        "description": "A solo or group practitioner — verify your NPI and license."
+      },
+      {
+        "selected": true,
+        "heading": "I represent an organization",
+        "description": "Register your practice, clinic, or facility to post program intakes."
+      }
+    ]) }}
     <article class="step-card{% if not org_representations %} step-card--action{% endif %}"
              id="claim-b-card">
       <header>
@@ -226,10 +245,5 @@
         {% endcall %}
       {% endif %}
     </article>
-    <p style="margin-top: 0.75rem;
-              font-size: 0.9em;
-              color: var(--pico-muted-color)">
-      Also a practicing clinician? <a href="/profile?path=clinician">Add your Type-1 NPI</a> to enable clinician posting too.
-    </p>
   {% endif %}
 </section>

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -624,3 +624,11 @@ body {
   color: var(--pico-muted-color);
   font-size: 0.9rem;
 }
+.picker-option--selected {
+  border-color: var(--pico-primary);
+  background: var(--pico-card-sectioning-background-color);
+  cursor: default;
+}
+.picker-option--selected h2 {
+  color: var(--pico-primary);
+}

--- a/src/framework/templates/_shared/_picker.html
+++ b/src/framework/templates/_shared/_picker.html
@@ -5,19 +5,33 @@ macro anywhere a multi-option entry point needs to funnel the user to a
 kind- or type-specific sub-form before showing fields.
 
 Each option is a dict with keys:
-  href:        URL to navigate to on click
+  href:        URL to navigate to on click (ignored when selected=true)
   heading:     short label (e.g. "Solo practice")
   description: one-line tagline
+  selected:    (optional bool) when true, renders as a non-link selected
+               card (.picker-option--selected) with a checkmark — use
+               this to show which path is currently active.
 #}
 {%- macro picker(options) -%}
   <div class="picker">
     {%- for opt in options %}
-      <a href="{{ opt.href }}" class="picker-option">
-        <hgroup>
-          <h2>{{ opt.heading }}</h2>
-          <p>{{ opt.description }}</p>
-        </hgroup>
-      </a>
+      {%- if opt.selected %}
+        <div class="picker-option picker-option--selected">
+          <hgroup>
+            <h2>
+              <i class="icon-check"></i> {{ opt.heading }}
+            </h2>
+            <p>{{ opt.description }}</p>
+          </hgroup>
+        </div>
+      {%- else %}
+        <a href="{{ opt.href }}" class="picker-option">
+          <hgroup>
+            <h2>{{ opt.heading }}</h2>
+            <p>{{ opt.description }}</p>
+          </hgroup>
+        </a>
+      {%- endif %}
     {%- endfor %}
   </div>
 {%- endmacro %}


### PR DESCRIPTION
## Summary

- Parameterises `_picker.html` with an optional `selected: true` key per option — renders as a highlighted non-link card (`.picker-option--selected`) with a checkmark icon instead of an anchor
- Adds `.picker-option--selected` CSS (primary border + sectioning background, non-interactive)
- Both clinician and org onboarding sub-flows now open with the picker at the top showing the active path selected and the alternative as a switchable link — replacing the small muted footer links that previously gave no visual sense of context

## Test plan

- [ ] `GET /profile/identity?path=clinician` — picker shows "I'm a clinician" selected (checkmark, no anchor), "I represent an organization" as a link card
- [ ] Clicking "I represent an organization" navigates to `/profile/identity?path=org` and the picker flips — org selected, clinician linkable
- [ ] `GET /profile/identity` (no hint) — still shows the unselected chooser (both options as link cards)
- [ ] All existing profile route tests pass (`dev test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)