### PR TITLE
Remove page-header-rule class

### DIFF
--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -410,9 +410,7 @@ dd { margin: 0; }
    breadcrumb (list pages): the placeholder is a real back-affordance
    shape, hidden — so the reserved height equals a rendered breadcrumb's
    and the rule lines up with detail pages. No size unit is pinned. */
-.page-header-crumb-placeholder { visibility: hidden; }
-.page-header-rule { margin-block: var(--pico-spacing) 0; }
-/* `<menu>` is HTML's native "list of commands" element — used
+.page-header-crumb-placeholder { visibility: hidden; }/* `<menu>` is HTML's native "list of commands" element — used
    by the page toolbar (`menu.toolbar`, `menu.toolbar-right`)
    and any in-row action cluster (e.g. the users-table Actions
    cell). Strip its default `<ul>`-style bullets + padding so

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -71,7 +71,7 @@ From top to bottom:
 │   primary nav        brand + auth-aware links             │
 │   breadcrumb row     ← Resource   (hidden placeholder if none) │  ← captured `{% block breadcrumb %}`
 │   toolbar row        <h1> title              [actions ▶]  │  ← captured `{% block toolbar %}`
-│   ─────────────────────────────────────────────────────  │  ← single `<hr class="page-header-rule">`
+│   ─────────────────────────────────────────────────────  │  ← single `<hr>`
 ├───────────────────────────────────────────────────────────┤
 │ (onboarding banner removed)                               │
 │ subtitle (optional)  NPI · Verified                       │  ← `{% block subtitle %}` (rendered below the rule, top of `<main>`)

--- a/src/framework/templates/_shared/_page_header.html
+++ b/src/framework/templates/_shared/_page_header.html
@@ -2,7 +2,7 @@
 
 Renders one `<header class="container page-header">` whose rows, top to
 bottom, are: primary nav → breadcrumb slot → page-title/toolbar slot →
-a single `<hr class="page-header-rule">` boundary. The rule sits at the
+a single `<hr>` boundary. The rule sits at the
 same Y on every app page at a given screen size: the breadcrumb row is
 reserved with an invisible intrinsic-height placeholder when a page has
 no real breadcrumb (list pages), so a list page's rule lines up with a
@@ -82,6 +82,6 @@ and the constant-boundary rationale (one source of truth).
       {%- endif %}
     </div>
     {{ _toolbar_html }}
-    <hr class="page-header-rule" />
+    <hr />
   {%- endif %}
 </header>

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -135,9 +135,9 @@ def test_list_reserves_breadcrumb_row_with_hidden_placeholder() -> None:
 
 
 def test_band_owns_the_single_boundary_rule_and_main_has_none() -> None:
-    """Exactly one `<hr>` exists and it lives in the band (carrying the
-    `page-header-rule` class); `<main>` has none. The toolbar macro no
-    longer emits its own separator — the band owns the single divider."""
+    """Exactly one `<hr>` exists and it lives in the band; `<main>` has
+    none. The toolbar macro no longer emits its own separator — the band
+    owns the single divider."""
     env = _make_env()
     _add_child(env, "stub.html", _DETAIL_STUB)
     tree = HTMLParser(_render(env, "stub.html"))
@@ -145,7 +145,7 @@ def test_band_owns_the_single_boundary_rule_and_main_has_none() -> None:
     band = tree.css_first("header.page-header")
     assert band is not None
     assert len(band.css("hr")) == 1
-    assert band.css_first("hr.page-header-rule") is not None
+    assert band.css_first("hr") is not None
 
     main = tree.css_first("main")
     assert main is not None


### PR DESCRIPTION
## Summary

- Strips `class="page-header-rule"` from the `<hr>` boundary element in `_page_header.html`
- Removes the `.page-header-rule { margin-block: var(--pico-spacing) 0; }` rule from `framework.css`
- Updates the test selector from `hr.page-header-rule` to `hr`
- Updates the comment in `_page_header.html` and the ASCII diagram in `templates/README.md`

The class existed only to apply a single `margin-block` tweak; Pico's default `<hr>` spacing is sufficient and the dedicated class is unnecessary overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)