### PR TITLE
fix: grant owner rep + run NPI verification on canonical org create

### DIFF
--- a/src/domain/logic/clinicians/schema.py
+++ b/src/domain/logic/clinicians/schema.py
@@ -83,8 +83,9 @@ def _validate_npi(v: str | None) -> str | None:
 
 # NPI is a National Provider Identifier — 10 ASCII digits. The HTML
 # `pattern` hint mirrors the validator so the form's `<input>` rejects
-# bad values client-side too. Local to this module because only the
-# clinician entity has the column (rule-of-three).
+# bad values client-side too. Also imported by `OrganizationCreate` (the
+# org's Type-2 NPI); stays here as the single definition until a third
+# consumer justifies hoisting to `framework/schema_validators`.
 NpiText = Annotated[
     str | None,
     AfterValidator(_validate_npi),

--- a/src/domain/logic/organizations/handlers.py
+++ b/src/domain/logic/organizations/handlers.py
@@ -30,6 +30,9 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from src.domain.logic.org_representations.repository import (
+    OrgRepresentationRepository,
+)
 from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.models import Organization, User
@@ -62,6 +65,66 @@ async def organization_form_extras(
     if target is not None:
         orgs = [o for o in orgs if o.id != target.id]
     return {"parent_org_options": orgs}
+
+
+async def after_create_organization_owner_grant(
+    *,
+    row: Organization,
+    requesting_user: User,
+    org_rep_repo: OrgRepresentationRepository,
+    verification_repo: VerificationRepository,
+    organization_repo: OrganizationRepository,
+    verification_audit_repo: AuditRepository,
+    payload: BaseModel | None = None,
+) -> None:
+    """`after_create_path` target for `POST /organizations`.
+
+    Two side effects, both previously living only in the onboarding hub's
+    `POST /profile/org` and now run on the canonical create so a
+    self-service org registration via `/organizations/form` behaves the
+    same:
+
+    1. Grant the creating user an immediately-verified owner
+       `OrgRepresentation` (shared `grant_owner_representation` — see its
+       docstring for why self-create needs no review).
+    2. When the org carries a Type-2 `npi`, run the Claim-B NPPES
+       verification inline (symmetric with the clinician NPI path). No
+       NPI → `org_verified` stays False, addable later.
+
+    Runs inside the framework's `mutate(...)` block; `run_org_verification`
+    commits internally, so the row is refreshed afterwards to keep it
+    usable for the audit after-snapshot (mirrors
+    `after_create_clinician_verification`). `payload` is accepted for the
+    framework's hook signature but unused — everything is read off `row`.
+    """
+    from src.domain.logic.org_representations.handlers import (
+        grant_owner_representation,
+    )
+
+    await grant_owner_representation(
+        user_id=requesting_user.id,
+        org_id=row.id,
+        org_rep_repo=org_rep_repo,
+    )
+
+    if row.npi:
+        import httpx
+
+        from src.domain.logic.verifications.handlers import (
+            HTTP_TIMEOUT_SECONDS,
+            run_org_verification,
+        )
+
+        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT_SECONDS) as http:
+            await run_org_verification(
+                org_id=row.id,
+                verification_repo=verification_repo,
+                org_repo=organization_repo,
+                audit_repo=verification_audit_repo,
+                http=http,
+                actor_id=requesting_user.id,
+            )
+        await organization_repo.session.refresh(row)
 
 
 async def handle_set_org_verification_state(

--- a/src/domain/logic/organizations/schema.py
+++ b/src/domain/logic/organizations/schema.py
@@ -20,6 +20,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel
 
+from src.domain.logic.clinicians.schema import NpiText
 from src.domain.models.enums import ORGANIZATION_TYPES
 from src.framework.rendering.form_fields import HtmlPattern
 from src.framework.schema_validators import (
@@ -47,6 +48,11 @@ class OrganizationCreate(WirePayload):
 
     name: Annotated[StrippedText, HtmlPattern(maxlength=200)]
     type: Literal[*ORGANIZATION_TYPES]
+    # The org's Type-2 NPI (optional). When present, `POST /organizations`
+    # runs the Claim-B NPPES verification inline (see
+    # `after_create_organization_owner_grant`); blank/absent leaves
+    # `org_verified=False`, addable later from the manage view.
+    npi: NpiText = None
     # Blank HTML form input (`""`) is coerced to `None` at the
     # `WirePayload` layer — see `_coerce_blank_strings_on_nullable_scalars`.
     parent_org_id: uuid.UUID | None = None

--- a/src/domain/logic/organizations/test_handlers.py
+++ b/src/domain/logic/organizations/test_handlers.py
@@ -112,6 +112,98 @@ async def test_form_extras_edit_path_excludes_self(
         assert sibling_id in ids
 
 
+# --- after_create_organization_owner_grant -------------------------------
+
+
+class _RepRepo:
+    """Captures the OrgRepresentation passed to `create`."""
+
+    def __init__(self):
+        self.created = None
+
+    async def create(self, obj):
+        self.created = obj
+        obj.id = uuid.uuid4()
+        return obj
+
+
+async def test_org_after_create_grants_owner_rep_without_npi(monkeypatch):
+    """No NPI: the creator gets an immediately-verified owner rep and the
+    NPPES verification is skipped."""
+    from types import SimpleNamespace
+
+    from src.domain.logic.organizations import handlers as org_handlers
+
+    called = {"verify": False}
+
+    async def _fake_verify(**_):
+        called["verify"] = True
+
+    monkeypatch.setattr(
+        "src.domain.logic.verifications.handlers.run_org_verification", _fake_verify
+    )
+
+    user = SimpleNamespace(id=uuid.uuid4())
+    row = SimpleNamespace(id=uuid.uuid4(), npi=None)
+    rep_repo = _RepRepo()
+
+    await org_handlers.after_create_organization_owner_grant(
+        row=row,
+        requesting_user=user,
+        org_rep_repo=rep_repo,
+        verification_repo=None,
+        organization_repo=None,
+        verification_audit_repo=None,
+    )
+
+    assert rep_repo.created is not None
+    assert rep_repo.created.user_id == user.id
+    assert rep_repo.created.org_id == row.id
+    assert rep_repo.created.role == "owner"
+    assert rep_repo.created.authority_method == "admin_review"
+    assert rep_repo.created.authority_status == "verified"
+    assert called["verify"] is False
+
+
+async def test_org_after_create_runs_npi_verification_when_npi_present(monkeypatch):
+    """With an NPI: still grants the owner rep, and runs the NPPES
+    verification inline for the new org as the creating actor."""
+    from types import SimpleNamespace
+
+    from src.domain.logic.organizations import handlers as org_handlers
+
+    captured = {}
+
+    async def _fake_verify(*, org_id, actor_id, **_):
+        captured["org_id"] = org_id
+        captured["actor_id"] = actor_id
+
+    monkeypatch.setattr(
+        "src.domain.logic.verifications.handlers.run_org_verification", _fake_verify
+    )
+
+    user = SimpleNamespace(id=uuid.uuid4())
+    row = SimpleNamespace(id=uuid.uuid4(), npi="1234567890")
+    rep_repo = _RepRepo()
+
+    async def _refresh(*_a, **_kw): ...
+
+    org_repo = SimpleNamespace(session=SimpleNamespace(refresh=_refresh))
+
+    await org_handlers.after_create_organization_owner_grant(
+        row=row,
+        requesting_user=user,
+        org_rep_repo=rep_repo,
+        verification_repo=None,
+        organization_repo=org_repo,
+        verification_audit_repo=None,
+    )
+
+    assert rep_repo.created is not None
+    assert captured["org_id"] == row.id
+    assert captured["actor_id"] == user.id
+
+
 # --- Admin verification-state axis ---------------------------------------
 
 

--- a/src/domain/logic/profile/handlers.py
+++ b/src/domain/logic/profile/handlers.py
@@ -252,19 +252,18 @@ async def handle_org_create(
     """Create an org + auto-grant owner OrgRepresentation for non-clinician
     onboarding (and any user who wants to register a named practice).
 
-    The user becomes the org owner with ``authority_status='verified'``
-    immediately — no external proof required because they are creating the
-    org themselves.  ``org_verified`` stays ``False`` until an org-side NPI
-    verification passes; if ``org_npi`` is supplied the NPPES lookup runs
-    inline exactly as it does for clinician NPI verification.
+    Delegates the owner-grant + inline NPI verification to
+    ``after_create_organization_owner_grant`` — the same hook the canonical
+    ``POST /organizations`` runs — so the hub and the directory create can't
+    drift. The user becomes the org owner with ``authority_status='verified'``
+    immediately (creating the org is its own proof); ``org_verified`` stays
+    ``False`` until the NPPES lookup passes, which runs inline when
+    ``org_npi`` is supplied.
     """
-    import httpx
-
-    from src.domain.logic.verifications.handlers import (
-        HTTP_TIMEOUT_SECONDS,
-        run_org_verification,
+    from src.domain.logic.organizations.handlers import (
+        after_create_organization_owner_grant,
     )
-    from src.domain.models import Organization, OrgRepresentation
+    from src.domain.models import Organization
 
     org = Organization(
         name=org_name,
@@ -274,25 +273,14 @@ async def handle_org_create(
     )
     created_org = await organization_repo.create(org)
 
-    auto_rep = OrgRepresentation(
-        user_id=requesting_user.id,
-        org_id=created_org.id,
-        role="owner",
-        authority_method="admin_review",
-        authority_status="verified",
+    await after_create_organization_owner_grant(
+        row=created_org,
+        requesting_user=requesting_user,
+        org_rep_repo=org_rep_repo,
+        verification_repo=verification_repo,
+        organization_repo=organization_repo,
+        verification_audit_repo=audit_repo,
     )
-    await org_rep_repo.create(auto_rep)
-
-    if org_npi:
-        async with httpx.AsyncClient(timeout=HTTP_TIMEOUT_SECONDS) as http:
-            await run_org_verification(
-                org_id=created_org.id,
-                verification_repo=verification_repo,
-                org_repo=organization_repo,
-                audit_repo=audit_repo,
-                http=http,
-                actor_id=requesting_user.id,
-            )
 
     return created_org
 

--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -13,7 +13,7 @@ from selectolax.parser import HTMLParser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from src.domain.models import Organization, User
+from src.domain.models import Organization, OrgRepresentation, User
 from src.framework.audit.repository import AuditRepository
 from tests.helpers import create_test_user, make_organization_row
 
@@ -64,6 +64,26 @@ async def test_create_organization_happy_path(
         # Root invariant — created with no parent, root points at self.
         assert loaded.parent_org_id is None
         assert loaded.root_org_id == new_id
+
+        # Self-registering an org grants the creator an immediately-verified
+        # owner OrgRepresentation (#1166) — previously only the onboarding
+        # hub did this; the canonical create now matches.
+        owner_rep = (
+            (
+                await session.execute(
+                    select(OrgRepresentation).filter(
+                        OrgRepresentation.user_id == logged_in_user.id,
+                        OrgRepresentation.org_id == new_id,
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert owner_rep is not None
+        assert owner_rep.role == "owner"
+        assert owner_rep.authority_method == "admin_review"
+        assert owner_rep.authority_status == "verified"
 
     rows = await _audit_rows_for(db_test_session_manager, resource_id=new_id)
     assert len(rows) == 1

--- a/src/domain/specs/organization.py
+++ b/src/domain/specs/organization.py
@@ -4,6 +4,9 @@ practices, health systems, and solo-practice shells.
 
 from typing import Final
 
+from src.domain.logic.org_representations.repository import (
+    OrgRepresentationRepository,
+)
 from src.domain.logic.organizations.repository import (
     OrganizationRepository,
     get_organization_repository,
@@ -16,12 +19,14 @@ from src.domain.logic.organizations.schema import (
     OrganizationVerificationStateUpdate,
 )
 from src.domain.logic.posts.repository import get_post_repository
+from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.models import Organization
 from src.domain.models.enums import (
     ORGANIZATION_TYPES,
     ORGANIZATION_TYPES_LABELS,
 )
 from src.framework.audit.core import AuditAction
+from src.framework.audit.repository import AuditRepository
 from src.framework.dispatch.entity_spec import (
     AUTHENTICATED,
     OWNER_OR_ADMIN,
@@ -83,6 +88,22 @@ ORGANIZATION_ENTITY: Final[EntitySpec] = EntitySpec(
         "src.domain.logic.organizations.handlers.organization_form_extras"
     ),
     form_extras_repos=(("organization_repo", OrganizationRepository),),
+    # After the org row is persisted: grant the creator an owner
+    # OrgRepresentation, and (when an NPI was supplied) run the Claim-B
+    # NPPES verification inline. `verification_audit_repo` is the
+    # AuditRepository under a distinct name because `audit_repo` is a
+    # reserved factory-handler kwarg — same convention as the clinician
+    # spec's after_create.
+    after_create_path=(
+        "src.domain.logic.organizations.handlers"
+        ".after_create_organization_owner_grant"
+    ),
+    after_create_repos=(
+        ("org_rep_repo", OrgRepresentationRepository),
+        ("verification_repo", VerificationRepository),
+        ("organization_repo", OrganizationRepository),
+        ("verification_audit_repo", AuditRepository),
+    ),
     # Templates pull dropdown labels from the spec — same pattern as
     # `CLINICIAN_ENTITY.static_context` for credential vocabularies.
     static_context={

--- a/src/domain/templates/organizations/_form_new_fragment.html
+++ b/src/domain/templates/organizations/_form_new_fragment.html
@@ -25,6 +25,10 @@
   {% call form_section("Organization") %}
     {{ text_field("name", "Name", maxlength=200) }}
     {{ select_field("type", "Type", ORGANIZATION_TYPES, labels=ORGANIZATION_TYPES_LABELS, current=selected_type) }}
+    {# Optional Type-2 NPI. When filled, `POST /organizations` runs NPPES
+       verification inline; leaving it blank registers the org unverified
+       (addable later). Pattern/maxlength mirror `NpiText`. #}
+    {{ text_field("npi", "NPI", required=false, pattern="\\d{10}", maxlength=10, help="Your organization's 10-digit Type-2 NPI. Optional — you can add it later.") }}
     {# Parent-Org picker — replaces the free-text UUID input from #581.
        `parent_org_options` is populated by `organization_form_extras`
        (see `ORGANIZATION_ENTITY.form_extras_path`). Empty value =

--- a/tests/test_contract/tests/consumer/test_organization_create_form.py
+++ b/tests/test_contract/tests/consumer/test_organization_create_form.py
@@ -56,10 +56,13 @@ async def test_consumer_organization_create_form_submits(
     expected_request_headers = {
         "Content-Type": Like("application/x-www-form-urlencoded")
     }
-    # Browser serializes inputs in DOM order. `parent_org_id` is the
-    # third field in `form_new.html` and is left blank — the empty
-    # value is what shipped #550.
-    expected_request_body = "name=Acme+Counseling" "&type=clinic" "&parent_org_id="
+    # Browser serializes inputs in DOM order: name, type, npi (optional,
+    # left blank here), parent_org_id. The blank `parent_org_id=` pins the
+    # #550 regression; the blank `npi=` pins that the optional NPI field
+    # serializes empty without 422'ing (#1166).
+    expected_request_body = (
+        "name=Acme+Counseling" "&type=clinic" "&npi=" "&parent_org_id="
+    )
 
     (
         pact.given(PROVIDER_STATE_USER_CAN_CREATE_ORGANIZATION)


### PR DESCRIPTION
## Summary
Migrate the organization onboarding side-effects off `POST /profile/org` onto the canonical `POST /organizations`, mirroring the clinician consolidation (#1167, merged).

- `OrganizationCreate` gains an optional `npi` (reuses `NpiText`); the org create form renders an NPI input.
- New `after_create_organization_owner_grant` hook: grants the creator an immediately-verified owner `OrgRepresentation` (via the shared `grant_owner_representation` from #1167) and, when an NPI is present, runs the Claim-B NPPES verification inline. Wired onto `ORGANIZATION_ENTITY` as `after_create_path`.
- `handle_org_create` (onboarding hub) now delegates to that same hook, so the hub and the directory create can't drift.

Previously a self-service org registered via `/organizations/form` got **no** owner authority and **no** NPI verification; both now run on the canonical path. Part of #1166.

## Test plan
- [x] Extended `test_create_organization_happy_path` to assert the owner rep is granted through the real spec wiring.
- [x] New handler tests: `after_create` grants the rep and skips NPPES without an NPI; runs NPPES (mocked) for the new org as the creating actor when an NPI is present.
- [x] Updated the org-create consumer contract pact to include the blank `npi=` field; `dev test contract` green (40 passed).
- [x] `dev test` — 2341 passed, 101 skipped. `dev lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)