### PR TITLE
docs: align picker + identity-step comments with read-xor-form grammar

### DIFF
--- a/src/domain/templates/profile/step.html
+++ b/src/domain/templates/profile/step.html
@@ -2,7 +2,8 @@
    of contents links to (`/profile/email`, `/profile/identity`). The route
    (`profile:step`) 404s an unknown key and redirects a step that's already
    complete back to the hub, so this template only ever renders an
-   incomplete step's satisfying form.
+   incomplete step's satisfying surface — a form (email) or, for identity,
+   a read-only dispatching picker (read xor form; see RESOURCE_GRAMMAR.md).
 
    `step` is the `OnboardingStep` row; the rest of the context is the
    ordinary `build_profile_context` (clinicians, org_representations, etc.)
@@ -17,10 +18,12 @@
     <h1>{{ step.title }}</h1>
     <p style="color: var(--pico-muted-color); margin-top: -0.25rem;">{{ step.hint }}</p>
   </header>
-  {# Per-key dispatch: each step renders its own satisfying form. The
-     markup is inherently step-specific (the registry can't hold Jinja),
-     so adding a step adds a branch here — same shape the hub's mode
-     dispatch uses. #}
+  {# Per-key dispatch: each step renders its own satisfying surface — the
+     email step a create form, the identity step a read-only dispatching
+     picker that links out to `/clinicians/form` + `/organizations/form`
+     (it hosts no create form itself; read xor form). The markup is
+     inherently step-specific (the registry can't hold Jinja), so adding a
+     step adds a branch here — same shape the hub's mode dispatch uses. #}
   {% if step.key == "email" %}
     {% include "profile/_email.html" %}
   {% elif step.key == "identity" %}

--- a/src/framework/templates/_shared/_picker.html
+++ b/src/framework/templates/_shared/_picker.html
@@ -1,8 +1,14 @@
 {# _picker(options) — renders a "choose your path" card grid.
 
-Adopted from the `/posts/form` picker pattern (issue #704). Use this
-macro anywhere a multi-option entry point needs to funnel the user to a
-kind- or type-specific sub-form before showing fields.
+Two species, one component (full contract: the picker entry in
+`framework/templates/README.md`, which extends RESOURCE_GRAMMAR.md):
+a *discriminator/type picker* funnels to a kind-/type-specific sub-form of
+the SAME resource via a selecting query param (`/posts/form?kind=…`,
+`/organizations/form?type=…`); a *dispatching picker* points its cards OUT
+at OTHER resources' create forms (`/profile/identity` → `/clinicians/form`
++ `/organizations/form`). The macro only renders {href, heading,
+description} — self- vs cross-resource hrefs are the caller's business.
+Adopted from the `/posts/form` pattern (issue #704).
 
 Each option is a dict with keys:
   href:        URL to navigate to on click (ignored when selected=true)


### PR DESCRIPTION
## Summary
Follow-up doc polish for the RESTful UI grammar codified under #1166 (PRs #1175 / #1179). A full cross-file audit of every README, `.py` docstring, and template `{# #}` comment found the grammar already consistent — **no stale docs to remove**. It surfaced two colocated comments that contradicted the grammar at the point a reader actually looks; this fixes both.

- **`src/domain/templates/profile/step.html`** — comments called the rendered surface a "satisfying form," but the identity step renders a read-only **dispatching picker**, not a form. Reworded to "satisfying surface — a form (email) or a read-only dispatching picker (identity); read xor form."
- **`src/framework/templates/_shared/_picker.html`** — the macro header described only the *discriminator* picker species, silently omitting the *dispatching* species. Now names both and points to `framework/templates/README.md` → `RESOURCE_GRAMMAR.md` as the canonical home (link, not restate).

Comment-only changes; no behavior change.

## Test plan
- [x] `dev lint` passes
- [x] pre-commit hooks pass
- [ ] No code paths touched (template comments only) — existing `test_picker.py` / profile route tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)