### PR TITLE
refactor: drive re-verify card from reason_meta; close claim_b_lapsed vocab gap

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -40,6 +40,7 @@ REASON_EMAIL_UNVERIFIED = "email_unverified"
 REASON_CLAIM_A_UNVERIFIED = "claim_a_unverified"
 REASON_CLAIM_B_UNVERIFIED = "claim_b_unverified"
 REASON_CLAIM_A_LAPSED = "claim_a_lapsed"
+REASON_CLAIM_B_LAPSED = "claim_b_lapsed"
 REASON_AFFILIATION_MISSING = "affiliation_missing"
 # Read-side gate (not a write affordance): the viewer hasn't cleared
 # verification, so contact/identity details on a post detail are withheld
@@ -53,9 +54,12 @@ class ReasonMeta:
     """The human-facing half of a gating reason: everything a locked
     affordance needs to render, in one place.
 
-    - `unlock`: imperative sentence shown under a disabled action or in
-      place of a withheld field ("Add a verified clinician profile to
-      unlock this.").
+    - `title`: short claim/section name ("Clinician identity"). Used where
+      the affordance carries its own heading — e.g. the re-verify card's
+      `<strong>` — so the template doesn't re-derive a per-reason title.
+    - `unlock`: imperative sentence shown under a disabled action, in place
+      of a withheld field, or as the re-verify card's body ("Add a verified
+      clinician profile to unlock this.").
     - `fix_label`: CTA link text ("Complete clinician setup").
     - `fix_url`: deep-link to where the reason gets fixed. The two
       onboarding-floor reasons (email, claim A) point at their dedicated
@@ -69,6 +73,7 @@ class ReasonMeta:
     a `ReasonMeta` entry falls back to the generic hub pointer.
     """
 
+    title: str
     unlock: str
     fix_label: str
     fix_url: str
