### PR TITLE
fix: grant owner OrgRepresentation on canonical clinician solo-create

### DIFF
--- a/src/domain/logic/clinicians/handlers.py
+++ b/src/domain/logic/clinicians/handlers.py
@@ -9,6 +9,9 @@ from pydantic import BaseModel
 
 from src.domain.logic.clinicians.repository import ClinicianRepository
 from src.domain.logic.favorites.repository import UserFavoriteRepository
+from src.domain.logic.org_representations.repository import (
+    OrgRepresentationRepository,
+)
 from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.users.repository import UserRepository
 from src.domain.logic.verifications.repository import VerificationRepository
@@ -91,14 +94,24 @@ async def _assert_clinician_payload_org_ownership(
     payload: BaseModel,
     requesting_user: User,
     organization_repo: OrganizationRepository,
+    org_rep_repo: OrgRepresentationRepository,
 ) -> Organization | None:
     """Payload authz for clinician create/update.
 
     Solo-practice path: when ``payload.solo_practice`` is True,
     auto-create a solo-practice Organization, patch ``payload.org_id``,
-    and return the created org so the caller can wire up an OrgRepresentation.
+    grant the user an immediately-verified owner ``OrgRepresentation`` over
+    it, and return the created org. Wiring the owner rep here (rather than
+    in each caller) keeps the canonical ``POST /clinicians`` solo path and
+    the onboarding hub on the same owner-grant — previously only the hub
+    created the rep, so a solo clinician made via ``/clinicians/form`` got
+    an org with no authority over it.
     Normal path: delegate to the framework's FK-ownership guard, return None.
     """
+    from src.domain.logic.org_representations.handlers import (
+        grant_owner_representation,
+    )
+
     if getattr(payload, "solo_practice", False):
         practice_name = (getattr(payload, "practice_name", None) or "").strip()
         if not practice_name:
@@ -115,6 +128,11 @@ async def _assert_clinician_payload_org_ownership(
         )
         created_org = await organization_repo.create(auto_org)
         payload.org_id = created_org.id
