### PR TITLE
feat: redacted post-detail rows render locked_field placeholders

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -41,6 +41,11 @@ REASON_CLAIM_A_UNVERIFIED = "claim_a_unverified"
 REASON_CLAIM_B_UNVERIFIED = "claim_b_unverified"
 REASON_CLAIM_A_LAPSED = "claim_a_lapsed"
 REASON_AFFILIATION_MISSING = "affiliation_missing"
+# Read-side gate (not a write affordance): the viewer hasn't cleared
+# verification, so contact/identity details on a post detail are withheld
+# (`can_read_full_feed` is False). Distinct from the claim-to-*post*
+# reasons above — this one fixes by completing any verification path.
+REASON_VIEW_UNVERIFIED = "view_unverified"
 
 
 @dataclass(frozen=True)
@@ -93,6 +98,11 @@ _REASON_META = {
     REASON_AFFILIATION_MISSING: ReasonMeta(
         unlock="Add a clinician affiliation to unlock this.",
         fix_label="Manage affiliations",
+        fix_url="/profile",
+    ),
+    REASON_VIEW_UNVERIFIED: ReasonMeta(
+        unlock="Verify your account to see contact details.",
+        fix_label="Complete verification",
         fix_url="/profile",
     ),
 }

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -522,6 +522,16 @@ def test_reason_meta_known_reason_carries_full_copy():
     )
 
 
