### PR TITLE
Capability requirements panel: Pico-native design, dual-label grammar, shared macro

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -139,18 +139,30 @@ _FALLBACK_META = ReasonMeta(
 
 @dataclass(frozen=True)
 class Condition:
-    """Atomic boolean leaf in a capability tree."""
+    """Atomic boolean leaf in a capability tree.
 
-    label: str
+    Two labels encode the verb-subject grammar: `label_active` is the
+    imperative action shown when the condition is unmet ("Verify email");
+    `label_done` is the passive-past confirmation shown when met ("Email
+    verified"). Templates must never show the wrong label for the state.
+    """
+
+    label_active: str  # imperative: "Verify email"
+    label_done: str  # passive-past: "Email verified"
     met: bool
     fix_url: str  # the resource that changes this condition
 
 
 @dataclass(frozen=True)
 class Bundle:
-    """AND node — all children must pass."""
+    """AND node — all children must pass.
 
-    label: str
+    Same two-label grammar as Condition: `label_active` when the bundle
+    is unmet, `label_done` when every child is satisfied.
+    """
+
+    label_active: str
+    label_done: str
     children: tuple  # tuple[Condition | Bundle | Gate, ...]
 
     @property
@@ -160,9 +172,14 @@ class Bundle:
 
 @dataclass(frozen=True)
 class Gate:
-    """OR node — any one child suffices."""
+    """OR node — any one child suffices.
 
-    label: str
+    Same two-label grammar as Condition: `label_active` when unmet,
+    `label_done` when at least one child is satisfied.
+    """
+
+    label_active: str
+    label_done: str
     children: tuple  # tuple[Condition | Bundle | Gate, ...]
 
     @property
@@ -281,23 +298,28 @@ def check_network(user: Any) -> CapabilityCheck:
     return CapabilityCheck(
         name="network",
         tree=Bundle(
-            label="Read full feed",
+            label_active="Read full feed",
+            label_done="Read full feed",
             children=(
                 Condition(
-                    label="Email verified",
+                    label_active="Verify email",
+                    label_done="Email verified",
                     met=_email_met,
                     fix_url="/users/me/email/form",
                 ),
                 Gate(
-                    label="Verified via any one",
+                    label_active="Verify your status",
+                    label_done="Status verified",
                     children=(
                         Condition(
-                            label="Clinician identity verified",
+                            label_active="Verify clinician identity",
+                            label_done="Clinician identity verified",
                             met=_clin_met,
                             fix_url="/clinicians/form",
                         ),
                         Condition(
-                            label="Organization representative verified",
+                            label_active="Verify organization rep",
+                            label_done="Organization rep verified",
                             met=_org_met,
                             fix_url="/organizations/form",
                         ),

--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -166,6 +166,10 @@ class Bundle:
     children: tuple  # tuple[Condition | Bundle | Gate, ...]
 
     @property
+    def op(self) -> str:
+        return "all"
+
+    @property
     def met(self) -> bool:
         return all(c.met for c in self.children)
 
@@ -181,6 +185,10 @@ class Gate:
     label_active: str
     label_done: str
     children: tuple  # tuple[Condition | Bundle | Gate, ...]
+
+    @property
+    def op(self) -> str:
+        return "any"
 
     @property
     def met(self) -> bool:

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -584,7 +584,7 @@ def test_check_network_email_unverified_denied():
     assert check.granted is False
     # The Condition for email should be unmet.
     email_condition = check.tree.children[0]
-    assert email_condition.label == "Email verified"
+    assert email_condition.label_done == "Email verified"
     assert email_condition.met is False
 
 
@@ -609,7 +609,7 @@ def test_check_network_clinician_verified_granted():
     assert check.granted is True
     gate = check.tree.children[1]
     clin_condition = gate.children[0]
-    assert clin_condition.label == "Clinician identity verified"
+    assert clin_condition.label_done == "Clinician identity verified"
     assert clin_condition.met is True
 
 
@@ -624,7 +624,7 @@ def test_check_network_org_rep_granted():
     assert check.granted is True
     gate = check.tree.children[1]
     org_condition = gate.children[1]
-    assert org_condition.label == "Organization representative verified"
+    assert org_condition.label_done == "Organization rep verified"
     assert org_condition.met is True
 
 

--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -2,8 +2,7 @@
 
 Covers:
   - Unauthenticated requests are redirected / denied.
-  - Authenticated requests to the index render the access overview.
-  - Authenticated requests to /capabilities list all capabilities.
+  - Authenticated requests to the index return 200 with capability listings.
   - Authenticated requests to a capability detail return 200 with tree.
   - Unknown capability names return 404.
 """
@@ -23,50 +22,36 @@ async def test_access_index_unauthenticated_redirected(test_client: AsyncClient)
 async def test_access_index_authenticated_returns_200(
     authenticated_client: AsyncClient,
 ):
-    """Authenticated GET /users/me/access renders the access overview with a
-    link to the capabilities list."""
+    """Authenticated GET /users/me/access renders the capability index."""
     response = await authenticated_client.get("/users/me/access")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
-    assert "Capabilities" in response.text
-    assert "/users/me/access/capabilities" in response.text
+    # The one registered capability name appears in the response.
+    assert "can_read_feed" in response.text
 
 
-async def test_capabilities_index_unauthenticated_redirected(test_client: AsyncClient):
-    """Unauthenticated GET /users/me/access/capabilities is bounced."""
-    response = await test_client.get(
-        "/users/me/access/capabilities", follow_redirects=False
-    )
-    assert response.status_code != 200
-
-
-async def test_capabilities_index_authenticated_returns_200(
+async def test_access_index_shows_granted_or_denied(
     authenticated_client: AsyncClient,
 ):
-    """Authenticated GET /users/me/access/capabilities lists all capabilities."""
-    response = await authenticated_client.get("/users/me/access/capabilities")
+    """The index page surfaces a granted/denied label for each capability."""
+    response = await authenticated_client.get("/users/me/access")
     assert response.status_code == 200
-    assert response.headers["content-type"].startswith("text/html")
-    assert "network" in response.text
-
-
-async def test_capabilities_index_shows_granted_or_denied(
-    authenticated_client: AsyncClient,
-):
-    """The capabilities list surfaces a granted/denied label for each capability."""
-    response = await authenticated_client.get("/users/me/access/capabilities")
-    assert response.status_code == 200
+    # A fresh dev user is unverified, so the feed capability is denied.
     assert "Granted" in response.text or "Denied" in response.text
 
 
-async def test_capability_detail_network_returns_200(
+async def test_capability_detail_can_read_feed_returns_200(
     authenticated_client: AsyncClient,
 ):
-    """GET /users/me/access/capabilities/network renders the detail tree."""
-    response = await authenticated_client.get("/users/me/access/capabilities/network")
+    """GET /users/me/access/capabilities/can_read_feed renders the detail tree."""
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/can_read_feed"
+    )
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
-    assert "network" in response.text
+    # Capability label appears in the page heading.
+    assert "Read full feed" in response.text
+    # Tree node labels appear.
     assert "Email verified" in response.text
     assert "Clinician identity verified" in response.text
     assert "Organization representative verified" in response.text
@@ -75,10 +60,12 @@ async def test_capability_detail_network_returns_200(
 async def test_capability_detail_shows_status(
     authenticated_client: AsyncClient,
 ):
-    """The detail page shows a granted/denied badge."""
-    response = await authenticated_client.get("/users/me/access/capabilities/network")
+    """The detail page shows an available/locked badge."""
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/can_read_feed"
+    )
     assert response.status_code == 200
-    assert "Granted" in response.text or "Denied" in response.text
+    assert "Available" in response.text or "Not available yet" in response.text
 
 
 async def test_capability_detail_nonexistent_returns_404(
@@ -92,9 +79,9 @@ async def test_capability_detail_nonexistent_returns_404(
 
 
 async def test_capability_detail_unauthenticated_redirected(test_client: AsyncClient):
-    """Unauthenticated GET /users/me/access/capabilities/network is bounced."""
+    """Unauthenticated GET /users/me/access/capabilities/can_read_feed is bounced."""
     response = await test_client.get(
-        "/users/me/access/capabilities/network",
+        "/users/me/access/capabilities/can_read_feed",
         follow_redirects=False,
     )
     assert response.status_code != 200

--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -51,10 +51,16 @@ async def test_capability_detail_can_read_feed_returns_200(
     assert response.headers["content-type"].startswith("text/html")
     # Capability label appears in the page heading.
     assert "Read full feed" in response.text
-    # Tree node labels appear.
-    assert "Email verified" in response.text
-    assert "Clinician identity verified" in response.text
-    assert "Organization representative verified" in response.text
+    # Tree node labels appear — active form for unmet, done form for met.
+    assert "Verify email" in response.text or "Email verified" in response.text
+    assert (
+        "Verify clinician identity" in response.text
+        or "Clinician identity verified" in response.text
+    )
+    assert (
+        "Verify organization rep" in response.text
+        or "Organization rep verified" in response.text
+    )
 
 
 async def test_capability_detail_shows_status(

--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -2,7 +2,8 @@
 
 Covers:
   - Unauthenticated requests are redirected / denied.
-  - Authenticated requests to the index return 200 with capability listings.
+  - Authenticated requests to the index render the access overview.
+  - Authenticated requests to /capabilities list all capabilities.
   - Authenticated requests to a capability detail return 200 with tree.
   - Unknown capability names return 404.
 """
@@ -22,34 +23,50 @@ async def test_access_index_unauthenticated_redirected(test_client: AsyncClient)
 async def test_access_index_authenticated_returns_200(
     authenticated_client: AsyncClient,
 ):
-    """Authenticated GET /users/me/access renders the capability index."""
+    """Authenticated GET /users/me/access renders the access overview with a
+    link to the capabilities list."""
     response = await authenticated_client.get("/users/me/access")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
-    # The one registered capability name appears in the response.
-    assert "can_read_feed" in response.text
+    assert "Capabilities" in response.text
+    assert "/users/me/access/capabilities" in response.text
 
 
-async def test_access_index_shows_granted_or_denied(
+async def test_capabilities_index_unauthenticated_redirected(test_client: AsyncClient):
+    """Unauthenticated GET /users/me/access/capabilities is bounced."""
+    response = await test_client.get(
+        "/users/me/access/capabilities", follow_redirects=False
+    )
+    assert response.status_code != 200
+
+
+async def test_capabilities_index_authenticated_returns_200(
     authenticated_client: AsyncClient,
 ):
-    """The index page surfaces a granted/denied label for each capability."""
-    response = await authenticated_client.get("/users/me/access")
+    """Authenticated GET /users/me/access/capabilities lists all capabilities."""
+    response = await authenticated_client.get("/users/me/access/capabilities")
     assert response.status_code == 200
-    # A fresh dev user is unverified, so the feed capability is denied.
+    assert response.headers["content-type"].startswith("text/html")
+    assert "network" in response.text
+
+
+async def test_capabilities_index_shows_granted_or_denied(
+    authenticated_client: AsyncClient,
+):
+    """The capabilities list surfaces a granted/denied label for each capability."""
+    response = await authenticated_client.get("/users/me/access/capabilities")
+    assert response.status_code == 200
     assert "Granted" in response.text or "Denied" in response.text
 
 
-async def test_capability_detail_can_read_feed_returns_200(
+async def test_capability_detail_network_returns_200(
     authenticated_client: AsyncClient,
 ):
-    """GET /users/me/access/capabilities/can_read_feed renders the detail tree."""
-    response = await authenticated_client.get(
-        "/users/me/access/capabilities/can_read_feed"
-    )
+    """GET /users/me/access/capabilities/network renders the requirement tree."""
+    response = await authenticated_client.get("/users/me/access/capabilities/network")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
-    # Capability label appears in the page heading.
+    # Capability label_active appears in the page heading and breadcrumb.
     assert "Read full feed" in response.text
     # Tree node labels appear — active form for unmet, done form for met.
     assert "Verify email" in response.text or "Email verified" in response.text
@@ -67,9 +84,7 @@ async def test_capability_detail_shows_status(
     authenticated_client: AsyncClient,
 ):
     """The detail page shows an available/locked badge."""
-    response = await authenticated_client.get(
-        "/users/me/access/capabilities/can_read_feed"
-    )
+    response = await authenticated_client.get("/users/me/access/capabilities/network")
     assert response.status_code == 200
     assert "Available" in response.text or "Not available yet" in response.text
 
@@ -85,9 +100,9 @@ async def test_capability_detail_nonexistent_returns_404(
 
 
 async def test_capability_detail_unauthenticated_redirected(test_client: AsyncClient):
-    """Unauthenticated GET /users/me/access/capabilities/can_read_feed is bounced."""
+    """Unauthenticated GET /users/me/access/capabilities/network is bounced."""
     response = await test_client.get(
-        "/users/me/access/capabilities/can_read_feed",
+        "/users/me/access/capabilities/network",
         follow_redirects=False,
     )
     assert response.status_code != 200

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -297,10 +297,8 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .onboarding-step-action > form { margin-bottom: 0; }
 
 /* ── Capability requirements panel (users/access/capabilities/detail.html) ── */
-/* Tree: no bullets; nested gets indent + left guide rule */
-.cap-reqs, .cap-reqs ul { list-style: none; margin: 0; padding: 0; }
+.cap-reqs { list-style: none; margin: 0; padding: 0; }
 .cap-reqs li { list-style: none; }
-.cap-reqs ul { margin-left: .6rem; border-left: 1px solid var(--pico-muted-border-color); padding-left: 1.25rem; }
 
 /* Row: flex line — checkbox + label (or link) */
 .cap-reqs li > span { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -297,25 +297,23 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .onboarding-step-action > form { margin-bottom: 0; }
 
 /* ── Capability requirements panel (users/access/capabilities/detail.html) ── */
-/* Row: flex line of icon + label + optional action chevron */
+/* Row: flex line — native checkbox + label + optional Lucide chevron */
 .cap-row { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
-.cap-row .cap-label { flex: 1; min-width: 0; }
-/* Done state: muted label; icon goes green via currentColor cascade */
+.cap-row .cap-label { flex: 1; }
 .cap-row.done { color: var(--pico-muted-color); }
-.cap-row.done .cap-icon { color: var(--pico-ins-color); }
-/* Clickable row: suppress default link styles; add hover surface */
 a.cap-row { color: inherit; text-decoration: none; border-radius: var(--pico-border-radius); margin: 0 -.5rem; padding-inline: .5rem; }
 a.cap-row:hover { background: var(--pico-secondary-background); }
-a.cap-row:hover .cap-chevron { color: var(--pico-primary); }
-/* SVG icons: muted by default; parent state overrides color via currentColor */
-.cap-icon { width: 1.25rem; height: 1.25rem; flex: none; fill: none; stroke: currentColor; stroke-width: 2; color: var(--pico-muted-color); }
-.cap-chevron { color: var(--pico-muted-color); }
+a.cap-row:hover i { color: var(--pico-primary); }
+/* Checkboxes are display-only state indicators; pointer-events prevents toggling */
+.cap-row input[type="checkbox"] { pointer-events: none; flex: none; margin: 0; }
+.cap-row.done input[type="checkbox"] { accent-color: var(--pico-ins-color); }
 /* Tree: no bullets; nested gets indent + left guide rule */
 .cap-reqs, .cap-reqs ul { list-style: none; margin: 0; padding: 0; }
+.cap-reqs li { list-style: none; }
 .cap-reqs ul { margin-left: .6rem; border-left: 1px solid var(--pico-muted-border-color); padding-left: 1.25rem; }
-/* Satisfied branch children: HTML `inert` → non-interactive; opacity for visual */
+/* Satisfied branch children: HTML inert → non-interactive; opacity for visual */
 .cap-reqs [inert] { opacity: .55; }
-/* <kbd> used for operator chips and status badge: reset Pico's monospace font */
-.cap-reqs kbd, .cap-badge { font-family: inherit; display: inline-flex; align-items: center; gap: .35rem; }
-/* Unlocked badge: green text + border cascade to child SVG via currentColor */
+/* <kbd> for operator chips and status badge: clear Pico code bg, muted text */
+.cap-reqs kbd, .cap-badge { font-family: inherit; background: transparent; display: inline-flex; align-items: center; gap: .35rem; color: var(--pico-muted-color); }
+/* Unlocked badge: green (cascades to child icon via currentColor) */
 .cap-badge[data-state="unlocked"] { color: var(--pico-ins-color); border-color: var(--pico-ins-color); }

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -303,14 +303,12 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .cap-reqs ul { margin-left: .6rem; border-left: 1px solid var(--pico-muted-border-color); padding-left: 1.25rem; }
 /* Satisfied branch children: HTML inert → non-interactive; opacity for visual */
 .cap-reqs [inert] { opacity: .55; }
-/* Row: flex line — direct child span or a of each li */
-.cap-reqs li > span, .cap-reqs li > a { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
-/* Label span takes remaining space */
-.cap-reqs li > span > span, .cap-reqs li > a > span { flex: 1; }
+/* Row: flex line — checkbox + label (or link) */
+.cap-reqs li > span { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
+/* Label (span or a) takes remaining space */
+.cap-reqs li > span > span, .cap-reqs li > span > a { flex: 1; }
 /* Done row: muted text */
 .cap-reqs li > span.done { color: var(--pico-muted-color); }
-/* Link row: inherit color, no underline */
-.cap-reqs li > a { color: inherit; text-decoration: none; border-radius: var(--pico-border-radius); margin: 0 -.5rem; padding-inline: .5rem; }
 /* Checkboxes are display-only state indicators; pointer-events prevents toggling */
 .cap-reqs input[type="checkbox"] { pointer-events: none; flex: none; margin: 0; }
 .cap-reqs li > span.done input[type="checkbox"] { accent-color: var(--pico-ins-color); }

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -299,12 +299,3 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 /* ── Capability requirements panel (users/access/capabilities/detail.html) ── */
 .cap-reqs { list-style: none; margin: 0; padding: 0; }
 .cap-reqs li { list-style: none; }
-
-/* Row: flex line — checkbox + label (or link) */
-.cap-reqs li > span { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
-/* Label (span or a) takes remaining space */
-.cap-reqs li > span > span, .cap-reqs li > span > a { flex: 1; }
-/* Checkboxes are display-only state indicators; pointer-events prevents toggling */
-.cap-reqs input[type="checkbox"] { pointer-events: none; flex: none; margin: 0; }
-/* Unlocked badge: green */
-article header small[data-state="unlocked"] { color: var(--pico-ins-color); }

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -301,8 +301,7 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .cap-reqs, .cap-reqs ul { list-style: none; margin: 0; padding: 0; }
 .cap-reqs li { list-style: none; }
 .cap-reqs ul { margin-left: .6rem; border-left: 1px solid var(--pico-muted-border-color); padding-left: 1.25rem; }
-/* Satisfied branch children: HTML inert → non-interactive; opacity for visual */
-.cap-reqs [inert] { opacity: .55; }
+
 /* Row: flex line — checkbox + label (or link) */
 .cap-reqs li > span { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
 /* Label (span or a) takes remaining space */

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -307,10 +307,7 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .cap-reqs li > span { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
 /* Label (span or a) takes remaining space */
 .cap-reqs li > span > span, .cap-reqs li > span > a { flex: 1; }
-/* Done row: muted text */
-.cap-reqs li > span.done { color: var(--pico-muted-color); }
 /* Checkboxes are display-only state indicators; pointer-events prevents toggling */
 .cap-reqs input[type="checkbox"] { pointer-events: none; flex: none; margin: 0; }
-.cap-reqs li > span.done input[type="checkbox"] { accent-color: var(--pico-ins-color); }
 /* Unlocked badge: green */
 article header small[data-state="unlocked"] { color: var(--pico-ins-color); }

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -295,3 +295,27 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 /* ── Onboarding step page (profile/step.html) ─────────────────── */
 .onboarding-step-back { margin-bottom: 0.5rem; font-size: 0.9em; }
 .onboarding-step-action > form { margin-bottom: 0; }
+
+/* ── Capability requirements panel (users/access/capabilities/detail.html) ── */
+/* Row: flex line of icon + label + optional action chevron */
+.cap-row { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
+.cap-row .cap-label { flex: 1; min-width: 0; }
+/* Done state: muted label; icon goes green via currentColor cascade */
+.cap-row.done { color: var(--pico-muted-color); }
+.cap-row.done .cap-icon { color: var(--pico-ins-color); }
+/* Clickable row: suppress default link styles; add hover surface */
+a.cap-row { color: inherit; text-decoration: none; border-radius: var(--pico-border-radius); margin: 0 -.5rem; padding-inline: .5rem; }
+a.cap-row:hover { background: var(--pico-secondary-background); }
+a.cap-row:hover .cap-chevron { color: var(--pico-primary); }
+/* SVG icons: muted by default; parent state overrides color via currentColor */
+.cap-icon { width: 1.25rem; height: 1.25rem; flex: none; fill: none; stroke: currentColor; stroke-width: 2; color: var(--pico-muted-color); }
+.cap-chevron { color: var(--pico-muted-color); }
+/* Tree: no bullets; nested gets indent + left guide rule */
+.cap-reqs, .cap-reqs ul { list-style: none; margin: 0; padding: 0; }
+.cap-reqs ul { margin-left: .6rem; border-left: 1px solid var(--pico-muted-border-color); padding-left: 1.25rem; }
+/* Satisfied branch children: HTML `inert` → non-interactive; opacity for visual */
+.cap-reqs [inert] { opacity: .55; }
+/* <kbd> used for operator chips and status badge: reset Pico's monospace font */
+.cap-reqs kbd, .cap-badge { font-family: inherit; display: inline-flex; align-items: center; gap: .35rem; }
+/* Unlocked badge: green text + border cascade to child SVG via currentColor */
+.cap-badge[data-state="unlocked"] { color: var(--pico-ins-color); border-color: var(--pico-ins-color); }

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -297,23 +297,22 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .onboarding-step-action > form { margin-bottom: 0; }
 
 /* ── Capability requirements panel (users/access/capabilities/detail.html) ── */
-/* Row: flex line — native checkbox + label + optional Lucide chevron */
-.cap-row { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
-.cap-row .cap-label { flex: 1; }
-.cap-row.done { color: var(--pico-muted-color); }
-a.cap-row { color: inherit; text-decoration: none; border-radius: var(--pico-border-radius); margin: 0 -.5rem; padding-inline: .5rem; }
-a.cap-row:hover { background: var(--pico-secondary-background); }
-a.cap-row:hover i { color: var(--pico-primary); }
-/* Checkboxes are display-only state indicators; pointer-events prevents toggling */
-.cap-row input[type="checkbox"] { pointer-events: none; flex: none; margin: 0; }
-.cap-row.done input[type="checkbox"] { accent-color: var(--pico-ins-color); }
 /* Tree: no bullets; nested gets indent + left guide rule */
 .cap-reqs, .cap-reqs ul { list-style: none; margin: 0; padding: 0; }
 .cap-reqs li { list-style: none; }
 .cap-reqs ul { margin-left: .6rem; border-left: 1px solid var(--pico-muted-border-color); padding-left: 1.25rem; }
 /* Satisfied branch children: HTML inert → non-interactive; opacity for visual */
 .cap-reqs [inert] { opacity: .55; }
-/* <kbd> for operator chips and status badge: clear Pico code bg, muted text */
-.cap-reqs kbd, .cap-badge { font-family: inherit; background: transparent; display: inline-flex; align-items: center; gap: .35rem; color: var(--pico-muted-color); }
-/* Unlocked badge: green (cascades to child icon via currentColor) */
-.cap-badge[data-state="unlocked"] { color: var(--pico-ins-color); border-color: var(--pico-ins-color); }
+/* Row: flex line — direct child span or a of each li */
+.cap-reqs li > span, .cap-reqs li > a { display: flex; align-items: center; gap: .6rem; padding: .35rem 0; }
+/* Label span takes remaining space */
+.cap-reqs li > span > span, .cap-reqs li > a > span { flex: 1; }
+/* Done row: muted text */
+.cap-reqs li > span.done { color: var(--pico-muted-color); }
+/* Link row: inherit color, no underline */
+.cap-reqs li > a { color: inherit; text-decoration: none; border-radius: var(--pico-border-radius); margin: 0 -.5rem; padding-inline: .5rem; }
+/* Checkboxes are display-only state indicators; pointer-events prevents toggling */
+.cap-reqs input[type="checkbox"] { pointer-events: none; flex: none; margin: 0; }
+.cap-reqs li > span.done input[type="checkbox"] { accent-color: var(--pico-ins-color); }
+/* Unlocked badge: green */
+article header small[data-state="unlocked"] { color: var(--pico-ins-color); }

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -753,7 +753,6 @@ it's dev-only chrome that should never ship to production. #}
               <small>1 of 2 requirements met</small>
               <progress value="1" max="2"></progress>
             </header>
-            <hr>
             <ul class="cap-reqs">
               <li>
                 <small>All of these</small>
@@ -802,7 +801,6 @@ it's dev-only chrome that should never ship to production. #}
               <small>2 of 2 requirements met</small>
               <progress value="2" max="2"></progress>
             </header>
-            <hr>
             <ul class="cap-reqs">
               <li>
                 <small>All of these</small>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -222,6 +222,14 @@ it's dev-only chrome that should never ship to production. #}
                 </ul>
               </li>
               <li>
+                <span class="gallery-nav-subgroup">Access</span>
+                <ul>
+                  <li>
+                    <a href="#capability-requirements">Capability requirements</a>
+                  </li>
+                </ul>
+              </li>
+              <li>
                 <span class="gallery-nav-subgroup">Layouts</span>
                 <ul>
                   <li>
@@ -721,6 +729,161 @@ it's dev-only chrome that should never ship to production. #}
               </li>
             </ul>
           </div>
+        </div>
+      </section>
+      {# ═══════════════════════════════════════════════════════════ #}
+      {# DOMAIN: ACCESS                                               #}
+      {# ═══════════════════════════════════════════════════════════ #}
+      <section class="gallery-section" id="capability-requirements">
+        <h2>Capability requirements</h2>
+        <p>
+          <small>Classes: <code>.cap-reqs</code> / <code>.cap-row</code> / <code>.cap-badge</code>. Operator chips and badges use <code>&lt;kbd&gt;</code> (Pico-styled). Satisfied branches use the HTML <code>inert</code> attribute. SVG sprite must be on the page — see <code>detail.html</code>.</small>
+        </p>
+        {# Local sprite IDs prefixed gc- to avoid collision with the detail-page sprite #}
+        <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+          <symbol id="gc-check" viewBox="0 0 24 24">
+          <circle cx="12" cy="12" r="9" />
+          <path d="M8.4 12.4l2.5 2.5 4.7-5.2" stroke-linecap="round" stroke-linejoin="round" />
+          </symbol>
+          <symbol id="gc-circle" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" /></symbol>
+          <symbol id="gc-lock" viewBox="0 0 24 24">
+          <path d="M8 10V7a4 4 0 0 1 8 0v3" stroke-linecap="round" />
+          <rect x="5" y="10" width="14" height="9.5" rx="2" />
+          </symbol>
+          <symbol id="gc-chevron" viewBox="0 0 24 24">
+          <path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
+          </symbol>
+        </svg>
+        <div class="gallery-row">
+          {# Locked: 1 of 2 met — email done, status group pending #}
+          <article style="max-width:420px">
+            <header>
+              <hgroup>
+                <h3>Read full feed</h3>
+                <p>Clinical case discussions, peer commentary, and member-only research notes.</p>
+              </hgroup>
+              <kbd class="cap-badge" data-state="locked">
+                <svg class="cap-icon">
+                  <use href="#gc-lock" />
+                </svg>
+                Not available yet
+              </kbd>
+              <small>1 of 2 requirements met</small>
+              <progress value="1" max="2"></progress>
+            </header>
+            <hr>
+            <ul class="cap-reqs">
+              <li>
+                <kbd>All of these</kbd>
+              </li>
+              <li>
+                <span class="cap-row done">
+                  <svg class="cap-icon">
+                    <use href="#gc-check" />
+                  </svg>
+                  <span class="cap-label">Email verified</span>
+                </span>
+              </li>
+              <li>
+                <span class="cap-row">
+                  <svg class="cap-icon">
+                    <use href="#gc-circle" />
+                  </svg>
+                  <span class="cap-label">Verified via any one</span>
+                </span>
+                <ul>
+                  <li>
+                    <kbd>Any one of these</kbd>
+                  </li>
+                  <li>
+                    <a class="cap-row" href="#">
+                      <svg class="cap-icon">
+                        <use href="#gc-circle" />
+                      </svg>
+                      <span class="cap-label">Clinician identity verified</span>
+                      <svg class="cap-icon cap-chevron">
+                        <use href="#gc-chevron" />
+                      </svg>
+                    </a>
+                  </li>
+                  <li>
+                    <a class="cap-row" href="#">
+                      <svg class="cap-icon">
+                        <use href="#gc-circle" />
+                      </svg>
+                      <span class="cap-label">Organization representative verified</span>
+                      <svg class="cap-icon cap-chevron">
+                        <use href="#gc-chevron" />
+                      </svg>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </article>
+          {# Unlocked: 2 of 2 met — satisfied branch uses HTML inert #}
+          <article style="max-width:420px">
+            <header>
+              <hgroup>
+                <h3>Read full feed</h3>
+                <p>Clinical case discussions, peer commentary, and member-only research notes.</p>
+              </hgroup>
+              <kbd class="cap-badge" data-state="unlocked">
+                <svg class="cap-icon">
+                  <use href="#gc-check" />
+                </svg>
+                Available
+              </kbd>
+              <small>2 of 2 requirements met</small>
+              <progress value="2" max="2"></progress>
+            </header>
+            <hr>
+            <ul class="cap-reqs">
+              <li>
+                <kbd>All of these</kbd>
+              </li>
+              <li>
+                <span class="cap-row done">
+                  <svg class="cap-icon">
+                    <use href="#gc-check" />
+                  </svg>
+                  <span class="cap-label">Email verified</span>
+                </span>
+              </li>
+              <li>
+                <span class="cap-row done">
+                  <svg class="cap-icon">
+                    <use href="#gc-check" />
+                  </svg>
+                  <span class="cap-label">Verified via any one</span>
+                </span>
+                <ul inert>
+                  <li>
+                    <kbd>Any one of these</kbd>
+                  </li>
+                  <li>
+                    <span class="cap-row done">
+                      <svg class="cap-icon">
+                        <use href="#gc-check" />
+                      </svg>
+                      <span class="cap-label">Clinician identity verified</span>
+                    </span>
+                  </li>
+                  <li>
+                    <a class="cap-row" href="#">
+                      <svg class="cap-icon">
+                        <use href="#gc-circle" />
+                      </svg>
+                      <span class="cap-label">Organization representative verified</span>
+                      <svg class="cap-icon cap-chevron">
+                        <use href="#gc-chevron" />
+                      </svg>
+                    </a>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </article>
         </div>
       </section>
     </div>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -737,7 +737,7 @@ it's dev-only chrome that should never ship to production. #}
       <section class="gallery-section" id="capability-requirements">
         <h2>Capability requirements</h2>
         <p>
-          <small>One scoping class (<code>.cap-reqs</code>) on the root <code>&lt;ul&gt;</code>. Operator chips and badge use <code>&lt;small&gt;</code> (Pico-muted natively). State indicators are native checkboxes (<code>pointer-events:none</code>). Satisfied branches use HTML <code>inert</code>. Labels follow active/done grammar: imperative when unmet, passive-past when met.</small>
+          <small>One scoping class (<code>.cap-reqs</code>) on the root <code>&lt;ul&gt;</code>. Operator chips and badge use <code>&lt;small&gt;</code> (Pico-muted natively). State indicators are native checkboxes (<code>pointer-events:none</code>). Labels follow active/done grammar: imperative when unmet, passive-past when met.</small>
         </p>
         <div class="gallery-row">
           {# Locked: 1 of 2 met — email done, status branch pending. #}
@@ -789,7 +789,7 @@ it's dev-only chrome that should never ship to production. #}
               </li>
             </ul>
           </article>
-          {# Unlocked: 2 of 2 met — all done. Satisfied branch uses inert to dim its children. #}
+          {# Unlocked: 2 of 2 met — all done. #}
           <article style="max-width:420px">
             <header>
               <hgroup>
@@ -818,7 +818,7 @@ it's dev-only chrome that should never ship to production. #}
                   <input type="checkbox" checked aria-hidden="true">
                   <span>Status verified</span>
                 </span>
-                <ul inert>
+                <ul>
                   <li>
                     <small>Any one of these</small>
                   </li>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -737,25 +737,11 @@ it's dev-only chrome that should never ship to production. #}
       <section class="gallery-section" id="capability-requirements">
         <h2>Capability requirements</h2>
         <p>
-          <small>Classes: <code>.cap-reqs</code> / <code>.cap-row</code> / <code>.cap-badge</code>. Operator chips and badges use <code>&lt;kbd&gt;</code> (Pico-styled). Satisfied branches use the HTML <code>inert</code> attribute. SVG sprite must be on the page — see <code>detail.html</code>.</small>
+          <small>Classes: <code>.cap-reqs</code> / <code>.cap-row</code> / <code>.cap-badge</code>. Operator chips and badges use <code>&lt;kbd&gt;</code>. State indicators are native checkboxes (<code>pointer-events:none</code>). Satisfied branches use HTML <code>inert</code>. Labels follow active/done grammar: imperative when unmet, passive-past when met.</small>
         </p>
-        {# Local sprite IDs prefixed gc- to avoid collision with the detail-page sprite #}
-        <svg width="0" height="0" style="position:absolute" aria-hidden="true">
-          <symbol id="gc-check" viewBox="0 0 24 24">
-          <circle cx="12" cy="12" r="9" />
-          <path d="M8.4 12.4l2.5 2.5 4.7-5.2" stroke-linecap="round" stroke-linejoin="round" />
-          </symbol>
-          <symbol id="gc-circle" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" /></symbol>
-          <symbol id="gc-lock" viewBox="0 0 24 24">
-          <path d="M8 10V7a4 4 0 0 1 8 0v3" stroke-linecap="round" />
-          <rect x="5" y="10" width="14" height="9.5" rx="2" />
-          </symbol>
-          <symbol id="gc-chevron" viewBox="0 0 24 24">
-          <path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
-          </symbol>
-        </svg>
         <div class="gallery-row">
-          {# Locked: 1 of 2 met — email done, status group pending #}
+          {# Locked: 1 of 2 met — email done, status branch pending.
+             Labels: label_active (verb subject) for unmet, label_done (subject verb-past) for met. #}
           <article style="max-width:420px">
             <header>
               <hgroup>
@@ -763,10 +749,7 @@ it's dev-only chrome that should never ship to production. #}
                 <p>Clinical case discussions, peer commentary, and member-only research notes.</p>
               </hgroup>
               <kbd class="cap-badge" data-state="locked">
-                <svg class="cap-icon">
-                  <use href="#gc-lock" />
-                </svg>
-                Not available yet
+                <i class="icon-lock" aria-hidden="true"></i>Not available yet
               </kbd>
               <small>1 of 2 requirements met</small>
               <progress value="1" max="2"></progress>
@@ -778,18 +761,14 @@ it's dev-only chrome that should never ship to production. #}
               </li>
               <li>
                 <span class="cap-row done">
-                  <svg class="cap-icon">
-                    <use href="#gc-check" />
-                  </svg>
+                  <input type="checkbox" checked aria-hidden="true">
                   <span class="cap-label">Email verified</span>
                 </span>
               </li>
               <li>
                 <span class="cap-row">
-                  <svg class="cap-icon">
-                    <use href="#gc-circle" />
-                  </svg>
-                  <span class="cap-label">Verified via any one</span>
+                  <input type="checkbox" aria-hidden="true">
+                  <span class="cap-label">Verify your status</span>
                 </span>
                 <ul>
                   <li>
@@ -797,31 +776,23 @@ it's dev-only chrome that should never ship to production. #}
                   </li>
                   <li>
                     <a class="cap-row" href="#">
-                      <svg class="cap-icon">
-                        <use href="#gc-circle" />
-                      </svg>
-                      <span class="cap-label">Clinician identity verified</span>
-                      <svg class="cap-icon cap-chevron">
-                        <use href="#gc-chevron" />
-                      </svg>
+                      <input type="checkbox" aria-hidden="true">
+                      <span class="cap-label">Verify clinician identity</span>
+                      <i class="icon-chevron-right" aria-hidden="true"></i>
                     </a>
                   </li>
                   <li>
                     <a class="cap-row" href="#">
-                      <svg class="cap-icon">
-                        <use href="#gc-circle" />
-                      </svg>
-                      <span class="cap-label">Organization representative verified</span>
-                      <svg class="cap-icon cap-chevron">
-                        <use href="#gc-chevron" />
-                      </svg>
+                      <input type="checkbox" aria-hidden="true">
+                      <span class="cap-label">Verify organization rep</span>
+                      <i class="icon-chevron-right" aria-hidden="true"></i>
                     </a>
                   </li>
                 </ul>
               </li>
             </ul>
           </article>
-          {# Unlocked: 2 of 2 met — satisfied branch uses HTML inert #}
+          {# Unlocked: 2 of 2 met — all done. Satisfied branch uses inert to dim its children. #}
           <article style="max-width:420px">
             <header>
               <hgroup>
@@ -829,10 +800,7 @@ it's dev-only chrome that should never ship to production. #}
                 <p>Clinical case discussions, peer commentary, and member-only research notes.</p>
               </hgroup>
               <kbd class="cap-badge" data-state="unlocked">
-                <svg class="cap-icon">
-                  <use href="#gc-check" />
-                </svg>
-                Available
+                <i class="icon-check" aria-hidden="true"></i>Available
               </kbd>
               <small>2 of 2 requirements met</small>
               <progress value="2" max="2"></progress>
@@ -844,18 +812,14 @@ it's dev-only chrome that should never ship to production. #}
               </li>
               <li>
                 <span class="cap-row done">
-                  <svg class="cap-icon">
-                    <use href="#gc-check" />
-                  </svg>
+                  <input type="checkbox" checked aria-hidden="true">
                   <span class="cap-label">Email verified</span>
                 </span>
               </li>
               <li>
                 <span class="cap-row done">
-                  <svg class="cap-icon">
-                    <use href="#gc-check" />
-                  </svg>
-                  <span class="cap-label">Verified via any one</span>
+                  <input type="checkbox" checked aria-hidden="true">
+                  <span class="cap-label">Status verified</span>
                 </span>
                 <ul inert>
                   <li>
@@ -863,22 +827,15 @@ it's dev-only chrome that should never ship to production. #}
                   </li>
                   <li>
                     <span class="cap-row done">
-                      <svg class="cap-icon">
-                        <use href="#gc-check" />
-                      </svg>
+                      <input type="checkbox" checked aria-hidden="true">
                       <span class="cap-label">Clinician identity verified</span>
                     </span>
                   </li>
                   <li>
-                    <a class="cap-row" href="#">
-                      <svg class="cap-icon">
-                        <use href="#gc-circle" />
-                      </svg>
-                      <span class="cap-label">Organization representative verified</span>
-                      <svg class="cap-icon cap-chevron">
-                        <use href="#gc-chevron" />
-                      </svg>
-                    </a>
+                    <span class="cap-row">
+                      <input type="checkbox" aria-hidden="true">
+                      <span class="cap-label">Verify organization rep</span>
+                    </span>
                   </li>
                 </ul>
               </li>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -737,54 +737,53 @@ it's dev-only chrome that should never ship to production. #}
       <section class="gallery-section" id="capability-requirements">
         <h2>Capability requirements</h2>
         <p>
-          <small>Classes: <code>.cap-reqs</code> / <code>.cap-row</code> / <code>.cap-badge</code>. Operator chips and badges use <code>&lt;kbd&gt;</code>. State indicators are native checkboxes (<code>pointer-events:none</code>). Satisfied branches use HTML <code>inert</code>. Labels follow active/done grammar: imperative when unmet, passive-past when met.</small>
+          <small>One scoping class (<code>.cap-reqs</code>) on the root <code>&lt;ul&gt;</code>. Operator chips and badge use <code>&lt;small&gt;</code> (Pico-muted natively). State indicators are native checkboxes (<code>pointer-events:none</code>). Satisfied branches use HTML <code>inert</code>. Labels follow active/done grammar: imperative when unmet, passive-past when met.</small>
         </p>
         <div class="gallery-row">
-          {# Locked: 1 of 2 met — email done, status branch pending.
-             Labels: label_active (verb subject) for unmet, label_done (subject verb-past) for met. #}
+          {# Locked: 1 of 2 met — email done, status branch pending. #}
           <article style="max-width:420px">
             <header>
               <hgroup>
                 <h3>Read full feed</h3>
                 <p>Clinical case discussions, peer commentary, and member-only research notes.</p>
               </hgroup>
-              <kbd class="cap-badge" data-state="locked">
+              <small data-state="locked">
                 <i class="icon-lock" aria-hidden="true"></i>Not available yet
-              </kbd>
+              </small>
               <small>1 of 2 requirements met</small>
               <progress value="1" max="2"></progress>
             </header>
             <hr>
             <ul class="cap-reqs">
               <li>
-                <kbd>All of these</kbd>
+                <small>All of these</small>
               </li>
               <li>
-                <span class="cap-row done">
+                <span class="done">
                   <input type="checkbox" checked aria-hidden="true">
-                  <span class="cap-label">Email verified</span>
+                  <span>Email verified</span>
                 </span>
               </li>
               <li>
-                <span class="cap-row">
+                <span>
                   <input type="checkbox" aria-hidden="true">
-                  <span class="cap-label">Verify your status</span>
+                  <span>Verify your status</span>
                 </span>
                 <ul>
                   <li>
-                    <kbd>Any one of these</kbd>
+                    <small>Any one of these</small>
                   </li>
                   <li>
-                    <a class="cap-row" href="#">
+                    <a href="#">
                       <input type="checkbox" aria-hidden="true">
-                      <span class="cap-label">Verify clinician identity</span>
+                      <span>Verify clinician identity</span>
                       <i class="icon-chevron-right" aria-hidden="true"></i>
                     </a>
                   </li>
                   <li>
-                    <a class="cap-row" href="#">
+                    <a href="#">
                       <input type="checkbox" aria-hidden="true">
-                      <span class="cap-label">Verify organization rep</span>
+                      <span>Verify organization rep</span>
                       <i class="icon-chevron-right" aria-hidden="true"></i>
                     </a>
                   </li>
@@ -799,42 +798,42 @@ it's dev-only chrome that should never ship to production. #}
                 <h3>Read full feed</h3>
                 <p>Clinical case discussions, peer commentary, and member-only research notes.</p>
               </hgroup>
-              <kbd class="cap-badge" data-state="unlocked">
+              <small data-state="unlocked">
                 <i class="icon-check" aria-hidden="true"></i>Available
-              </kbd>
+              </small>
               <small>2 of 2 requirements met</small>
               <progress value="2" max="2"></progress>
             </header>
             <hr>
             <ul class="cap-reqs">
               <li>
-                <kbd>All of these</kbd>
+                <small>All of these</small>
               </li>
               <li>
-                <span class="cap-row done">
+                <span class="done">
                   <input type="checkbox" checked aria-hidden="true">
-                  <span class="cap-label">Email verified</span>
+                  <span>Email verified</span>
                 </span>
               </li>
               <li>
-                <span class="cap-row done">
+                <span class="done">
                   <input type="checkbox" checked aria-hidden="true">
-                  <span class="cap-label">Status verified</span>
+                  <span>Status verified</span>
                 </span>
                 <ul inert>
                   <li>
-                    <kbd>Any one of these</kbd>
+                    <small>Any one of these</small>
                   </li>
                   <li>
-                    <span class="cap-row done">
+                    <span class="done">
                       <input type="checkbox" checked aria-hidden="true">
-                      <span class="cap-label">Clinician identity verified</span>
+                      <span>Clinician identity verified</span>
                     </span>
                   </li>
                   <li>
-                    <span class="cap-row">
+                    <span>
                       <input type="checkbox" aria-hidden="true">
-                      <span class="cap-label">Verify organization rep</span>
+                      <span>Verify organization rep</span>
                     </span>
                   </li>
                 </ul>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -759,7 +759,7 @@ it's dev-only chrome that should never ship to production. #}
                 <small>All of these</small>
               </li>
               <li>
-                <span class="done">
+                <span>
                   <input type="checkbox" checked aria-hidden="true">
                   <span>Email verified</span>
                 </span>
@@ -808,13 +808,13 @@ it's dev-only chrome that should never ship to production. #}
                 <small>All of these</small>
               </li>
               <li>
-                <span class="done">
+                <span>
                   <input type="checkbox" checked aria-hidden="true">
                   <span>Email verified</span>
                 </span>
               </li>
               <li>
-                <span class="done">
+                <span>
                   <input type="checkbox" checked aria-hidden="true">
                   <span>Status verified</span>
                 </span>
@@ -823,7 +823,7 @@ it's dev-only chrome that should never ship to production. #}
                     <small>Any one of these</small>
                   </li>
                   <li>
-                    <span class="done">
+                    <span>
                       <input type="checkbox" checked aria-hidden="true">
                       <span>Clinician identity verified</span>
                     </span>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -831,7 +831,7 @@ it's dev-only chrome that should never ship to production. #}
                   <li>
                     <span>
                       <input type="checkbox" aria-hidden="true">
-                      <span>Verify organization rep</span>
+                      <a href="#">Verify organization rep</a>
                     </span>
                   </li>
                 </ul>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -19,6 +19,7 @@ it's dev-only chrome that should never ship to production. #}
 {%- from "_shared/_clinician_card.html" import clinician_card -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {%- from "_shared/_picker.html" import picker -%}
+{%- from "_shared/_capability_requirements.html" import capability_requirements_panel -%}
 {% extends "base.html" %}
 {% block head %}
   <style>
@@ -741,101 +742,77 @@ it's dev-only chrome that should never ship to production. #}
         </p>
         <div class="gallery-row">
           {# Locked: 1 of 2 met — email done, status branch pending. #}
-          <article style="max-width:420px">
-            <header>
-              <hgroup>
-                <h3>Read full feed</h3>
-                <p>Clinical case discussions, peer commentary, and member-only research notes.</p>
-              </hgroup>
-              <small data-state="locked">
-                <i class="icon-lock" aria-hidden="true"></i>Not available yet
-              </small>
-              <small>1 of 2 requirements met</small>
-              <progress value="1" max="2"></progress>
-            </header>
-            <ul class="cap-reqs">
-              <li>
-                <small>All of these</small>
-              </li>
-              <li>
-                <span>
-                  <input type="checkbox" checked aria-hidden="true">
-                  <span>Email verified</span>
-                </span>
-              </li>
-              <li>
-                <span>
-                  <input type="checkbox" aria-hidden="true">
-                  <span>Verify your status</span>
-                </span>
-                <ul>
-                  <li>
-                    <small>Any one of these</small>
-                  </li>
-                  <li>
-                    <span>
-                      <input type="checkbox" aria-hidden="true">
-                      <a href="#">Verify clinician identity</a>
-                    </span>
-                  </li>
-                  <li>
-                    <span>
-                      <input type="checkbox" aria-hidden="true">
-                      <a href="#">Verify organization rep</a>
-                    </span>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </article>
-          {# Unlocked: 2 of 2 met — all done. #}
-          <article style="max-width:420px">
-            <header>
-              <hgroup>
-                <h3>Read full feed</h3>
-                <p>Clinical case discussions, peer commentary, and member-only research notes.</p>
-              </hgroup>
-              <small data-state="unlocked">
-                <i class="icon-check" aria-hidden="true"></i>Available
-              </small>
-              <small>2 of 2 requirements met</small>
-              <progress value="2" max="2"></progress>
-            </header>
-            <ul class="cap-reqs">
-              <li>
-                <small>All of these</small>
-              </li>
-              <li>
-                <span>
-                  <input type="checkbox" checked aria-hidden="true">
-                  <span>Email verified</span>
-                </span>
-              </li>
-              <li>
-                <span>
-                  <input type="checkbox" checked aria-hidden="true">
-                  <span>Status verified</span>
-                </span>
-                <ul>
-                  <li>
-                    <small>Any one of these</small>
-                  </li>
-                  <li>
-                    <span>
-                      <input type="checkbox" checked aria-hidden="true">
-                      <span>Clinician identity verified</span>
-                    </span>
-                  </li>
-                  <li>
-                    <span>
-                      <input type="checkbox" aria-hidden="true">
-                      <a href="#">Verify organization rep</a>
-                    </span>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </article>
+          {% set locked_tree = {
+            "label_active": "Read full feed",
+            "label_done": "Read full feed",
+            "op": "all",
+            "met": false,
+            "children": [
+              {
+                "label_active": "Verify email",
+                "label_done": "Email verified",
+                "met": true,
+                "fix_url": "#"
+              },
+              {
+                "label_active": "Verify your status",
+                "label_done": "Status verified",
+                "op": "any",
+                "met": false,
+                "children": [
+                  {
+                    "label_active": "Verify clinician identity",
+                    "label_done": "Clinician identity verified",
+                    "met": false,
+                    "fix_url": "#"
+                  },
+                  {
+                    "label_active": "Verify organization rep",
+                    "label_done": "Organization rep verified",
+                    "met": false,
+                    "fix_url": "#"
+                  }
+                ]
+              }
+            ]
+          } %}
+          <div style="max-width:420px">{{ capability_requirements_panel(locked_tree, false) }}</div>
+          {# Unlocked: 2 of 2 met — email + clinician identity both done. #}
+          {% set unlocked_tree = {
+            "label_active": "Read full feed",
+            "label_done": "Read full feed",
+            "op": "all",
+            "met": true,
+            "children": [
+              {
+                "label_active": "Verify email",
+                "label_done": "Email verified",
+                "met": true,
+                "fix_url": "#"
+              },
+              {
+                "label_active": "Verify your status",
+                "label_done": "Status verified",
+                "op": "any",
+                "met": true,
+                "children": [
+                  {
+                    "label_active": "Verify clinician identity",
+                    "label_done": "Clinician identity verified",
+                    "met": true,
+                    "fix_url": "#"
+                  },
+                  {
+                    "label_active": "Verify organization rep",
+                    "label_done": "Organization rep verified",
+                    "met": false,
+                    "fix_url": "#"
+                  }
+                ]
+              }
+            ]
+          } %}
+          <div style="max-width:420px">{{ capability_requirements_panel(unlocked_tree, true) }}</div>
         </div>
       </section>
     </div>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -774,18 +774,16 @@ it's dev-only chrome that should never ship to production. #}
                     <small>Any one of these</small>
                   </li>
                   <li>
-                    <a href="#">
+                    <span>
                       <input type="checkbox" aria-hidden="true">
-                      <span>Verify clinician identity</span>
-                      <i class="icon-chevron-right" aria-hidden="true"></i>
-                    </a>
+                      <a href="#">Verify clinician identity</a>
+                    </span>
                   </li>
                   <li>
-                    <a href="#">
+                    <span>
                       <input type="checkbox" aria-hidden="true">
-                      <span>Verify organization rep</span>
-                      <i class="icon-chevron-right" aria-hidden="true"></i>
-                    </a>
+                      <a href="#">Verify organization rep</a>
+                    </span>
                   </li>
                 </ul>
               </li>

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -22,7 +22,7 @@
     </span>
   {% endmacro %}
   {# render_node: dispatches on __class__.__name__. Branches get a <small> operator chip
-     and a child <ul>; when met the <ul> gets `inert` (non-interactive + dimmed).
+     and a child <ul>. Jinja macros cannot self-call; children are inlined for the two-level tree.
      Jinja macros cannot self-call; children are inlined for the two-level tree. #}
   {% macro render_node(node) %}
     {% set kind = node.__class__.__name__ %}
@@ -37,7 +37,7 @@
                  aria-hidden="true">
           <span>{{ node.label_done if node.met else node.label_active }}</span>
         </span>
-        <ul {% if node.met %}inert{% endif %}>
+        <ul>
           <li>
             <small>{{ op_text }}</small>
           </li>
@@ -54,7 +54,7 @@
                          aria-hidden="true">
                   <span>{{ child.label_done if child.met else child.label_active }}</span>
                 </span>
-                <ul {% if child.met %}inert{% endif %}>
+                <ul>
                   <li>
                     <small>{{ cop_text }}</small>
                   </li>

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -7,23 +7,19 @@
 {% endblock %}
 {% block content %}
   {# render_leaf: picks label_active (imperative) when unmet, label_done (passive-past)
-     when met. Actionable unmet leaves render as links with a chevron; everything else
-     is a span. The macro enforces the active/done grammar — callers supply both labels. #}
+     when met. Actionable unmet leaves are plain links inside the row span.
+     The macro enforces the active/done grammar — callers supply both labels. #}
   {% macro render_leaf(node) %}
-    {% if not node.met and node.fix_url %}
-      <a href="{{ node.fix_url }}">
-        <input type="checkbox" aria-hidden="true">
-        <span>{{ node.label_active }}</span>
-        <i class="icon-chevron-right" aria-hidden="true"></i>
-      </a>
-    {% else %}
-      <span {% if node.met %}class="done"{% endif %}>
-        <input type="checkbox"
-               {% if node.met %}checked{% endif %}
-               aria-hidden="true">
+    <span {% if node.met %}class="done"{% endif %}>
+      <input type="checkbox"
+             {% if node.met %}checked{% endif %}
+             aria-hidden="true">
+      {% if not node.met and node.fix_url %}
+        <a href="{{ node.fix_url }}">{{ node.label_active }}</a>
+      {% else %}
         <span>{{ node.label_done if node.met else node.label_active }}</span>
-      </span>
-    {% endif %}
+      {% endif %}
+    </span>
   {% endmacro %}
   {# render_node: dispatches on __class__.__name__. Branches get a <small> operator chip
      and a child <ul>; when met the <ul> gets `inert` (non-interactive + dimmed).

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -1,70 +1,126 @@
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
-{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
-{% block title %}{{ check.name }}{% endblock %}
-{% block breadcrumb %}
-  {{ breadcrumb([
-    ("Profile", entity_url('user', id='me') ),
-  ("Access", access_index_url),
-  ("Capabilities", capabilities_url),
-  (check.name, none),
-  ]) }}
-{% endblock %}
+{% block title %}{{ check.tree.label }}{% endblock %}
 {% block toolbar %}
-  {% call page_toolbar(heading=check.name) %}
+  {% call page_toolbar(heading=check.tree.label) %}
   {% endcall %}
 {% endblock %}
 {% block content %}
-  {# Recursive macro — dispatches on node.__class__.__name__. Jinja macros
-     cannot call themselves directly; we work around that by rendering
-     children in a loop and relying on the macro being defined before use.
-     For the two-level tree in `network` this is sufficient: the root
-     is always a Bundle whose children are a Condition and a Gate, and the
-     Gate's children are always Conditions. #}
+  {# Icon sprite for capability requirement icons — paste once per page #}
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <symbol id="ic-check" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="9" />
+    <path d="M8.4 12.4l2.5 2.5 4.7-5.2" stroke-linecap="round" stroke-linejoin="round" />
+    </symbol>
+    <symbol id="ic-circle" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" /></symbol>
+    <symbol id="ic-lock" viewBox="0 0 24 24">
+    <path d="M8 10V7a4 4 0 0 1 8 0v3" stroke-linecap="round" />
+    <rect x="5" y="10" width="14" height="9.5" rx="2" />
+    </symbol>
+    <symbol id="ic-chevron" viewBox="0 0 24 24">
+    <path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
+    </symbol>
+  </svg>
+  {# Leaf: clickable link when not yet met and has a fix URL, plain span otherwise.
+     Icon color comes from parent .cap-row state via currentColor — no per-icon class. #}
+  {% macro render_leaf(node) %}
+    {% set icon = "check" if node.met else "circle" %}
+    {% if not node.met and node.fix_url %}
+      <a class="cap-row" href="{{ node.fix_url }}">
+        <svg class="cap-icon">
+          <use href="#ic-{{ icon }}" />
+        </svg>
+        <span class="cap-label">{{ node.label }}</span>
+        <svg class="cap-icon cap-chevron">
+          <use href="#ic-chevron" />
+        </svg>
+      </a>
+    {% else %}
+      <span class="cap-row{% if node.met %} done{% endif %}">
+        <svg class="cap-icon">
+          <use href="#ic-{{ icon }}" />
+        </svg>
+        <span class="cap-label">{{ node.label }}</span>
+      </span>
+    {% endif %}
+  {% endmacro %}
+  {# Node: dispatches on __class__.__name__. Branches get a <kbd> operator chip and
+     a child <ul>; when met the <ul> gets `inert` (HTML state → non-interactive + dim).
+     Jinja macros cannot self-call; children are inlined to cover the current two-level tree. #}
   {% macro render_node(node) %}
     {% set kind = node.__class__.__name__ %}
     {% if kind == "Condition" %}
-      <li class="capability-node capability-node--condition">
-        {% if node.met %}
-          <span class="capability-check capability-check--met">&#10003;</span>
-        {% else %}
-          <span class="capability-check capability-check--unmet">&#10007;</span>
-        {% endif %}
-        {{ node.label }}
-        {% if not node.met %}<a href="{{ node.fix_url }}">Fix →</a>{% endif %}
-      </li>
-    {% elif kind == "Bundle" %}
-      <li class="capability-node capability-node--bundle">
-        <span class="capability-operator">AND</span> {{ node.label }}
-        <ul class="capability-children">
-          {% for child in node.children %}{{ render_node(child) }}{% endfor %}
-        </ul>
-      </li>
-    {% elif kind == "Gate" %}
-      <li class="capability-node capability-node--gate">
-        <span class="capability-operator">OR</span> {{ node.label }}
-        <ul class="capability-children">
-          {% for child in node.children %}{{ render_node(child) }}{% endfor %}
+      <li>{{ render_leaf(node) }}</li>
+    {% else %}
+      {% set op_text = "All of these" if kind == "Bundle" else "Any one of these" %}
+      {% set branch_icon = "check" if node.met else "circle" %}
+      <li>
+        <span class="cap-row{% if node.met %} done{% endif %}">
+          <svg class="cap-icon">
+            <use href="#ic-{{ branch_icon }}" />
+          </svg>
+          <span class="cap-label">{{ node.label }}</span>
+        </span>
+        <ul {% if node.met %}inert{% endif %}>
+          <li>
+            <kbd>{{ op_text }}</kbd>
+          </li>
+          {% for child in node.children %}
+            {% set ckind = child.__class__.__name__ %}
+            {% if ckind == "Condition" %}
+              <li>{{ render_leaf(child) }}</li>
+            {% else %}
+              {% set cop_text = "All of these" if ckind == "Bundle" else "Any one of these" %}
+              {% set cbranch_icon = "check" if child.met else "circle" %}
+              <li>
+                <span class="cap-row{% if child.met %} done{% endif %}">
+                  <svg class="cap-icon">
+                    <use href="#ic-{{ cbranch_icon }}" />
+                  </svg>
+                  <span class="cap-label">{{ child.label }}</span>
+                </span>
+                <ul {% if child.met %}inert{% endif %}>
+                  <li>
+                    <kbd>{{ cop_text }}</kbd>
+                  </li>
+                  {% for gc in child.children %}<li>{{ render_leaf(gc) }}</li>{% endfor %}
+                </ul>
+              </li>
+            {% endif %}
+          {% endfor %}
         </ul>
       </li>
     {% endif %}
   {% endmacro %}
-  <section class="entity-card">
-    <header class="entity-header">
-      <strong>{{ check.name }}</strong>
-      {% if check.granted %}
-        <span class="capability-badge capability-badge--granted">Granted</span>
-      {% else %}
-        <span class="capability-badge capability-badge--denied">Denied</span>
-      {% endif %}
+  {% set root = check.tree %}
+  {% set root_met = root.children | selectattr("met") | list | length %}
+  {% set root_total = root.children | list | length %}
+  {% set root_op = "All of these" if root.__class__.__name__ == "Bundle" else "Any one of these" %}
+  {% set badge_icon = "check" if check.granted else "lock" %}
+  <article>
+    <header>
+      <hgroup>
+        <h3>{{ root.label }}</h3>
+      </hgroup>
+      <kbd class="cap-badge"
+           data-state="{{ 'unlocked' if check.granted else 'locked' }}">
+        <svg class="cap-icon">
+          <use href="#ic-{{ badge_icon }}" />
+        </svg>
+        {{ "Available" if check.granted else "Not available yet" }}
+      </kbd>
+      <small>{{ root_met }} of {{ root_total }} requirements met</small>
+      <progress value="{{ root_met }}" max="{{ root_total }}"></progress>
     </header>
-    <section class="entity-facts">
-      <ul class="capability-tree">
-        {{ render_node(check.tree) }}
-      </ul>
-    </section>
-    <footer class="entity-footer">
-      <a href="{{ access_index_url }}">← All capabilities</a>
-    </footer>
-  </section>
+    <hr>
+    <ul class="cap-reqs">
+      <li>
+        <kbd>{{ root_op }}</kbd>
+      </li>
+      {% for child in root.children %}{{ render_node(child) }}{% endfor %}
+    </ul>
+  </article>
+  <p>
+    <a href="{{ access_index_url }}">← All capabilities</a>
+  </p>
 {% endblock %}

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -11,21 +11,21 @@
      is a span. The macro enforces the active/done grammar — callers supply both labels. #}
   {% macro render_leaf(node) %}
     {% if not node.met and node.fix_url %}
-      <a class="cap-row" href="{{ node.fix_url }}">
+      <a href="{{ node.fix_url }}">
         <input type="checkbox" aria-hidden="true">
-        <span class="cap-label">{{ node.label_active }}</span>
+        <span>{{ node.label_active }}</span>
         <i class="icon-chevron-right" aria-hidden="true"></i>
       </a>
     {% else %}
-      <span class="cap-row{% if node.met %} done{% endif %}">
+      <span {% if node.met %}class="done"{% endif %}>
         <input type="checkbox"
                {% if node.met %}checked{% endif %}
                aria-hidden="true">
-        <span class="cap-label">{{ node.label_done if node.met else node.label_active }}</span>
+        <span>{{ node.label_done if node.met else node.label_active }}</span>
       </span>
     {% endif %}
   {% endmacro %}
-  {# render_node: dispatches on __class__.__name__. Branches get a <kbd> operator chip
+  {# render_node: dispatches on __class__.__name__. Branches get a <small> operator chip
      and a child <ul>; when met the <ul> gets `inert` (non-interactive + dimmed).
      Jinja macros cannot self-call; children are inlined for the two-level tree. #}
   {% macro render_node(node) %}
@@ -35,15 +35,15 @@
     {% else %}
       {% set op_text = "All of these" if kind == "Bundle" else "Any one of these" %}
       <li>
-        <span class="cap-row{% if node.met %} done{% endif %}">
+        <span {% if node.met %}class="done"{% endif %}>
           <input type="checkbox"
                  {% if node.met %}checked{% endif %}
                  aria-hidden="true">
-          <span class="cap-label">{{ node.label_done if node.met else node.label_active }}</span>
+          <span>{{ node.label_done if node.met else node.label_active }}</span>
         </span>
         <ul {% if node.met %}inert{% endif %}>
           <li>
-            <kbd>{{ op_text }}</kbd>
+            <small>{{ op_text }}</small>
           </li>
           {% for child in node.children %}
             {% set ckind = child.__class__.__name__ %}
@@ -52,15 +52,15 @@
             {% else %}
               {% set cop_text = "All of these" if ckind == "Bundle" else "Any one of these" %}
               <li>
-                <span class="cap-row{% if child.met %} done{% endif %}">
+                <span {% if child.met %}class="done"{% endif %}>
                   <input type="checkbox"
                          {% if child.met %}checked{% endif %}
                          aria-hidden="true">
-                  <span class="cap-label">{{ child.label_done if child.met else child.label_active }}</span>
+                  <span>{{ child.label_done if child.met else child.label_active }}</span>
                 </span>
                 <ul {% if child.met %}inert{% endif %}>
                   <li>
-                    <kbd>{{ cop_text }}</kbd>
+                    <small>{{ cop_text }}</small>
                   </li>
                   {% for gc in child.children %}<li>{{ render_leaf(gc) }}</li>{% endfor %}
                 </ul>
@@ -80,21 +80,20 @@
       <hgroup>
         <h3>{{ root.label_active }}</h3>
       </hgroup>
-      <kbd class="cap-badge"
-           data-state="{{ 'unlocked' if check.granted else 'locked' }}">
+      <small data-state="{{ 'unlocked' if check.granted else 'locked' }}">
         {% if check.granted %}
           <i class="icon-check" aria-hidden="true"></i>Available
         {% else %}
           <i class="icon-lock" aria-hidden="true"></i>Not available yet
         {% endif %}
-      </kbd>
+      </small>
       <small>{{ root_met }} of {{ root_total }} requirements met</small>
       <progress value="{{ root_met }}" max="{{ root_total }}"></progress>
     </header>
     <hr>
     <ul class="cap-reqs">
       <li>
-        <kbd>{{ root_op }}</kbd>
+        <small>{{ root_op }}</small>
       </li>
       {% for child in root.children %}{{ render_node(child) }}{% endfor %}
     </ul>

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -1,98 +1,22 @@
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
+{%- from "_shared/_breadcrumb.html" import breadcrumb -%}
+{%- from "_shared/_capability_requirements.html" import capability_requirements_panel -%}
 {% block title %}{{ check.tree.label_active }}{% endblock %}
+{% block breadcrumb %}
+  {{ breadcrumb([
+    ("Profile", entity_url('user', id='me') ),
+  ("Access", access_index_url),
+  ("Capabilities", capabilities_url),
+  (check.tree.label_active, none),
+  ]) }}
+{% endblock %}
 {% block toolbar %}
   {% call page_toolbar(heading=check.tree.label_active) %}
   {% endcall %}
 {% endblock %}
 {% block content %}
-  {# render_leaf: picks label_active (imperative) when unmet, label_done (passive-past)
-     when met. Actionable unmet leaves are plain links inside the row span.
-     The macro enforces the active/done grammar — callers supply both labels. #}
-  {% macro render_leaf(node) %}
-    <span>
-      <input type="checkbox"
-             {% if node.met %}checked{% endif %}
-             aria-hidden="true">
-      {% if not node.met and node.fix_url %}
-        <a href="{{ node.fix_url }}">{{ node.label_active }}</a>
-      {% else %}
-        <span>{{ node.label_done if node.met else node.label_active }}</span>
-      {% endif %}
-    </span>
-  {% endmacro %}
-  {# render_node: dispatches on __class__.__name__. Branches get a <small> operator chip
-     and a child <ul>. Jinja macros cannot self-call; children are inlined for the two-level tree.
-     Jinja macros cannot self-call; children are inlined for the two-level tree. #}
-  {% macro render_node(node) %}
-    {% set kind = node.__class__.__name__ %}
-    {% if kind == "Condition" %}
-      <li>{{ render_leaf(node) }}</li>
-    {% else %}
-      {% set op_text = "All of these" if kind == "Bundle" else "Any one of these" %}
-      <li>
-        <span>
-          <input type="checkbox"
-                 {% if node.met %}checked{% endif %}
-                 aria-hidden="true">
-          <span>{{ node.label_done if node.met else node.label_active }}</span>
-        </span>
-        <ul>
-          <li>
-            <small>{{ op_text }}</small>
-          </li>
-          {% for child in node.children %}
-            {% set ckind = child.__class__.__name__ %}
-            {% if ckind == "Condition" %}
-              <li>{{ render_leaf(child) }}</li>
-            {% else %}
-              {% set cop_text = "All of these" if ckind == "Bundle" else "Any one of these" %}
-              <li>
-                <span>
-                  <input type="checkbox"
-                         {% if child.met %}checked{% endif %}
-                         aria-hidden="true">
-                  <span>{{ child.label_done if child.met else child.label_active }}</span>
-                </span>
-                <ul>
-                  <li>
-                    <small>{{ cop_text }}</small>
-                  </li>
-                  {% for gc in child.children %}<li>{{ render_leaf(gc) }}</li>{% endfor %}
-                </ul>
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </li>
-    {% endif %}
-  {% endmacro %}
-  {% set root = check.tree %}
-  {% set root_met = root.children | selectattr("met") | list | length %}
-  {% set root_total = root.children | list | length %}
-  {% set root_op = "All of these" if root.__class__.__name__ == "Bundle" else "Any one of these" %}
-  <article>
-    <header>
-      <hgroup>
-        <h3>{{ root.label_active }}</h3>
-      </hgroup>
-      <small data-state="{{ 'unlocked' if check.granted else 'locked' }}">
-        {% if check.granted %}
-          <i class="icon-check" aria-hidden="true"></i>Available
-        {% else %}
-          <i class="icon-lock" aria-hidden="true"></i>Not available yet
-        {% endif %}
-      </small>
-      <small>{{ root_met }} of {{ root_total }} requirements met</small>
-      <progress value="{{ root_met }}" max="{{ root_total }}"></progress>
-    </header>
-    <ul class="cap-reqs">
-      <li>
-        <small>{{ root_op }}</small>
-      </li>
-      {% for child in root.children %}{{ render_node(child) }}{% endfor %}
-    </ul>
-  </article>
+  {{ capability_requirements_panel(check.tree, check.granted) }}
   <p>
     <a href="{{ access_index_url }}">← All capabilities</a>
   </p>

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -10,7 +10,7 @@
      when met. Actionable unmet leaves are plain links inside the row span.
      The macro enforces the active/done grammar — callers supply both labels. #}
   {% macro render_leaf(node) %}
-    <span {% if node.met %}class="done"{% endif %}>
+    <span>
       <input type="checkbox"
              {% if node.met %}checked{% endif %}
              aria-hidden="true">
@@ -31,7 +31,7 @@
     {% else %}
       {% set op_text = "All of these" if kind == "Bundle" else "Any one of these" %}
       <li>
-        <span {% if node.met %}class="done"{% endif %}>
+        <span>
           <input type="checkbox"
                  {% if node.met %}checked{% endif %}
                  aria-hidden="true">
@@ -48,7 +48,7 @@
             {% else %}
               {% set cop_text = "All of these" if ckind == "Bundle" else "Any one of these" %}
               <li>
-                <span {% if child.met %}class="done"{% endif %}>
+                <span>
                   <input type="checkbox"
                          {% if child.met %}checked{% endif %}
                          aria-hidden="true">

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -1,65 +1,45 @@
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
-{% block title %}{{ check.tree.label }}{% endblock %}
+{% block title %}{{ check.tree.label_active }}{% endblock %}
 {% block toolbar %}
-  {% call page_toolbar(heading=check.tree.label) %}
+  {% call page_toolbar(heading=check.tree.label_active) %}
   {% endcall %}
 {% endblock %}
 {% block content %}
-  {# Icon sprite for capability requirement icons — paste once per page #}
-  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
-    <symbol id="ic-check" viewBox="0 0 24 24">
-    <circle cx="12" cy="12" r="9" />
-    <path d="M8.4 12.4l2.5 2.5 4.7-5.2" stroke-linecap="round" stroke-linejoin="round" />
-    </symbol>
-    <symbol id="ic-circle" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" /></symbol>
-    <symbol id="ic-lock" viewBox="0 0 24 24">
-    <path d="M8 10V7a4 4 0 0 1 8 0v3" stroke-linecap="round" />
-    <rect x="5" y="10" width="14" height="9.5" rx="2" />
-    </symbol>
-    <symbol id="ic-chevron" viewBox="0 0 24 24">
-    <path d="M9 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
-    </symbol>
-  </svg>
-  {# Leaf: clickable link when not yet met and has a fix URL, plain span otherwise.
-     Icon color comes from parent .cap-row state via currentColor — no per-icon class. #}
+  {# render_leaf: picks label_active (imperative) when unmet, label_done (passive-past)
+     when met. Actionable unmet leaves render as links with a chevron; everything else
+     is a span. The macro enforces the active/done grammar — callers supply both labels. #}
   {% macro render_leaf(node) %}
-    {% set icon = "check" if node.met else "circle" %}
     {% if not node.met and node.fix_url %}
       <a class="cap-row" href="{{ node.fix_url }}">
-        <svg class="cap-icon">
-          <use href="#ic-{{ icon }}" />
-        </svg>
-        <span class="cap-label">{{ node.label }}</span>
-        <svg class="cap-icon cap-chevron">
-          <use href="#ic-chevron" />
-        </svg>
+        <input type="checkbox" aria-hidden="true">
+        <span class="cap-label">{{ node.label_active }}</span>
+        <i class="icon-chevron-right" aria-hidden="true"></i>
       </a>
     {% else %}
       <span class="cap-row{% if node.met %} done{% endif %}">
-        <svg class="cap-icon">
-          <use href="#ic-{{ icon }}" />
-        </svg>
-        <span class="cap-label">{{ node.label }}</span>
+        <input type="checkbox"
+               {% if node.met %}checked{% endif %}
+               aria-hidden="true">
+        <span class="cap-label">{{ node.label_done if node.met else node.label_active }}</span>
       </span>
     {% endif %}
   {% endmacro %}
-  {# Node: dispatches on __class__.__name__. Branches get a <kbd> operator chip and
-     a child <ul>; when met the <ul> gets `inert` (HTML state → non-interactive + dim).
-     Jinja macros cannot self-call; children are inlined to cover the current two-level tree. #}
+  {# render_node: dispatches on __class__.__name__. Branches get a <kbd> operator chip
+     and a child <ul>; when met the <ul> gets `inert` (non-interactive + dimmed).
+     Jinja macros cannot self-call; children are inlined for the two-level tree. #}
   {% macro render_node(node) %}
     {% set kind = node.__class__.__name__ %}
     {% if kind == "Condition" %}
       <li>{{ render_leaf(node) }}</li>
     {% else %}
       {% set op_text = "All of these" if kind == "Bundle" else "Any one of these" %}
-      {% set branch_icon = "check" if node.met else "circle" %}
       <li>
         <span class="cap-row{% if node.met %} done{% endif %}">
-          <svg class="cap-icon">
-            <use href="#ic-{{ branch_icon }}" />
-          </svg>
-          <span class="cap-label">{{ node.label }}</span>
+          <input type="checkbox"
+                 {% if node.met %}checked{% endif %}
+                 aria-hidden="true">
+          <span class="cap-label">{{ node.label_done if node.met else node.label_active }}</span>
         </span>
         <ul {% if node.met %}inert{% endif %}>
           <li>
@@ -71,13 +51,12 @@
               <li>{{ render_leaf(child) }}</li>
             {% else %}
               {% set cop_text = "All of these" if ckind == "Bundle" else "Any one of these" %}
-              {% set cbranch_icon = "check" if child.met else "circle" %}
               <li>
                 <span class="cap-row{% if child.met %} done{% endif %}">
-                  <svg class="cap-icon">
-                    <use href="#ic-{{ cbranch_icon }}" />
-                  </svg>
-                  <span class="cap-label">{{ child.label }}</span>
+                  <input type="checkbox"
+                         {% if child.met %}checked{% endif %}
+                         aria-hidden="true">
+                  <span class="cap-label">{{ child.label_done if child.met else child.label_active }}</span>
                 </span>
                 <ul {% if child.met %}inert{% endif %}>
                   <li>
@@ -96,18 +75,18 @@
   {% set root_met = root.children | selectattr("met") | list | length %}
   {% set root_total = root.children | list | length %}
   {% set root_op = "All of these" if root.__class__.__name__ == "Bundle" else "Any one of these" %}
-  {% set badge_icon = "check" if check.granted else "lock" %}
   <article>
     <header>
       <hgroup>
-        <h3>{{ root.label }}</h3>
+        <h3>{{ root.label_active }}</h3>
       </hgroup>
       <kbd class="cap-badge"
            data-state="{{ 'unlocked' if check.granted else 'locked' }}">
-        <svg class="cap-icon">
-          <use href="#ic-{{ badge_icon }}" />
-        </svg>
-        {{ "Available" if check.granted else "Not available yet" }}
+        {% if check.granted %}
+          <i class="icon-check" aria-hidden="true"></i>Available
+        {% else %}
+          <i class="icon-lock" aria-hidden="true"></i>Not available yet
+        {% endif %}
       </kbd>
       <small>{{ root_met }} of {{ root_total }} requirements met</small>
       <progress value="{{ root_met }}" max="{{ root_total }}"></progress>

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -86,7 +86,6 @@
       <small>{{ root_met }} of {{ root_total }} requirements met</small>
       <progress value="{{ root_met }}" max="{{ root_total }}"></progress>
     </header>
-    <hr>
     <ul class="cap-reqs">
       <li>
         <small>{{ root_op }}</small>

--- a/src/framework/templates/_shared/_capability_requirements.html
+++ b/src/framework/templates/_shared/_capability_requirements.html
@@ -1,0 +1,94 @@
+{# Capability requirements panel.
+
+   Usage: {{ capability_requirements_panel(tree, granted) }}
+     tree    — root Bundle/Gate node (or a plain dict with the same shape:
+               label_active, label_done, op, children, met)
+     granted — bool — whether the root requirement is satisfied
+
+   Leaf nodes have no `children`; branches carry `op` ("all" / "any") and a
+   `children` sequence. The macro detects which is which via duck-typing so
+   it works with both Python dataclass instances and plain Jinja dicts. #}
+{% macro capability_requirements_panel(tree, granted) %}
+  {% macro render_leaf(node) %}
+    <span>
+      <input type="checkbox"
+             {% if node.met %}checked{% endif %}
+             readonly
+             aria-hidden="true">
+      {% if not node.met and node.fix_url %}
+        <a href="{{ node.fix_url }}">{{ node.label_active }}</a>
+      {% else %}
+        <span>{{ node.label_done if node.met else node.label_active }}</span>
+      {% endif %}
+    </span>
+  {% endmacro %}
+  {# render_node: branches inline their children (macros cannot self-call in Jinja). #}
+  {% macro render_node(node) %}
+    {% if node.children %}
+      {% set op_text = "All of these" if node.op == "all" else "Any one of these" %}
+      <li>
+        <span>
+          <input type="checkbox"
+                 {% if node.met %}checked{% endif %}
+                 readonly
+                 aria-hidden="true">
+          <span>{{ node.label_done if node.met else node.label_active }}</span>
+        </span>
+        <ul>
+          <li>
+            <small>{{ op_text }}</small>
+          </li>
+          {% for child in node.children %}
+            {% if child.children %}
+              {% set cop_text = "All of these" if child.op == "all" else "Any one of these" %}
+              <li>
+                <span>
+                  <input type="checkbox"
+                         {% if child.met %}checked{% endif %}
+                         readonly
+                         aria-hidden="true">
+                  <span>{{ child.label_done if child.met else child.label_active }}</span>
+                </span>
+                <ul>
+                  <li>
+                    <small>{{ cop_text }}</small>
+                  </li>
+                  {% for gc in child.children %}<li>{{ render_leaf(gc) }}</li>{% endfor %}
+                </ul>
+              </li>
+            {% else %}
+              <li>{{ render_leaf(child) }}</li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </li>
+    {% else %}
+      <li>{{ render_leaf(node) }}</li>
+    {% endif %}
+  {% endmacro %}
+  {% set root_met = tree.children | selectattr("met") | list | length %}
+  {% set root_total = tree.children | list | length %}
+  {% set root_op_text = "All of these" if tree.op == "all" else "Any one of these" %}
+  <article>
+    <header>
+      <hgroup>
+        <h3>{{ tree.label_active }}</h3>
+      </hgroup>
+      <small data-state="{{ 'unlocked' if granted else 'locked' }}">
+        {% if granted %}
+          <i class="icon-check" aria-hidden="true"></i>Available
+        {% else %}
+          <i class="icon-lock" aria-hidden="true"></i>Not available yet
+        {% endif %}
+      </small>
+      <small>{{ root_met }} of {{ root_total }} requirements met</small>
+      <progress value="{{ root_met }}" max="{{ root_total }}"></progress>
+    </header>
+    <ul class="cap-reqs">
+      <li>
+        <small>{{ root_op_text }}</small>
+      </li>
+      {% for child in tree.children %}{{ render_node(child) }}{% endfor %}
+    </ul>
+  </article>
+{% endmacro %}


### PR DESCRIPTION
## Summary

- **Dual-label grammar** on `Condition`, `Bundle`, `Gate`: `label_active` (imperative, shown when unmet — "Verify email") + `label_done` (passive-past, shown when met — "Email verified"). The macro enforces this contract structurally; wrong-label rendering is impossible.
- **`op` property** on `Bundle`/`Gate` — returns `"all"` / `"any"` — enables duck-typed dispatch in Jinja that works with both Python dataclass instances and plain Jinja dicts (needed for the gallery fixtures).
- **Shared macro** `_shared/_capability_requirements.html` — `capability_requirements_panel(tree, granted)` — reused by both `detail.html` and the dev component gallery.
- **Pico-native rendering**: `<article>` card, `<header>`/`<hgroup>`, `<small>` for operator chips and status badge, `<progress>` bar, native checkboxes (`readonly`) as display-only state indicators. Two custom CSS rules total: a list-reset on `.cap-reqs`.
- **Actionable leaves** stay links regardless of branch met-state; branches are never links (delegate to children).
- **Tests updated**: `test_access.py` uses `/capabilities/network` (matches the registered "network" capability), asserts dual-label text and the "Available"/"Not available yet" Pico badge wording.

## Test plan

- [x] `dev test` passes (2309 passed)
- [x] `dev lint` passes
- [ ] `GET /users/me/access/capabilities/network` shows Pico card with requirement tree, correct locked/unlocked badge, readonly checkboxes
- [ ] Component gallery (`/dev/components#capability-requirements`) shows locked + unlocked states rendered via the shared macro

🤖 Generated with [Claude Code](https://claude.com/claude-code)