### PR TITLE
Unify top chrome into one fixed-boundary page-header band

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -178,6 +178,19 @@ async def test_home_renders_post_ctas_when_claim_a_verified(
     assert "+ Post a referral" in response.text
     assert "+ Post an opening" in response.text
 
+    # The post CTAs ride the unified page-header toolbar (not an inline
+    # content section): each active create link is a `<li>` inside the
+    # band's `menu.toolbar-right`, and the page title is the band's H1.
+    tree = HTMLParser(response.text)
+    h1 = tree.css_first("header.page-header div.toolbar h1")
+    assert h1 is not None and h1.text(strip=True) == "Home"
+    cta_labels = {
+        li.text(strip=True)
+        for li in tree.css("header.page-header menu.toolbar-right li")
+        if li.text(strip=True).startswith("+ Post")
+    }
+    assert cta_labels == {"+ Post a referral", "+ Post an opening"}
+
 
 async def test_home_shows_locked_post_actions_for_claim_b_only_org_rep(
     authenticated_client: AsyncClient,

--- a/src/domain/routes/test_profile.py
+++ b/src/domain/routes/test_profile.py
@@ -45,6 +45,26 @@ async def test_profile_hub_links_identity_row_to_step_subroute(
     assert link.attributes.get("href") == "/profile/identity"
 
 
+async def test_profile_hub_title_and_mode_line_flow_through_page_header(
+    authenticated_client: AsyncClient,
+):
+    """The Profile hub routes its title + mode line through the unified
+    page-header slots instead of a hand-rolled `<header>`: the title is the
+    band's toolbar `<h1>`, and the mode-dependent line renders below the
+    band's rule as the subtitle `<small class="meta">`. Pins the outlier
+    migration so a regression back to inline `<header><h1>` is caught."""
+    response = await authenticated_client.get("/profile")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    h1 = tree.css_first("header.page-header div.toolbar h1")
+    assert h1 is not None and h1.text(strip=True) == "Profile"
+    # Setup-mode subtitle renders in the meta slot (top of <main>, below
+    # the band's rule), not inside the header band.
+    subtitle = tree.css_first("main small.meta")
+    assert subtitle is not None
+    assert "Complete these steps" in subtitle.text(strip=True)
+
+
 async def test_profile_identity_step_renders_dispatching_picker(
     authenticated_client: AsyncClient,
 ):

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -2,34 +2,44 @@
 {%- from "_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {%- from "_shared/_locked.html" import locked_action -%}
+{%- from "_shared/_toolbar.html" import page_toolbar -%}
 {%- macro _no_poster_row(post) %}{{ post_feed_row(post, show_poster=False) }}{%- endmacro -%}
   {% block title %}Home{% endblock %}
-  {% block content %}
-    {# Home per handoff §8.2. The post-action row shows only once the user
-       holds at least one claim: a posting-capable user (Claim A) gets
-       active create links; a Claim-B-only org rep gets the same actions
-       DISABLED with the unlock path (`locked_action`), since that's their
-       only signal — the chrome banner is silent for them (onboarding
-       complete). A *no-claim* user is suppressed here entirely: the single
-       chrome `#onboarding-banner` (base.html) is their one finish-setup
-       nudge, so a per-page card or locked-button repeat would be the exact
-       redundancy that banner replaced. The server's
-       `_assert_post_payload_authz` is the real gate; a disabled button
-       leaks nothing. `can_post` is derived once in `base_context()` —
-       don't re-derive from raw `claims.*`. #}
-    {% if claims.a or claims.b %}
-      <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
-        {% if can_post %}
+  {# Home title + post actions ride the unified page-header toolbar. The
+     active create links appear only for a posting-capable user (`can_post`).
+     A Claim-B-only org rep (holds a claim but can't post yet) keeps the
+     DISABLED locked controls — but those are a two-line affordance that
+     can't sit in the single-row band, so they stay in `{% block content %}`
+     below. A *no-claim* user gets neither: the chrome `#onboarding-banner`
+     (base.html) is their one finish-setup nudge. The server's
+     `_assert_post_payload_authz` is the real gate; a disabled button leaks
+     nothing. `can_post` is derived once in `base_context()` — don't
+     re-derive from raw `claims.*`. #}
+  {% block toolbar %}
+    {% call page_toolbar(heading="Home") %}
+      {% if can_post %}
+        <li>
           <a href="{{ entity_form_url('post') }}?kind=referral"
              role="button"
              class="outline">+ Post a referral</a>
+        </li>
+        <li>
           <a href="{{ entity_form_url('post') }}?kind=clinician_opening"
              role="button"
              class="outline">+ Post an opening</a>
-        {% else %}
-          {{ locked_action(capabilities.REASON_CLAIM_A_UNVERIFIED, "+ Post a referral") }}
-          {{ locked_action(capabilities.REASON_CLAIM_A_UNVERIFIED, "+ Post an opening") }}
-        {% endif %}
+        </li>
+      {% endif %}
+    {% endcall %}
+  {% endblock %}
+  {% block content %}
+    {# Claim-B-only org rep: the locked create controls are their only
+       signal (the chrome banner is silent once onboarding is complete).
+       Suppressed for a posting-capable user (actions are in the toolbar
+       above) and for a no-claim user (covered by the chrome banner). #}
+    {% if (claims.a or claims.b) and not can_post %}
+      <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
+        {{ locked_action(capabilities.REASON_CLAIM_A_UNVERIFIED, "+ Post a referral") }}
+        {{ locked_action(capabilities.REASON_CLAIM_A_UNVERIFIED, "+ Post an opening") }}
       </section>
     {% endif %}
     {% if can_post %}

--- a/src/domain/templates/profile/hub.html
+++ b/src/domain/templates/profile/hub.html
@@ -1,20 +1,25 @@
 {% extends "base.html" %}
+{%- from "_shared/_toolbar.html" import page_toolbar -%}
 {% block title %}Profile{% endblock %}
+{# Profile title + mode line flow through the unified page-header slots:
+   the title via the toolbar `<h1>`, the mode-dependent line via the
+   subtitle slot (rendered below the band's rule as muted meta text). #}
+{% block toolbar %}
+  {% call page_toolbar(heading="Profile") %}
+  {% endcall %}
+{% endblock %}
+{% block subtitle %}
+  {% if mode == "setup" %}
+    Complete these steps to start posting and see full referral details.
+  {% elif mode == "manage" %}
+    Manage your verification claims and profile.
+  {% elif mode == "add-a-claim" %}
+    Add a capability to your account.
+  {% elif mode == "re-verify" %}
+    Something needs your attention.
+  {% endif %}
+{% endblock %}
 {% block content %}
-  <header>
-    <h1>Profile</h1>
-    <p style="color: var(--pico-muted-color); margin-top: -0.25rem;">
-      {% if mode == "setup" %}
-        Complete these steps to start posting and see full referral details.
-      {% elif mode == "manage" %}
-        Manage your verification claims and profile.
-      {% elif mode == "add-a-claim" %}
-        Add a capability to your account.
-      {% elif mode == "re-verify" %}
-        Something needs your attention.
-      {% endif %}
-    </p>
-  </header>
   {# Registry-driven setup table of contents. In setup mode this *is* the
      page: it lists the onboarding steps and links each incomplete one to
      its own subroute (`/profile/email`, `/profile/identity`), where the

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -338,20 +338,80 @@ dd { margin: 0; }
   align-items: center;
   gap: 0.75rem;
 }
+/* The H1 is the `minmax(0, 1fr)` cell, so it must be allowed to shrink
+   (`min-width: 0`) and truncate (`white-space: nowrap` + `overflow` +
+   `text-overflow: ellipsis`) rather than wrap to a second line and push
+   the band's boundary down. The `auto` actions cell keeps its single
+   row beside it. */
+.toolbar h1 {
+  /* Explicitly pinned to row 1 / col 1 so it overlaps the hidden reserve
+     button (also at 1/1) instead of being pushed to a second row by
+     auto-placement. The actions cell still auto-flows — to col 2 on
+     desktop, to row 2 on the ≤640px single-column stack. */
+  grid-row: 1;
+  grid-column: 1;
+  min-width: 0;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 /* Pico's default `<button>` is `display: block; width: 100%`
    (form-shaped); the toolbar overrides to natural-width inline
    buttons. Reaches every nested `<button>` / `[role="button"]`
    regardless of whether it lives in a form, menu, or `<li>`. */
 .toolbar button, .toolbar [role="button"] { width: auto; margin: 0; }
+/* Action-row height reservation. The hidden reserve button shares the
+   H1's grid cell (`grid-area: 1 / 1`) so the toolbar row is always one
+   real-button tall — the band boundary lands at the same Y on pages with
+   and without actions. Hidden and removed from interaction; its only job
+   is to contribute the button's intrinsic height. */
+.toolbar-reserve {
+  grid-row: 1;
+  grid-column: 1;
+  visibility: hidden;
+  pointer-events: none;
+}
+/* The actions cell never wraps among itself and never shrinks — it keeps
+   its single row so the band stays one row tall and the boundary rule
+   doesn't get pushed down. The H1 (the flexible grid cell) ellipsizes
+   instead. The intentional ≤640px stacking (whole actions cell drops
+   below the heading, atomically) lives in the grid media query and is
+   unaffected. */
 .toolbar-actions {
   display: flex;
   align-items: center;
   gap: 0.75rem;
   justify-content: flex-end;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
 }
 .toolbar-filter-link { min-width: 0; }
-.toolbar-right { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+.toolbar-right { display: flex; flex-wrap: nowrap; align-items: center; gap: 0.5rem; }
+/* Mobile: the toolbar collapses to a single column so the whole actions
+   cell drops below the heading atomically (the heading keeps its own
+   row; the filter link + action menu move to the next row together). The
+   actions never wrap *among themselves* at any width (`nowrap` above);
+   this is the page-level stack, not an intra-cluster wrap. The band's
+   height grows by one row on mobile — that's the intended intrinsic
+   change across screen sizes, and it stays identical across pages at a
+   given size because the heading row is always one (ellipsized) line. */
+@media (max-width: 640px) {
+  .toolbar { grid-template-columns: 1fr; }
+}
+/* Page-header band — the single fixed top-chrome element
+   (`_shared/_page_header.html`). Stacks nav → breadcrumb row → toolbar
+   row → boundary rule. The rule is the page's one horizontal divider and
+   sits at a constant Y across pages at a given screen size (see the
+   partial's header for the reservation rationale). */
+.page-header { display: flex; flex-direction: column; }
+.page-header-crumb { margin-block-start: 0.25rem; }
+/* Reserve the breadcrumb row's intrinsic height on pages without a real
+   breadcrumb (list pages): the placeholder is a real back-affordance
+   shape, hidden — so the reserved height equals a rendered breadcrumb's
+   and the rule lines up with detail pages. No size unit is pinned. */
+.page-header-crumb-placeholder { visibility: hidden; }
+.page-header-rule { margin-block: var(--pico-spacing) 0; }
 /* `<menu>` is HTML's native "list of commands" element — used
    by the page toolbar (`menu.toolbar`, `menu.toolbar-right`)
    and any in-row action cluster (e.g. the users-table Actions
@@ -514,6 +574,12 @@ legend { font-size: 0.8em; text-transform: uppercase; letter-spacing: 0.06em; co
   align-items: center;
   gap: 1rem;
   padding-block: 0.5rem;
+  /* Positioning context for the mobile menu's absolutely-positioned
+     dropdown (`#nav-menu[open] > ul`, below). Scoped to the nav rather
+     than the whole `.page-header` band so the menu drops directly under
+     the nav row (`top: 100%`) instead of below the breadcrumb + toolbar
+     + rule that now share the band. */
+  position: relative;
 }
 /* Primary nav hamburger — strip Pico's built-in chevron */
 .nav-menu-toggle { list-style: none; margin-bottom: 0; }
@@ -531,9 +597,9 @@ legend { font-size: 0.8em; text-transform: uppercase; letter-spacing: 0.06em; co
   #nav-menu { flex: 1; display: flex; }
   #nav-menu > ul { list-style: none; padding: 0; margin: 0 0 0 auto; gap: 1rem; display: flex; }
 }
-/* Mobile: hamburger shows, open menu covers full screen below nav */
+/* Mobile: hamburger shows, open menu covers full screen below nav.
+   The positioning context lives on `#primary-nav` (above), not here. */
 @media (max-width: 640px) {
-  header.container { position: relative; }
   #nav-menu:not([open]) .nav-menu-close-icon { display: none; }
   #nav-menu[open] .nav-menu-open-icon { display: none; }
   #nav-menu[open] > ul {

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -4,8 +4,8 @@ The framework's template root holds the domain-agnostic pieces: the site shell, 
 
 ```
 src/framework/templates/
-├── base.html         ← every page extends this. HTMX setup + primary nav + chrome strips.
-├── _shared/          ← cross-resource macros (form fields, table chrome, breadcrumb/toolbar primitives, etc.).
+├── base.html         ← every page extends this. HTMX setup + the unified page-header band + content/footer slots.
+├── _shared/          ← cross-resource macros + partials (form fields, table chrome, breadcrumb/toolbar primitives, the `_page_header.html` band, etc.).
 └── views/            ← generic view-type chrome: list, detail, form_new, form_edit.
 ```
 
@@ -30,7 +30,7 @@ A template under `<resource>/` in either root may only `{% extends %}` / `{% inc
 
 ## Generic view-type templates (`views/`)
 
-Each view-type template wires the same three-strip chrome (nav + breadcrumb + toolbar + content) from `base.html` with the breadcrumb and toolbar shape that matches the verb. A child template extending one of these declares only what's unique: a label, a URL, the body markup, and an optional action cluster.
+Each view-type template fills the same unified page-header band (nav + breadcrumb + toolbar + boundary rule, see "Page chrome contract" below) from `base.html` with the breadcrumb and toolbar shape that matches the verb. A child template extending one of these declares only what's unique: a label, a URL, the body markup, and an optional action cluster.
 
 | View type     | Breadcrumb back target                    | Toolbar                                    | Child must declare                                       |
 | ------------- | ----------------------------------------- | ------------------------------------------ | -------------------------------------------------------- |
@@ -56,21 +56,29 @@ The macros under `_shared/` are still the primitives — `views/*` compose them.
 
 ## Page chrome contract
 
-Every page extending `base.html` lands the same three-strip chrome above its content. From top to bottom:
+Every page extending `base.html` lands the same unified page-header **band** — a single `<header class="page-header">` ([`_shared/_page_header.html`](_shared/_page_header.html)) that stacks the chrome rows and closes with **one** horizontal rule. The rule is the page's only divider and sits at the **same Y on every app page at a given screen size**. Two rows are reserved to make that true, both intrinsically (no pinned size units, so the boundary still changes across screen sizes):
+
+- **Breadcrumb row** — pages with no real breadcrumb (list pages) get an invisible back-affordance placeholder (`.page-header-crumb-placeholder`, `visibility: hidden`), so a list page's rule lines up with a detail page's.
+- **Toolbar action row** — a button is taller than the bare `<h1>`, so a hidden non-interactive reserve `<button class="toolbar-reserve">` shares the H1's grid cell on every toolbar; the row is always one real-button tall whether or not the page has actions. The actions cell still auto-flows (to col 2 on desktop, to row 2 in the ≤640px stack — where actions-below-heading is the intended layout).
+
+From top to bottom:
 
 ```
 ┌───────────────────────────────────────────────────────────┐
-│ <header> primary nav        brand + auth-aware right slot │  ← `base.html`
+│ <header class="page-header">                              │  ← `_shared/_page_header.html`
+│   primary nav        brand + auth-aware links             │
+│   breadcrumb row     ← Resource   (hidden placeholder if none) │  ← captured `{% block breadcrumb %}`
+│   toolbar row        <h1> title              [actions ▶]  │  ← captured `{% block toolbar %}`
+│   ─────────────────────────────────────────────────────  │  ← single `<hr class="page-header-rule">`
 ├───────────────────────────────────────────────────────────┤
-│ breadcrumb zone bar          Resource › … › Current        │  ← `{% block breadcrumb %}` (detail/form pages only)
-├───────────────────────────────────────────────────────────┤
-│ toolbar / action bar         [filters left]    [actions ▶] │  ← `{% block toolbar %}`
-├───────────────────────────────────────────────────────────┤
+│ subtitle (optional)  NPI · Verified                       │  ← `{% block subtitle %}` (rendered below the rule, top of `<main>`)
 │ page content                                              │  ← `{% block content %}`
 ├───────────────────────────────────────────────────────────┤
 │ <footer> site chrome           &copy; … · support@ …      │  ← `{% block footer %}` (default body in `base.html`)
 └───────────────────────────────────────────────────────────┘
 ```
+
+`{% include %}` can't see the including template's blocks, so `base.html` captures the `breadcrumb` / `toolbar` / `subtitle` block output into context vars and hands the pre-rendered HTML to the band partial. Children still just override `{% block breadcrumb %}` / `{% block toolbar %}` / `{% block subtitle %}` — the capture indirection is transparent. The band's lower rows + rule render only when there's app chrome to show (any breadcrumb/toolbar content, or an authenticated viewer), so anonymous public pages (landing, the `/auth/*` flow) keep their bare brand nav with no rule.
 
 **Body layout.** `<header>`, `<main>`, and `<footer>` are direct siblings of `<body>`, and `<body>` is a three-row CSS grid (`grid-template-rows: auto 1fr auto`) sized to `min-height: 100dvh`. Short pages pin the footer to the viewport bottom instead of leaving it floating; tall pages flow normally and push the footer below. The landing page reuses this scaffold to vertically center its hero inside the `<main>` row (see [`../../domain/templates/landing.html`](../../domain/templates/landing.html)).
 
@@ -90,7 +98,7 @@ The active tab carries `aria-current="page"` plus `class="contrast"`, and `base.
 | Resource edit    | `/posts/{id}/form`             | `Posts › Post › Edit`                 |
 | Subresource list | `/users/{id}/clinicians`        | `Users › <username> › Clinicians`      |
 
-Every prior segment is a link (`<a href="…">`); the trailing segment is the current page (no `href`, gets `aria-current="page"`). Single-segment list breadcrumbs are still wrapped in the nav so the chrome strip is present and the strip height stays consistent across pages.
+Every prior segment is a link (`<a href="…">`); the trailing segment is the current page (no `href`, gets `aria-current="page"`). List pages render no breadcrumb at all; the band reserves the breadcrumb row with a hidden placeholder (`.page-header-crumb-placeholder`) so the boundary rule still lines up with detail/form pages — the strip height stays consistent across pages without a stray single-segment trail.
 
 Public auth-flow pages (`/auth/login`, `/auth/register`, …) opt out — they aren't in the resource hierarchy.
 
@@ -113,7 +121,7 @@ Files prefixed with `_` (e.g. `_breadcrumb.html`, `_toolbar.html`, `_credential_
 - `_card.html` — `card(id, headline_url, headline, subtitle=None, data_kind=None)`: the universal list-item card. Every `/<collection>` list page wraps its items in this macro and provides the per-resource body (and optional `<footer>`) via `{% call %}`. The card emits an `<article class="entity-card" data-row-id="…">` with a header band carrying the headline link and an optional `<small class="meta">` subtitle. Tests select rows by `article[data-row-id="…"]`. Fact-row bodies use a `<section class="entity-facts">` containing a `<dl>` of `<div data-fact="key">` rows so tests resolve fact cells via `div[data-fact="…"] dd` rather than the display-string `<dt>` text. The post family's `posts/_shared/_item.html` composes `card` + `_facts_block` for its kind-specific body; non-post lists call `card` directly with an inline `<section class="entity-facts">`.
 - `_clinician_card.html` — `clinician_card(clinician)`: the shared clinician directory card, used by `/clinicians`, `/users/me/favorites`, `/users/{id}/clinicians`, and the embedded preview on `/users/{id}`. Headline is `"{first_name} {last_name}"` (falls back to whichever is set, then to the literal `"Unnamed clinician"`), linked to `/clinicians/{id}`. Body emits Practice / Location / Licensed in / Insurance fact rows. Lives at the framework level (not under the clinicians cluster) because four templates across three clusters render it; cross-cluster template imports aren't allowed (see the layering rule).
 - `_feed_row.html` — `post_feed_row(post, show_poster=True)` and `post_feed_empty(message, link_href=None, link_label=…)`: the description-led feed row + empty state for `Post` lists. Emits `<article class="post-feed-row" data-kind="…">` (type-tag pill · poster · timestamp, full-width headline link, muted meta strip); `post_feed_empty` emits `<article class="post-feed-empty">`. Reads the `post_card_view` / `post_feed_headline` template globals and the `can_read_full_feed` context flag. Rendered by the home feed (`home.html`), `/posts` (`posts/list.html`), and the per-owner projections (`/clinicians/{id}/openings`, `/clinicians/{id}/referrals`, `/organizations/{id}/intakes`). Lives at the framework level — same rationale as `_clinician_card.html`: it's rendered across the posts, home, clinicians, and organizations clusters, and cross-cluster template imports aren't allowed.
-- `_toolbar.html` — `page_toolbar(active_filters=(), search_url=None)`: the toolbar shell that both `views/list.html` and `views/detail.html` compose. Emits a right-aligned `<div class="toolbar">` strip with up to two pieces — a filter link `<a class="toolbar-filter-link">` (omitted when `search_url` is `None`, as on detail pages) and the action `<menu class="toolbar-right">` (caller body is `<li>` items). The filter link reads ``Filters`` when none are active and collapses to a two-chip-plus-`+N` summary otherwise. There is no in-toolbar Clear-all — the search page's form owns clearing. On list pages the context comes from `handle_list` (`active_filters`, `search_url`); detail pages pass no args.
+- `_toolbar.html` — `page_toolbar(active_filters=(), search_url=None)`: the toolbar shell that both `views/list.html` and `views/detail.html` compose. Emits a right-aligned `<div class="toolbar">` strip with up to two pieces — a filter link `<a class="toolbar-filter-link">` (omitted when `search_url` is `None`, as on detail pages) and the action `<menu class="toolbar-right">` (caller body is `<li>` items). The macro emits **no** separator — the single boundary rule below the toolbar is owned by the page-header band (`_page_header.html`). The filter link reads ``Filters`` when none are active and collapses to a two-chip-plus-`+N` summary otherwise. There is no in-toolbar Clear-all — the search page's form owns clearing. On list pages the context comes from `handle_list` (`active_filters`, `search_url`); detail pages pass no args.
 - `_picker.html` — `picker(options)`: the "choose your path" card grid. Each option is a dict of `href` / `heading` / `description`; the macro emits a `<div class="picker">` grid wrapping one `<a class="picker-option"><hgroup><h2>…</h2><p>…</p></hgroup></a>` card per option. The `.picker` / `.picker-option` styling lives in `framework.css` — bordered cards with a link-coloured heading and muted (non-underlined) description, so the chooser reads as the page's primary action rather than a stack of underlined links. Two usages, one component: a *discriminator/type picker* funnels to a kind-/type-specific sub-form of the **same** resource via a selecting query param (`/posts/form` `?kind=`, `/organizations/form` `?type=`); a *dispatching picker* points its cards at **other** resources' create forms (`/profile/identity` → `/clinicians/form` and `/organizations/form`). The macro only takes `{href, heading, description}` — self- vs cross-resource hrefs are the caller's business. Extracted from the posts pattern (#704).
 - `pagination.html` — `pagination(page_meta, paginator_base_query)`: Prev / Page N / Next footer rendered automatically by `views/list.html` after the `{% block content %}`. Reads the `Page` snapshot from [`../dispatch/pagination.py`](../dispatch/pagination.py) (set by `handle_list` and the bespoke list handlers) and emits nothing when the result fits on a single page. `paginator_base_query` is the request's query string with `page=` stripped, so the Prev/Next links round-trip filter state across page navigation.
 
@@ -148,4 +156,5 @@ Handlers pass only resource-specific data. Chrome scalars (`is_authenticated`, `
 ## Tests
 
 - `test_views.py` (colocated): renders each view-type template via stub child templates and pins the breadcrumb / toolbar / content contract. A regression in the chrome wiring is caught here even before any domain page is changed.
+- `test_page_header.py` (colocated): pins the unified band — the toolbar `<h1>` and breadcrumb render *inside* `header.page-header`, list pages reserve the breadcrumb row with a hidden placeholder, exactly one `<hr>` lives in the band (none in `<main>`), plus CSS-regex pins for the no-wrap / truncation / reserved-placeholder rules.
 - Per-entity rendering is exercised indirectly via route tests under [`../../domain/routes/`](../../domain/routes/). Selector conventions for template tests live in [`../../../tests/README.md`](../../../tests/README.md).

--- a/src/framework/templates/_shared/_page_header.html
+++ b/src/framework/templates/_shared/_page_header.html
@@ -1,0 +1,86 @@
+{# Unified page-header band — the app's permanent top chrome.
+
+Renders one `<header class="container page-header">` whose rows, top to
+bottom, are: primary nav → breadcrumb slot → page-title/toolbar slot →
+a single `<hr class="page-header-rule">` boundary. The rule sits at the
+same Y on every app page at a given screen size: the breadcrumb row is
+reserved with an invisible intrinsic-height placeholder when a page has
+no real breadcrumb (list pages), so a list page's rule lines up with a
+detail page's. The reserved height is content-derived (a real
+back-affordance shape, hidden via `visibility: hidden`), never pinned
+with a CSS size unit — so it changes across screen sizes but is
+identical across pages at one size.
+
+`{% include %}` can't see the including template's `{% block %}`s, so
+`base.html` captures the breadcrumb / toolbar block output into context
+vars and this partial renders them as pre-rendered HTML. The partial
+inherits the caller's context, so `_on_home` / `_on_posts` /
+`_on_profile` / `is_authenticated` resolve normally.
+
+The band's lower rows (breadcrumb + toolbar + rule) render only when
+there's app chrome to show — any breadcrumb or toolbar content, or an
+authenticated viewer. Anonymous public pages (landing, the `/auth/*`
+flow) thus keep their bare brand nav with no rule, while every
+authenticated app page gets the full constant-boundary band.
+
+Required context (set by `base.html` before the include):
+  _breadcrumb_html — rendered `{% block breadcrumb %}` output (may be empty)
+  _toolbar_html    — rendered `{% block toolbar %}` output (may be empty)
+  is_authenticated, _on_home, _on_posts, _on_profile — nav state
+
+See `templates/README.md` § "Page chrome contract" for the slot list
+and the constant-boundary rationale (one source of truth).
+#}
+<header class="container page-header">
+  <nav aria-label="Primary" id="primary-nav">
+    <a href="/"><strong>Bedlam Connect</strong></a>
+    {% if is_authenticated %}
+      <details id="nav-menu">
+        <summary class="nav-menu-toggle" aria-label="Menu">
+          <i class="icon-menu nav-menu-open-icon"></i>
+          <i class="icon-x nav-menu-close-icon"></i>
+        </summary>
+        <ul>
+          <li>
+            <a href="/home" {% if _on_home %}aria-current="page"{% endif %}>Home</a>
+          </li>
+          <li>
+            <a href="{{ entity_url('post') }}"
+               {% if _on_posts %}aria-current="page"{% endif %}>Posts</a>
+          </li>
+          <li>
+            <a href="/profile" {% if _on_profile %}aria-current="page"{% endif %}>Profile</a>
+          </li>
+          <li>
+            <a href="#" hx-post="/auth/sign-out">Sign out</a>
+          </li>
+        </ul>
+      </details>
+      <script>
+        (function () {
+          var mq = window.matchMedia("(min-width: 641px)");
+          var menu = document.getElementById("nav-menu");
+          function sync() { menu.open = mq.matches; }
+          sync();
+          mq.addEventListener("change", sync);
+        })();
+      </script>
+    {% endif %}
+    {# Anonymous visitors get only the brand link. #}
+  </nav>
+  {%- if (_breadcrumb_html | trim) or (_toolbar_html | trim) or is_authenticated %}
+    {# Breadcrumb row. Reserves its height with an invisible
+       back-affordance placeholder when a page has no real breadcrumb,
+       so the rule below sits at a constant Y across pages. #}
+    <div class="page-header-crumb">
+      {%- if _breadcrumb_html | trim %}{{ _breadcrumb_html }}
+      {%- else %}
+        <nav aria-hidden="true" class="page-header-crumb-placeholder">
+          <a class="breadcrumb-back"><i class="icon-arrow-left" aria-hidden="true"></i><span class="breadcrumb-back-label">&nbsp;</span></a>
+        </nav>
+      {%- endif %}
+    </div>
+    {{ _toolbar_html }}
+    <hr class="page-header-rule" />
+  {%- endif %}
+</header>

--- a/src/framework/templates/_shared/_toolbar.html
+++ b/src/framework/templates/_shared/_toolbar.html
@@ -1,8 +1,10 @@
 {# Top-of-page zone bar primitive.
 
-Every page renders one toolbar strip above its content, followed
-by an `<hr />` separator. The row carries up to three things,
-left-to-right:
+Every page renders one toolbar strip above its content. The
+single boundary `<hr>` below the toolbar is owned by the
+page-header band (`_shared/_page_header.html`), not this macro —
+the macro emits only the `<div class="toolbar">` row. The row
+carries up to three things, left-to-right:
 
   Heading (`<h1>`) — the page title. Required arg. Lives in the
     same row as the actions so the chrome compacts to a single
@@ -85,6 +87,18 @@ Args:
   {%- set has_actions = actions_html | trim -%}
   <div class="toolbar">
     <h1>{{ heading }}</h1>
+    {# Reserve the action-row height on every page so the band's boundary
+       rule sits at a constant Y whether or not a page has toolbar actions:
+       a hidden, non-interactive real `<button>` shares the H1's grid cell
+       and contributes a real button's intrinsic height (taller than the
+       bare H1). Pages with real actions are unaffected (same height);
+       action-free pages reserve the maximal single-row layout. Same
+       "reserve via real content, not a pinned size unit" approach the
+       breadcrumb placeholder uses — see `_page_header.html`. #}
+    <button type="button"
+            tabindex="-1"
+            aria-hidden="true"
+            class="toolbar-reserve">&nbsp;</button>
     {%- if search_url or has_actions %}
       {# Filter + menu live in one grid cell so the actions cluster
      reflows as a single unit (atomic wrap). See `.toolbar`'s grid
@@ -114,5 +128,4 @@ Args:
     </div>
   {%- endif %}
 </div>
-<hr />
 {%- endmacro %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -140,44 +140,22 @@
     {%- set _on_home = is_authenticated and request.url.path == '/home' -%}
     {%- set _posts_path = entity_url('post') -%}
     {%- set _on_posts = is_authenticated and (request.url.path == _posts_path or request.url.path.startswith(_posts_path + '/')) -%}
-    <header class="container">
-      <nav aria-label="Primary" id="primary-nav">
-        <a href="/"><strong>Bedlam Connect</strong></a>
-        {% if is_authenticated %}
-          <details id="nav-menu">
-            <summary class="nav-menu-toggle" aria-label="Menu">
-              <i class="icon-menu nav-menu-open-icon"></i>
-              <i class="icon-x nav-menu-close-icon"></i>
-            </summary>
-            <ul>
-              <li>
-                <a href="/home" {% if _on_home %}aria-current="page"{% endif %}>Home</a>
-              </li>
-              <li>
-                <a href="{{ entity_url('post') }}"
-                   {% if _on_posts %}aria-current="page"{% endif %}>Posts</a>
-              </li>
-              <li>
-                <a href="/profile" {% if _on_profile %}aria-current="page"{% endif %}>Profile</a>
-              </li>
-              <li>
-                <a href="#" hx-post="/auth/sign-out">Sign out</a>
-              </li>
-            </ul>
-          </details>
-          <script>
-            (function () {
-              var mq = window.matchMedia("(min-width: 641px)");
-              var menu = document.getElementById("nav-menu");
-              function sync() { menu.open = mq.matches; }
-              sync();
-              mq.addEventListener("change", sync);
-            })();
-          </script>
-        {% endif %}
-        {# Anonymous visitors get only the brand link. #}
-      </nav>
-    </header>
+    {# Unified page-header band. `{% include %}` can't see this template's
+       blocks, so capture each chrome block's output into a context var and
+       hand the pre-rendered HTML to the partial, which assembles the single
+       fixed band (nav + breadcrumb slot + toolbar slot + boundary rule).
+       The captured subtitle is rendered below the band, at the top of
+       `<main>`. See `_shared/_page_header.html` and `templates/README.md`. #}
+    {%- set _breadcrumb_html %}
+      {% block breadcrumb %}{% endblock %}
+    {% endset -%}
+    {%- set _toolbar_html %}
+      {% block toolbar %}{% endblock %}
+    {% endset -%}
+    {%- set _subtitle_html %}
+      {% block subtitle %}{% endblock %}
+    {% endset -%}
+    {% include "_shared/_page_header.html" %}
     {# Single global incomplete-profile banner — the *only* place the app
        nags about verification. One chrome signal that reads
        `onboarding_incomplete` from `base_context` — itself the
@@ -197,18 +175,19 @@
       </aside>
     {% endif %}
     <main class="container">
-      {# Breadcrumb zone bar — `{% block breadcrumb %}` accepts the
-         `breadcrumb(items)` macro from `_shared/_breadcrumb.html`.
-         Pages set their own location context; list pages and the
-         top-level home leave the block empty. #}
-      {% block breadcrumb %}{% endblock %}
-      {# Toolbar primitive — `{% block toolbar %}` accepts a `{% call %}`
-         of the shared `page_toolbar(...)` macro from
-         `_shared/_toolbar.html`. Renders page-scoped controls
-         right-aligned (with an optional left-zone search link on list
-         pages) and a horizontal rule below. Pages without a toolbar
-         leave the block empty. #}
-      {% block toolbar %}{% endblock %}
+      {# Subtitle slot — a one-line muted meta string rendered directly
+         below the page-header band's rule, above content (e.g. a
+         clinician's "NPI · Verified", a profile-mode line). The block is
+         captured in the band-assembly section above and rendered here so
+         it lands outside the reserved single-row band but at the top of
+         the body. Wrapped in `<small class="meta">` so multiple `<span>`
+         children auto-join with " · " (see the `.meta` rule). Empty on
+         pages that don't set `{% block subtitle %}`. #}
+      {%- if _subtitle_html | trim %}
+        <p>
+          <small class="meta">{{ _subtitle_html | trim | safe }}</small>
+        </p>
+      {%- endif %}
       {% block content %}{% endblock %}
       {# Post-content slot. `views/list.html` populates this with the
          pagination footer; non-list views leave it empty. Reserved

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -1,0 +1,206 @@
+"""Tests for the unified page-header band (``_shared/_page_header.html``).
+
+The band is the single fixed top-chrome element: primary nav + breadcrumb
+slot + toolbar slot + one boundary ``<hr>``. These tests render the generic
+view-type templates (which compose the band via ``base.html``) and pin the
+band's structure — the toolbar ``<h1>`` and breadcrumb live *inside*
+``header.page-header``, the breadcrumb row is reserved with a placeholder on
+list pages (so the rule sits at a constant Y), and exactly one ``<hr>``
+exists (in the band, none in ``<main>``).
+
+A second group pins the CSS rules the constant-boundary + no-wrap
+guarantees depend on, mirroring the regex-against-``framework.css`` style in
+``test_views.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+from jinja2 import (
+    ChoiceLoader,
+    DictLoader,
+    Environment,
+    FileSystemLoader,
+    select_autoescape,
+)
+from selectolax.parser import HTMLParser
+
+_CSS_PATH = Path(__file__).parent.parent / "static" / "css" / "framework.css"
+
+
+def _make_env() -> Environment:
+    framework_loader = FileSystemLoader("src/framework/templates")
+    stub_loader = DictLoader({})
+    env = Environment(
+        loader=ChoiceLoader([stub_loader, framework_loader]),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    from src.framework.rendering.labels import (
+        entity_create_label,
+        entity_filter_label,
+    )
+    from src.framework.rendering.route_urls import entity_form_url, entity_url
+
+    env.globals["entity_url"] = entity_url
+    env.globals["entity_form_url"] = entity_form_url
+    env.globals["entity_create_label"] = entity_create_label
+    env.globals["entity_filter_label"] = entity_filter_label
+    return env
+
+
+def _add_child(env: Environment, name: str, body: str) -> None:
+    env.loader.loaders[0].mapping[name] = textwrap.dedent(body).lstrip()
+
+
+class _RequestStub:
+    class _Url:
+        path = "/"
+
+    url = _Url()
+    query_params: dict[str, str] = {}
+
+
+def _request_stub(path: str = "/") -> _RequestStub:
+    stub = _RequestStub()
+    stub.url = _RequestStub._Url()
+    stub.url.path = path
+    stub.query_params = {}
+    return stub
+
+
+def _render(env: Environment, name: str, **ctx: object) -> str:
+    base: dict[str, object] = dict(
+        request=_request_stub(), is_authenticated=False, is_development=False
+    )
+    base.update(ctx)
+    return env.get_template(name).render(**base)
+
+
+_DETAIL_STUB = """
+    {% extends "views/detail.html" %}
+    {% set resource_url = "/clinicians" %}
+    {% block resource_label %}Clinicians{% endblock %}
+    {% block current_label %}Sunrise Therapy{% endblock %}
+    {% block content %}<p>body</p>{% endblock %}
+"""
+
+_LIST_STUB = """
+    {% extends "views/list.html" %}
+    {% block resource_label %}Clinicians{% endblock %}
+    {% block content %}<p>body</p>{% endblock %}
+"""
+
+
+def test_detail_toolbar_h1_and_breadcrumb_live_inside_the_band() -> None:
+    """A detail page's page title (`<h1>`) and breadcrumb both render
+    *inside* `header.page-header` — the band owns the whole top chrome, not
+    just the nav. The real breadcrumb means no reserved placeholder."""
+    env = _make_env()
+    _add_child(env, "stub.html", _DETAIL_STUB)
+    tree = HTMLParser(_render(env, "stub.html"))
+
+    assert tree.css_first("header.page-header div.toolbar h1") is not None
+    assert tree.css_first('header.page-header nav[aria-label="breadcrumb"]') is not None
+    # A real breadcrumb is present, so the reserved placeholder is absent.
+    assert tree.css_first(".page-header-crumb-placeholder") is None
+
+
+def test_list_reserves_breadcrumb_row_with_hidden_placeholder() -> None:
+    """List pages carry no real breadcrumb, but the band still reserves the
+    breadcrumb row with a hidden placeholder so the boundary rule sits at
+    the same Y as a detail page's. The toolbar `<h1>` still lives in the
+    band."""
+    env = _make_env()
+    _add_child(env, "stub.html", _LIST_STUB)
+    tree = HTMLParser(_render(env, "stub.html"))
+
+    # No real breadcrumb on list pages...
+    assert tree.css_first('header.page-header nav[aria-label="breadcrumb"]') is None
+    # ...but the row is reserved with the placeholder.
+    assert (
+        tree.css_first("header.page-header .page-header-crumb-placeholder") is not None
+    )
+    assert tree.css_first("header.page-header div.toolbar h1") is not None
+
+
+def test_band_owns_the_single_boundary_rule_and_main_has_none() -> None:
+    """Exactly one `<hr>` exists and it lives in the band (carrying the
+    `page-header-rule` class); `<main>` has none. The toolbar macro no
+    longer emits its own separator — the band owns the single divider."""
+    env = _make_env()
+    _add_child(env, "stub.html", _DETAIL_STUB)
+    tree = HTMLParser(_render(env, "stub.html"))
+
+    band = tree.css_first("header.page-header")
+    assert band is not None
+    assert len(band.css("hr")) == 1
+    assert band.css_first("hr.page-header-rule") is not None
+
+    main = tree.css_first("main")
+    assert main is not None
+    assert len(main.css("hr")) == 0
+
+
+def test_every_toolbar_reserves_the_action_row_height() -> None:
+    """Each toolbar renders a hidden, non-interactive reserve `<button>` so
+    the action-row height (and thus the band boundary's Y) is constant
+    whether or not a page has real actions. Pinned on an action-free list
+    stub and an action-bearing detail stub; the reserve is aria-hidden and
+    removed from the tab order so it's chrome-only."""
+    env = _make_env()
+    _add_child(env, "liststub.html", _LIST_STUB)
+    _add_child(env, "detailstub.html", _DETAIL_STUB)
+    for name in ("liststub.html", "detailstub.html"):
+        tree = HTMLParser(_render(env, name))
+        reserve = tree.css_first(
+            "header.page-header div.toolbar button.toolbar-reserve"
+        )
+        assert reserve is not None, f"{name}: toolbar must render the reserve button"
+        assert reserve.attributes.get("aria-hidden") == "true"
+        assert reserve.attributes.get("tabindex") == "-1"
+
+
+def test_css_pins_no_wrap_truncation_and_reserved_band() -> None:
+    """Pin the CSS the band's guarantees rest on: the actions cells never
+    wrap (so they don't grow the band), the toolbar `<h1>` truncates rather
+    than wraps (constant one-line heading), and the breadcrumb placeholder
+    reserves its row via `visibility: hidden` (intrinsic height, no pinned
+    size unit)."""
+    css = _CSS_PATH.read_text()
+
+    assert re.search(
+        r"\.toolbar-actions[^{]*\{[^}]*flex-wrap:\s*nowrap", css, re.DOTALL
+    ), ".toolbar-actions must declare `flex-wrap: nowrap` so actions don't grow the band"
+    assert re.search(
+        r"\.toolbar-right\b[^{]*\{[^}]*flex-wrap:\s*nowrap", css, re.DOTALL
+    ), ".toolbar-right must declare `flex-wrap: nowrap`"
+
+    h1_rule = re.search(r"\.toolbar\s+h1\s*\{([^}]*)\}", css, re.DOTALL)
+    assert h1_rule is not None, ".toolbar h1 must have a rule"
+    h1_body = h1_rule.group(1)
+    for decl in ("text-overflow: ellipsis", "white-space: nowrap", "min-width: 0"):
+        assert (
+            decl in h1_body
+        ), f".toolbar h1 must declare `{decl}` so the title truncates"
+
+    assert re.search(
+        r"\.page-header-crumb-placeholder\s*\{[^}]*visibility:\s*hidden", css, re.DOTALL
+    ), ".page-header-crumb-placeholder must reserve its row via `visibility: hidden`"
+
+    # The action-row reserve: a hidden button sharing the H1's grid cell.
+    # Both the H1 and the reserve must be pinned to row 1 / col 1 so the
+    # reserve overlaps the H1 (instead of being pushed to a second row) and
+    # the actions cell still auto-flows for the mobile stack.
+    h1_grid = re.search(r"\.toolbar\s+h1\s*\{([^}]*)\}", css, re.DOTALL).group(1)
+    assert "grid-row: 1" in h1_grid and "grid-column: 1" in h1_grid, (
+        ".toolbar h1 must be explicitly placed at row 1 / col 1 so the reserve "
+        "button overlaps it"
+    )
+    reserve_rule = re.search(r"\.toolbar-reserve\s*\{([^}]*)\}", css, re.DOTALL)
+    assert reserve_rule is not None, ".toolbar-reserve must have a rule"
+    reserve_body = reserve_rule.group(1)
+    for decl in ("grid-row: 1", "grid-column: 1", "visibility: hidden"):
+        assert decl in reserve_body, f".toolbar-reserve must declare `{decl}`"

--- a/src/framework/templates/views/detail.html
+++ b/src/framework/templates/views/detail.html
@@ -70,13 +70,9 @@ Child contract:
   {% call page_toolbar(heading=current | trim) %}
     {{ actions_body }}
   {% endcall %}
-  {%- set sub %}
-    {% block subtitle %}{% endblock %}
-  {% endset -%}
-  {%- if sub | trim %}
-    <p>
-      <small class="meta">{{ sub | trim | safe }}</small>
-    </p>
-  {% endif %}
 {% endblock %}
+{# Subtitle renders below the band's rule (top of `<main>`) — base.html
+   captures this block and wraps it in `<p><small class="meta">…`. Net
+   position is unchanged from when it lived after the toolbar call. #}
+{% block subtitle %}{% endblock %}
 {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary

- Collapse the primary nav, breadcrumb, and toolbar into a single `<header class="page-header">` (`_shared/_page_header.html`) that closes with **one** `<hr>`. `base.html` captures the `breadcrumb`/`toolbar`/`subtitle` blocks and hands the pre-rendered HTML to the band partial (an `{% include %}` can't see caller blocks); the subtitle renders below the rule at the top of `<main>`.
- The boundary sits at a **constant Y across pages at a given screen size**, achieved intrinsically (no pinned size units, so it still changes across screen sizes): the breadcrumb row is reserved with a hidden back-affordance placeholder on list pages, and the action row with a hidden reserve `<button>` sharing the H1's grid cell (a button is taller than the bare H1).
- The H1 truncates instead of wrapping; the actions cell never wraps among itself but still drops below the heading atomically at ≤640px.
- `/home` and `/profile` outliers now route their title/actions/subtitle through the shared slots instead of bespoke inline `<header>` markup; the `page_toolbar` macro no longer emits its own separator.

## Verification

Measured via Playwright at a fixed viewport: `/home`, `/profile`, `/posts`, a post detail, and a clinician detail all land the rule at **141.28px** at 1280px, and the value moves (113.28px) at 375px — confirming it's intrinsic, not pinned. At 320px a long-title detail ellipsizes to one line and its 3 actions share one `offsetTop` (no wrap), stacked below the heading. Anonymous pages (login/landing) keep the bare brand nav with no rule.

## Test plan

- [x] New `src/framework/templates/test_page_header.py` — band structure (H1 + breadcrumb inside `header.page-header`, list-page placeholder, exactly one `<hr>` in band / none in `<main>`, action-row reserve) + CSS-regex pins (no-wrap, H1 truncation, reserved placeholder, reserve grid placement).
- [x] Extended `test_chrome_banner.py` / `test_profile.py` to pin the `/home` and `/profile` outlier slot placement.
- [x] `dev test` + `dev lint` green (incl. after rebase onto latest main).
- [x] Manual Playwright pass: constant boundary, intrinsic resize, mobile stack, anonymous-page gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)