+def test_reason_meta_view_unverified_is_the_read_side_gate():
+    """The redaction reason (withheld post-detail contact/identity rows)
+    carries verification-oriented copy and points at the hub root, where
+    the viewer can complete any verification path."""
+    meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED)
+    assert "Complete verification" == meta.fix_label
+    assert meta.fix_url == "/profile"
+    assert meta.unlock
+
+
 def test_reason_meta_unknown_reason_falls_back():
     """An unmapped code returns the generic hub pointer, never raises —
     a stray reason renders a sane nudge rather than blank chrome."""

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -666,3 +666,75 @@ async def test_detail_shows_email_for_verified(
     assert response.status_code == 200
     assert f"mailto:{author_email}" in response.text
     assert "Verify to contact" not in response.text
+
+
+async def test_detail_redacts_identity_rows_as_locked_placeholders_for_unverified(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """A viewer who can't read the full feed sees the practice /
+    organization / address rows on post detail as `locked_field`
+    placeholders ("Hidden — Complete verification →"), not silently
+    dropped. The real links + address value are NOT emitted — withholding,
+    not CSS-hiding."""
+    author = create_test_user(username=f"author-{uuid.uuid4()}")
+    clinician = make_clinician_with_org(owner_id=author.id, practice_name="Acme Health")
+    clinician.id = clinician.id or uuid.uuid4()
+    post = _opening_post(owner_id=author.id, clinician=clinician)
+    org_id = clinician.org.id
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    # The rows still render (the viewer knows the detail exists)...
+    for fact_key in ("practice", "organization", "address"):
+        dd = tree.css_first(f'div[data-fact="{fact_key}"] dd')
+        assert dd is not None, f"{fact_key} row should still render when redacted"
+        assert (
+            dd.css_first("span.locked-field") is not None
+        ), f"{fact_key} should render a locked placeholder"
+        assert dd.css_first("a").attributes.get("href") == "/profile"
+
+    # ...but the real navigable links + the address value are withheld.
+    assert tree.css_first(f"a[href='/clinicians/{clinician.id}']") is None
+    assert tree.css_first(f"a[href='/organizations/{org_id}']") is None
+    assert "Springfield, IL" not in response.text
+    assert "Complete verification" in response.text
+
+
+async def test_detail_shows_identity_rows_for_verified_viewer(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """A verified viewer (can read the full feed) sees the real practice /
+    organization links and the full address — no locked placeholders."""
+    viewer_clinician = make_clinician_with_org(
+        owner_id=logged_in_user.id, npi="1234567890"
+    )
+    viewer_clinician.npi_match_status = "matched"
+    viewer_clinician.clinician_verified = True
+
+    author = create_test_user(username=f"author-{uuid.uuid4()}")
+    clinician = make_clinician_with_org(owner_id=author.id, practice_name="Acme Health")
+    clinician.id = clinician.id or uuid.uuid4()
+    post = _opening_post(owner_id=author.id, clinician=clinician)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(viewer_clinician)
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    assert tree.css_first(f"a[href='/clinicians/{clinician.id}']") is not None
+    assert "Springfield, IL" in response.text
+    assert tree.css_first("span.locked-field") is None

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -22,6 +22,13 @@ Two modes:
     (PA/program only), languages (suppressed when ["en"] alone),
     insurance_posture, treatment_modality.
 
+  redacted=True (detail page, viewer who can't read the full feed) —
+    the identity/contact rows (practice, program, organization, address)
+    render a `locked_field` placeholder ("Hidden — Complete verification →")
+    instead of the real value/link. The row stays visible so the viewer
+    knows the detail exists and how to unlock it; the value itself is
+    never emitted. All other rows render normally.
+
   expanded=True (detail page) — every chunk the compact mode shows
     PLUS the detail-only rows: practice link (PA) / program link
     (program), organization link (PA + program — clickable jump to
@@ -47,6 +54,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
 `DESIRED_TIME_SLOT_LABELS`, `REFERRAL_SERVICE_LABELS`,
 `TREATMENT_SETTINGS_LABELS`) are Jinja globals. #}
 {%- from "_shared/sections.html" import fact -%}
+{%- from "_shared/_locked.html" import locked_field -%}
 {% macro facts_block(view, expanded=False, redacted=False) -%}
   <section class="entity-facts">
     <dl>
@@ -123,40 +131,62 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- for g in view.ages -%}{%- set _ = ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
                       {{ fact('age', 'Age', ages | join(", ") , icon='users') }}
                     {%- endif %}
-                    {%- if view.practice_link and not redacted %}
-                      {%- call fact('practice', 'Practice') %}<a href="{{ entity_url('clinician', id=view.practice_link.id) }}">{{ view.practice_link.name }}</a>
-                    {% endcall %}
-                  {%- endif %}
-                  {%- if view.program_link and not redacted %}
-                    {%- call fact('program', 'Program') %}<a href="{{ entity_url('program', id=view.program_link.id) }}">{{ view.program_link.name }}</a>
-                  {% endcall %}
-                {%- endif %}
-                {%- if view.organization_link and not redacted %}
-                  {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a>
-                {% endcall %}
-              {%- endif %}
-              {%- if view.full_address and not redacted %}{{ fact('address', 'Address', view.full_address, icon='map-pin') }}{%- endif %}
-                {%- if view.in_person is not none %}
-                  {{ fact('in_person_sessions', 'In-person sessions', LOCATION_AVAILABILITY_LABELS[view.in_person], icon='monitor') }}
-                {%- endif %}
-                {%- if view.virtual is not none %}
-                  {{ fact('virtual_sessions', 'Virtual sessions', LOCATION_AVAILABILITY_LABELS[view.virtual], icon='monitor') }}
-                {%- endif %}
-                {%- if view.desired_times %}
-                  {%- set times = [] -%}
-                  {%- for slot in view.desired_times -%}{%- set _ = times.append(DESIRED_TIME_SLOT_LABELS[slot]) -%}{%- endfor -%}
-                    {{ fact('desired_times', 'Desired times', times | join(", ") ) }}
-                  {%- endif %}
-                  {%- if view.schedule_text %}{{ fact('schedule_notes', 'Schedule notes', view.schedule_text) }}{%- endif %}
-                    {%- if view.network_preference %}
-                      {{ fact('network_preference', 'Network preference', NETWORK_PREFERENCE_LABELS[view.network_preference], icon='shield') }}
+                    {%- if view.practice_link %}
+                      {%- call fact('practice', 'Practice') %}
+                        {% if redacted %}
+                          {{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}
+                        {% else %}
+                          <a href="{{ entity_url('clinician', id=view.practice_link.id) }}">{{ view.practice_link.name }}</a>
+                        {% endif %}
+                      {% endcall %}
                     {%- endif %}
-                    {%- if view.insurance_carrier and view.network_preference and view.network_preference != "no_preference" %}
-                      {{ fact('insurance_carrier', 'Insurance carrier', INSURANCE_CARRIER_LABELS[view.insurance_carrier], icon='shield') }}
+                    {%- if view.program_link %}
+                      {%- call fact('program', 'Program') %}
+                        {% if redacted %}
+                          {{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}
+                        {% else %}
+                          <a href="{{ entity_url('program', id=view.program_link.id) }}">{{ view.program_link.name }}</a>
+                        {% endif %}
+                      {% endcall %}
                     {%- endif %}
-                    {%- if view.sliding_scale %}{{ fact('sliding_scale', 'Sliding scale', 'Yes') }}{%- endif %}
-                      {%- if view.cost %}{{ fact('cost', 'Cost', view.cost) }}{%- endif %}
+                    {%- if view.organization_link %}
+                      {%- call fact('organization', 'Organization') %}
+                        {% if redacted %}
+                          {{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}
+                        {% else %}
+                          <a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a>
+                        {% endif %}
+                      {% endcall %}
+                    {%- endif %}
+                    {%- if view.full_address %}
+                      {% if redacted %}
+                        {%- call fact('address', 'Address', icon='map-pin') %}{{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}
+                        {% endcall %}
+                      {% else %}
+                        {{ fact('address', 'Address', view.full_address, icon='map-pin') }}
+                      {% endif %}
+                    {%- endif %}
+                    {%- if view.in_person is not none %}
+                      {{ fact('in_person_sessions', 'In-person sessions', LOCATION_AVAILABILITY_LABELS[view.in_person], icon='monitor') }}
+                    {%- endif %}
+                    {%- if view.virtual is not none %}
+                      {{ fact('virtual_sessions', 'Virtual sessions', LOCATION_AVAILABILITY_LABELS[view.virtual], icon='monitor') }}
+                    {%- endif %}
+                    {%- if view.desired_times %}
+                      {%- set times = [] -%}
+                      {%- for slot in view.desired_times -%}{%- set _ = times.append(DESIRED_TIME_SLOT_LABELS[slot]) -%}{%- endfor -%}
+                        {{ fact('desired_times', 'Desired times', times | join(", ") ) }}
                       {%- endif %}
-                    </dl>
-                  </section>
-                {%- endmacro %}
+                      {%- if view.schedule_text %}{{ fact('schedule_notes', 'Schedule notes', view.schedule_text) }}{%- endif %}
+                        {%- if view.network_preference %}
+                          {{ fact('network_preference', 'Network preference', NETWORK_PREFERENCE_LABELS[view.network_preference], icon='shield') }}
+                        {%- endif %}
+                        {%- if view.insurance_carrier and view.network_preference and view.network_preference != "no_preference" %}
+                          {{ fact('insurance_carrier', 'Insurance carrier', INSURANCE_CARRIER_LABELS[view.insurance_carrier], icon='shield') }}
+                        {%- endif %}
+                        {%- if view.sliding_scale %}{{ fact('sliding_scale', 'Sliding scale', 'Yes') }}{%- endif %}
+                          {%- if view.cost %}{{ fact('cost', 'Cost', view.cost) }}{%- endif %}
+                          {%- endif %}
+                        </dl>
+                      </section>
+                    {%- endmacro %}

--- a/src/framework/templates/_shared/_locked.html
+++ b/src/framework/templates/_shared/_locked.html
@@ -9,12 +9,15 @@
      (e.g. `_assert_post_payload_authz`), so a disabled control leaks no
      data.
 
-   - `locked_field(reason, label)` — for withheld DATA values (practice
-     name, description, full address). Renders a placeholder that names
-     the field in place of its value. The caller passes the field's NAME,
-     never its value — so this macro CANNOT leak the data. Withholding the
-     real value is the VIEW layer's job (null it server-side); this macro
-     only renders the gap and the path to unlock it.
+   - `locked_field(reason, label="")` — for withheld DATA values (practice
+     name, description, full address). Renders a placeholder in place of
+     the value. Pass the field's NAME as `label` when the placeholder
+     stands alone ("Practice name hidden — …"); omit it inside an already-
+     labeled row (a `<dl>` `<dt>` carries the name, so the `<dd>` reads
+     just "Hidden — …"). The caller passes the field's NAME, never its
+     value — so this macro CANNOT leak the data. Withholding the real
+     value is the VIEW layer's job; this macro only renders the gap and
+     the path to unlock it.
 
    Copy + fix link both come from `capabilities.reason_meta(reason)` so a
    given reason reads identically everywhere. `capabilities` is a Jinja
@@ -31,10 +34,16 @@
     </small>
   </div>
 {%- endmacro %}
-{% macro locked_field(reason, label) -%}
+{% macro locked_field(reason, label="") -%}
   {%- set meta = capabilities.reason_meta(reason) -%}
   <span class="locked-field" title="{{ meta.unlock }}">
-    <i class="icon-lock" aria-hidden="true"></i>{{ label }} hidden —
+    <i class="icon-lock" aria-hidden="true"></i>
+    {% if label %}
+      {{ label }} hidden
+    {% else %}
+      Hidden
+    {% endif %}
+    —
     <a href="{{ meta.fix_url }}">{{ meta.fix_label }} →</a>
   </span>
 {%- endmacro %}

--- a/src/framework/templates/_shared/test_locked.py
+++ b/src/framework/templates/_shared/test_locked.py
@@ -103,3 +103,21 @@ def test_locked_field_unknown_reason_falls_back_not_raises() -> None:
     link = HTMLParser(html).css_first(".locked-field a")
     assert link is not None
     assert link.attributes.get("href") == "/profile"
+
+
+def test_locked_field_without_label_reads_just_hidden() -> None:
+    """Inside an already-labeled row (a `<dl>` `<dt>` names the field) the
+    placeholder omits the name and reads "Hidden — …" — no redundant
+    "<field> hidden". The fix link still renders."""
+    env = _make_env()
+    template = (
+        '{%- from "_shared/_locked.html" import locked_field -%}'
+        "{{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}"
+    )
+    html = env.from_string(template).render()
+    placeholder = HTMLParser(html).css_first(".locked-field")
+    assert placeholder is not None
+    text = placeholder.text(strip=True)
+    assert text.startswith("Hidden"), text
+    assert "hidden" not in text.replace("Hidden", "", 1).lower(), text
+    assert placeholder.css_first("a") is not None


### PR DESCRIPTION
## Summary

**PR 2 of the locked-affordance sequence** (PR 1 was #1149). Previously an unverified viewer's post detail *silently dropped* the practice / program / organization / address rows — the user had no idea those details existed. Now each renders a `locked_field` placeholder, **"🔒 Hidden — Complete verification →"**, so the gap is visible with the path to unlock it. The real links + address value are still never emitted (withholding, not CSS-hiding).

| Before (redacted viewer) | After |
|---|---|
| Practice / Org / Address rows just gone | Rows render: `🔒 Hidden — Complete verification →` |

## Changes

| File | Change |
|---|---|
| `src/domain/logic/capabilities.py` | new `REASON_VIEW_UNVERIFIED` (read-side gate) + `ReasonMeta`, copy mirroring the feed teaser notice, `fix_url` → hub root |
| `src/framework/templates/_shared/_locked.html` | `locked_field` label now **optional** — omit it inside an already-labeled `<dl>` row so the `<dd>` reads "Hidden — …" without repeating the `<dt>` field name |
| `src/domain/templates/posts/_shared/_facts_block.html` | the four redacted rows route through `locked_field` |
| `*/test_*.py` | new reason coverage, optional-label macro test, two `/posts/{id}` detail integration tests (redacted → placeholders + values withheld; verified → real links/address) |

## Why a new reason code

The redaction gate is **read-side** (`can_read_full_feed`) — semantically distinct from the claim-to-*post* reasons. It fixes by completing *any* verification path, so it points at the hub root `/profile` (same target as the existing feed teaser notice), with copy to match.

## Notes

- Only `posts/detail.html` passes `redacted=` (list cards never reach the expanded rows), so this is the complete surface. No existing test asserted these were hidden — purely additive.
- `locked_field` never receives the real value (only the field name / nothing), so it cannot leak; withholding stays the view layer's concern.

## Test plan

- [x] `test_detail_redacts_identity_rows_as_locked_placeholders_for_unverified` — placeholders present, real `/clinicians/…` + `/organizations/…` links absent, address value absent
- [x] `test_detail_shows_identity_rows_for_verified_viewer` — real links + address present, no placeholders
- [x] `locked_field` no-label variant reads "Hidden — …"
- [x] reason-meta coverage + membership guardrail
- [x] Visually verified the in-row treatment (screenshot of the `<dl>` rows)
- [x] Full suite: 2334 passed, 0 failed; `dev lint` clean

## Follow-up (PR 3)

Converge profile cards (`_manage.html`, `_reverify.html`) + remaining CTAs onto the shared copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)