### PR TITLE
Reuse stopped-container ports in worktree port allocator

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import re
 import shutil
+import socket
 import subprocess
 import sys
 from pathlib import Path
@@ -770,20 +771,28 @@ class WorktreeCommands:
         return 0
 
     def _assign_worktree_port(self) -> int:
-        # Find the lowest unused port starting from 8001 by scanning all
-        # existing .worktree-port files under the worktrees root.
-        used: set = set()
+        # Find the lowest available port starting from 8001. A port from a
+        # .worktree-port file is only treated as occupied if a process is
+        # actually listening on it — stopped containers release their
+        # reservation automatically without needing GC.
+        claimed: set = set()
         wt_root = self._worktrees_root()
         if wt_root.is_dir():
             for port_file in wt_root.glob("*/.worktree-port"):
                 try:
-                    used.add(int(port_file.read_text().split()[0]))
+                    claimed.add(int(port_file.read_text().split()[0]))
                 except (ValueError, IndexError):
                     pass
         port = 8001
-        while port in used:
+        while port in claimed and self._port_bound(port):
             port += 1
         return port
+
+    @staticmethod
+    def _port_bound(port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.05)
+            return s.connect_ex(("127.0.0.1", port)) == 0
 
     def _looks_like_uuid(self, name: str) -> bool:
         # Heuristic: 6+ consecutive hex chars and no human-meaningful

--- a/scripts/test_dev_cli.py
+++ b/scripts/test_dev_cli.py
@@ -345,7 +345,7 @@ def test_assign_worktree_port_starts_at_8001(tmp_path: Path, monkeypatch):
 
 
 def test_assign_worktree_port_skips_used_ports(tmp_path: Path, monkeypatch):
-    """Ports already taken by existing .worktree-port files are skipped."""
+    """Ports claimed by .worktree-port files AND actually bound are skipped."""
     runner = _make_worktree_runner(tmp_path, monkeypatch)
     wt_root = tmp_path / ".claude" / "worktrees"
     (wt_root / "issue-1").mkdir(parents=True)
@@ -353,7 +353,25 @@ def test_assign_worktree_port_skips_used_ports(tmp_path: Path, monkeypatch):
     (wt_root / "issue-1" / ".worktree-port").write_text("8001 35730\n")
     (wt_root / "issue-2" / ".worktree-port").write_text("8002 35731\n")
     wt_cmds = WorktreeCommands(runner)
+    # Simulate both ports having live containers behind them.
+    monkeypatch.setattr(
+        WorktreeCommands, "_port_bound", staticmethod(lambda p: p in {8001, 8002})
+    )
     assert wt_cmds._assign_worktree_port() == 8003
+
+
+def test_assign_worktree_port_reuses_stopped_container_port(
+    tmp_path: Path, monkeypatch
+):
+    """A .worktree-port file whose container is stopped does not block reuse."""
+    runner = _make_worktree_runner(tmp_path, monkeypatch)
+    wt_root = tmp_path / ".claude" / "worktrees"
+    (wt_root / "old-feature").mkdir(parents=True)
+    (wt_root / "old-feature" / ".worktree-port").write_text("8001 35730\n")
+    wt_cmds = WorktreeCommands(runner)
+    # Port file exists but nothing is listening — should reclaim 8001.
+    monkeypatch.setattr(WorktreeCommands, "_port_bound", staticmethod(lambda p: False))
+    assert wt_cmds._assign_worktree_port() == 8001
 
 
 def test_assign_worktree_port_ignores_corrupt_sibling(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

- `_assign_worktree_port` was treating every `.worktree-port` file as a live reservation, so ports from old/stopped worktrees accumulated and new ones climbed well above 8001
- Now adds a `_port_bound()` check: a port is only skipped if a process is *actually listening* on it — stopped containers release their slot without needing `dev worktree gc`
- Updates the existing `test_assign_worktree_port_skips_used_ports` to mock `_port_bound` (simulating live containers), and adds `test_assign_worktree_port_reuses_stopped_container_port` for the reclaim case

## Test plan

- [ ] `dev test scripts/test_dev_cli.py` — all 4 port-assignment tests pass
- [ ] Create a new worktree with no dev containers running: confirm it gets port 8001 even if `.worktree-port` files exist for old worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)