### PR TITLE
feat: re-run NPI verification on canonical clinician update

### DIFF
--- a/src/domain/logic/clinicians/handlers.py
+++ b/src/domain/logic/clinicians/handlers.py
@@ -89,6 +89,38 @@ async def after_create_clinician_verification(
     await clinician_repo.session.refresh(row)
 
 
+async def after_update_clinician_verification(
+    *,
+    row: Clinician,
+    payload: BaseModel,
+    requesting_user: User,
+    changed_fields: set[str],
+    verification_repo: VerificationRepository,
+    clinician_repo: ClinicianRepository,
+    verification_audit_repo: AuditRepository,
+) -> None:
+    """Re-run NPI verification when a `PATCH /clinicians/{id}` changes the
+    clinician's `npi`.
+
+    Canonical replacement for the retired `POST /profile/clinician/{id}/identity`
+    retry flow: editing the NPI on the clinician's own page re-checks NPPES
+    instead of leaving the row stuck at its prior `npi_match_status`. Keyed
+    on the *value* changing (not merely being present in the payload), so an
+    edit that only touches location/availability doesn't fire a needless
+    NPPES lookup. Other edits are a no-op.
+    """
+    if "npi" not in changed_fields:
+        return
+    await after_create_clinician_verification(
+        row=row,
+        payload=payload,
+        requesting_user=requesting_user,
+        verification_repo=verification_repo,
+        clinician_repo=clinician_repo,
+        verification_audit_repo=verification_audit_repo,
+    )
+
+
 async def _assert_clinician_payload_org_ownership(
     *,
     payload: BaseModel,

--- a/src/domain/logic/clinicians/test_handlers.py
+++ b/src/domain/logic/clinicians/test_handlers.py
@@ -1038,3 +1038,65 @@ async def test_after_create_clinician_verification_no_npi_records_skipped(
         else:
             os.environ["LEIE_CSV_PATH"] = old_path
         oig_module._reset_cache_for_tests()
+
+
+# --- after_update_clinician_verification (re-verify on npi change) -------
+
+
+async def test_after_update_reverifies_when_npi_changed(monkeypatch):
+    """When `npi` is among the changed fields, the update hook delegates to
+    the NPI-verification pipeline. (The pipeline mechanics are covered by the
+    after_create DB test; this pins the change-gating + delegation.)"""
+    from types import SimpleNamespace
+    from uuid import uuid4
+
+    from src.domain.logic.clinicians import handlers as h
+
+    seen: dict = {}
+
+    async def _fake_verify(**kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr(h, "after_create_clinician_verification", _fake_verify)
+
+    row = SimpleNamespace(id=uuid4())
+    user = SimpleNamespace(id=uuid4())
+    await h.after_update_clinician_verification(
+        row=row,
+        payload=SimpleNamespace(),
+        requesting_user=user,
+        changed_fields={"npi", "first_name"},
+        verification_repo="vr",
+        clinician_repo="cr",
+        verification_audit_repo="ar",
+    )
+    assert seen.get("row") is row
+    assert seen.get("clinician_repo") == "cr"
+
+
+async def test_after_update_noop_when_npi_unchanged(monkeypatch):
+    """A non-NPI edit (e.g. location only) must NOT re-run NPI verification —
+    no needless NPPES lookup."""
+    from types import SimpleNamespace
+    from uuid import uuid4
+
+    from src.domain.logic.clinicians import handlers as h
+
+    called = False
+
+    async def _fake_verify(**kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(h, "after_create_clinician_verification", _fake_verify)
+
+    await h.after_update_clinician_verification(
+        row=SimpleNamespace(id=uuid4()),
+        payload=SimpleNamespace(),
+        requesting_user=SimpleNamespace(id=uuid4()),
+        changed_fields={"location_city", "location_state"},
+        verification_repo="vr",
+        clinician_repo="cr",
+        verification_audit_repo="ar",
+    )
+    assert called is False

--- a/src/domain/logic/verifications/README.md
+++ b/src/domain/logic/verifications/README.md
@@ -12,11 +12,12 @@ Persistence + pure-function primitives for the clinician verification pipeline. 
 - `handlers.py` — NPPES pipeline: `run_clinician_verification(...)`, `run_org_verification(...)`, and their admin-only retrigger wrappers. Composes the primitives with persistence + audit + an `httpx.AsyncClient`. The bespoke route lives at [`../../routes/verifications.py`](../../routes/verifications.py) and is wired into `src/main.py` next to the other hand-rolled routers.
 - `events.py` — `recompute_clinician_claim(clinician)`, `recompute_org_claim(org)`, and `record_verification_event(...)`. These three live outside the NPPES pipeline because they are called by `clinicians/handlers.py` and `org_representations/handlers.py` without any HTTP dependency. The recompute helpers are nearly pure (no I/O; they mutate their argument in place); `record_verification_event` is the single append-only writer for the non-NPPES §9 transitions.
 
-The pipeline orchestrators have three callers each:
+The pipeline orchestrators have these callers:
 
 1. **`after_create_clinician_verification`** in [`../clinicians/handlers.py`](../clinicians/handlers.py) (post-create hook wired to `CLINICIAN_ENTITY.after_create_path`; runs inline on `POST /clinicians` so the first Verification row lands in the same request as the row itself).
-2. **`submit_clinician_npi` / `submit_organization_npi`** in [`../../routes/verifications.py`](../../routes/verifications.py) (end-user NPI submission; the route runs the pipeline inline so the response carries the resolved state — see that file's docstring).
-3. **`handle_create_clinician_verification` / `handle_create_org_verification`** in `handlers.py` (admin retrigger; `actor_id=requesting_user.id`).
+2. **`after_update_clinician_verification`** in [`../clinicians/handlers.py`](../clinicians/handlers.py) (post-update hook wired to `CLINICIAN_ENTITY.after_update_path`; re-runs the pipeline inline on `PATCH /clinicians/{id}` **only when the `npi` value changes** — the canonical replacement for the retired profile identity-retry flow).
+3. **`submit_clinician_npi` / `submit_organization_npi`** in [`../../routes/verifications.py`](../../routes/verifications.py) (end-user NPI submission; the route runs the pipeline inline so the response carries the resolved state — see that file's docstring).
+4. **`handle_create_clinician_verification` / `handle_create_org_verification`** in `handlers.py` (admin retrigger; `actor_id=requesting_user.id`).
 
 There is no scheduled job — see [`../../../jobs/README.md`](../../../jobs/README.md) for the rationale (NPPES is fast enough to run inline; a worker buys polling and pending-state complexity in exchange for no real latency win).
 

--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -1792,3 +1792,81 @@ async def test_get_clinician_openings_404_for_missing_clinician(
     """A nonexistent clinician id 404s rather than rendering an empty list."""
     response = await authenticated_client.get(f"/clinicians/{uuid.uuid4()}/openings")
     assert response.status_code == 404
+
+
+async def test_patch_clinician_npi_change_reruns_verification(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """PATCH /clinicians/{id} changing `npi` re-runs NPPES verification via
+    the `after_update` hook — the canonical replacement for the retired
+    `POST /profile/clinician/{id}/identity` retry (#1166). `nppes_lookup` is
+    patched so no real HTTP fires; LEIE points at the fixture CSV."""
+    import os
+    from pathlib import Path
+    from unittest.mock import AsyncMock, patch
+
+    from src.domain.logic.verifications import oig as oig_module
+    from src.domain.logic.verifications.nppes import NppesResult
+
+    leie_fixture = (
+        Path(__file__).parent.parent
+        / "logic"
+        / "verifications"
+        / "test_data"
+        / "leie_sample.csv"
+    )
+    oig_module._reset_cache_for_tests()
+    old_path = os.environ.get("LEIE_CSV_PATH")
+    os.environ["LEIE_CSV_PATH"] = str(leie_fixture)
+    try:
+        clinician = make_clinician_with_org(
+            owner_id=logged_in_user.id,
+            npi="1111111111",
+            npi_match_status="mismatch",
+            first_name="Jane",
+            last_name="Smith",
+        )
+        clinician.clinician_verified = False
+        async with db_test_session_manager() as session:
+            async with session.begin():
+                session.add(clinician)
+        clinician_id = clinician.id
+
+        nppes_match = NppesResult(
+            found=True, first_name="Jane", last_name="Smith", raw={}
+        )
+        with patch(
+            "src.domain.logic.verifications.handlers.nppes_lookup",
+            new=AsyncMock(return_value=nppes_match),
+        ):
+            response = await authenticated_client.patch(
+                f"/clinicians/{clinician_id}",
+                data={"npi": "9999999999"},
+            )
+        assert response.status_code == 200
+
+        async with db_test_session_manager() as session:
+            loaded = await session.get(Clinician, clinician_id)
+            assert loaded.npi == "9999999999"
+            # Re-verification ran and resolved the new NPI as a match.
+            assert loaded.npi_match_status == "matched"
+            rows = (
+                (
+                    await session.execute(
+                        select(Verification).filter(
+                            Verification.clinician_id == clinician_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert any(r.event_type == "npi_resolved" for r in rows)
+    finally:
+        if old_path is None:
+            os.environ.pop("LEIE_CSV_PATH", None)
+        else:
+            os.environ["LEIE_CSV_PATH"] = old_path
+        oig_module._reset_cache_for_tests()

--- a/src/domain/specs/clinician.py
+++ b/src/domain/specs/clinician.py
@@ -163,6 +163,18 @@ CLINICIAN_ENTITY: Final[EntitySpec] = EntitySpec(
         ("clinician_repo", ClinicianRepository),
         ("verification_audit_repo", AuditRepository),
     ),
+    # Re-run NPI verification when a `PATCH /clinicians/{id}` changes `npi`
+    # (canonical replacement for the retired
+    # `POST /profile/clinician/{id}/identity` retry). Keyed on the value
+    # changing, so non-NPI edits don't trigger a needless NPPES lookup.
+    after_update_path=(
+        "src.domain.logic.clinicians.handlers.after_update_clinician_verification"
+    ),
+    after_update_repos=(
+        ("verification_repo", VerificationRepository),
+        ("clinician_repo", ClinicianRepository),
+        ("verification_audit_repo", AuditRepository),
+    ),
     # Clinician templates render credential-type display labels and the
     # tuples behind the filter/select dropdowns. Tying them to the spec
     # (instead of Jinja globals) means a new credential-type tuple

--- a/src/framework/dispatch/entity_spec.py
+++ b/src/framework/dispatch/entity_spec.py
@@ -560,6 +560,30 @@ class EntitySpec:
     after_create_path: str | None = None
     after_create_repos: tuple[tuple[str, type], ...] = ()
 
+    # `after_update_path` is the update-side mirror of `after_create_path`:
+    # a dotted path to an async callable `handle_update` invokes AFTER the
+    # row is patched and BEFORE the audit `after`-snapshot, inside the same
+    # `mutate(...)` block. Unlike the create hook it also receives
+    # `changed_fields: set[str]` — the column names whose value actually
+    # changed — so it can react to real changes (e.g. re-run verification
+    # only when `npi` differs).
+    #
+    #   async def hook(
+    #       *,
+    #       row: <model>,                   # the just-patched row
+    #       payload: BaseModel,             # the validated update payload
+    #       requesting_user: User,
+    #       changed_fields: set[str],
+    #       **typed_repos,                  # one kwarg per entry in after_update_repos
+    #   ) -> None:
+    #       ...
+    #
+    # Only fires on the non-polymorphic update path (the discriminator
+    # branch patches a detail row and is left alone); declaring it on a
+    # spec with a `discriminator` is rejected below.
+    after_update_path: str | None = None
+    after_update_repos: tuple[tuple[str, type], ...] = ()
+
     # Static context bindings -------------------------------------------
     # Constant key→value pairs that `handle_detail` / `handle_list` merge
     # into the template context after the framework's auto-injected keys
@@ -955,6 +979,26 @@ class EntitySpec:
                 f"EntitySpec({self.name!r}) declares after_create_repos but "
                 "no after_create_path — the typed-repo kwargs would have "
                 "no consumer."
+            )
+        # `after_update` only fires from `handle_update`'s non-polymorphic
+        # path; declaring it without `routes.update=True`, with leftover
+        # repos, or on a polymorphic spec is dead/unsupported config.
+        if self.after_update_path is not None and not self.routes.update:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares after_update_path but "
+                "routes.update is False — the hook would never run."
+            )
+        if self.after_update_repos and self.after_update_path is None:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares after_update_repos but "
+                "no after_update_path — the typed-repo kwargs would have "
+                "no consumer."
+            )
+        if self.after_update_path is not None and self.discriminator is not None:
+            raise ValueError(
+                f"EntitySpec({self.name!r}) declares after_update_path with a "
+                "discriminator — the polymorphic update path patches a detail "
+                "row and does not run the hook. Not supported."
             )
         if self.read_schema is not None:
             schema = self.read_schema

--- a/src/framework/dispatch/mounts/_factory.py
+++ b/src/framework/dispatch/mounts/_factory.py
@@ -59,6 +59,10 @@ class _FactoryShape:
     # signature params for each declared typed repo, and forwards both
     # to the underlying handler.
     after_create_call: bool = False
+    # Verbs that route through `after_update` (update only). Same plumbing
+    # as `after_create_call`, on the update shape. A shape uses one of
+    # `after_create_call` / `after_update_call`, never both.
+    after_update_call: bool = False
 
 
 _DELETE_SHAPE = _FactoryShape(
@@ -82,6 +86,7 @@ _UPDATE_SHAPE = _FactoryShape(
     include_parent_id=True,
     include_audit_repo=True,
     payload_authz_call=True,
+    after_update_call=True,
 )
 _EDIT_FORM_SHAPE = _FactoryShape(
     name_template="_handle_get_{name}_edit_form",
@@ -129,6 +134,8 @@ def _make_factory_handler(
     payload_authz_repos: tuple[tuple[str, type], ...] = (),
     after_create: Callable[..., Awaitable[None]] | None = None,
     after_create_repos: tuple[tuple[str, type], ...] = (),
+    after_update: Callable[..., Awaitable[None]] | None = None,
+    after_update_repos: tuple[tuple[str, type], ...] = (),
 ):
     """Build the wrapper the mount layer introspects and calls.
 
@@ -154,7 +161,13 @@ def _make_factory_handler(
     after_create_repo_names = (
         tuple(name for name, _ in after_create_repos) if shape.after_create_call else ()
     )
-    if shape.payload_authz_call or shape.after_create_call:
+    after_update_repo_names = (
+        tuple(name for name, _ in after_update_repos) if shape.after_update_call else ()
+    )
+    # The post-persist hook for this shape — `after_create` on the create
+    # shape, `after_update` on the update shape (never both).
+    after_hook_repo_names = after_create_repo_names + after_update_repo_names
+    if shape.payload_authz_call or shape.after_create_call or shape.after_update_call:
         reserved = {
             "payload",
             "repo",
@@ -166,24 +179,25 @@ def _make_factory_handler(
             reserved.add(parent_id_param)
         clashes = [
             n
-            for n in (*payload_authz_repo_names, *after_create_repo_names)
+            for n in (*payload_authz_repo_names, *after_hook_repo_names)
             if n in reserved
         ]
         if clashes:
             raise ValueError(
                 f"_make_factory_handler({spec.name!r}): payload_authz_repos / "
-                f"after_create_repos name(s) {clashes!r} collide with the "
-                "factory-generated signature params — pick distinct names."
+                f"after_create_repos / after_update_repos name(s) {clashes!r} "
+                "collide with the factory-generated signature params — pick "
+                "distinct names."
             )
         # Names must also not collide with each other (a single
         # `inspect.Parameter` per name).
         seen: set[str] = set()
-        for n in (*payload_authz_repo_names, *after_create_repo_names):
+        for n in (*payload_authz_repo_names, *after_hook_repo_names):
             if n in seen:
                 raise ValueError(
                     f"_make_factory_handler({spec.name!r}): repo name "
-                    f"{n!r} declared in both payload_authz_repos and "
-                    "after_create_repos — synthesize one slot, share it via "
+                    f"{n!r} declared in both payload_authz_repos and the "
+                    "after-hook repos — synthesize one slot, share it via "
                     "a single declaration."
                 )
             seen.add(n)
@@ -235,11 +249,14 @@ def _make_factory_handler(
     if shape.payload_authz_call:
         for name, repo_type in payload_authz_repos:
             sig_params.append(_param(name, repo_type))
-    if shape.after_create_call:
+    if shape.after_create_call or shape.after_update_call:
         # Skip names already added via `payload_authz_repos` — a spec
         # can reuse the same repo for both hooks; one slot is enough.
         existing = set(payload_authz_repo_names) if shape.payload_authz_call else set()
-        for name, repo_type in after_create_repos:
+        after_hook_repos = (
+            after_create_repos if shape.after_create_call else after_update_repos
+        )
+        for name, repo_type in after_hook_repos:
             if name in existing:
                 continue
             sig_params.append(_param(name, repo_type))
@@ -279,6 +296,11 @@ def _make_factory_handler(
             call_kwargs["after_create"] = after_create
             call_kwargs["after_create_kwargs"] = {
                 n: kwargs[n] for n in after_create_repo_names
+            }
+        if shape.after_update_call and after_update is not None:
+            call_kwargs["after_update"] = after_update
+            call_kwargs["after_update_kwargs"] = {
+                n: kwargs[n] for n in after_update_repo_names
             }
         return await handler_fn(spec, **call_kwargs)
 

--- a/src/framework/dispatch/mounts/entity.py
+++ b/src/framework/dispatch/mounts/entity.py
@@ -185,6 +185,13 @@ def mount_entity(
             "— pick one. The hook runs in the factory-built create path; "
             "an explicit create handler would silently bypass it."
         )
+    if entity.after_update_path is not None and "update" in handlers:
+        raise ValueError(
+            f"mount_entity({entity.name!r}): spec declares "
+            "after_update_path alongside an explicit handlers['update'] "
+            "— pick one. The hook runs in the factory-built update path; "
+            "an explicit update handler would silently bypass it."
+        )
 
     detail_extras = (
         resolve_dotted_path(entity, entity.detail_extras_path, "detail_extras_path")
@@ -209,6 +216,11 @@ def mount_entity(
     after_create = (
         resolve_dotted_path(entity, entity.after_create_path, "after_create_path")
         if entity.after_create_path is not None
+        else None
+    )
+    after_update = (
+        resolve_dotted_path(entity, entity.after_update_path, "after_update_path")
+        if entity.after_update_path is not None
         else None
     )
 
@@ -267,6 +279,8 @@ def mount_entity(
                 entity,
                 payload_authz=payload_authz,
                 payload_authz_repos=entity.payload_authz_repos,
+                after_update=after_update,
+                after_update_repos=entity.after_update_repos,
             )
         else:
             built = maker(entity)

--- a/src/framework/dispatch/mounts/test_update.py
+++ b/src/framework/dispatch/mounts/test_update.py
@@ -584,3 +584,135 @@ def test_make_update_handler_with_payload_authz_signature():
     sig = inspect.signature(handler)
     assert "organization_repo" in sig.parameters
     assert sig.parameters["organization_repo"].annotation is _StubOrgRepo
+
+
+# --- after_update hook ---------------------------------------------------
+
+
+class _StubVerifyRepo:
+    """Stand-in typed repo passed through `after_update_repos`."""
+
+
+@pytest.mark.asyncio
+async def test_update_invokes_after_update_with_changed_fields_and_repos():
+    """`after_update` is awaited with `row`, `payload`, `requesting_user`,
+    the typed repos, and `changed_fields` reflecting only columns whose
+    value actually changed (not merely fields present in the payload)."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_AnyRow,
+        audit=make_audit(),
+    )
+    repo = _update_fake_repo()
+    target_id = uuid4()
+    # `location_city` is set in the payload to its existing value, so it
+    # must NOT appear in changed_fields.
+    target = _AnyRow(id=target_id, practice_name="Old", location_city="SameCity")
+    repo.seed(_AnyRow, target)
+    audit_repo = FakeAuditRepo()
+    seen: dict[str, _Any] = {}
+    stub_repo = _StubVerifyRepo()
+
+    async def hook(*, row, payload, requesting_user, changed_fields, verify_repo):
+        seen["row"] = row
+        seen["payload"] = payload
+        seen["changed_fields"] = changed_fields
+        seen["verify_repo"] = verify_repo
+
+    await handle_update(
+        spec,
+        target_id=target_id,
+        payload=_UpdatePayload(practice_name="New", location_city="SameCity"),
+        repo=repo,
+        audit_repo=audit_repo,
+        requesting_user=make_user(),
+        after_update=hook,
+        after_update_kwargs={"verify_repo": stub_repo},
+    )
+
+    assert seen["row"] is target
+    assert seen["verify_repo"] is stub_repo
+    # practice_name changed Old→New; location_city was set but unchanged.
+    assert seen["changed_fields"] == {"practice_name"}
+
+
+@pytest.mark.asyncio
+async def test_update_skips_after_update_when_not_supplied():
+    """`after_update=None` is the default — the update path still patches."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_AnyRow,
+        audit=make_audit(),
+    )
+    repo = _update_fake_repo()
+    target_id = uuid4()
+    repo.seed(_AnyRow, _AnyRow(id=target_id, practice_name="Old"))
+    await handle_update(
+        spec,
+        target_id=target_id,
+        payload=_UpdatePayload(practice_name="New"),
+        repo=repo,
+        audit_repo=FakeAuditRepo(),
+        requesting_user=make_user(),
+    )
+    assert repo.patched[0][1] == {"practice_name": "New"}
+
+
+@pytest.mark.asyncio
+async def test_update_after_update_exception_rolls_back_transaction():
+    """If `after_update` raises, the `mutate(...)` block rolls back — no
+    audit row is written."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_AnyRow,
+        audit=make_audit(),
+    )
+    repo = _update_fake_repo()
+    target_id = uuid4()
+    repo.seed(_AnyRow, _AnyRow(id=target_id, practice_name="Old"))
+    audit_repo = FakeAuditRepo()
+
+    async def hook(*, row, payload, requesting_user, changed_fields):
+        raise ValueError("after_update rejected this row")
+
+    with pytest.raises(ValueError, match="after_update rejected"):
+        await handle_update(
+            spec,
+            target_id=target_id,
+            payload=_UpdatePayload(practice_name="New"),
+            repo=repo,
+            audit_repo=audit_repo,
+            requesting_user=make_user(),
+            after_update=hook,
+        )
+    assert audit_repo.calls == []
+
+
+def test_make_update_handler_with_after_update_signature():
+    """Synthesized update-handler signature includes declared
+    `after_update_repos` kwargs as typed params."""
+    spec = EntitySpec(
+        name="widget",
+        url_collection="widgets",
+        id_param="widget_id",
+        model=_AnyRow,
+        audit=make_audit(),
+    )
+
+    async def hook(**_kw):  # pragma: no cover
+        return None
+
+    handler = make_update_handler(
+        spec,
+        after_update=hook,
+        after_update_repos=(("verify_repo", _StubVerifyRepo),),
+    )
+    sig = inspect.signature(handler)
+    assert "verify_repo" in sig.parameters
+    assert sig.parameters["verify_repo"].annotation is _StubVerifyRepo

--- a/src/framework/dispatch/mounts/update.py
+++ b/src/framework/dispatch/mounts/update.py
@@ -106,6 +106,8 @@ async def handle_update(
     parent_id: UUID | None = None,
     payload_authz: Callable[..., Awaitable[None]] | None = None,
     payload_authz_kwargs: dict[str, Any] | None = None,
+    after_update: Callable[..., Awaitable[None]] | None = None,
+    after_update_kwargs: dict[str, Any] | None = None,
 ) -> Any:
     """Generic update handler driven by `spec`.
 
@@ -113,7 +115,15 @@ async def handle_update(
     and AFTER `write_authz` has run on parent-or-target, and BEFORE the
     payload is consumed (discriminator dispatch / patch). When the
     target 404s, the hook is never called — the 404 fires first. See
-    `EntitySpec.payload_authz_path` for the contract."""
+    `EntitySpec.payload_authz_path` for the contract.
+
+    `after_update` (if supplied) is invoked AFTER the row is patched and
+    BEFORE the audit `after`-snapshot, inside the same `mutate(...)`
+    block (raises roll back the whole update). It receives `row=`,
+    `payload=`, `requesting_user=`, `changed_fields=` (the set of column
+    names whose value actually changed) and `**after_update_kwargs`. Only
+    fires on the non-polymorphic update path — see
+    `EntitySpec.after_update_path`."""
     if spec.audit is None:
         raise ValueError(
             f"handle_update: spec {spec.name!r} has no audit binding; "
@@ -188,6 +198,13 @@ async def handle_update(
         return target
 
     update_fields = payload.model_dump(exclude_unset=True)
+    # Compute which columns actually change *before* the patch so an
+    # `after_update` hook can react to real value changes (e.g. re-run
+    # verification only when `npi` differs), not merely to a field being
+    # present in the payload.
+    changed_fields = {
+        f for f, v in update_fields.items() if getattr(target, f, None) != v
+    }
     async with mutate(
         repo,
         audit_repo,
@@ -197,6 +214,14 @@ async def handle_update(
         verb="update",
     ):
         await repo.patch(target, **update_fields)
+        if after_update is not None:
+            await after_update(
+                row=target,
+                payload=payload,
+                requesting_user=requesting_user,
+                changed_fields=changed_fields,
+                **(after_update_kwargs or {}),
+            )
     return target
 
 
@@ -205,6 +230,8 @@ def make_update_handler(
     *,
     payload_authz: Callable[..., Awaitable[None]] | None = None,
     payload_authz_repos: tuple[tuple[str, type], ...] = (),
+    after_update: Callable[..., Awaitable[None]] | None = None,
+    after_update_repos: tuple[tuple[str, type], ...] = (),
 ):
     from src.framework.dispatch.mounts._factory import (
         _UPDATE_SHAPE,
@@ -217,4 +244,6 @@ def make_update_handler(
         handle_update,
         payload_authz=payload_authz,
         payload_authz_repos=payload_authz_repos,
+        after_update=after_update,
+        after_update_repos=after_update_repos,
     )


### PR DESCRIPTION
## Summary
Adds a general **`after_update`** spec hook (the update-side mirror of `after_create`) to the dispatch framework, and wires it on the clinician so editing NPI re-runs verification.

- `EntitySpec.after_update_path` + `after_update_repos`, plumbed through `_factory` / `entity` / `handle_update` exactly like `after_create`. The hook runs inside the update's `mutate(...)` block and uniquely receives **`changed_fields`** — the columns whose value actually changed — so it reacts to real changes, not mere field presence. Guarded to the non-polymorphic update path (rejected on a spec with a `discriminator`).
- `CLINICIAN_ENTITY.after_update_path` → `after_update_clinician_verification`: re-runs the NPPES pipeline when `PATCH /clinicians/{id}` changes `npi`. A non-NPI edit (location/availability) triggers no lookup.

This restores, on the clinician's own canonical page, the NPI-mismatch **retry** that #1171 removed from `/profile/identity` — closing the first of that PR's two accepted regressions. Part of #1166.

## Test plan
- [x] Framework (`test_update.py`): `after_update` fires with `row`/`payload`/`changed_fields`/repos; `changed_fields` excludes a field set to its existing value; `after_update=None` still patches; an exception rolls back the `mutate` block; synthesized signature includes `after_update_repos`.
- [x] Handler unit tests: re-verifies when `npi` in `changed_fields`; no-op otherwise.
- [x] Route e2e: `PATCH /clinicians/{id}` changing `npi` (NPPES mocked) produces an `npi_resolved` Verification and flips `npi_match_status` to `matched`.
- [x] `dev test` — 2348 passed, 101 skipped. `dev lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)