### PR TITLE
Nest the onboarding banner inside <main> as its first child

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -17,6 +17,9 @@ return. These tests assert:
 3. Post CTAs on `/home` are gated on `claims.a` being populated.
 4. The global `#onboarding-banner` shows for an incomplete authed user
    off `/profile`, hides on `/profile`, and hides once a claim verifies.
+5. When shown, the banner is the *first child of `<main>`* — so the only
+   top-level body elements stay `<header>`, `<main>`, `<footer>` (the three
+   rows of the body grid), never a stray top-level `<aside>` band.
 """
 
 import pytest
@@ -260,6 +263,23 @@ async def test_onboarding_banner_shown_off_profile_for_incomplete_user(
     banner = tree.css_first("#onboarding-banner")
     assert banner is not None
     assert banner.css_first("a").attributes["href"].startswith("/profile")
+
+
+async def test_onboarding_banner_renders_inside_main(
+    authenticated_client: AsyncClient,
+):
+    """End-to-end (real route + `base_context` wiring): when shown, the
+    banner is the first element child of `<main>`, not a top-level `<aside>`
+    band. The structural invariant across view types is pinned at the
+    template level in `framework/templates/test_page_header.py`; this just
+    proves the live `/home` render lands the banner in the right place."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first("#onboarding-banner") is not None
+    main_children = tree.css("main > *")
+    assert main_children, "main has no element children"
+    assert main_children[0].attributes.get("id") == "onboarding-banner"
 
 
 async def test_onboarding_banner_suppressed_on_profile(

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -71,6 +71,7 @@ From top to bottom:
 │   toolbar row        <h1> title              [actions ▶]  │  ← captured `{% block toolbar %}`
 │   ─────────────────────────────────────────────────────  │  ← single `<hr class="page-header-rule">`
 ├───────────────────────────────────────────────────────────┤
+│ onboarding banner    Finish setting up your profile… →    │  ← `#onboarding-banner` (first child of `<main>`, incomplete authed off `/profile`)
 │ subtitle (optional)  NPI · Verified                       │  ← `{% block subtitle %}` (rendered below the rule, top of `<main>`)
 │ page content                                              │  ← `{% block content %}`
 ├───────────────────────────────────────────────────────────┤

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -156,25 +156,34 @@
       {% block subtitle %}{% endblock %}
     {% endset -%}
     {% include "_shared/_page_header.html" %}
-    {# Single global incomplete-profile banner — the *only* place the app
-       nags about verification. One chrome signal that reads
-       `onboarding_incomplete` from `base_context` — itself the
-       `onboarding_checklist` registry projection — so it can't disagree
-       with the itemized steps on `/profile`. Explains *why* content is
-       gated and links to the next actionable step (`onboarding_next_href`,
-       a `/profile/<step>` deep-link). Pages don't repeat this with their
-       own finish-setup cards or feed notices. Suppressed on `/profile`
-       itself, where the full checklist is already on screen — a banner
-       there would just point at the page you're on. #}
-    {% if is_authenticated and onboarding_incomplete and not _on_profile %}
-      <aside role="status" id="onboarding-banner" class="container">
-        <strong>Finish setting up your profile.</strong>
-        Clinician names and contact details stay hidden, and you can't post,
-        until you verify.
-        <a href="{{ onboarding_next_href }}">Continue setup →</a>
-      </aside>
-    {% endif %}
     <main class="container">
+      {# Single global incomplete-profile banner — the *only* place the app
+         nags about verification. One chrome signal that reads
+         `onboarding_incomplete` from `base_context` — itself the
+         `onboarding_checklist` registry projection — so it can't disagree
+         with the itemized steps on `/profile`. Explains *why* content is
+         gated and links to the next actionable step (`onboarding_next_href`,
+         a `/profile/<step>` deep-link). Pages don't repeat this with their
+         own finish-setup cards or feed notices. Suppressed on `/profile`
+         itself, where the full checklist is already on screen — a banner
+         there would just point at the page you're on.
+
+         No `.container` class here: the parent `<main class="container">`
+         already supplies the max-width centering; a nested `.container`
+         would inset the banner from the rest of the body. (That it's the
+         first child of `<main>`, and that `<header><main><footer>` stay the
+         only top-level body elements, is pinned by
+         `framework/templates/test_page_header.py`.) #}
+      {% if is_authenticated and onboarding_incomplete and not _on_profile %}
+        <aside role="status" id="onboarding-banner">
+          <p>
+            <strong>Finish setting up your profile.</strong>
+            Clinician names and contact details stay hidden, and you can't post,
+            until you verify.
+            <a href="{{ onboarding_next_href }}">Continue setup →</a>
+          </p>
+        </aside>
+      {% endif %}
       {# Subtitle slot — a one-line muted meta string rendered directly
          below the page-header band's rule, above content (e.g. a
          clinician's "NPI · Verified", a profile-mode line). The block is

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -176,12 +176,12 @@
          `framework/templates/test_page_header.py`.) #}
       {% if is_authenticated and onboarding_incomplete and not _on_profile %}
         <aside role="status" id="onboarding-banner">
-          <section>
+          <p>
             <strong>Finish setting up your profile.</strong>
             Clinician names and contact details stay hidden, and you can't post,
             until you verify.
             <a href="{{ onboarding_next_href }}">Continue setup →</a>
-          </section>
+          </p>
         </aside>
       {% endif %}
       {# Subtitle slot — a one-line muted meta string rendered directly

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -176,12 +176,12 @@
          `framework/templates/test_page_header.py`.) #}
       {% if is_authenticated and onboarding_incomplete and not _on_profile %}
         <aside role="status" id="onboarding-banner">
-          <p>
+          <section>
             <strong>Finish setting up your profile.</strong>
             Clinician names and contact details stay hidden, and you can't post,
             until you verify.
             <a href="{{ onboarding_next_href }}">Continue setup →</a>
-          </p>
+          </section>
         </aside>
       {% endif %}
       {# Subtitle slot — a one-line muted meta string rendered directly

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -11,6 +11,14 @@ exists (in the band, none in ``<main>``).
 A second group pins the CSS rules the constant-boundary + no-wrap
 guarantees depend on, mirroring the regex-against-``framework.css`` style in
 ``test_views.py``.
+
+A third group pins the **body-layout invariant**: ``base.html`` emits
+exactly ``<header>``, ``<main>``, ``<footer>`` as the top-level children of
+``<body>`` (the three rows of the body grid). This holds even with the
+incomplete-profile banner showing — the banner is the first child of
+``<main>``, never a fourth top-level ``<aside>`` band. Pinned across view
+types since they all compose ``base.html``; this is the structural
+enforcement that replaces a "keep it inside ``<main>``" comment.
 """
 
 from __future__ import annotations
@@ -161,6 +169,58 @@ def test_every_toolbar_reserves_the_action_row_height() -> None:
         assert reserve is not None, f"{name}: toolbar must render the reserve button"
         assert reserve.attributes.get("aria-hidden") == "true"
         assert reserve.attributes.get("tabindex") == "-1"
+
+
+# Context that makes the incomplete-profile banner render: an authenticated
+# viewer who hasn't finished onboarding, on a non-`/profile` page (the stub
+# request path is "/"). `onboarding_next_href` is the banner's CTA target.
+_BANNER_CTX: dict[str, object] = dict(
+    is_authenticated=True,
+    onboarding_incomplete=True,
+    onboarding_next_href="/profile/email",
+)
+
+
+def test_body_top_level_children_are_header_main_footer_only() -> None:
+    """The body scaffold emits exactly three top-level elements —
+    `<header>`, `<main>`, `<footer>`, the three rows of the body grid — and
+    nothing else. Pinned with the incomplete-profile banner SHOWING, which
+    is the case that would regress: the banner must be a child of `<main>`,
+    never a fourth top-level `<aside>` band. Checked across both generic
+    view types since every full page composes one of them via `base.html`."""
+    env = _make_env()
+    _add_child(env, "liststub.html", _LIST_STUB)
+    _add_child(env, "detailstub.html", _DETAIL_STUB)
+    for name in ("liststub.html", "detailstub.html"):
+        tree = HTMLParser(_render(env, name, **_BANNER_CTX))
+        # The banner really is rendered for this context (guards against the
+        # assertion below passing vacuously if the gate ever changes).
+        assert tree.css_first("#onboarding-banner") is not None, name
+        top_level = [n.tag for n in tree.css("body > *")]
+        assert top_level == ["header", "main", "footer"], f"{name}: {top_level}"
+
+
+def test_onboarding_banner_is_first_child_of_main() -> None:
+    """When shown, the incomplete-profile banner is the first *element*
+    child of `<main>` — ahead of the subtitle and content — so it reads as
+    the page's lead nudge and `<main>` stays the body grid's single content
+    row. Carries no `.container` class (the parent `<main>` already does)."""
+    env = _make_env()
+    _add_child(env, "detailstub.html", _DETAIL_STUB)
+    tree = HTMLParser(_render(env, "detailstub.html", **_BANNER_CTX))
+
+    main_children = tree.css("main > *")
+    assert main_children, "main has no element children"
+    first = main_children[0]
+    assert first.attributes.get("id") == "onboarding-banner"
+    assert first.tag == "aside"
+    assert "container" not in (first.attributes.get("class") or "")
+    # The banner's copy is wrapped in a single `<p>` (block-level body, not
+    # bare inline text directly under the `<aside>`).
+    paragraph = first.css_first("p")
+    assert paragraph is not None
+    assert paragraph.css_first("strong") is not None
+    assert paragraph.css_first("a") is not None
 
 
 def test_css_pins_no_wrap_truncation_and_reserved_band() -> None:

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -215,12 +215,12 @@ def test_onboarding_banner_is_first_child_of_main() -> None:
     assert first.attributes.get("id") == "onboarding-banner"
     assert first.tag == "aside"
     assert "container" not in (first.attributes.get("class") or "")
-    # The banner's copy is wrapped in a single `<section>` (block-level body,
-    # not bare inline text directly under the `<aside>`).
-    section = first.css_first("section")
-    assert section is not None
-    assert section.css_first("strong") is not None
-    assert section.css_first("a") is not None
+    # The banner's copy is wrapped in a single `<p>` (block-level body, not
+    # bare inline text directly under the `<aside>`).
+    paragraph = first.css_first("p")
+    assert paragraph is not None
+    assert paragraph.css_first("strong") is not None
+    assert paragraph.css_first("a") is not None
 
 
 def test_css_pins_no_wrap_truncation_and_reserved_band() -> None:

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -215,12 +215,12 @@ def test_onboarding_banner_is_first_child_of_main() -> None:
     assert first.attributes.get("id") == "onboarding-banner"
     assert first.tag == "aside"
     assert "container" not in (first.attributes.get("class") or "")
-    # The banner's copy is wrapped in a single `<p>` (block-level body, not
-    # bare inline text directly under the `<aside>`).
-    paragraph = first.css_first("p")
-    assert paragraph is not None
-    assert paragraph.css_first("strong") is not None
-    assert paragraph.css_first("a") is not None
+    # The banner's copy is wrapped in a single `<section>` (block-level body,
+    # not bare inline text directly under the `<aside>`).
+    section = first.css_first("section")
+    assert section is not None
+    assert section.css_first("strong") is not None
+    assert section.css_first("a") is not None
 
 
 def test_css_pins_no_wrap_truncation_and_reserved_band() -> None:


### PR DESCRIPTION
## Summary
- Move the persistent incomplete-profile `<aside>` ("Finish setting up your profile") from a top-level body band into `<main>` as its **first child**, so `<header>`, `<main>`, `<footer>` are the only top-level children of `<body>` (the three rows of the body grid). Previously a shown banner was a fourth top-level element, which would consume the grid's `1fr` row.
- Drop the banner's `.container` class (the parent `<main class="container">` already centers; a nested container would inset it) and wrap its copy in a `<p>`.
- Replace the "keep it inside `<main>`" comment with a **structural test**: `test_page_header.py` now pins that `<body>`'s only top-level children are `<header>/<main>/<footer>` — across both generic view types (list + detail), with the banner showing — and that the banner is `<main>`'s first child with its copy in a `<p>`.

## Test plan
- [x] `dev lint` passes
- [x] `dev test` passes (full suite: 2341 passed, 101 skipped)
- [x] New `test_page_header.py` invariant tests pass (body top-level = header/main/footer; banner first child of main; `<p>` wrapper)
- [x] `test_chrome_banner.py` integration check: banner renders inside `<main>` on a live `/home` render
- [ ] Manual: load `/home` as an onboarding-incomplete user and confirm the `#onboarding-banner` `<aside>` renders inside `<main>` with a `<p>` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)