### PR TITLE
Auto-inject breadcrumbs on subresource list pages via display_label_fn

### DIFF
--- a/src/domain/routes/test_favorites.py
+++ b/src/domain/routes/test_favorites.py
@@ -202,3 +202,20 @@ async def test_add_favorite_requires_auth(
     clinician_id = await _seed_clinician(db_test_session_manager)
     response = await test_client.post(f"/users/me/favorites/{clinician_id}")
     assert response.status_code in (302, 401)
+
+
+async def test_list_my_favorites_renders_breadcrumb(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`GET /users/me/favorites` now renders a breadcrumb back-affordance
+    pointing at the current user's profile page — auto-injected by
+    `mount_edge_routes` via `USER_ENTITY.display_label_fn`."""
+    response = await authenticated_client.get("/users/me/favorites")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
+    assert back is not None, "favorites list must render a breadcrumb back-affordance"
+    assert back.attributes.get("href") == "/users/me"
+    label = back.css_first("span.breadcrumb-back-label")
+    assert label is not None and label.text(strip=True) == logged_in_user.username

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -1009,3 +1009,22 @@ async def test_get_user_clinicians_404_for_unknown_user(
 
     response = await authenticated_client.get(f"/users/{uuid.uuid4()}/clinicians")
     assert response.status_code == 404
+
+
+async def test_get_my_clinicians_renders_breadcrumb(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`GET /users/me/clinicians` renders a breadcrumb back-affordance
+    pointing at the current user's profile — auto-injected by
+    `mount_related_list` via `USER_ENTITY.display_label_fn`."""
+    response = await authenticated_client.get("/users/me/clinicians")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
+    assert (
+        back is not None
+    ), "user clinicians list must render a breadcrumb back-affordance"
+    assert back.attributes.get("href") == f"/users/{logged_in_user.id}"
+    label = back.css_first("span.breadcrumb-back-label")
+    assert label is not None and label.text(strip=True) == logged_in_user.username

--- a/src/domain/specs/clinician.py
+++ b/src/domain/specs/clinician.py
@@ -82,6 +82,8 @@ CLINICIAN_ENTITY: Final[EntitySpec] = EntitySpec(
     url_collection="clinicians",
     id_param="clinician_id",
     model=Clinician,
+    display_label_fn=lambda c: f"{c.first_name or ''} {c.last_name or ''}".strip()
+    or "Clinician",
     repo_dep=get_clinician_repository,
     auth_deps=AUTHENTICATED,
     auth_policy=OWNER_OR_ADMIN,

--- a/src/domain/specs/organization.py
+++ b/src/domain/specs/organization.py
@@ -53,6 +53,7 @@ ORGANIZATION_ENTITY: Final[EntitySpec] = EntitySpec(
     url_collection="organizations",
     id_param="organization_id",
     model=Organization,
+    display_label_fn=lambda o: o.name,
     repo_dep=get_organization_repository,
     auth_deps=AUTHENTICATED,
     auth_policy=OWNER_OR_ADMIN,

--- a/src/domain/specs/user.py
+++ b/src/domain/specs/user.py
@@ -53,6 +53,7 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
     id_param="user_id",
     model=User,
     owner_attr=None,  # the resource *is* the user; not owned by another user
+    display_label_fn=lambda u: u.username,
     repo_dep=get_user_repository,
     auth_deps=ADMIN_FOR_WRITE,
     audit_snapshot=UserAuditSnapshot,

--- a/src/domain/templates/clinicians/openings_list.html
+++ b/src/domain/templates/clinicians/openings_list.html
@@ -1,19 +1,9 @@
 {% extends "views/list.html" %}
 {%- from "_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 {%- from "_shared/_item_list.html" import item_list -%}
-{# Owner-scoped projection over /posts — this clinician's openings. #}
+{# Owner-scoped projection over /posts — this clinician's openings.
+   Breadcrumb auto-injected by mount_related_list via CLINICIAN_ENTITY.display_label_fn. #}
 {% block resource_label %}{% endblock %}
-{%- set _fn = clinician.first_name or "" -%}
-{%- set _ln = clinician.last_name or "" -%}
-{%- set clinician_label = (_fn ~ " " ~ _ln) | trim or "Clinician" -%}
-{% block breadcrumb %}
-  {{ breadcrumb([
-    ("Clinicians", entity_url('clinician') ),
-  (clinician_label, entity_url('clinician', id=clinician.id)),
-  ("Openings", none),
-  ]) }}
-{% endblock %}
 {% block content %}
   {%- set _empty %}{{ post_feed_empty("No openings posted for this clinician yet.") }}{%- endset %}
     {{ item_list(posts, post_feed_row, "clinician-openings-list", "post-feed-list",

--- a/src/domain/templates/clinicians/referrals_list.html
+++ b/src/domain/templates/clinicians/referrals_list.html
@@ -1,21 +1,11 @@
 {% extends "views/list.html" %}
 {%- from "_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {# Owner-scoped projection over /posts — referrals attributed to this
    clinician (the `referring_clinician_id` the post-create authz treats
-   as referral ownership). #}
+   as referral ownership). Breadcrumb auto-injected by mount_related_list
+   via CLINICIAN_ENTITY.display_label_fn. #}
 {% block resource_label %}{% endblock %}
-{%- set _fn = clinician.first_name or "" -%}
-{%- set _ln = clinician.last_name or "" -%}
-{%- set clinician_label = (_fn ~ " " ~ _ln) | trim or "Clinician" -%}
-{% block breadcrumb %}
-  {{ breadcrumb([
-    ("Clinicians", entity_url('clinician') ),
-  (clinician_label, entity_url('clinician', id=clinician.id)),
-  ("Referrals", none),
-  ]) }}
-{% endblock %}
 {% block content %}
   {%- set _empty %}{{ post_feed_empty("No referrals attributed to this clinician yet.") }}{%- endset %}
     {{ item_list(posts, post_feed_row, "clinician-referrals-list", "post-feed-list",

--- a/src/domain/templates/organizations/intakes_list.html
+++ b/src/domain/templates/organizations/intakes_list.html
@@ -1,17 +1,10 @@
 {% extends "views/list.html" %}
 {%- from "_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {# Owner-scoped projection over /posts — intakes whose Program belongs to
-   this org. #}
+   this org. Breadcrumb auto-injected by mount_related_list via
+   ORGANIZATION_ENTITY.display_label_fn. #}
 {% block resource_label %}{% endblock %}
-{% block breadcrumb %}
-  {{ breadcrumb([
-    ("Organizations", entity_url('organization') ),
-  (organization.name, entity_url('organization', id=organization.id)),
-  ("Intakes", none),
-  ]) }}
-{% endblock %}
 {% block content %}
   {%- set _empty %}{{ post_feed_empty("No program intakes posted for this organization yet.") }}{%- endset %}
     {{ item_list(posts, post_feed_row, "org-intakes-list", "post-feed-list",

--- a/src/domain/templates/users/clinicians_list.html
+++ b/src/domain/templates/users/clinicians_list.html
@@ -1,18 +1,10 @@
 {% extends "views/list.html" %}
 {%- from "_shared/_clinician_card.html" import clinician_card -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 {%- from "_shared/_item_list.html" import item_list -%}
-{# Subresource list — three-segment breadcrumb instead of the default
-   single-segment `resource_label`. Suppress the auto-injected label so
-   the breadcrumb carries all the navigation context. #}
+{# Subresource list — breadcrumb is auto-injected by mount_related_list via
+   USER_ENTITY.display_label_fn. Suppress resource_label so the breadcrumb
+   carries all navigation context. #}
 {% block resource_label %}{% endblock %}
-{% block breadcrumb %}
-  {{ breadcrumb([
-    ("Users", entity_url('user') ),
-  (target_user.username, entity_url('user', id=target_user.id)),
-  ("Clinicians", none),
-  ]) }}
-{% endblock %}
 {% block actions %}
   {% if is_self %}
     <li>

--- a/src/framework/dispatch/entity_spec.py
+++ b/src/framework/dispatch/entity_spec.py
@@ -197,6 +197,12 @@ class EntitySpec:
     # and `src/framework/rendering/labels.py`. The pin test
     # `test_form_chrome_labels` asserts the structural equivalence.
     singular_label: str | None = None
+    # Human-readable label for a single row of this entity — used by the
+    # framework to auto-inject breadcrumb items on related-list and edge
+    # pages. Return a short, user-visible string (e.g. a username, a full
+    # name, an org name). Leave None for entities that never appear as a
+    # parent in a URL ancestry chain.
+    display_label_fn: Callable[[Any], str] | None = None
     owner_attr: str | None = "owner_id"
 
     # Parent (owned subentity link) --------------------------------------

--- a/src/framework/dispatch/mounts/edge.py
+++ b/src/framework/dispatch/mounts/edge.py
@@ -79,6 +79,12 @@ def mount_edge_routes(
     # cluster mate `entity_spec`).
     from src.framework.persistence.dependencies import get_audit_repository
 
+    # Resolve breadcrumb metadata once at mount time. Edge routes are
+    # self-only (the "parent" is always the requesting user), so the
+    # ancestry chain is: from_entity collection → user row → edge collection.
+    _from_entity = entity.relation.from_entity
+    _from_label_fn = _from_entity.display_label_fn
+
     @router.get("", name=f"{entity.name}:list")
     async def _list_route(  # noqa: F811 — closure, not re-exported
         request: Request,
@@ -86,6 +92,19 @@ def mount_edge_routes(
         repo: Any = Depends(repo_dep),
     ):
         context = await list_handler(request=request, repo=repo, requesting_user=user)
+        if _from_label_fn is not None:
+            collection = _from_entity.url_collection
+            # Use the singleton alias path (e.g. /users/me) when available
+            # so the back link reads the canonical self-path, not a bare UUID.
+            alias = _from_entity.singleton_alias
+            parent_path = (
+                f"/{collection}/{alias[0]}" if alias else f"/{collection}/{user.id}"
+            )
+            context["_breadcrumb_items"] = [
+                (collection.capitalize(), f"/{collection}"),
+                (_from_label_fn(user), parent_path),
+                (entity.url_collection.capitalize(), None),
+            ]
         return APIResponse.html_response(
             template_name=list_template,
             context=context,

--- a/src/framework/dispatch/mounts/related_list.py
+++ b/src/framework/dispatch/mounts/related_list.py
@@ -47,6 +47,11 @@ def mount_related_list(
     ``current_active_user().id`` and passed to the handler — same handler,
     same template, same response. The alias is purely an id-derivation
     convenience.
+
+    When ``parent_spec.entity_spec`` declares a ``display_label_fn``, the
+    mount fetches the parent row (one PK lookup) and injects
+    ``_breadcrumb_items`` into the template context so ``views/list.html``
+    can auto-render the ancestry chain without any per-template boilerplate.
     """
     if not template:
         raise ValueError(
@@ -57,15 +62,44 @@ def mount_related_list(
     parent_id_param = parent_spec.id_param
     path = f"/{{{parent_id_param}}}/{child_spec.collection}"
 
+    # Resolve the parent entity spec once at mount time so the response
+    # builder closure doesn't re-check on every request.
+    _parent_entity_spec = getattr(parent_spec, "entity_spec", None)
+    _parent_label_fn = (
+        _parent_entity_spec.display_label_fn
+        if _parent_entity_spec is not None
+        else None
+    )
+    # Whether to inject an extra parent-repo dep for the breadcrumb fetch.
+    _need_parent_repo = _parent_label_fn is not None
+    _parent_repo_dep = parent_spec.repo_dep if _need_parent_repo else None
+
     async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
         context = await call_handler_with(handler, handler_kwarg_names, kwargs)
+        if _parent_label_fn is not None:
+            parent_id = kwargs[parent_id_param]
+            parent_repo = kwargs["__parent_repo__"]
+            parent_entity = await parent_repo.get_by_model_id(
+                _parent_entity_spec.model, parent_id
+            )
+            if parent_entity is not None:
+                collection = _parent_entity_spec.url_collection
+                context["_breadcrumb_items"] = [
+                    (collection.capitalize(), f"/{collection}"),
+                    (_parent_label_fn(parent_entity), f"/{collection}/{parent_id}"),
+                    (child_spec.collection.capitalize(), None),
+                ]
         return APIResponse.html_response(
             template_name=template,
             context=context,
             request=request,
             current_user=kwargs.get("requesting_user"),
         )
+
+    _breadcrumb_dep: tuple[tuple[str, Any], ...] = (
+        (("__parent_repo__", _parent_repo_dep),) if _need_parent_repo else ()
+    )
 
     # The route renders children, so the synthesis hands the handler the
     # *child's* repo under `repo`. The parent-id path param is bound by
@@ -76,6 +110,7 @@ def mount_related_list(
         options=SynthOptions(
             user_dep=parent_spec.read_user_dep,
             path_param_names=(parent_id_param,),
+            extra_static_deps=_breadcrumb_dep,
         ),
         response_builder=response_builder,
     )
@@ -101,7 +136,8 @@ def mount_related_list(
             options=SynthOptions(
                 user_dep=None,
                 handler_supplied_names=(parent_id_param, "requesting_user"),
-                extra_static_deps=(("__session_user__", session_dep),),
+                extra_static_deps=(("__session_user__", session_dep),)
+                + _breadcrumb_dep,
             ),
             response_builder=alias_response_builder,
         )

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -34,13 +34,15 @@ Each view-type template fills the same unified page-header band (nav + breadcrum
 
 | View type     | Breadcrumb back target                    | Toolbar                                    | Child must declare                                       |
 | ------------- | ----------------------------------------- | ------------------------------------------ | -------------------------------------------------------- |
-| `list.html`   | _(none — list pages omit the breadcrumb)_ | optional filter widget + actions cluster   | `resource_label`, `content`. Optional: `actions`, `filters`/`filter_action`/`filter_values` (context). |
+| `list.html`   | _(auto-injected when `_breadcrumb_items` is in context — see below)_ | optional filter widget + actions cluster   | `resource_label`, `content`. Optional: `actions`, `filters`/`filter_action`/`filter_values` (context). |
 | `detail.html` | `← Resource`                              | optional actions cluster                   | `resource_label`, `current_label`, `content`, `resource_url` (context). Optional: `actions`. |
 | `form_new.html` | `← Resource`                            | none — form's submit button is the action  | `resource_label`, `content`, `resource_url` (context). H1 = `create_heading`, sourced from `entity_create_label(spec.name, kind=...)` via the form handler — children don't override the H1. |
 | `form_edit.html` | `← <current>`                          | none — form's Save/Cancel buttons are the actions | `resource_label`, `current_label`, `content`, `resource_url`, `resource_detail_url` (context). `current_label` is the **specific resource being edited** (e.g. `{{ organization.name }}`, `{{ view.headline }}`) — not a generic kind noun. |
 | `search.html` | `← Resource`                              | none — form's submit button is the action  | `resource_label` (context). H1 = `filter_heading`, sourced from `entity_filter_label(spec.name)` via the search handler. |
 
-The breadcrumb is always a single back affordance — a left chevron + the deepest clickable parent's label — at every viewport. The macro picks the back target by walking the chain backward to the last item with a non-`None` href, so a child template can override `{% block breadcrumb %}` with a multi-item chain (e.g. `[("Users", …), (username, /users/<id>), ("Clinicians", None)]` on `/users/{id}/clinicians`) to shift the back link one level up the tree without changing the visible shape.
+The breadcrumb is always a single back affordance — a left chevron + the deepest clickable parent's label — at every viewport. The macro picks the back target by walking the chain backward to the last item with a non-`None` href.
+
+**Automatic breadcrumbs on subresource list pages.** `mount_related_list` and `mount_edge_routes` inject `_breadcrumb_items` — a list of `(label, href|None)` tuples — into the template context when the parent entity's spec declares `display_label_fn`. `views/list.html` renders the breadcrumb block automatically when `_breadcrumb_items` is present; top-level list pages have no such injection and render no breadcrumb. Child templates that need a custom chain (labels derived from multiple context variables) still override `{% block breadcrumb %}` directly.
 
 ### Create / filter labels — single source of truth
 

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -97,6 +97,65 @@ def test_list_view_renders_h1_in_toolbar_and_omits_breadcrumb() -> None:
     assert '<div id="body">ok</div>' in html
 
 
+def test_list_view_renders_auto_breadcrumb_when_items_injected() -> None:
+    """When the mount injects ``_breadcrumb_items`` into the context,
+    ``views/list.html`` renders it as the breadcrumb back-affordance
+    automatically — no per-template ``{% block breadcrumb %}`` needed.
+    The back link points at the deepest parent with a non-None href."""
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block content %}<div id="body">ok</div>{% endblock %}
+        """,
+    )
+
+    items = [
+        ("Users", "/users"),
+        ("will", "/users/me"),
+        ("Clinicians", None),
+    ]
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+        _breadcrumb_items=items,
+    )
+
+    tree = HTMLParser(html)
+    back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
+    assert back is not None, "breadcrumb must render when _breadcrumb_items is injected"
+    assert back.attributes.get("href") == "/users/me"
+    label = back.css_first("span.breadcrumb-back-label")
+    assert label is not None and label.text(strip=True) == "will"
+
+
+def test_list_view_omits_breadcrumb_without_items() -> None:
+    """Without ``_breadcrumb_items`` in context the breadcrumb block
+    renders nothing — top-level list pages are unaffected."""
+    env = _make_env()
+    _add_child(
+        env,
+        "stub.html",
+        """
+        {% extends "views/list.html" %}
+        {% block resource_label %}Clinicians{% endblock %}
+        {% block content %}body{% endblock %}
+        """,
+    )
+
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+    )
+
+    tree = HTMLParser(html)
+    assert tree.css_first('nav[aria-label="breadcrumb"]') is None
+
+
 def test_list_view_renders_toolbar_with_h1_even_without_actions() -> None:
     """The toolbar shell always renders on list pages now because
     it owns the page `<h1>`; previously it was suppressed when

--- a/src/framework/templates/views/list.html
+++ b/src/framework/templates/views/list.html
@@ -1,13 +1,16 @@
 {# Generic list-view chrome.
 
-A list view (`/posts`, `/clinicians`, `/users`,
-`/users/me/favorites`, `/users/{id}/clinicians`) renders the page
-heading + actions in a single toolbar row above the list body. No
-breadcrumb: a single-segment "Posts" trail duplicates what the
-active global-nav tab already communicates (the breadcrumb guide
-flags this case explicitly), so list pages skip the breadcrumb
-block and let the `<h1>` in the toolbar carry the section name.
-Detail/form pages keep the breadcrumb for real ancestry.
+A list view (`/posts`, `/clinicians`, `/users`) renders the page
+heading + actions in a single toolbar row above the list body. Top-level
+list pages carry no breadcrumb — a single-segment "Posts" trail duplicates
+what the active global-nav tab already communicates.
+
+Subresource list pages (`/users/me/favorites`, `/users/{id}/clinicians`,
+`/clinicians/{id}/openings`) get a breadcrumb automatically when the
+mount injects `_breadcrumb_items` into the context (set by
+`mount_related_list` / `mount_edge_routes` when the parent entity's spec
+declares `display_label_fn`). The breadcrumb block below renders it when
+present; templates that need a custom chain override the block as before.
 
 Toolbar row contents (left-to-right):
   - `<h1>` heading (resource_label)
@@ -39,38 +42,48 @@ Child contract:
                      `<li>` because the menu is
                      `<menu class="toolbar-right">` (a commands
                      list). Empty by default.
-    breadcrumb     — full breadcrumb override for subresource lists
-                     with multi-segment chains (e.g.
-                     `/users/{id}/clinicians`). The default list
-                     view renders no breadcrumb; this override lets
-                     subresource list pages opt back in when there's
-                     real ancestry worth showing.
+    breadcrumb     — override the auto-injected breadcrumb. Use when
+                     `_breadcrumb_items` can't express the chain (e.g.
+                     a label computed from multiple context variables).
+                     Top-level list pages don't need this — they have
+                     no `_breadcrumb_items` and the block renders nothing.
 
   Context the framework's `handle_list` injects (children don't set
   these by hand):
     active_filters, search_url, resource_label, pager.
+
+  Context the framework's mount helpers inject for subresource pages:
+    _breadcrumb_items — list of (label, href|None) tuples; the last
+                        entry's href is None (current page). Injected
+                        by `mount_related_list` and `mount_edge_routes`
+                        when the parent entity spec declares
+                        `display_label_fn`. Absent on top-level lists.
 #}
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
-{% block toolbar %}
-  {%- set label %}
-    {% block resource_label %}{{ resource_label | default("") }}{% endblock %}
-  {% endset -%}
-  {%- set actions_body %}
-    {% block actions %}{% endblock %}
-  {% endset -%}
-  {%- set has_search = search_url is defined and search_url -%}
-  {# `filter_heading` is `entity_filter_label(spec.name)` from `handle_list`
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+{% block breadcrumb %}
+  {%- if _breadcrumb_items is defined %}{{ breadcrumb(_breadcrumb_items) }}{%- endif %}
+  {% endblock %}
+  {% block toolbar %}
+    {%- set label %}
+      {% block resource_label %}{{ resource_label | default("") }}{% endblock %}
+    {% endset -%}
+    {%- set actions_body %}
+      {% block actions %}{% endblock %}
+    {% endset -%}
+    {%- set has_search = search_url is defined and search_url -%}
+    {# `filter_heading` is `entity_filter_label(spec.name)` from `handle_list`
    (set only when `routes.search` is opted in). When absent, the toolbar
    macro falls back to its default ``"Filters"`` label. #}
-  {% call page_toolbar(
-    heading=label | trim,
-    active_filters=active_filters|default([]),
-    search_url=search_url if has_search else none,
-    filter_label=filter_heading or "Filters"
-    ) %}
-    {{ actions_body }}
-  {% endcall %}
-{% endblock %}
-{% block content %}{% endblock %}
-{% block after_content %}{% endblock %}
+    {% call page_toolbar(
+      heading=label | trim,
+      active_filters=active_filters|default([]),
+      search_url=search_url if has_search else none,
+      filter_label=filter_heading or "Filters"
+      ) %}
+      {{ actions_body }}
+    {% endcall %}
+  {% endblock %}
+  {% block content %}{% endblock %}
+  {% block after_content %}{% endblock %}


### PR DESCRIPTION
## Summary

- Adds `display_label_fn: Callable[[Any], str] | None` to `EntitySpec` — each entity that appears as a URL parent declares how to produce its human-readable row label (username, full name, org name)
- `mount_related_list` now fetches the parent row (one PK lookup) and injects `_breadcrumb_items` into the template context automatically
- `mount_edge_routes` does the same, using the requesting user as the parent and the entity's singleton alias path (e.g. `/users/me`) when available
- `views/list.html` renders the breadcrumb block when `_breadcrumb_items` is present; top-level list pages (no injection) render nothing as before

Fixes the missing breadcrumb on `/users/me/favorites`. Removes manual `{% block breadcrumb %}` boilerplate from four existing subresource templates. Any future subresource whose parent spec declares `display_label_fn` gets a breadcrumb for free.

## Test plan

- [ ] `dev test src/framework/templates/test_views.py` — new tests: auto-renders when `_breadcrumb_items` injected, omits when absent
- [ ] `dev test src/domain/routes/test_favorites.py` — new test: `/users/me/favorites` breadcrumb back-link points at `/users/me` with username label
- [ ] `dev test src/domain/routes/test_users.py` — new test: `/users/me/clinicians` breadcrumb back-link points at `/users/<id>` with username label
- [ ] `dev test` (full suite) — 2309 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)