### PR TITLE
fix: make the chrome onboarding banner the single verification nudge

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -9,8 +9,9 @@ full checklist is already on screen. The old `_verify_banner.html`
 remains removed — this banner is the single consolidated signal, not its
 return. These tests assert:
 
-1. `/home` still shows the "Finish setting up" card for a no-claim user
-   (that copy lives in `home.html`, not in the old banner).
+1. `/home` shows no per-page finish-setup card for a no-claim user — the
+   post-action row is suppressed entirely and the only nudge is the chrome
+   `#onboarding-banner`.
 2. `/profile` shows the email-verify section for unverified users and
    hides it for verified users (dev users are auto-verified).
 3. Post CTAs on `/home` are gated on `claims.a` being populated.
@@ -29,15 +30,21 @@ from tests.helpers import (  # noqa: F401  (kept available for future tests)
 pytestmark = pytest.mark.asyncio
 
 
-async def test_new_user_sees_finish_setup_card_on_home(
+async def test_new_user_sees_no_finish_setup_card_on_home(
     authenticated_client: AsyncClient,
 ):
-    """A fresh dev user (no claims) lands on `/home` with the
-    no-claim Finish-setup card pointing at `/profile`."""
+    """A fresh dev user (no claims) lands on `/home` with no per-page
+    finish-setup card: the old `#finish-setup-card` / "Open Profile" CTA is
+    gone, and no post-action buttons stand in for it. The chrome
+    `#onboarding-banner` is the single finish-setup nudge."""
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
-    assert "Finish setting up" in response.text
-    assert "Open Profile" in response.text
+    tree = HTMLParser(response.text)
+    assert tree.css_first("#finish-setup-card") is None
+    assert "Open Profile" not in response.text
+    assert "+ Post a referral" not in response.text
+    # The single nudge is the chrome banner.
+    assert tree.css_first("#onboarding-banner") is not None
 
 
 async def test_profile_email_verify_hidden_for_verified_user(

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -529,34 +529,19 @@ async def test_create_form_preselects_first_clinician(
 # --- Anonymization gate (can_read_full_feed) ---------------------------------
 
 
-async def test_list_shows_verify_notice_for_unverified(
+async def test_list_has_no_inline_verify_notice_for_unverified(
     authenticated_client: AsyncClient,
     logged_in_user,
 ):
-    """Unverified users see a CTA on /posts directing them to complete
-    verification, since poster names and contact info are hidden."""
-    response = await authenticated_client.get("/posts")
-    assert response.status_code == 200
-    assert "posts-verify-notice" in response.text
-    assert "Complete verification" in response.text
-
-
-async def test_list_hides_verify_notice_for_verified(
-    authenticated_client: AsyncClient,
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-    logged_in_user,
-):
-    """Verified users (Claim A active) see no verify-notice on /posts."""
-    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
-    clinician.npi_match_status = "matched"
-    clinician.clinician_verified = True
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(clinician)
-
+    """The /posts list carries no inline verify notice, even for an
+    unverified viewer. Poster names / contact are anonymized server-side;
+    the single chrome `#onboarding-banner` is the only place that explains
+    verification unlocks the full view — the old `posts-verify-notice` is
+    gone."""
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     assert "posts-verify-notice" not in response.text
+    assert "Complete verification" not in response.text
 
 
 # --- Toolbar Create CTA gate (posting-capable claim) -------------------------

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -5,37 +5,19 @@
 {%- macro _no_poster_row(post) %}{{ post_feed_row(post, show_poster=False) }}{%- endmacro -%}
   {% block title %}Home{% endblock %}
   {% block content %}
-    {# Three-branch home per handoff §8.2:
-       1. No claim → "Finish setting up" card + anonymized teaser feed.
-       2. ≥1 claim → existing body (my posts + network feed).
-       3. Any claim lapsed → yellow banner above the existing body
-          naming the lapsed claim. The banner copy is owned by
-          `_verify_banner.html` (claim-aware) above the chrome — the
-          per-page repeat here would be redundant. #}
-    {% set _no_claim = not claims.a and not claims.b %}
-    {% if _no_claim %}
-      <article id="finish-setup-card">
-        <header>
-          <strong>Finish setting up</strong>
-          <small style="display: block; color: var(--pico-muted-color);">
-            Tell us what you want to do on Bedlam Connect — we'll only ask for what that needs.
-          </small>
-        </header>
-        <p>
-          {# title-case-ignore: "Claim A" / "Claim B" are user-facing labels for the two-claim model #}
-          Add a verified clinician profile (Claim A) to post referrals or openings as yourself, and/or become a verified representative of an organization (Claim B) to post program intakes on its behalf.
-        </p>
-        {# title-case-ignore: "Profile" is the page label, kept capitalized #}
-        <a href="/profile" role="button">Open Profile</a>
-      </article>
-    {% else %}
-      {# Post CTAs gate on `can_post` (Claim A only). A Claim-B-only org
-         rep can't post as themselves, but rather than hide the actions we
-         render them DISABLED with the unlock path (`locked_action`), so
-         the user sees the capability exists and how to reach it. The
-         server's `_assert_post_payload_authz` is the real gate; a disabled
-         button leaks nothing. `can_post` is derived once in
-         `base_context()` — don't re-derive from raw `claims.*`. #}
+    {# Home per handoff §8.2. The post-action row shows only once the user
+       holds at least one claim: a posting-capable user (Claim A) gets
+       active create links; a Claim-B-only org rep gets the same actions
+       DISABLED with the unlock path (`locked_action`), since that's their
+       only signal — the chrome banner is silent for them (onboarding
+       complete). A *no-claim* user is suppressed here entirely: the single
+       chrome `#onboarding-banner` (base.html) is their one finish-setup
+       nudge, so a per-page card or locked-button repeat would be the exact
+       redundancy that banner replaced. The server's
+       `_assert_post_payload_authz` is the real gate; a disabled button
+       leaks nothing. `can_post` is derived once in `base_context()` —
+       don't re-derive from raw `claims.*`. #}
+    {% if claims.a or claims.b %}
       <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
         {% if can_post %}
           <a href="{{ entity_form_url('post') }}?kind=referral"
@@ -83,19 +65,11 @@
         <a href="{{ entity_url('post') }}">Adjust filters</a>
           {# djlint:on #}
         </p>
-        {# Identifying info (poster name, practice, contact) is
-           anonymized server-side via `can_read_full_feed`. Show a
-           CTA so unverified users know verification unlocks the full
-           view. Verified users see nothing extra here. #}
-        {% if not can_read_full_feed %}
-          <p id="feed-verify-notice"
-             style="font-size: 0.875rem;
-                    color: var(--pico-muted-color);
-                    margin-bottom: 1rem">
-            Clinician names and contact details are hidden until you verify.
-            <a href="/profile">Complete verification →</a>
-          </p>
-        {% endif %}
+        {# Identifying info (poster name, practice, contact) is anonymized
+           server-side via `can_read_full_feed`. The chrome
+           `#onboarding-banner` (base.html) is the single place that
+           explains verification unlocks the full view — no per-feed
+           notice repeats it. #}
         {{ item_list(network_posts, post_feed_row, "network-posts-list", "post-feed-list") }}
       </section>
     {% endif %}

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -26,15 +26,10 @@
   {%- set _empty %}{{ post_feed_empty("No posts match these filters." if active_filter_count else "No posts found.",
     link_href=entity_url("post") if active_filter_count else none
     ) }}{%- endset %}
-    {% if not can_read_full_feed %}
-      <p id="posts-verify-notice"
-         style="font-size: 0.875rem;
-                color: var(--pico-muted-color);
-                margin-bottom: 1rem">
-        Clinician names and contact details are hidden until you verify.
-        <a href="/profile">Complete verification →</a>
-      </p>
-    {% endif %}
+    {# Poster names / contact are anonymized server-side via
+       `can_read_full_feed`. The chrome `#onboarding-banner` (base.html)
+       is the single place explaining verification unlocks the full view —
+       no per-list notice repeats it. #}
     <div class="posts-browse-layout">
       <aside class="posts-filter-sidebar">
         <hgroup>

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -178,14 +178,16 @@
         {# Anonymous visitors get only the brand link. #}
       </nav>
     </header>
-    {# Single global incomplete-profile banner. One chrome signal that
-       reads `onboarding_incomplete` from `base_context` — itself the
+    {# Single global incomplete-profile banner — the *only* place the app
+       nags about verification. One chrome signal that reads
+       `onboarding_incomplete` from `base_context` — itself the
        `onboarding_checklist` registry projection — so it can't disagree
        with the itemized steps on `/profile`. Explains *why* content is
-       gated and links to the next actionable step (a `/profile?focus=…`
-       deep-link). Suppressed on `/profile` itself, where the full
-       checklist is already on screen — a banner there would just point
-       at the page you're on. #}
+       gated and links to the next actionable step (`onboarding_next_href`,
+       a `/profile/<step>` deep-link). Pages don't repeat this with their
+       own finish-setup cards or feed notices. Suppressed on `/profile`
+       itself, where the full checklist is already on screen — a banner
+       there would just point at the page you're on. #}
     {% if is_authenticated and onboarding_incomplete and not _on_profile %}
       <aside role="status" id="onboarding-banner" class="container">
         <strong>Finish setting up your profile.</strong>

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -61,17 +61,19 @@ async def test_home_page_shows_post_buttons_when_claim_a_verified(
     assert tree.css_first('a[href="/posts/form?kind=clinician_opening"]') is not None
 
 
-async def test_home_page_hides_post_buttons_without_claim_a(
+async def test_home_page_no_post_actions_for_no_claim_user(
     authenticated_client: AsyncClient,
 ):
-    """An unverified user (the default dev fixture) sees no post CTAs
-    on /home — they're shown the no-claim "Finish setting up" card
-    instead."""
+    """A no-claim user (the default dev fixture) gets no post-action row on
+    /home at all — neither an active create link nor a disabled locked
+    button. The single chrome `#onboarding-banner` is their one nudge, so
+    the page hosts no finish-setup card either."""
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert tree.css_first('a[href="/posts/form?kind=referral"]') is None
-    assert "Finish setting up" in response.text
+    assert "+ Post a referral" not in response.text
+    assert tree.css_first("#finish-setup-card") is None
 
 
 async def test_home_page_no_blur_element(authenticated_client: AsyncClient):
@@ -83,13 +85,15 @@ async def test_home_page_no_blur_element(authenticated_client: AsyncClient):
     assert "feed-teaser-blur" not in response.text
 
 
-async def test_home_page_verify_notice_for_unverified_with_network_posts(
+async def test_home_page_has_no_inline_feed_verify_notice(
     authenticated_client: AsyncClient,
     db_test_session_manager,
     logged_in_user,
 ):
-    """When the viewer can't read the full feed and there are network posts,
-    the home page shows a CTA directing them to complete verification."""
+    """The home network feed carries no inline verify notice, even for an
+    unverified viewer with network posts. The single chrome
+    `#onboarding-banner` is the only place that explains verification
+    unlocks the full view — the old `feed-verify-notice` is gone."""
     from tests.helpers import create_test_user, make_referral_detail
 
     author = create_test_user(username="net-poster")
@@ -102,37 +106,8 @@ async def test_home_page_verify_notice_for_unverified_with_network_posts(
 
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
-    assert "feed-verify-notice" in response.text
-    assert "Complete verification" in response.text
-
-
-async def test_home_page_no_verify_notice_for_verified_user(
-    authenticated_client: AsyncClient,
-    db_test_session_manager,
-    logged_in_user,
-):
-    """A verified user (Claim A active) sees no verify-notice on /home."""
-    from tests.helpers import (
-        create_test_user,
-        make_clinician_with_org,
-        make_referral_detail,
-    )
-
-    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
-    clinician.npi_match_status = "matched"
-    clinician.clinician_verified = True
-    author = create_test_user(username="net-poster-v")
-    post = Post(kind="referral", owner_id=author.id)
-    post.referral_detail = make_referral_detail()
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(clinician)
-            session.add(author)
-            session.add(post)
-
-    response = await authenticated_client.get("/home")
-    assert response.status_code == 200
     assert "feed-verify-notice" not in response.text
+    assert "Complete verification" not in response.text
 
 
 async def test_home_page_shows_primary_nav(authenticated_client: AsyncClient):


### PR DESCRIPTION
## Summary
- Removes the redundant per-page verification surfaces that duplicated the global `#onboarding-banner`:
  - the no-claim **"Finish setting up" card** on `/home` (with the "Tell us what you want to do…" / Claim A·B copy and "Open Profile" CTA),
  - the inline **"Clinician names and contact details are hidden until you verify → Complete verification"** notices on `/home` (`feed-verify-notice`) and `/posts` (`posts-verify-notice`).
- A no-claim user's only finish-setup signal is now the chrome banner ("Finish setting up your profile. … Continue setup →"). The home post-action row is **suppressed** for no-claim users rather than restated as disabled buttons; it still renders (disabled, via `locked_action`) for Claim-B-only org reps, where the banner is silent (onboarding complete).
- Updates the `base.html` banner comment to state it's the single verification nudge and to drop a stale `/profile?focus=…` reference.

## Test plan
- [x] `dev test` — full suite green (2328 passed, 101 skipped)
- [x] `dev test contract` — 40 passed
- [x] `dev lint` — all checks pass
- [x] Browser-verified `/home` for a fresh no-claim user: single chrome banner present, no finish-setup card, no inline notices
- [x] Updated colocated tests: `test_main.py`, `test_chrome_banner.py`, `test_posts.py` (notices/card removal pinned as negative assertions; Claim-B-only locked-action behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)