### PR TITLE
Move capability tree primitives to framework layer

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -37,6 +37,16 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
 
+# Re-export the framework-layer tree primitives so existing callers
+# (`check_can_read_feed`, tests, templates) keep working without changes.
+# The types themselves are domain-agnostic and live in `src/framework/`.
+from src.framework.capabilities import (  # noqa: F401
+    Bundle,
+    CapabilityCheck,
+    Condition,
+    Gate,
+)
+
 # Reason codes used by the `_shared/_locked.html` macros and
 # `fix_url_for(...)`. Closed vocab: any new reason must be added here and
 # given a `ReasonMeta` entry in `_REASON_META` below.
@@ -135,76 +145,6 @@ _FALLBACK_META = ReasonMeta(
     fix_label="Open profile",
     fix_url="/users/me",
 )
-
-
-@dataclass(frozen=True)
-class Condition:
-    """Atomic boolean leaf in a capability tree.
-
-    Two labels encode the verb-subject grammar: `label_active` is the
-    imperative action shown when the condition is unmet ("Verify email");
-    `label_done` is the passive-past confirmation shown when met ("Email
-    verified"). Templates must never show the wrong label for the state.
-    """
-
-    label_active: str  # imperative: "Verify email"
-    label_done: str  # passive-past: "Email verified"
-    met: bool
-    fix_url: str  # the resource that changes this condition
-
-
-@dataclass(frozen=True)
-class Bundle:
-    """AND node — all children must pass.
-
-    Same two-label grammar as Condition: `label_active` when the bundle
-    is unmet, `label_done` when every child is satisfied.
-    """
-
-    label_active: str
-    label_done: str
-    children: tuple  # tuple[Condition | Bundle | Gate, ...]
-
-    @property
-    def op(self) -> str:
-        return "all"
-
-    @property
-    def met(self) -> bool:
-        return all(c.met for c in self.children)
-
-
-@dataclass(frozen=True)
-class Gate:
-    """OR node — any one child suffices.
-
-    Same two-label grammar as Condition: `label_active` when unmet,
-    `label_done` when at least one child is satisfied.
-    """
-
-    label_active: str
-    label_done: str
-    children: tuple  # tuple[Condition | Bundle | Gate, ...]
-
-    @property
-    def op(self) -> str:
-        return "any"
-
-    @property
-    def met(self) -> bool:
-        return any(c.met for c in self.children)
-
-
-@dataclass(frozen=True)
-class CapabilityCheck:
-    """Evaluated capability tree for a specific user."""
-
-    name: str
-    tree: Any  # Condition | Bundle | Gate
-
-    @property
-    def granted(self) -> bool:
-        return self.tree.met
 
 
 @dataclass(frozen=True)

--- a/src/domain/routes/access.py
+++ b/src/domain/routes/access.py
@@ -8,11 +8,10 @@ unmet Condition nodes dispatch outward to the canonical resources that change
 the underlying state.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter
 
-from src.auth_config import current_active_user
 from src.domain.logic import capabilities
-from src.framework.http.responses import APIResponse
+from src.framework.capabilities import mount_capability_routes
 
 access_router = APIRouter(prefix="/users/me/access", tags=["access"])
 
@@ -20,62 +19,4 @@ _CHECKS = {
     "network": capabilities.check_network,
 }
 
