### PR TITLE
Add access/capability model: Condition/Bundle/Gate tree + /users/me/access routes

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -18,8 +18,9 @@ not import domain models — see `src/README.md` import discipline.
 Phase status: production reads. `clinician_verified` consults the
 `Clinician.clinician_verified` denorm cache; `org_rep_verified(user, org)`
 walks `User.org_representations` against `Organization.org_verified`;
-feed read-access honors `Clinician.ever_verified_at` (the once-verified
-retention rule per handoff §7.1).
+feed read-access is gated on email + any current claim (the `ever_verified_at`
+once-verified retention rule was removed — access reverts immediately when
+the underlying claim lapses).
 
 The predicates remain duck-typed via `getattr` so test stubs (and any
 non-ORM Actor-like object) keep working without constructing real
@@ -120,7 +121,7 @@ _REASON_META = {
         title="Contact details",
         unlock="Verify your account to see contact details.",
         fix_label="Complete verification",
-        fix_url="/profile",
+        fix_url="/users/me/access/capabilities/can_read_feed",
     ),
 }
 
@@ -132,6 +133,51 @@ _FALLBACK_META = ReasonMeta(
     fix_label="Open profile",
     fix_url="/profile",
 )
+
+
+@dataclass(frozen=True)
+class Condition:
+    """Atomic boolean leaf in a capability tree."""
+
+    label: str
+    met: bool
+    fix_url: str  # the resource that changes this condition
+
+
+@dataclass(frozen=True)
+class Bundle:
+    """AND node — all children must pass."""
+
+    label: str
+    children: tuple  # tuple[Condition | Bundle | Gate, ...]
+
+    @property
+    def met(self) -> bool:
+        return all(c.met for c in self.children)
+
+
+@dataclass(frozen=True)
+class Gate:
+    """OR node — any one child suffices."""
+
+    label: str
+    children: tuple  # tuple[Condition | Bundle | Gate, ...]
+
+    @property
+    def met(self) -> bool:
+        return any(c.met for c in self.children)
+
+
+@dataclass(frozen=True)
+class CapabilityCheck:
+    """Evaluated capability tree for a specific user."""
+
+    name: str
+    tree: Any  # Condition | Bundle | Gate
+
+    @property
+    def granted(self) -> bool:
+        return self.tree.met
 
 
 @dataclass(frozen=True)
@@ -218,17 +264,51 @@ def any_org_rep_verified(user: Any) -> bool:
     return bool(_verified_active_reps(user))
 
 
-def can_read_full_feed(user: Any) -> bool:
-    """Feed-teaser gate per handoff §7.1: full feed once any claim is
-    verified; once-verified users retain read access after a lapse
-    (`ever_verified_at`). New users see the blurred teaser until they
-    clear the first verification."""
-    if user is None:
-        return False
-    if clinician_verified(user) or any_org_rep_verified(user):
-        return True
+def check_can_read_feed(user: Any) -> CapabilityCheck:
+    """Structured capability check for full-feed read access.
+
+    Tree: email_verified AND (clinician_verified OR org_rep_verified).
+    `ever_verified_at` retention is intentionally excluded — access
+    reverts immediately when the underlying claim lapses.
+    """
+    _email_met = email_verified(user)
     clinicians = getattr(user, "clinicians", None) or ()