+        await grant_owner_representation(
+            user_id=requesting_user.id,
+            org_id=created_org.id,
+            org_rep_repo=org_rep_repo,
+        )
         return created_org
     await assert_fk_ownership(
         payload=payload,

--- a/src/domain/logic/org_representations/handlers.py
+++ b/src/domain/logic/org_representations/handlers.py
@@ -67,6 +67,36 @@ logger = logging.getLogger(__name__)
 _AO_NAME_MATCH_THRESHOLD = 0.80
 
 
+async def grant_owner_representation(
+    *,
+    user_id: UUID,
+    org_id: UUID,
+    org_rep_repo: OrgRepresentationRepository,
+) -> OrgRepresentation:
+    """Grant the user who just created an org an immediately-verified
+    *owner* representation.
+
+    Self-creating an org — a clinician's solo-practice auto-org, or a
+    self-service org registration — is itself proof of authority, so the
+    owner skips the `pending` review the `authorized_official` /
+    `rep_approval` methods go through: `authority_status='verified'` from
+    the start. `authority_method='admin_review'` records that the grant
+    rests on the create action rather than an external proof.
+
+    Shared by the clinician solo-practice create path
+    (`_assert_clinician_payload_org_ownership`) and the organization
+    create path so the two can't drift on the owner-grant shape.
+    """
+    rep = OrgRepresentation(
+        user_id=user_id,
+        org_id=org_id,
+        role="owner",
+        authority_method="admin_review",
+        authority_status="verified",
+    )
+    return await org_rep_repo.create(rep)
+
+
 def _verified_clinician_full_name(user: User) -> str | None:
     """First-verified Clinician's `<first> <last>` form, or None if the
     user has no `clinician_verified=True` row with both names."""

--- a/src/domain/logic/profile/handlers.py
+++ b/src/domain/logic/profile/handlers.py
@@ -196,7 +196,7 @@ async def handle_clinician_create(
         after_create_clinician_verification,
     )
     from src.domain.logic.clinicians.schema import ClinicianCreate
-    from src.domain.models import Clinician, OrgRepresentation
+    from src.domain.models import Clinician
 
     payload = ClinicianCreate(
         first_name=first_name,
@@ -209,21 +209,15 @@ async def handle_clinician_create(
         location_zip=location_zip,
     )
 
-    auto_org = await _assert_clinician_payload_org_ownership(
+    # Auto-creates the solo-practice org, patches `payload.org_id`, and
+    # grants the owner OrgRepresentation — the same owner-grant the
+    # canonical `POST /clinicians` solo path runs.
+    await _assert_clinician_payload_org_ownership(
         payload=payload,
         requesting_user=requesting_user,
         organization_repo=organization_repo,
+        org_rep_repo=org_rep_repo,
     )
-
-    if auto_org is not None:
-        auto_rep = OrgRepresentation(
-            user_id=requesting_user.id,
-            org_id=auto_org.id,
-            role="owner",
-            authority_method="admin_review",
-            authority_status="verified",
-        )
-        await org_rep_repo.create(auto_rep)
 
     clinician = Clinician(
         owner_id=requesting_user.id,

--- a/src/domain/logic/profile/test_handlers.py
+++ b/src/domain/logic/profile/test_handlers.py
@@ -239,6 +239,97 @@ def test_build_profile_context_exposes_setup_path():
 # ---------------------------------------------------------------------------
 
 
+class _RepMockRepo:
+    """Captures the OrgRepresentation passed to `create`."""
+
+    def __init__(self):
+        self.created = None
+
+    async def create(self, obj):
+        self.created = obj
+        obj.id = uuid4()
+        return obj
+
+
+async def test_clinician_solo_path_grants_owner_representation():
+    """The solo-practice branch must grant the user an immediately-verified
+    owner OrgRepresentation over the auto-created org, on both the canonical
+    create path and the onboarding hub (they share this function)."""
+    from types import SimpleNamespace
+
+    from src.domain.logic.clinicians.handlers import (
+        _assert_clinician_payload_org_ownership,
+    )
+
+    class _OrgRepo:
+        async def create(self, obj):
+            obj.id = uuid4()
+            return obj
+
+    user = SimpleNamespace(
+        id=uuid4(), username="alice", is_superuser=False, is_verified=True
+    )
+
+    class _Payload:
+        solo_practice = True
+        practice_name = "Solo Practice"
+        first_name = "Katie"
+        last_name = "Reeves"
+        org_id = None
+
+    org_repo = _OrgRepo()
+    rep_repo = _RepMockRepo()
+    created_org = await _assert_clinician_payload_org_ownership(
+        payload=_Payload(),
+        requesting_user=user,
+        organization_repo=org_repo,
+        org_rep_repo=rep_repo,
+    )
+
+    assert rep_repo.created is not None
+    assert rep_repo.created.user_id == user.id
+    assert rep_repo.created.org_id == created_org.id
+    assert rep_repo.created.role == "owner"
+    assert rep_repo.created.authority_method == "admin_review"
+    assert rep_repo.created.authority_status == "verified"
+
+
+async def test_clinician_non_solo_path_grants_no_representation():
+    """The non-solo path delegates to the FK-ownership guard and must not
+    create an OrgRepresentation."""
+    from types import SimpleNamespace
+    from uuid import uuid4 as _uuid4
+
+    from src.domain.logic.clinicians.handlers import (
+        _assert_clinician_payload_org_ownership,
+    )
+
+    owned_org_id = _uuid4()
+
+    class _OrgRepo:
+        async def get_by_model_id(self, model, _id):
+            return SimpleNamespace(id=owned_org_id, owner_id=user.id)
+
+    user = SimpleNamespace(
+        id=uuid4(), username="alice", is_superuser=False, is_verified=True
+    )
+
+    class _Payload:
+        solo_practice = False
+        org_id = owned_org_id
+
+    rep_repo = _RepMockRepo()
+    result = await _assert_clinician_payload_org_ownership(
+        payload=_Payload(),
+        requesting_user=user,
+        organization_repo=_OrgRepo(),
+        org_rep_repo=rep_repo,
+    )
+
+    assert result is None
+    assert rep_repo.created is None
+
+
 async def test_clinician_create_handler_uses_practice_name():
     """_assert_clinician_payload_org_ownership should use practice_name over
     first+last when it is provided, so the auto-org gets the right display name."""
@@ -275,6 +366,7 @@ async def test_clinician_create_handler_uses_practice_name():
         payload=_Payload(),
         requesting_user=user,
         organization_repo=repo,
+        org_rep_repo=_RepMockRepo(),
     )
     assert result is not None
     assert _MockRepo.last_created.name == "Single Thread Psychiatry"
@@ -311,5 +403,6 @@ async def test_clinician_create_handler_falls_back_to_name():
         payload=_Payload(),
         requesting_user=user,
         organization_repo=_MockRepo(),
+        org_rep_repo=_RepMockRepo(),
     )
     assert _MockRepo.last_created.name == "Katie Reeves"

--- a/src/domain/models/org_representations/README.md
+++ b/src/domain/models/org_representations/README.md
@@ -20,7 +20,7 @@ A clinician can be affiliated with an org without being authorized to speak for 
 - `authorized_official` — NPPES Authorized-Official name-match against the requesting user's verified `Clinician` name. Auto, covers most solos.
 - `domain_email` — verified email at the org's domain. **v1 stub**: handler returns "not yet enabled" until an `OrganizationDomain` table + email-at-domain verification flow lands.
 - `rep_approval` — an existing verified rep (or admin) approves the new rep via the `authority` state axis. Sets `approved_by` to the approver's user id.
-- `admin_review` — fallback for orgs where neither auto-path applies.
+- `admin_review` — fallback for orgs where neither auto-path applies. Also the method recorded when a user **creates the org themselves** — a clinician's solo-practice auto-org or a self-service org registration — where the create action is its own proof: the owner rep is granted immediately `verified` (no pending review) via `grant_owner_representation` in [`logic/org_representations/handlers.py`](../../logic/org_representations/handlers.py), the single helper shared by the clinician solo-create and organization-create paths.
 
 The org's Type-2 NPI is verified **once per Organization** (`Organization.org_verified`). Authority is per-(user, org) and lives here.
 

--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -272,8 +272,10 @@ async def test_create_clinician_solo_practice_auto_creates_org(
     logged_in_user: User,
 ):
     """POST /clinicians with solo_practice=true auto-creates a solo-practice
-    Org named after the clinician — no separate /organizations/form step (#699)."""
-    from src.domain.models import Organization
+    Org named after the clinician — no separate /organizations/form step (#699)
+    — and grants the user an immediately-verified owner OrgRepresentation over
+    it, so the canonical create matches the onboarding hub (#1166)."""
+    from src.domain.models import Organization, OrgRepresentation
 
     response = await authenticated_client.post(
         "/clinicians",
@@ -305,6 +307,18 @@ async def test_create_clinician_solo_practice_auto_creates_org(
         assert auto_org.name == "Jane Smith"
         assert auto_org.type == "solo_practice"
         assert auto_org.owner_id == logged_in_user.id
+
+        rep_result = await session.execute(
+            select(OrgRepresentation).filter(
+                OrgRepresentation.user_id == logged_in_user.id,
+                OrgRepresentation.org_id == auto_org.id,
+            )
+        )
+        owner_rep = rep_result.scalars().first()
+        assert owner_rep is not None
+        assert owner_rep.role == "owner"
+        assert owner_rep.authority_method == "admin_review"
+        assert owner_rep.authority_status == "verified"
 
 
 # --- Clinician reads -------------------------------------------------------

--- a/src/domain/specs/clinician.py
+++ b/src/domain/specs/clinician.py
@@ -28,6 +28,9 @@ from src.domain.logic.clinicians.schema import (
     ClinicianVerificationStateUpdate,
 )
 from src.domain.logic.favorites.repository import UserFavoriteRepository
+from src.domain.logic.org_representations.repository import (
+    OrgRepresentationRepository,
+)
 from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.posts.repository import get_post_repository
 from src.domain.logic.verifications.repository import VerificationRepository
@@ -139,10 +142,15 @@ CLINICIAN_ENTITY: Final[EntitySpec] = EntitySpec(
     form_extras_path="src.domain.logic.clinicians.handlers.clinician_form_extras",
     form_extras_repos=(("organization_repo", OrganizationRepository),),
     # Write-time check: a user may only attach a Clinician to an Org they own.
+    # On the solo-practice path it also auto-creates the org and grants the
+    # user an owner OrgRepresentation over it (hence `org_rep_repo`).
     payload_authz_path=(
         "src.domain.logic.clinicians.handlers._assert_clinician_payload_org_ownership"
     ),
-    payload_authz_repos=(("organization_repo", OrganizationRepository),),
+    payload_authz_repos=(
+        ("organization_repo", OrganizationRepository),
+        ("org_rep_repo", OrgRepresentationRepository),
+    ),
     # Run NPI verification immediately after a clinician row is persisted.
     # `verification_audit_repo` is the AuditRepository under a distinct
     # name because `audit_repo` is a reserved factory-handler kwarg and


### PR DESCRIPTION
## Summary
- The canonical `POST /clinicians` solo-practice path auto-created the solo-practice org but **never** granted the user an `OrgRepresentation` over it — so a solo clinician created via `/clinicians/form` owned an org they had no authority to speak for. Only the onboarding hub (`POST /profile/clinician`) created the owner rep.
- Move the owner-grant into the shared `_assert_clinician_payload_org_ownership` (the create/update `payload_authz`) so **both** paths grant it, wiring `org_rep_repo` into the clinician spec's `payload_authz_repos`.
- Extract a single `grant_owner_representation` helper in the `org_representations` cluster (`owner` / `admin_review` / `verified`) so the clinician solo-create and the upcoming organization-create path can't drift on the owner-grant shape.
- `handle_clinician_create` (onboarding hub) drops its now-duplicate rep block.

First of the #1166 consolidation sequence (clinician). Org owner-grant + NPI on the canonical `POST /organizations` follows as a separate PR.

## Test plan
- [x] New handler tests: solo path grants the owner rep (correct user/org/role/method/status); non-solo path grants none.
- [x] Extended `test_create_clinician_solo_practice_auto_creates_org` to assert the owner rep is created through the real spec wiring (`payload_authz_repos` injection).
- [x] `dev test` — 2339 passed, 101 skipped.
- [x] `dev lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)