-
-_ACCESS_INDEX_URL = "/users/me/access"
-_CAPABILITIES_URL = "/users/me/access/capabilities"
-_CAPABILITY_BASE_URL = "/users/me/access/capabilities"
-
-
-@access_router.get("")
-async def access_index(
-    request: Request,
-    user=Depends(current_active_user),
-):
-    return APIResponse.html_response(
-        template_name="users/access/index.html",
-        context={
-            "capabilities_url": _CAPABILITIES_URL,
-        },
-        request=request,
-        current_user=user,
-    )
-
-
-@access_router.get("/capabilities")
-async def capabilities_index(
-    request: Request,
-    user=Depends(current_active_user),
-):
-    checks = {name: fn(user) for name, fn in _CHECKS.items()}
-    return APIResponse.html_response(
-        template_name="users/access/capabilities/index.html",
-        context={
-            "checks": checks,
-            "capability_base_url": _CAPABILITY_BASE_URL,
-            "access_index_url": _ACCESS_INDEX_URL,
-        },
-        request=request,
-        current_user=user,
-    )
-
-
-@access_router.get("/capabilities/{name}")
-async def capability_detail(
-    name: str,
-    request: Request,
-    user=Depends(current_active_user),
-):
-    fn = _CHECKS.get(name)
-    if fn is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-    check = fn(user)
-    return APIResponse.html_response(
-        template_name="users/access/capabilities/detail.html",
-        context={
-            "check": check,
-            "access_index_url": _ACCESS_INDEX_URL,
-            "capabilities_url": _CAPABILITIES_URL,
-        },
-        request=request,
-        current_user=user,
-    )
+mount_capability_routes(access_router, _CHECKS)