-    return any(getattr(c, "ever_verified_at", None) for c in clinicians)
+    _clin_met = any(getattr(c, "clinician_verified", False) for c in clinicians)
+    _org_met = bool(_verified_active_reps(user))
+
+    return CapabilityCheck(
+        name="can_read_feed",
+        tree=Bundle(
+            label="Read full feed",
+            children=(
+                Condition(
+                    label="Email verified",
+                    met=_email_met,
+                    fix_url="/users/me/email/form",
+                ),
+                Gate(
+                    label="Verified via any one",
+                    children=(
+                        Condition(
+                            label="Clinician identity verified",
+                            met=_clin_met,
+                            fix_url="/clinicians/form",
+                        ),
+                        Condition(
+                            label="Organization representative verified",
+                            met=_org_met,
+                            fix_url="/organizations/form",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def can_read_full_feed(user: Any) -> bool:
+    """Feed-teaser gate: delegates to `check_can_read_feed`."""
+    return check_can_read_feed(user).granted
 
 
 def can_post_referral(user: Any) -> bool:

--- a/src/domain/logic/profile/test_view.py
+++ b/src/domain/logic/profile/test_view.py
@@ -73,12 +73,12 @@ def test_claim_b_alone_unlocks_posting():
     assert r.next_label is None
 
 
-def test_lapsed_clinician_retains_feed_but_cannot_post():
-    """Once-verified (ever_verified_at set) but not currently verified:
-    full-feed read is retained, but posting is not — the projection
-    surfaces the identity next-step again (the `/profile/identity` subroute,
-    where the re-verification flow lives)."""
+def test_lapsed_clinician_loses_feed_access():
+    """The `ever_verified_at` retention rule was removed — access reverts
+    immediately when the underlying claim lapses. A clinician with only
+    `ever_verified_at` set (no current `clinician_verified=True`) is denied
+    feed access and is directed back to the identity step."""
     r = onboarding_readiness(_user(claim_a=False, ever_verified=True))
-    assert r.can_read_full_feed is True
+    assert r.can_read_full_feed is False
     assert r.can_post is False
     assert r.next_href == "/profile/identity"

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -261,10 +261,10 @@ def test_can_read_full_feed_verified_clinician_true():
     assert capabilities.can_read_full_feed(user) is True
 
 
-def test_can_read_full_feed_ever_verified_retains_access():
-    """Per handoff §7.1: once a user has been verified, they retain
-    feed read-access after a regression. A clinician with
-    `clinician_verified=False` but `ever_verified_at` set still passes."""
+def test_can_read_full_feed_ever_verified_no_longer_retains_access():
+    """The `ever_verified_at` retention clause was removed — access reverts
+    immediately when the underlying claim lapses. A clinician with
+    `clinician_verified=False` and only `ever_verified_at` set is denied."""
     import datetime as _dt
 
     user = _user(
@@ -277,7 +277,7 @@ def test_can_read_full_feed_ever_verified_retains_access():
             )
         ],
     )
-    assert capabilities.can_read_full_feed(user) is True
+    assert capabilities.can_read_full_feed(user) is False
 
 
 def test_can_read_full_feed_org_rep_unlocks_for_user_without_clinician():
@@ -538,11 +538,11 @@ def test_reason_meta_lapsed_reasons_carry_resume_copy():
 
 def test_reason_meta_view_unverified_is_the_read_side_gate():
     """The redaction reason (withheld post-detail contact/identity rows)
-    carries verification-oriented copy and points at the hub root, where
-    the viewer can complete any verification path."""
+    carries verification-oriented copy and points at the capability detail
+    page where the viewer can see exactly what needs to change."""
     meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED)
     assert "Complete verification" == meta.fix_label
-    assert meta.fix_url == "/profile"
+    assert meta.fix_url == "/users/me/access/capabilities/can_read_feed"
     assert meta.unlock
 
 
@@ -564,6 +564,93 @@ def test_reason_meta_covers_every_reason_constant_with_nonempty_copy():
         assert meta.title, f"REASON {reason!r} has empty title"
         assert meta.unlock, f"REASON {reason!r} has empty unlock copy"
         assert meta.fix_label, f"REASON {reason!r} has empty fix_label"
+
+
+# ---------- check_can_read_feed -------------------------------------------
+
+
+def test_check_can_read_feed_anon_denied():
+    """None user: email not verified → entire Bundle fails."""
+    check = capabilities.check_can_read_feed(None)
+    assert check.granted is False
+    assert check.name == "can_read_feed"
+
+
+def test_check_can_read_feed_email_unverified_denied():
+    """Email unverified: Bundle root fails even if a claim would pass."""
+    user = _user(
+        is_verified=False,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
+    )
+    check = capabilities.check_can_read_feed(user)
+    assert check.granted is False
+    # The Condition for email should be unmet.
+    email_condition = check.tree.children[0]
+    assert email_condition.label == "Email verified"
+    assert email_condition.met is False
+
+
+def test_check_can_read_feed_email_verified_no_claims_denied():
+    """Email verified but no clinician or org rep claim → Gate fails."""
+    user = _user(is_verified=True)
+    check = capabilities.check_can_read_feed(user)
+    assert check.granted is False
+    email_condition = check.tree.children[0]
+    assert email_condition.met is True
+    gate = check.tree.children[1]
+    assert gate.met is False
+
+
+def test_check_can_read_feed_clinician_verified_granted():
+    """Email + clinician_verified → Bundle passes."""
+    user = _user(
+        is_verified=True,
+        clinicians=[_clinician(npi="1234567890", clinician_verified=True)],
+    )
+    check = capabilities.check_can_read_feed(user)
+    assert check.granted is True
+    gate = check.tree.children[1]
+    clin_condition = gate.children[0]
+    assert clin_condition.label == "Clinician identity verified"
+    assert clin_condition.met is True
+
+
+def test_check_can_read_feed_org_rep_granted():
+    """Email + verified org rep → Bundle passes via the Gate's second child."""
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+    )
+    check = capabilities.check_can_read_feed(user)
+    assert check.granted is True
+    gate = check.tree.children[1]
+    org_condition = gate.children[1]
+    assert org_condition.label == "Organization representative verified"
+    assert org_condition.met is True
+
+
+def test_check_can_read_feed_fix_urls_present():
+    """Unmet Condition nodes carry fix_url links to the canonical resources."""
+    user = _user(is_verified=True)  # no claims
+    check = capabilities.check_can_read_feed(user)
+    gate = check.tree.children[1]
+    clin_condition = gate.children[0]
+    org_condition = gate.children[1]
+    assert clin_condition.fix_url == "/clinicians/form"
+    assert org_condition.fix_url == "/organizations/form"
+
+
+def test_check_can_read_feed_tree_structure():
+    """The tree is always Bundle > (Condition, Gate > (Condition, Condition))."""
+    check = capabilities.check_can_read_feed(_user())
+    assert check.tree.__class__.__name__ == "Bundle"
+    assert len(check.tree.children) == 2
+    assert check.tree.children[0].__class__.__name__ == "Condition"
+    gate = check.tree.children[1]
+    assert gate.__class__.__name__ == "Gate"
+    assert len(gate.children) == 2
+    assert all(c.__class__.__name__ == "Condition" for c in gate.children)
 
 
 # ---------- UUID type sanity for claim_state.b ----------------------------

--- a/src/domain/routes/README.md
+++ b/src/domain/routes/README.md
@@ -35,6 +35,7 @@ The grammar fits resource-shaped CRUD. These stay hand-written:
 | `GET /auth/{register,login,forgot-password,reset-password/{token}}` | `auth_pages.py` | Pure form rendering. |
 | `GET /users/me`, `GET /users/me/clinicians` | `users.py` | Singleton aliases — mounted via `singleton_alias=` on the existing `mount_detail` / `mount_related_list`. |
 | `POST/DELETE/GET /users/me/favorites[/{clinician_id}]` | `favorites.py` | M:N edge add/remove — no `mount_*` helper for edge mutations. |
+| `GET /users/me/access`, `GET /users/me/access/capabilities/{name}` | `access.py` | Derived read view — capability posture, no stored row. |
 | `GET /`, `GET /health` | `../../main.py` | Utility endpoints. |
 
 ## Tests

--- a/src/domain/routes/access.py
+++ b/src/domain/routes/access.py
@@ -1,0 +1,63 @@
+"""Read-only routes for `/users/me/access` — the current user's capability posture.
+
+  GET /users/me/access                         all named capabilities, granted/denied
+  GET /users/me/access/capabilities/{name}     requirement tree for one capability
+
+Derived read views only — no stored rows, no write operations. Fix links on
+unmet Condition nodes dispatch outward to the canonical resources that change
+the underlying state.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from src.auth_config import current_active_user
+from src.domain.logic import capabilities
+from src.framework.http.responses import APIResponse
+
+access_router = APIRouter(prefix="/users/me/access", tags=["access"])
+
+_CHECKS = {
+    "can_read_feed": capabilities.check_can_read_feed,
+}
+
+
+_ACCESS_INDEX_URL = "/users/me/access"
+_CAPABILITY_BASE_URL = "/users/me/access/capabilities"
+
+
+@access_router.get("")
+async def access_index(
+    request: Request,
+    user=Depends(current_active_user),
+):
+    checks = {name: fn(user) for name, fn in _CHECKS.items()}
+    return APIResponse.html_response(
+        template_name="users/access/index.html",
+        context={
+            "checks": checks,
+            "capability_base_url": _CAPABILITY_BASE_URL,
+        },
+        request=request,
+        current_user=user,
+    )
+
+
+@access_router.get("/capabilities/{name}")
+async def capability_detail(
+    name: str,
+    request: Request,
+    user=Depends(current_active_user),
+):
+    fn = _CHECKS.get(name)
+    if fn is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    check = fn(user)
+    return APIResponse.html_response(
+        template_name="users/access/capabilities/detail.html",
+        context={
+            "check": check,
+            "access_index_url": _ACCESS_INDEX_URL,
+        },
+        request=request,
+        current_user=user,
+    )

--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -1,0 +1,87 @@
+"""Integration tests for the `/users/me/access` bespoke route.
+
+Covers:
+  - Unauthenticated requests are redirected / denied.
+  - Authenticated requests to the index return 200 with capability listings.
+  - Authenticated requests to a capability detail return 200 with tree.
+  - Unknown capability names return 404.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_access_index_unauthenticated_redirected(test_client: AsyncClient):
+    """Unauthenticated GET /users/me/access is bounced — not 200."""
+    response = await test_client.get("/users/me/access", follow_redirects=False)
+    assert response.status_code != 200
+
+
+async def test_access_index_authenticated_returns_200(
+    authenticated_client: AsyncClient,
+):
+    """Authenticated GET /users/me/access renders the capability index."""
+    response = await authenticated_client.get("/users/me/access")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    # The one registered capability name appears in the response.
+    assert "can_read_feed" in response.text
+
+
+async def test_access_index_shows_granted_or_denied(
+    authenticated_client: AsyncClient,
+):
+    """The index page surfaces a granted/denied label for each capability."""
+    response = await authenticated_client.get("/users/me/access")
+    assert response.status_code == 200
+    # A fresh dev user is unverified, so the feed capability is denied.
+    assert "Granted" in response.text or "Denied" in response.text
+
+
+async def test_capability_detail_can_read_feed_returns_200(
+    authenticated_client: AsyncClient,
+):
+    """GET /users/me/access/capabilities/can_read_feed renders the detail tree."""
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/can_read_feed"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    # Capability name appears in the page.
+    assert "can_read_feed" in response.text
+    # Tree node labels appear.
+    assert "Email verified" in response.text
+    assert "Clinician identity verified" in response.text
+    assert "Organization representative verified" in response.text
+
+
+async def test_capability_detail_shows_status(
+    authenticated_client: AsyncClient,
+):
+    """The detail page shows a granted/denied badge."""
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/can_read_feed"
+    )
+    assert response.status_code == 200
+    assert "Granted" in response.text or "Denied" in response.text
+
+
+async def test_capability_detail_nonexistent_returns_404(
+    authenticated_client: AsyncClient,
+):
+    """GET /users/me/access/capabilities/<unknown> returns 404."""
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/nonexistent"
+    )
+    assert response.status_code == 404
+
+
+async def test_capability_detail_unauthenticated_redirected(test_client: AsyncClient):
+    """Unauthenticated GET /users/me/access/capabilities/can_read_feed is bounced."""
+    response = await test_client.get(
+        "/users/me/access/capabilities/can_read_feed",
+        follow_redirects=False,
+    )
+    assert response.status_code != 200

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -699,7 +699,10 @@ async def test_detail_redacts_identity_rows_as_locked_placeholders_for_unverifie
         assert (
             dd.css_first("span.locked-field") is not None
         ), f"{fact_key} should render a locked placeholder"
-        assert dd.css_first("a").attributes.get("href") == "/profile"
+        assert (
+            dd.css_first("a").attributes.get("href")
+            == "/users/me/access/capabilities/can_read_feed"
+        )
 
     # ...but the real navigable links + the address value are withheld.
     assert tree.css_first(f"a[href='/clinicians/{clinician.id}']") is None

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{%- from "_shared/_toolbar.html" import page_toolbar -%}
+{% block title %}{{ check.name }}{% endblock %}
+{% block toolbar %}
+  {% call page_toolbar(heading=check.name) %}
+  {% endcall %}
+{% endblock %}
+{% block content %}
+  {# Recursive macro — dispatches on node.__class__.__name__. Jinja macros
+     cannot call themselves directly; we work around that by rendering
+     children in a loop and relying on the macro being defined before use.
+     For the two-level tree in `can_read_feed` this is sufficient: the root
+     is always a Bundle whose children are a Condition and a Gate, and the
+     Gate's children are always Conditions. #}
+  {% macro render_node(node) %}
+    {% set kind = node.__class__.__name__ %}
+    {% if kind == "Condition" %}
+      <li class="capability-node capability-node--condition">
+        {% if node.met %}
+          <span class="capability-check capability-check--met">&#10003;</span>
+        {% else %}
+          <span class="capability-check capability-check--unmet">&#10007;</span>
+        {% endif %}
+        {{ node.label }}
+        {% if not node.met %}<a href="{{ node.fix_url }}">Fix →</a>{% endif %}
+      </li>
+    {% elif kind == "Bundle" %}
+      <li class="capability-node capability-node--bundle">
+        <span class="capability-operator">AND</span> {{ node.label }}
+        <ul class="capability-children">
+          {% for child in node.children %}{{ render_node(child) }}{% endfor %}
+        </ul>
+      </li>
+    {% elif kind == "Gate" %}
+      <li class="capability-node capability-node--gate">
+        <span class="capability-operator">OR</span> {{ node.label }}
+        <ul class="capability-children">
+          {% for child in node.children %}{{ render_node(child) }}{% endfor %}
+        </ul>
+      </li>
+    {% endif %}
+  {% endmacro %}
+  <section class="entity-card">
+    <header class="entity-header">
+      <strong>{{ check.name }}</strong>
+      {% if check.granted %}
+        <span class="capability-badge capability-badge--granted">Granted</span>
+      {% else %}
+        <span class="capability-badge capability-badge--denied">Denied</span>
+      {% endif %}
+    </header>
+    <section class="entity-facts">
+      <ul class="capability-tree">
+        {{ render_node(check.tree) }}
+      </ul>
+    </section>
+    <footer class="entity-footer">
+      <a href="{{ access_index_url }}">← All capabilities</a>
+    </footer>
+  </section>
+{% endblock %}

--- a/src/domain/templates/users/access/index.html
+++ b/src/domain/templates/users/access/index.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{%- from "_shared/_toolbar.html" import page_toolbar -%}
+{% block title %}Access{% endblock %}
+{% block toolbar %}
+  {% call page_toolbar(heading="Access") %}
+  {% endcall %}
+{% endblock %}
+{% block content %}
+  <section class="entity-card">
+    <header class="entity-header">
+      <strong>Capabilities</strong>
+    </header>
+    <section class="entity-facts">
+      <dl>
+        {% for name, check in checks.items() %}
+          <div>
+            <dt>{{ name }}</dt>
+            <dd>
+              {% if check.granted %}
+                <span class="capability-badge capability-badge--granted">Granted</span>
+              {% else %}
+                <span class="capability-badge capability-badge--denied">Denied</span>
+              {% endif %}
+              <a href="{{ capability_base_url }}/{{ name }}">View details →</a>
+            </dd>
+          </div>
+        {% endfor %}
+      </dl>
+    </section>
+  </section>
+{% endblock %}

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,7 @@ from src.domain.logic.posts.repository import get_post_repository
 from src.domain.logic.users.schema import UserRead
 from src.domain.models.posts.post import Post
 from src.domain.routes import (
+    access,
     auth_pages,
     auth_routes,
     dev_auth,
@@ -207,6 +208,7 @@ app.include_router(
 )
 app.include_router(verifications.verifications_api_router)
 app.include_router(profile.profile_pages_router)
+app.include_router(access.access_router)
 
 # Every entity route file calls `register_entity(SPEC)` at import time
 # (see `src/framework/dispatch/registry.py`). The package import above


### PR DESCRIPTION
## Summary

- Introduces `Condition`, `Bundle` (AND), `Gate` (OR), `CapabilityCheck` dataclasses to `capabilities.py` — a structured tree model for evaluating user access
- Adds `check_can_read_feed(user) -> CapabilityCheck` as the first capability definition; `can_read_full_feed` now delegates to it
- Removes the `ever_verified_at` once-verified retention clause — feed access reverts immediately when a claim lapses
- Wires `REASON_VIEW_UNVERIFIED.fix_url` to the new `/users/me/access/capabilities/can_read_feed` page instead of `/profile`
- Adds `GET /users/me/access` and `GET /users/me/access/capabilities/{name}` as bespoke read-only routes — derived views, no stored rows
- Updates locked-field CTAs on post detail to link to the capability breakdown page

## Behavioural note

Users whose clinician license has lapsed but `ever_verified_at` was set previously retained feed access — they will now see locked fields again. This is intentional (swift revocation per design discussion; see issue #1185).

## Follow-up

`Condition`/`Bundle`/`Gate`/`CapabilityCheck` belong in `framework/` (they're domain-agnostic primitives); `mount_capability_routes()` should be a framework mount helper parallel to `mount_entity`. Next PR moves those pieces to the right layer.

## Test plan

- [ ] `GET /posts/{id}` as unverified user — locked fields now link to `/users/me/access/capabilities/can_read_feed`
- [ ] `GET /users/me/access` — lists `can_read_feed` with granted/denied badge
- [ ] `GET /users/me/access/capabilities/can_read_feed` — renders requirement tree; unmet conditions show fix links
- [ ] `GET /users/me/access/capabilities/nonexistent` — 404
- [ ] 2355 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)