@@ -76,31 +81,43 @@ class ReasonMeta:
 
 _REASON_META = {
     REASON_EMAIL_UNVERIFIED: ReasonMeta(
+        title="Email verification",
         unlock="Verify your email to unlock this.",
         fix_label="Verify email",
         fix_url="/profile/email",
     ),
     REASON_CLAIM_A_UNVERIFIED: ReasonMeta(
+        title="Clinician identity",
         unlock="Add a verified clinician profile to unlock this.",
         fix_label="Complete clinician setup",
         fix_url="/profile/identity",
     ),
     REASON_CLAIM_A_LAPSED: ReasonMeta(
+        title="Clinician identity",
         unlock="Re-attest your license to resume this.",
         fix_label="Re-verify license",
         fix_url="/profile",
     ),
     REASON_CLAIM_B_UNVERIFIED: ReasonMeta(
+        title="Organization representation",
         unlock="Become a verified organization representative to unlock this.",
         fix_label="Complete organization setup",
         fix_url="/profile",
     ),
+    REASON_CLAIM_B_LAPSED: ReasonMeta(
+        title="Organization representation",
+        unlock="Re-verify your authority to resume this.",
+        fix_label="Re-verify authority",
+        fix_url="/profile",
+    ),
     REASON_AFFILIATION_MISSING: ReasonMeta(
+        title="Clinician affiliation",
         unlock="Add a clinician affiliation to unlock this.",
         fix_label="Manage affiliations",
         fix_url="/profile",
     ),
     REASON_VIEW_UNVERIFIED: ReasonMeta(
+        title="Contact details",
         unlock="Verify your account to see contact details.",
         fix_label="Complete verification",
         fix_url="/profile",
@@ -110,6 +127,7 @@ _REASON_META = {
 # Unknown reasons land here: a generic nudge into the hub root. Keeps a
 # caller that passes an unmapped code from rendering an empty affordance.
 _FALLBACK_META = ReasonMeta(
+    title="Profile",
     unlock="Finish setting up your profile to unlock this.",
     fix_label="Open profile",
     fix_url="/profile",

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -511,15 +511,29 @@ def test_fix_url_table_covers_every_reason_constant():
 
 
 def test_reason_meta_known_reason_carries_full_copy():
-    """A known reason resolves to non-empty unlock copy, a fix label, and
-    the same deep-link `fix_url_for` returns — one source for both."""
+    """A known reason resolves to a title, non-empty unlock copy, a fix
+    label, and the same deep-link `fix_url_for` returns — one source for
+    every display string."""
     meta = capabilities.reason_meta(capabilities.REASON_CLAIM_A_UNVERIFIED)
+    assert meta.title
     assert meta.unlock
     assert meta.fix_label
     assert meta.fix_url == "/profile/identity"
     assert meta.fix_url == capabilities.fix_url_for(
         capabilities.REASON_CLAIM_A_UNVERIFIED
     )
+
+
+def test_reason_meta_lapsed_reasons_carry_resume_copy():
+    """Both lapsed reasons (A and the newly-added B) resolve to a section
+    title + a re-verify CTA — the re-verify card reads entirely from this,
+    so a missing B entry would have rendered a raw reason code."""
+    a = capabilities.reason_meta(capabilities.REASON_CLAIM_A_LAPSED)
+    b = capabilities.reason_meta(capabilities.REASON_CLAIM_B_LAPSED)
+    assert a.title == "Clinician identity"
+    assert b.title == "Organization representation"
+    assert a.fix_label == "Re-verify license"
+    assert b.fix_label == "Re-verify authority"
 
 
 def test_reason_meta_view_unverified_is_the_read_side_gate():
@@ -543,10 +557,11 @@ def test_reason_meta_unknown_reason_falls_back():
 
 def test_reason_meta_covers_every_reason_constant_with_nonempty_copy():
     """Guardrail mirroring the fix-URL one, for the human copy: every
-    REASON_* must resolve to non-empty unlock + fix_label text so no
-    surface renders an empty locked affordance."""
+    REASON_* must resolve to non-empty title + unlock + fix_label text so
+    no surface renders an empty locked affordance or an untitled card."""
     for reason in _declared_reasons():
         meta = capabilities.reason_meta(reason)
+        assert meta.title, f"REASON {reason!r} has empty title"
         assert meta.unlock, f"REASON {reason!r} has empty unlock copy"
         assert meta.fix_label, f"REASON {reason!r} has empty fix_label"
 

--- a/src/domain/templates/profile/_reverify.html
+++ b/src/domain/templates/profile/_reverify.html
@@ -14,25 +14,21 @@
     </p>
   </hgroup>
 </header>
+{# Each lapsed card is fully driven by `capabilities.reason_meta(reason)`
+   — title, body copy, and the Fix CTA's target + label all come from the
+   single source in `capabilities.py`, keyed by the same `REASON_*` codes
+   `claim_state.lapsed` carries. No per-reason copy is authored here. #}
 {% for reason in claim_state.lapsed %}
+  {%- set meta = capabilities.reason_meta(reason) %}
   <article class="step-card step-card--error">
     <header>
       <div class="step-card-meta">
         <span class="step-status step-status--error"><i class="icon-shield-x"></i> Lapsed</span>
-        {% if reason == "claim_a_lapsed" %}
-          {# title-case-ignore: "Claim A" is a user-facing label #}
-          <strong>Clinician identity</strong>
-          <small>Re-attest your license to resume posting referrals and openings</small>
-        {% elif reason == "claim_b_lapsed" %}
-          {# title-case-ignore: "Claim B" is a user-facing label #}
-          <strong>Organization representation</strong>
-          <small>Re-verify your authority for the affected organization to resume posting on its behalf</small>
-        {% else %}
-          <strong>{{ reason }}</strong>
-        {% endif %}
+        <strong>{{ meta.title }}</strong>
+        <small>{{ meta.unlock }}</small>
       </div>
     </header>
-    <a href="/profile" role="button">Fix now</a>
+    <a href="{{ meta.fix_url }}" role="button">{{ meta.fix_label }}</a>
   </article>
 {% endfor %}
 <article class="step-card">
@@ -43,8 +39,10 @@
     </div>
   </header>
   <ul class="step-summary-list">
-    {% if claim_state.a and "claim_a_lapsed" not in claim_state.lapsed %}<li>Clinician identity — verified</li>{% endif %}
-    {% if claim_state.b and "claim_b_lapsed" not in claim_state.lapsed %}
+    {% if claim_state.a and capabilities.REASON_CLAIM_A_LAPSED not in claim_state.lapsed %}
+      <li>Clinician identity — verified</li>
+    {% endif %}
+    {% if claim_state.b and capabilities.REASON_CLAIM_B_LAPSED not in claim_state.lapsed %}
       <li>Organization representation — {{ claim_state.b|length }} organization(s)</li>
     {% endif %}
     <li>Feed browsing — retained</li>

--- a/src/domain/templates/profile/test_reverify.py
+++ b/src/domain/templates/profile/test_reverify.py
@@ -1,0 +1,76 @@
+"""Tests for the re-verify partial (`profile/_reverify.html`).
+
+Re-verify mode is unreachable in production today — `claim_state()` always
+returns `lapsed=()`, so `resolve_profile_mode` never picks it (it lands when
+the Phase-3 recompute helpers detect a regression). These template-unit tests
+render the partial directly with a stubbed `claim_state` so the lapsed-card
+markup is pinned *now*, and assert it reads entirely from
+`capabilities.reason_meta(...)` — the convergence this file exists to lock in:
+
+- the card title, body copy, and Fix CTA all come from the single source,
+  keyed by the same `REASON_*` codes `claim_state.lapsed` carries;
+- the newly-added `REASON_CLAIM_B_LAPSED` renders real copy (before, the
+  template's `claim_b_lapsed` branch referenced a reason absent from the
+  closed vocab);
+- an unknown lapsed code degrades to the fallback, never a raw code or crash.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from jinja2 import Environment, FileSystemLoader
+from selectolax.parser import HTMLParser
+
+from src.domain.logic import capabilities
+
+
+def _render(*, a=False, b=frozenset(), lapsed=()) -> str:
+    domain_templates = Path(__file__).resolve().parents[1]  # src/domain/templates
+    env = Environment(loader=FileSystemLoader(str(domain_templates)))
+    env.globals["capabilities"] = capabilities
+    claim_state = SimpleNamespace(a=a, b=b, lapsed=tuple(lapsed))
+    return env.get_template("profile/_reverify.html").render(claim_state=claim_state)
+
+
+def test_reverify_lapsed_card_reads_entirely_from_reason_meta() -> None:
+    meta = capabilities.reason_meta(capabilities.REASON_CLAIM_A_LAPSED)
+    tree = HTMLParser(_render(lapsed=[capabilities.REASON_CLAIM_A_LAPSED]))
+    card = tree.css_first("article.step-card--error")
+    assert card is not None
+    assert card.css_first("strong").text(strip=True) == meta.title
+    assert meta.unlock in card.text()
+    fix = card.css_first("a[role='button']")
+    assert fix.attributes.get("href") == meta.fix_url
+    assert meta.fix_label in fix.text()
+    # The raw reason code never leaks into the rendered card.
+    assert "claim_a_lapsed" not in card.text()
+
+
+def test_reverify_renders_newly_added_claim_b_lapsed() -> None:
+    """Pins the vocab-gap fix: before `REASON_CLAIM_B_LAPSED` existed, the
+    template's `claim_b_lapsed` branch named a reason absent from the closed
+    vocab. It now resolves to real copy via `reason_meta`."""
+    tree = HTMLParser(_render(lapsed=[capabilities.REASON_CLAIM_B_LAPSED]))
+    card = tree.css_first("article.step-card--error")
+    assert card.css_first("strong").text(strip=True) == "Organization representation"
+    assert "Re-verify authority" in card.css_first("a[role='button']").text()
+
+
+def test_reverify_unknown_lapsed_reason_falls_back_not_raises() -> None:
+    fallback = capabilities.reason_meta("totally-not-a-reason")
+    tree = HTMLParser(_render(lapsed=["totally-not-a-reason"]))
+    card = tree.css_first("article.step-card--error")
+    assert card.css_first("strong").text(strip=True) == fallback.title
+    assert card.css_first("a[role='button']").attributes.get("href") == "/profile"
+
+
+def test_reverify_still_active_card_lists_unlapsed_claims() -> None:
+    """The 'Still active' card keys its membership checks off the REASON_*
+    constants (not loose string literals), so it can't drift from the vocab."""
+    from uuid import uuid4
+
+    html = _render(a=True, b=frozenset({uuid4()}), lapsed=())
+    assert "Clinician identity — verified" in html
+    assert "Organization representation — 1 organization(s)" in html


### PR DESCRIPTION
## Summary

**PR 3 (final) of the locked-affordance series** (PRs #1149, #1161). `_reverify.html` was the one profile surface keyed by `REASON_*` codes that still hand-authored per-reason copy in an `if/elif` — and it branched on `"claim_b_lapsed"`, **a reason string absent from the closed vocab** in `capabilities.py` (a live violation of the "closed vocab" invariant that file declares).

- **`capabilities.py`**: add the missing `REASON_CLAIM_B_LAPSED` + its `ReasonMeta`; add a `title` field to `ReasonMeta` so the re-verify card's heading is single-sourced too (not re-derived per reason in the template).
- **`_reverify.html`**: each lapsed card now reads title / body / Fix CTA entirely from `reason_meta(reason)`; the "Still active" card keys its membership checks off the `REASON_*` constants instead of loose string literals.
- **First test coverage for `_reverify.html`** — re-verify mode is unreachable in prod until Phase-3 lapsed detection wires up (`claim_state().lapsed` is always `()`), so these are template-unit tests with a stubbed `claim_state`.

## Scope decision — what I deliberately did NOT converge

`_manage.html` and `_add_claim.html` are **left as-is**. They're the fix *destinations*: their CTAs deep-link to specific edit forms (e.g. `/clinicians/{id}/form`) and their copy is intentionally more specific than the cross-surface nudge. Routing them through `reason_meta` would make the links **circular** (`→ /profile` while already on `/profile`) and **flatten** correct copy — forcing the abstraction rather than reducing real drift. The genuine convergence target was the reason-keyed `_reverify` card.

## Why this is present-tense work, not Phase-3 speculation

The anchor isn't "prepare for lapsed detection" — it's that `_reverify.html` **currently references a reason absent from the closed vocab**. Fixing that (add the constant, drive the template from the vocab so it can't reference a non-existent reason again) is correctness work today; the convergence is just the clean way to do it.

## Test plan

- [x] `reason_meta` now carries `title`; coverage guardrail extended (every `REASON_*` has non-empty title/unlock/fix_label)
- [x] `REASON_CLAIM_B_LAPSED` resolves to real copy (membership guardrail auto-covers it)
- [x] `_reverify` lapsed card reads title/body/CTA from `reason_meta`; raw reason code never leaks
- [x] `_reverify` renders the newly-added B-lapsed reason; unknown reason falls back, doesn't crash
- [x] Full suite: 2337 passed, 0 failed; `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)