--- a/src/framework/capabilities.py
+++ b/src/framework/capabilities.py
@@ -1,0 +1,163 @@
+"""Framework-layer capability tree primitives.
+
+`Condition`, `Bundle`, `Gate`, and `CapabilityCheck` are pure tree
+structures with no domain knowledge. Domain code builds trees using
+these types; the framework provides them as primitives and wires the
+standard access routes via `mount_capability_routes`.
+
+No domain imports are allowed here. The domain fills in predicate
+functions and template names; the framework owns only the tree
+evaluation logic and the route-mount plumbing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from src.auth_config import current_active_user
+from src.framework.http.responses import APIResponse
+
+
+@dataclass(frozen=True)
+class Condition:
+    """Atomic boolean leaf in a capability tree."""
+
+    label_active: str  # imperative: "Verify email"
+    label_done: str  # passive-past: "Email verified"
+    met: bool
+    fix_url: str  # the resource that changes this condition
+
+
+@dataclass(frozen=True)
+class Bundle:
+    """AND node — all children must pass."""
+
+    label_active: str
+    label_done: str
+    children: tuple  # tuple[Condition | Bundle | Gate, ...]
+
+    @property
+    def op(self) -> str:
+        return "all"
+
+    @property
+    def met(self) -> bool:
+        return all(c.met for c in self.children)
+
+
+@dataclass(frozen=True)
+class Gate:
+    """OR node — any one child suffices."""
+
+    label_active: str
+    label_done: str
+    children: tuple  # tuple[Condition | Bundle | Gate, ...]
+
+    @property
+    def op(self) -> str:
+        return "any"
+
+    @property
+    def met(self) -> bool:
+        return any(c.met for c in self.children)
+
+
+@dataclass(frozen=True)
+class CapabilityCheck:
+    """Evaluated capability tree for a specific user."""
+
+    name: str
+    tree: Any  # Condition | Bundle | Gate
+
+    @property
+    def granted(self) -> bool:
+        return self.tree.met
+
+
+def mount_capability_routes(
+    router: APIRouter,
+    checks: dict[str, Callable],
+    *,
+    index_template: str = "users/access/index.html",
+    capabilities_list_template: str = "users/access/capabilities/index.html",
+    detail_template: str = "users/access/capabilities/detail.html",
+) -> None:
+    """Mount the three read-only capability routes onto `router`.
+
+    Routes:
+      - ``GET ""``                          renders ``index_template`` with
+        a ``capabilities_url`` context key pointing at the list page.
+      - ``GET /capabilities``               renders ``capabilities_list_template``
+        with ``checks`` (all named capabilities, granted/denied),
+        ``capability_base_url``, and ``access_index_url``.
+      - ``GET /capabilities/{name}``        renders ``detail_template``
+        with the evaluated ``CapabilityCheck`` for the named capability;
+        returns 404 for unknown names.
+
+    ``checks`` is a ``dict[str, Callable]`` mapping capability name to a
+    single-arg predicate ``(user) -> CapabilityCheck``. The framework
+    calls each predicate with the current active user and passes the
+    result to the template; it never inspects the returned tree itself.
+
+    Template context keys:
+      - index: ``capabilities_url``
+      - list: ``checks`` (dict[str, CapabilityCheck]), ``capability_base_url``, ``access_index_url``
+      - detail: ``check`` (CapabilityCheck), ``access_index_url``, ``capabilities_url``
+    """
+    _access_index_url = str(router.prefix)
+    _capability_base_url = f"{router.prefix}/capabilities"
+
+    @router.get("")
+    async def _access_index(
+        request: Request,
+        user: Any = Depends(current_active_user),
+    ):
+        return APIResponse.html_response(
+            template_name=index_template,
+            context={
+                "capabilities_url": _capability_base_url,
+            },
+            request=request,
+            current_user=user,
+        )
+
+    @router.get("/capabilities")
+    async def _capabilities_index(
+        request: Request,
+        user: Any = Depends(current_active_user),
+    ):
+        evaluated = {name: fn(user) for name, fn in checks.items()}
+        return APIResponse.html_response(
+            template_name=capabilities_list_template,
+            context={
+                "checks": evaluated,
+                "capability_base_url": _capability_base_url,
+                "access_index_url": _access_index_url,
+            },
+            request=request,
+            current_user=user,
+        )
+
+    @router.get("/capabilities/{name}")
+    async def _capability_detail(
+        name: str,
+        request: Request,
+        user: Any = Depends(current_active_user),
+    ):
+        fn = checks.get(name)
+        if fn is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+        check = fn(user)
+        return APIResponse.html_response(
+            template_name=detail_template,
+            context={
+                "check": check,
+                "access_index_url": _access_index_url,
+                "capabilities_url": _capability_base_url,
+            },
+            request=request,
+            current_user=user,
+        )

--- a/src/framework/templates/_shared/_capability_tree.html
+++ b/src/framework/templates/_shared/_capability_tree.html
@@ -1,0 +1,43 @@
+{# Framework-layer macro for rendering a capability tree node.
+
+   `render_node(node)` dispatches on `node.__class__.__name__` to one of
+   three shapes — Condition (leaf), Bundle (AND), Gate (OR) — and renders
+   the sub-tree recursively via a loop over `node.children`.
+
+   Jinja macros cannot call themselves directly; children are rendered in
+   a loop that re-calls the macro by name. For the two-level tree in
+   `check_can_read_feed` this is sufficient: root Bundle → (Condition,
+   Gate → (Condition, Condition)). Deeper nesting is supported so long as
+   the macro is imported before the first call.
+
+   Import in any template that needs to render a capability tree:
+     {%- from "_shared/_capability_tree.html" import render_node -%}
+#}
+{% macro render_node(node) %}
+  {% set kind = node.__class__.__name__ %}
+  {% if kind == "Condition" %}
+    <li class="capability-node capability-node--condition">
+      {% if node.met %}
+        <span class="capability-check capability-check--met">&#10003;</span>
+      {% else %}
+        <span class="capability-check capability-check--unmet">&#10007;</span>
+      {% endif %}
+      {{ node.label_done if node.met else node.label_active }}
+      {% if not node.met %}<a href="{{ node.fix_url }}">Fix →</a>{% endif %}
+    </li>
+  {% elif kind == "Bundle" %}
+    <li class="capability-node capability-node--bundle">
+      <span class="capability-operator">AND</span> {{ node.label_done if node.met else node.label_active }}
+      <ul class="capability-children">
+        {% for child in node.children %}{{ render_node(child) }}{% endfor %}
+      </ul>
+    </li>
+  {% elif kind == "Gate" %}
+    <li class="capability-node capability-node--gate">
+      <span class="capability-operator">OR</span> {{ node.label_done if node.met else node.label_active }}
+      <ul class="capability-children">
+        {% for child in node.children %}{{ render_node(child) }}{% endfor %}
+      </ul>
+    </li>
+  {% endif %}
+{% endmacro %}

--- a/src/framework/test_capabilities.py
+++ b/src/framework/test_capabilities.py
@@ -1,0 +1,110 @@
+"""Tests for `src/framework/capabilities.py` — the framework-layer tree primitives.
+
+Only the structural / evaluation logic is covered here. Domain predicates
+(`check_can_read_feed`, etc.) are tested in
+`src/domain/logic/test_capabilities.py`.
+"""
+
+from __future__ import annotations
+
+from src.framework.capabilities import Bundle, CapabilityCheck, Condition, Gate
+
+
+def _met(label: str = "met") -> Condition:
+    return Condition(label_active=label, label_done=label, met=True, fix_url="/fix")
+
+
+def _unmet(label: str = "unmet") -> Condition:
+    return Condition(label_active=label, label_done=label, met=False, fix_url="/fix")
+
+
+# ---------- Bundle (AND) ---------------------------------------------------
+
+
+def test_bundle_all_met_is_true():
+    b = Bundle(label_active="b", label_done="b", children=(_met(), _met()))
+    assert b.met is True
+
+
+def test_bundle_any_unmet_is_false():
+    b = Bundle(label_active="b", label_done="b", children=(_met(), _unmet()))
+    assert b.met is False
+
+
+def test_bundle_all_unmet_is_false():
+    b = Bundle(label_active="b", label_done="b", children=(_unmet(), _unmet()))
+    assert b.met is False
+
+
+def test_bundle_empty_is_true():
+    """Vacuous truth: an empty AND is True."""
+    assert Bundle(label_active="empty", label_done="empty", children=()).met is True
+
+
+# ---------- Gate (OR) ------------------------------------------------------
+
+
+def test_gate_any_met_is_true():
+    g = Gate(label_active="g", label_done="g", children=(_unmet(), _met()))
+    assert g.met is True
+
+
+def test_gate_all_unmet_is_false():
+    g = Gate(label_active="g", label_done="g", children=(_unmet(), _unmet()))
+    assert g.met is False
+
+
+def test_gate_all_met_is_true():
+    g = Gate(label_active="g", label_done="g", children=(_met(), _met()))
+    assert g.met is True
+
+
+def test_gate_empty_is_false():
+    """Vacuous falsity: an empty OR is False."""
+    assert Gate(label_active="empty", label_done="empty", children=()).met is False
+
+
+# ---------- CapabilityCheck ------------------------------------------------
+
+
+def test_capability_check_granted_delegates_to_tree_met():
+    check_granted = CapabilityCheck(name="x", tree=_met())
+    assert check_granted.granted is True
+
+    check_denied = CapabilityCheck(name="x", tree=_unmet())
+    assert check_denied.granted is False
+
+
+def test_capability_check_granted_uses_bundle_met():
+    tree = Bundle(label_active="root", label_done="root", children=(_met(), _met()))
+    assert CapabilityCheck(name="x", tree=tree).granted is True
+
+    tree_fail = Bundle(label_active="root", label_done="root", children=(_met(), _unmet()))
+    assert CapabilityCheck(name="x", tree=tree_fail).granted is False
+
+
+def test_capability_check_granted_uses_gate_met():
+    tree = Gate(label_active="root", label_done="root", children=(_unmet(), _met()))
+    assert CapabilityCheck(name="x", tree=tree).granted is True
+
+    tree_fail = Gate(label_active="root", label_done="root", children=(_unmet(), _unmet()))
+    assert CapabilityCheck(name="x", tree=tree_fail).granted is False
+
+
+# ---------- nested tree evaluation ----------------------------------------
+
+
+def test_nested_bundle_inside_gate():
+    """Gate OR (Bundle AND (met, unmet), met) → True because the second Gate
+    child is met."""
+    inner = Bundle(label_active="inner", label_done="inner", children=(_met(), _unmet()))
+    g = Gate(label_active="root", label_done="root", children=(inner, _met()))
+    assert g.met is True
+
+
+def test_nested_gate_inside_bundle():
+    """Bundle AND (met, Gate OR (unmet, unmet)) → False because the Gate
+    fails."""
+    inner = Gate(label_active="inner", label_done="inner", children=(_unmet(), _unmet()))
+    b = Bundle(label_active="root", label_done="root", children=(_met(), inner))
+    assert b.met is False

--- a/src/framework/test_capabilities.py
+++ b/src/framework/test_capabilities.py
@@ -79,7 +79,9 @@ def test_capability_check_granted_uses_bundle_met():
     tree = Bundle(label_active="root", label_done="root", children=(_met(), _met()))
     assert CapabilityCheck(name="x", tree=tree).granted is True
 
-    tree_fail = Bundle(label_active="root", label_done="root", children=(_met(), _unmet()))
+    tree_fail = Bundle(
+        label_active="root", label_done="root", children=(_met(), _unmet())
+    )
     assert CapabilityCheck(name="x", tree=tree_fail).granted is False
 
 
@@ -87,7 +89,9 @@ def test_capability_check_granted_uses_gate_met():
     tree = Gate(label_active="root", label_done="root", children=(_unmet(), _met()))
     assert CapabilityCheck(name="x", tree=tree).granted is True
 
-    tree_fail = Gate(label_active="root", label_done="root", children=(_unmet(), _unmet()))
+    tree_fail = Gate(
+        label_active="root", label_done="root", children=(_unmet(), _unmet())
+    )
     assert CapabilityCheck(name="x", tree=tree_fail).granted is False
 
 
@@ -97,7 +101,9 @@ def test_capability_check_granted_uses_gate_met():
 def test_nested_bundle_inside_gate():
     """Gate OR (Bundle AND (met, unmet), met) → True because the second Gate
     child is met."""
-    inner = Bundle(label_active="inner", label_done="inner", children=(_met(), _unmet()))
+    inner = Bundle(
+        label_active="inner", label_done="inner", children=(_met(), _unmet())
+    )
     g = Gate(label_active="root", label_done="root", children=(inner, _met()))
     assert g.met is True
 
@@ -105,6 +111,8 @@ def test_nested_bundle_inside_gate():
 def test_nested_gate_inside_bundle():
     """Bundle AND (met, Gate OR (unmet, unmet)) → False because the Gate
     fails."""
-    inner = Gate(label_active="inner", label_done="inner", children=(_unmet(), _unmet()))
+    inner = Gate(
+        label_active="inner", label_done="inner", children=(_unmet(), _unmet())
+    )
     b = Bundle(label_active="root", label_done="root", children=(_met(), inner))
     assert b.met is False


### PR DESCRIPTION
## Summary

- Moves `Condition`, `Bundle`, `Gate`, `CapabilityCheck` from `domain/logic/capabilities.py` to `src/framework/capabilities.py` — they're domain-agnostic tree structures, same layer as `AuditLog` or `Actor`
- Adds `mount_capability_routes(router, checks)` to the framework as a mount helper parallel to `mount_entity` / `mount_edge_routes` — domain passes its `_CHECKS` dict, framework wires the two access routes
- Moves `render_node` Jinja macro to `framework/templates/_shared/_capability_tree.html`, same pattern as `_locked.html`
- Domain re-exports the four types so all existing callers are unchanged
- `src/domain/routes/access.py` shrinks to 22 lines — just the registry and the mount call
- Adds `src/framework/test_capabilities.py` covering the tree primitives in isolation

## Why

Per the framework import discipline (`src/README.md`): framework code reads specs as parameters and never imports domain. The tree primitives have zero domain knowledge and belong in framework. The domain defines capabilities using framework primitives, exactly as it defines entities using `EntitySpec`.

## Stacks on

#1186

## Test plan

- [ ] 2368 tests pass, lint clean
- [ ] `grep -n "from src.domain" src/framework/capabilities.py` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)