### PR TITLE
Capability touchups: provider-network rename, locked affordances, Pico tooltips

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -131,8 +131,8 @@ _REASON_META = {
     ),
     REASON_VIEW_UNVERIFIED: ReasonMeta(
         title="Contact details",
-        unlock="Verify your account to see contact details.",
-        fix_label="Complete verification",
+        unlock="Get provider network access to see this.",
+        fix_label="Get access",
         fix_url="/users/me/access/capabilities/provider-network",
     ),
 }

--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -245,9 +245,10 @@ def check_network(user: Any) -> CapabilityCheck:
 
     return CapabilityCheck(
         name="network",
+        description="See full provider details and reach out directly.",
         tree=Bundle(
-            label_active="Read full feed",
-            label_done="Read full feed",
+            label_active="Connect with providers",
+            label_done="Connect with providers",
             children=(
                 Condition(
                     label_active="Verify email",

--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -133,7 +133,7 @@ _REASON_META = {
         title="Contact details",
         unlock="Verify your account to see contact details.",
         fix_label="Complete verification",
-        fix_url="/users/me/access/capabilities/network",
+        fix_url="/users/me/access/capabilities/provider-network",
     ),
 }
 
@@ -244,11 +244,11 @@ def check_network(user: Any) -> CapabilityCheck:
     _org_met = bool(_verified_active_reps(user))
 
     return CapabilityCheck(
-        name="network",
+        name="provider-network",
         description="See full provider details and reach out directly.",
         tree=Bundle(
-            label_active="Connect with providers",
-            label_done="Connect with providers",
+            label_active="Provider network",
+            label_done="Provider network",
             children=(
                 Condition(
                     label_active="Verify email",

--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -163,6 +163,9 @@ def _make_cr_post(**detail_overrides):
     defaults.update(detail_overrides)
     return SimpleNamespace(
         kind="referral",
+        owner=SimpleNamespace(
+            clinicians=[SimpleNamespace(first_name="Carlos", last_name="Rivera")]
+        ),
         referral_detail=SimpleNamespace(**defaults),
     )
 
@@ -171,6 +174,8 @@ def _make_pa_post(*, clinician_attrs=None, **detail_overrides):
     """Realistic PA stub. Defaults populate clinician + detail fields."""
     p = dict(
         id="prov-1",
+        first_name="Jane",
+        last_name="Smith",
         org=SimpleNamespace(id="org-1", name="Acme Counseling"),
         location_city="Brooklyn",
         location_state="NY",
@@ -590,6 +595,78 @@ def test_view_returns_dict_for_jinja_attribute_access():
     v = post_card_view(_make_cr_post())
     assert isinstance(v, dict)
     assert v["kind"] == "referral"
+
+
+# --- post_card_view: poster_name ----------------------------------------
+
+
+def test_poster_name_opening_uses_clinician_first_last():
+    v = post_card_view(_make_pa_post())
+    assert v["poster_name"] == "Jane Smith"
+
+
+def test_poster_name_opening_partial_name():
+    v = post_card_view(
+        _make_pa_post(clinician_attrs={"first_name": "Jane", "last_name": None})
+    )
+    assert v["poster_name"] == "Jane"
+
+
+def test_poster_name_opening_none_when_no_names():
+    v = post_card_view(
+        _make_pa_post(clinician_attrs={"first_name": None, "last_name": None})
+    )
+    assert v["poster_name"] is None
+
+
+def test_poster_name_opening_none_when_no_clinician():
+    post = SimpleNamespace(
+        kind="clinician_opening",
+        opening_detail=SimpleNamespace(
+            clinician=None,
+            services=[],
+            settings=[],
+            age_groups=[],
+            languages=[],
+            genders=[],
+            treatment_modality=None,
+            description=None,
+            schedule_text=None,
+            desired_times=[],
+            website=None,
+            referral_instructions=None,
+        ),
+    )
+    assert post_card_view(post)["poster_name"] is None
+
+
+def test_poster_name_intake_uses_org_name():
+    v = post_card_view(_make_program_post())
+    assert v["poster_name"] == "Acme Health"
+
+
+def test_poster_name_intake_none_when_no_org():
+    v = post_card_view(_make_program_post(program_attrs={"organization": None}))
+    assert v["poster_name"] is None
+
+
+def test_poster_name_referral_uses_owner_clinician_name():
+    v = post_card_view(_make_cr_post())
+    assert v["poster_name"] == "Carlos Rivera"
+
+
+def test_poster_name_referral_none_when_no_owner_clinicians():
+    post = _make_cr_post()
+    post.owner = SimpleNamespace(clinicians=[])
+    assert post_card_view(post)["poster_name"] is None
+
+
+def test_poster_name_referral_none_when_clinician_has_no_name():
+    post = _make_cr_post()
+    post.owner = SimpleNamespace(
+        clinicians=[SimpleNamespace(first_name=None, last_name=None)]
+    )
+    assert post_card_view(post)["poster_name"] is None
 
 
 # --- post_row_summary ---------------------------------------------------

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -280,6 +280,7 @@ def post_card_view(post) -> dict[str, Any]:
         "description": None,
         "schedule_text": None,
         "desired_times": [],
+        "poster_name": None,
         "practice_link": None,
         "program_link": None,
         "organization_link": None,
@@ -298,7 +299,13 @@ def post_card_view(post) -> dict[str, Any]:
         if d is None:
             return base
         _forward_detail_passthrough(base, d)
+        _owner = getattr(post, "owner", None)
+        _owner_clinicians = getattr(_owner, "clinicians", None) or []
+        _rc = _owner_clinicians[0] if _owner_clinicians else None
+        _fn = getattr(_rc, "first_name", None) if _rc else None
+        _ln = getattr(_rc, "last_name", None) if _rc else None
         base.update(
+            poster_name=" ".join(filter(None, [_fn, _ln])) or None,
             headline=referral_headline(d),
             in_person=getattr(d, "location_in_person", None),
             virtual=getattr(d, "location_virtual", None),
@@ -326,7 +333,10 @@ def post_card_view(post) -> dict[str, Any]:
             return base
         _forward_detail_passthrough(base, d)
         p = getattr(d, "clinician", None)
+        _fn = getattr(p, "first_name", None) if p else None
+        _ln = getattr(p, "last_name", None) if p else None
         base.update(
+            poster_name=" ".join(filter(None, [_fn, _ln])) or None,
             headline=(p.org.name if p and getattr(p, "org", None) else None),
             # `header_state` stays None — opening's location lives in
             # the demographics column via `location_chunk` (same row
@@ -388,7 +398,9 @@ def post_card_view(post) -> dict[str, Any]:
             return base
         _forward_detail_passthrough(base, d)
         prog = getattr(d, "program", None)
+        _prog_org = getattr(prog, "organization", None) if prog else None
         base.update(
+            poster_name=(getattr(_prog_org, "name", None) if _prog_org else None),
             headline=(getattr(prog, "name", None) if prog else None),
             header_state=(getattr(prog, "state_preference", None) if prog else None),
             program_link=(

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -651,6 +651,12 @@ def test_check_network_tree_structure():
     assert all(c.__class__.__name__ == "Condition" for c in gate.children)
 
 
+def test_check_network_label_and_description():
+    check = capabilities.check_network(_user())
+    assert check.tree.label_active == "Connect with providers"
+    assert check.description == "See full provider details and reach out directly."
+
+
 # ---------- UUID type sanity for claim_state.b ----------------------------
 
 

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -540,7 +540,7 @@ def test_reason_meta_view_unverified_is_the_read_side_gate():
     page where the viewer can see exactly what needs to change."""
     meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED)
     assert "Complete verification" == meta.fix_label
-    assert meta.fix_url == "/users/me/access/capabilities/network"
+    assert meta.fix_url == "/users/me/access/capabilities/provider-network"
     assert meta.unlock
 
 
@@ -571,7 +571,7 @@ def test_check_network_anon_denied():
     """None user: email not verified → entire Bundle fails."""
     check = capabilities.check_network(None)
     assert check.granted is False
-    assert check.name == "network"
+    assert check.name == "provider-network"
 
 
 def test_check_network_email_unverified_denied():
@@ -653,7 +653,7 @@ def test_check_network_tree_structure():
 
 def test_check_network_label_and_description():
     check = capabilities.check_network(_user())
-    assert check.tree.label_active == "Connect with providers"
+    assert check.tree.label_active == "Provider network"
     assert check.description == "See full provider details and reach out directly."
 
 

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -539,7 +539,7 @@ def test_reason_meta_view_unverified_is_the_read_side_gate():
     carries verification-oriented copy and points at the capability detail
     page where the viewer can see exactly what needs to change."""
     meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED)
-    assert "Complete verification" == meta.fix_label
+    assert "Get access" == meta.fix_label
     assert meta.fix_url == "/users/me/access/capabilities/provider-network"
     assert meta.unlock
 

--- a/src/domain/routes/access.py
+++ b/src/domain/routes/access.py
@@ -16,7 +16,7 @@ from src.framework.capabilities import mount_capability_routes
 access_router = APIRouter(prefix="/users/me/access", tags=["access"])
 
 _CHECKS = {
-    "network": capabilities.check_network,
+    "provider-network": capabilities.check_network,
 }
 
 mount_capability_routes(access_router, _CHECKS)

--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -67,7 +67,7 @@ async def test_capability_detail_network_returns_200(
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     # Capability label_active appears in the page heading and breadcrumb.
-    assert "Read full feed" in response.text
+    assert "Connect with providers" in response.text
     # Tree node labels appear — active form for unmet, done form for met.
     assert "Verify email" in response.text or "Email verified" in response.text
     assert (

--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -47,7 +47,7 @@ async def test_capabilities_index_authenticated_returns_200(
     response = await authenticated_client.get("/users/me/access/capabilities")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
-    assert "network" in response.text
+    assert "provider-network" in response.text
 
 
 async def test_capabilities_index_shows_granted_or_denied(
@@ -56,18 +56,20 @@ async def test_capabilities_index_shows_granted_or_denied(
     """The capabilities list surfaces a granted/denied label for each capability."""
     response = await authenticated_client.get("/users/me/access/capabilities")
     assert response.status_code == 200
-    assert "Granted" in response.text or "Denied" in response.text
+    assert "Available" in response.text or "Not available yet" in response.text
 
 
 async def test_capability_detail_network_returns_200(
     authenticated_client: AsyncClient,
 ):
-    """GET /users/me/access/capabilities/network renders the requirement tree."""
-    response = await authenticated_client.get("/users/me/access/capabilities/network")
+    """GET /users/me/access/capabilities/provider-network renders the requirement tree."""
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/provider-network"
+    )
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     # Capability label_active appears in the page heading and breadcrumb.
-    assert "Connect with providers" in response.text
+    assert "Provider network" in response.text
     # Tree node labels appear — active form for unmet, done form for met.
     assert "Verify email" in response.text or "Email verified" in response.text
     assert (
@@ -84,7 +86,9 @@ async def test_capability_detail_shows_status(
     authenticated_client: AsyncClient,
 ):
     """The detail page shows an available/locked badge."""
-    response = await authenticated_client.get("/users/me/access/capabilities/network")
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/provider-network"
+    )
     assert response.status_code == 200
     assert "Available" in response.text or "Not available yet" in response.text
 
@@ -100,9 +104,9 @@ async def test_capability_detail_nonexistent_returns_404(
 
 
 async def test_capability_detail_unauthenticated_redirected(test_client: AsyncClient):
-    """Unauthenticated GET /users/me/access/capabilities/network is bounced."""
+    """Unauthenticated GET /users/me/access/capabilities/provider-network is bounced."""
     response = await test_client.get(
-        "/users/me/access/capabilities/network",
+        "/users/me/access/capabilities/provider-network",
         follow_redirects=False,
     )
     assert response.status_code != 200

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -541,7 +541,7 @@ async def test_list_has_no_inline_verify_notice_for_unverified(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     assert "posts-verify-notice" not in response.text
-    assert "Complete verification" not in response.text
+    assert "Get access" not in response.text
 
 
 # --- Toolbar Create CTA gate (posting-capable claim) -------------------------
@@ -621,8 +621,8 @@ async def test_detail_hides_email_and_shows_cta_for_unverified(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """Unverified users see a 'Verify to contact' CTA on post detail instead
-    of the poster's email address — contact info is not sent to the browser."""
+    """Unverified users see a disabled Email button (not a mailto link) on
+    post detail — contact info is not sent to the browser."""
     author = create_test_user(
         username=f"detail-author-{uuid.uuid4()}",
         email=f"detail-author-{uuid.uuid4()}@example.com",
@@ -637,7 +637,8 @@ async def test_detail_hides_email_and_shows_cta_for_unverified(
     assert response.status_code == 200
     assert f"mailto:{author.email}" not in response.text
     assert author.email not in response.text
-    assert "Verify to contact" in response.text
+    assert "disabled" in response.text
+    assert "Email" in response.text
 
 
 async def test_detail_shows_email_for_verified(
@@ -665,7 +666,6 @@ async def test_detail_shows_email_for_verified(
     response = await authenticated_client.get(f"/posts/{post.id}")
     assert response.status_code == 200
     assert f"mailto:{author_email}" in response.text
-    assert "Verify to contact" not in response.text
 
 
 async def test_detail_redacts_identity_rows_as_locked_placeholders_for_unverified(
@@ -675,9 +675,8 @@ async def test_detail_redacts_identity_rows_as_locked_placeholders_for_unverifie
 ):
     """A viewer who can't read the full feed sees the practice /
     organization / address rows on post detail as `locked_field`
-    placeholders ("Hidden — Complete verification →"), not silently
-    dropped. The real links + address value are NOT emitted — withholding,
-    not CSS-hiding."""
+    placeholders (lock icon + fix link), not silently dropped. The real
+    links + address value are NOT emitted — withholding, not CSS-hiding."""
     author = create_test_user(username=f"author-{uuid.uuid4()}")
     clinician = make_clinician_with_org(owner_id=author.id, practice_name="Acme Health")
     clinician.id = clinician.id or uuid.uuid4()
@@ -708,7 +707,7 @@ async def test_detail_redacts_identity_rows_as_locked_placeholders_for_unverifie
     assert tree.css_first(f"a[href='/clinicians/{clinician.id}']") is None
     assert tree.css_first(f"a[href='/organizations/{org_id}']") is None
     assert "Springfield, IL" not in response.text
-    assert "Complete verification" in response.text
+    assert "Get access" in response.text
 
 
 async def test_detail_shows_identity_rows_for_verified_viewer(

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -701,7 +701,7 @@ async def test_detail_redacts_identity_rows_as_locked_placeholders_for_unverifie
         ), f"{fact_key} should render a locked placeholder"
         assert (
             dd.css_first("a").attributes.get("href")
-            == "/users/me/access/capabilities/network"
+            == "/users/me/access/capabilities/provider-network"
         )
 
     # ...but the real navigable links + the address value are withheld.

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -54,7 +54,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
 `DESIRED_TIME_SLOT_LABELS`, `REFERRAL_SERVICE_LABELS`,
 `TREATMENT_SETTINGS_LABELS`) are Jinja globals. #}
 {%- from "_shared/sections.html" import fact -%}
-{%- from "_shared/_locked.html" import locked_field -%}
+{%- from "_shared/_locked.html" import locked_field, locked_name -%}
 {% macro facts_block(view, expanded=False, redacted=False) -%}
   <section class="entity-facts">
     <dl>
@@ -121,6 +121,8 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
         compact card omits — practice/program identity, full address,
         scheduling, and per-kind insurance details. -#}
                 {%- if expanded %}
+                  {%- set _fix_url = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED).fix_url -%}
+                  {%- set _name_placeholder = "Doe Health Group" if view.kind == "program_intake" else "Dr. J. Doe" -%}
                   {%- if view.ages and view.kind == "referral" %}
                     {#- Referral expanded-only Age row: the headline already carries
           the age + gender combo, so the compact list-card body skips
@@ -134,7 +136,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- if view.practice_link %}
                       {%- call fact('practice', 'Practice') %}
                         {% if redacted %}
-                          {{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}
+                          {{ locked_name(_name_placeholder, _fix_url) }}
                         {% else %}
                           <a href="{{ entity_url('clinician', id=view.practice_link.id) }}">{{ view.practice_link.name }}</a>
                         {% endif %}
@@ -143,7 +145,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- if view.program_link %}
                       {%- call fact('program', 'Program') %}
                         {% if redacted %}
-                          {{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}
+                          {{ locked_name(_name_placeholder, _fix_url) }}{# title-case-ignore: placeholder org name #}
                         {% else %}
                           <a href="{{ entity_url('program', id=view.program_link.id) }}">{{ view.program_link.name }}</a>
                         {% endif %}
@@ -152,7 +154,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- if view.organization_link %}
                       {%- call fact('organization', 'Organization') %}
                         {% if redacted %}
-                          {{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}
+                          {{ locked_name(_name_placeholder, _fix_url) }}{# title-case-ignore: placeholder org name #}
                         {% else %}
                           <a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a>
                         {% endif %}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -35,9 +35,12 @@
              role="button"
              class="secondary outline">Email</a>
         {% else %}
-          <a href="{{ entity_url('user', id='me') }}"
-             role="button"
-             class="secondary outline">Verify to contact →</a>
+          {%- set _meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED) -%}
+          <span data-tooltip="{{ _meta.unlock }}">
+            <button type="button" disabled aria-disabled="true" class="secondary outline">
+              <i class="icon-lock" aria-hidden="true"></i> Email
+            </button>
+          </span>
         {% endif %}
       </footer>
     </section>

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -15,6 +15,4 @@
   {% call page_toolbar(heading=check.tree.label_active) %}
   {% endcall %}
 {% endblock %}
-{% block content %}
-  {{ capability_requirements_panel(check.tree, check.granted, check.description) }}
-{% endblock %}
+{% block content %}{{ capability_requirements_panel(check.tree, check.granted, check.description) }}{% endblock %}

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -16,6 +16,5 @@
   {% endcall %}
 {% endblock %}
 {% block content %}
-  {% if check.description %}<p>{{ check.description }}</p>{% endif %}
-  {{ capability_requirements_panel(check.tree, check.granted) }}
+  {{ capability_requirements_panel(check.tree, check.granted, check.description) }}
 {% endblock %}

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -16,8 +16,6 @@
   {% endcall %}
 {% endblock %}
 {% block content %}
+  {% if check.description %}<p>{{ check.description }}</p>{% endif %}
   {{ capability_requirements_panel(check.tree, check.granted) }}
-  <p>
-    <a href="{{ access_index_url }}">← All capabilities</a>
-  </p>
 {% endblock %}

--- a/src/domain/templates/users/access/capabilities/index.html
+++ b/src/domain/templates/users/access/capabilities/index.html
@@ -31,9 +31,7 @@
               {% endif %}
             </small>
           </header>
-          <footer>
-            <a href="{{ capability_base_url }}/{{ name }}">View requirements →</a>
-          </footer>
+          <a href="{{ capability_base_url }}/{{ name }}">View requirements →</a>
         </article>
       </li>
     {% endfor %}

--- a/src/domain/templates/users/access/capabilities/index.html
+++ b/src/domain/templates/users/access/capabilities/index.html
@@ -14,23 +14,28 @@
   {% endcall %}
 {% endblock %}
 {% block content %}
-  <section class="entity-card">
-    <section class="entity-facts">
-      <dl>
-        {% for name, check in checks.items() %}
-          <div>
-            <dt>{{ name }}</dt>
-            <dd>
+  <ul class="capability-list">
+    {% for name, check in checks.items() %}
+      <li>
+        <article>
+          <header>
+            <hgroup>
+              <h3>{{ check.tree.label_active }}</h3>
+              {% if check.description %}<p>{{ check.description }}</p>{% endif %}
+            </hgroup>
+            <small data-state="{{ 'unlocked' if check.granted else 'locked' }}">
               {% if check.granted %}
-                <span class="capability-badge capability-badge--granted">Granted</span>
+                <i class="icon-check" aria-hidden="true"></i>Available
               {% else %}
-                <span class="capability-badge capability-badge--denied">Denied</span>
+                <i class="icon-lock" aria-hidden="true"></i>Not available yet
               {% endif %}
-              <a href="{{ capability_base_url }}/{{ name }}">View details →</a>
-            </dd>
-          </div>
-        {% endfor %}
-      </dl>
-    </section>
-  </section>
+            </small>
+          </header>
+          <footer>
+            <a href="{{ capability_base_url }}/{{ name }}">View requirements →</a>
+          </footer>
+        </article>
+      </li>
+    {% endfor %}
+  </ul>
 {% endblock %}

--- a/src/framework/capabilities.py
+++ b/src/framework/capabilities.py
@@ -71,6 +71,7 @@ class CapabilityCheck:
 
     name: str
     tree: Any  # Condition | Bundle | Gate
+    description: str | None = None
 
     @property
     def granted(self) -> bool:

--- a/src/framework/templates/_shared/_capability_requirements.html
+++ b/src/framework/templates/_shared/_capability_requirements.html
@@ -30,7 +30,7 @@
         <span>
           <input type="checkbox"
                  {% if node.met %}checked{% endif %}
-                 readonly
+                 disabled
                  aria-hidden="true">
           <span>{{ node.label_done if node.met else node.label_active }}</span>
         </span>
@@ -45,7 +45,7 @@
                 <span>
                   <input type="checkbox"
                          {% if child.met %}checked{% endif %}
-                         readonly
+                         disabled
                          aria-hidden="true">
                   <span>{{ child.label_done if child.met else child.label_active }}</span>
                 </span>

--- a/src/framework/templates/_shared/_capability_requirements.html
+++ b/src/framework/templates/_shared/_capability_requirements.html
@@ -8,7 +8,7 @@
    Leaf nodes have no `children`; branches carry `op` ("all" / "any") and a
    `children` sequence. The macro detects which is which via duck-typing so
    it works with both Python dataclass instances and plain Jinja dicts. #}
-{% macro capability_requirements_panel(tree, granted) %}
+{% macro capability_requirements_panel(tree, granted, description=none) %}
   {% macro render_leaf(node) %}
     <span>
       <input type="checkbox"
@@ -73,6 +73,7 @@
     <header>
       <hgroup>
         <h3>{{ tree.label_active }}</h3>
+        {% if description %}<p>{{ description }}</p>{% endif %}
       </hgroup>
       <small data-state="{{ 'unlocked' if granted else 'locked' }}">
         {% if granted %}

--- a/src/framework/templates/_shared/_capability_requirements.html
+++ b/src/framework/templates/_shared/_capability_requirements.html
@@ -13,7 +13,7 @@
     <span>
       <input type="checkbox"
              {% if node.met %}checked{% endif %}
-             readonly
+             disabled
              aria-hidden="true">
       {% if not node.met and node.fix_url %}
         <a href="{{ node.fix_url }}">{{ node.label_active }}</a>

--- a/src/framework/templates/_shared/_feed_row.html
+++ b/src/framework/templates/_shared/_feed_row.html
@@ -1,3 +1,4 @@
+{%- from "_shared/_locked.html" import locked_name -%}
 {# Feed-row macro — renders a single clickable row for the home feed and
    browse list views.
 
@@ -42,9 +43,9 @@ under the "Feed rows" section. #}
 {%- else -%}
 {%- set _fix_url = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED).fix_url -%}
 {%- if post.kind == "program_intake" -%}
-<small class="locked-field"><a href="{{ _fix_url }}"><i class="icon-lock" aria-hidden="true"></i> Doe Health Group</a></small>{# title-case-ignore: placeholder org name #}
+<small>{{ locked_name("Doe Health Group", _fix_url) }}</small>{# title-case-ignore: placeholder org name #}
 {%- else -%}
-<small class="locked-field"><a href="{{ _fix_url }}"><i class="icon-lock" aria-hidden="true"></i> Dr. J. Doe</a></small>
+<small>{{ locked_name("Dr. J. Doe", _fix_url) }}</small>
 {%- endif -%}
 {%- endif -%}
 {%- endif -%}

--- a/src/framework/templates/_shared/_feed_row.html
+++ b/src/framework/templates/_shared/_feed_row.html
@@ -36,18 +36,16 @@ under the "Feed rows" section. #}
 <span class="post-feed-byline">
 {%- if show_poster and post.owner -%}
 {%- if can_access_network -%}
-{%- set _fn = post.owner.first_name -%}
-{%- set _ln = post.owner.last_name -%}
-{%- set _poster_name -%}
-{%- if _fn and _ln %}{{ _fn[0] }} . {{ _ln }}
-{%- elif _fn %}{{ _fn }}
-{%- elif _ln %}{{ _ln }}
-{%- else %}{{ post.owner.email }}
-{%- endif %}
-{%- endset -%}
-<small>{{ _poster_name | trim }}</small>
+{%- if view.poster_name -%}
+<small>{{ view.poster_name }}</small>
+{%- endif -%}
 {%- else -%}
-<small>Clinician</small>
+{%- set _fix_url = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED).fix_url -%}
+{%- if post.kind == "program_intake" -%}
+<small class="locked-field"><a href="{{ _fix_url }}"><i class="icon-lock" aria-hidden="true"></i> Doe Health Group</a></small>{# title-case-ignore: placeholder org name #}
+{%- else -%}
+<small class="locked-field"><a href="{{ _fix_url }}"><i class="icon-lock" aria-hidden="true"></i> Dr. J. Doe</a></small>
+{%- endif -%}
 {%- endif -%}
 {%- endif -%}
 <small>{{ post.created_at | days_ago }}</small>

--- a/src/framework/templates/_shared/_locked.html
+++ b/src/framework/templates/_shared/_locked.html
@@ -1,49 +1,41 @@
 {# Consistent "you can't do/see this yet" affordances, driven by the
-   closed `capabilities.REASON_*` vocab. Two treatments, picked by the
-   *type* of thing being gated:
+   closed `capabilities.REASON_*` vocab. Three treatments:
 
    - `locked_action(reason, label)` — for write affordances (buttons,
-     create links). Renders the control DISABLED and visible, with the
-     reason + fix link beneath. The user sees the action exists and what
-     unlocks it. Safe to render: the server re-checks authz on submit
-     (e.g. `_assert_post_payload_authz`), so a disabled control leaks no
-     data.
+     create links). Renders the control DISABLED inside a tooltip wrapper.
+     Safe to render: the server re-checks authz on submit.
 
-   - `locked_field(reason, label="")` — for withheld DATA values (practice
-     name, description, full address). Renders a placeholder in place of
-     the value. Pass the field's NAME as `label` when the placeholder
-     stands alone ("Practice name hidden — …"); omit it inside an already-
-     labeled row (a `<dl>` `<dt>` carries the name, so the `<dd>` reads
-     just "Hidden — …"). The caller passes the field's NAME, never its
-     value — so this macro CANNOT leak the data. Withholding the real
-     value is the VIEW layer's job; this macro only renders the gap and
-     the path to unlock it.
+   - `locked_field(reason)` — for withheld DATA values (full address).
+     Renders a lock icon + fix link inside a tooltip wrapper. The caller
+     never passes the real value — withholding is the VIEW layer's job.
 
-   Copy + fix link both come from `capabilities.reason_meta(reason)` so a
-   given reason reads identically everywhere. `capabilities` is a Jinja
-   global (registered in `src/domain/template_globals.py`), so these
-   macros need no `with context` on import. Add or change reason copy in
-`src/domain/logic/capabilities.py` — never inline here. #}
+   - `locked_name(placeholder, fix_url)` — for withheld identity names
+     (clinician name, org name). Renders the placeholder as a link inside
+     a tooltip wrapper, so the viewer knows there's a real name and how to
+     unlock it.
+
+   Tooltip text + fix link come from `capabilities.reason_meta(reason)`.
+   `capabilities` is a Jinja global (registered in
+   `src/domain/template_globals.py`), so these macros need no `with
+   context`. Add or change reason copy in
+   `src/domain/logic/capabilities.py` — never inline here. #}
 {% macro locked_action(reason, label) -%}
   {%- set meta = capabilities.reason_meta(reason) -%}
-  <div class="locked-action">
+  <span data-tooltip="{{ meta.unlock }}">
     <button type="button" class="outline" disabled aria-disabled="true">{{ label }}</button>
-    <small class="locked-reason">
-      <i class="icon-lock" aria-hidden="true"></i>{{ meta.unlock }}
-      <a href="{{ meta.fix_url }}">{{ meta.fix_label }} →</a>
-    </small>
-  </div>
+  </span>
 {%- endmacro %}
-{% macro locked_field(reason, label="") -%}
-  {%- set meta = capabilities.reason_meta(reason) -%}
-  <span class="locked-field" title="{{ meta.unlock }}">
+{% macro locked_name(placeholder, fix_url) -%}
+  {%- set _meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED) -%}
+  <span class="locked-field" data-tooltip="{{ _meta.unlock }}">
     <i class="icon-lock" aria-hidden="true"></i>
-    {% if label %}
-      {{ label }} hidden
-    {% else %}
-      Hidden
-    {% endif %}
-    —
-    <a href="{{ meta.fix_url }}">{{ meta.fix_label }} →</a>
+    <a href="{{ fix_url }}">{{ placeholder }}</a>
+  </span>
+{%- endmacro %}
+{% macro locked_field(reason) -%}
+  {%- set meta = capabilities.reason_meta(reason) -%}
+  <span class="locked-field" data-tooltip="{{ meta.unlock }}">
+    <i class="icon-lock" aria-hidden="true"></i>
+    <a href="{{ meta.fix_url }}">{{ meta.fix_label }}</a>
   </span>
 {%- endmacro %}

--- a/src/framework/templates/_shared/test_locked.py
+++ b/src/framework/templates/_shared/test_locked.py
@@ -1,16 +1,14 @@
 """Tests for the locked-affordance macros in ``_shared/_locked.html``.
 
-The two macros render the consistent "you can't do/see this yet" chrome
+Three macros render the consistent "you can't do/see this yet" chrome
 driven by the closed ``capabilities.REASON_*`` vocab:
 
-- ``locked_action`` — a *disabled, visible* control plus an unlock line.
-  Pins that the control is non-submittable (``disabled``) and that the
-  reason copy + fix link come from ``capabilities.reason_meta`` (not
-  inline), so a refactor can't silently drop the disabled attribute or
-  hard-code copy that drifts from the single source.
-- ``locked_field`` — a placeholder that names a *withheld* value. Pins
-  that the caller-supplied field NAME renders while no value is emitted
-  (the macro is handed a label, never data — it cannot leak).
+- ``locked_action`` — a *disabled, visible* control wrapped in a Pico
+  tooltip. The tooltip carries the unlock copy; the button is non-submittable.
+- ``locked_field`` — a lock icon + fix link in a tooltip wrapper, rendered
+  in place of a withheld data value (e.g. full address).
+- ``locked_name`` — a lock icon + placeholder name as a link in a tooltip
+  wrapper, rendered in place of a withheld identity name.
 
 The real ``capabilities`` module is registered as the ``capabilities``
 Jinja global so the assertions exercise the actual copy wiring, exactly
@@ -38,58 +36,71 @@ def _make_env() -> Environment:
     return env
 
 
-def _render(macro: str, reason: str, label: str) -> str:
+def _render_action(reason: str, label: str) -> str:
     template = textwrap.dedent(f"""\
-        {{%- from "_shared/_locked.html" import {macro} -%}}
-        {{{{ {macro}(capabilities.{reason}, {label!r}) }}}}
+        {{%- from "_shared/_locked.html" import locked_action -%}}
+        {{{{ locked_action(capabilities.{reason}, {label!r}) }}}}
+        """)
+    return _make_env().from_string(template).render()
+
+
+def _render_field(reason: str) -> str:
+    template = textwrap.dedent(f"""\
+        {{%- from "_shared/_locked.html" import locked_field -%}}
+        {{{{ locked_field(capabilities.{reason}) }}}}
         """)
     return _make_env().from_string(template).render()
 
 
 # ---------------------------------------------------------------------------
-# locked_action — disabled control + unlock line
+# locked_action — disabled control in tooltip wrapper
 # ---------------------------------------------------------------------------
 
 
 def test_locked_action_renders_disabled_button_with_label() -> None:
-    html = _render("locked_action", "REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
+    html = _render_action("REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
     button = HTMLParser(html).css_first("button")
     assert button is not None, "expected a <button> for the gated action"
     assert "disabled" in button.attributes, "gated action must be disabled"
     assert button.text(strip=True) == "+ Post a referral"
 
 
-def test_locked_action_shows_reason_copy_and_fix_link_from_capabilities() -> None:
-    """Copy + link come from `reason_meta`, not inline — assert the exact
-    strings the single source returns so drift is caught here."""
+def test_locked_action_tooltip_carries_unlock_copy() -> None:
+    """Unlock copy is in the tooltip wrapper, not inline — so a refactor
+    can't silently drop it or hard-code copy that drifts from the single source."""
     meta = capabilities.reason_meta(capabilities.REASON_CLAIM_A_UNVERIFIED)
-    html = _render("locked_action", "REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
-    tree = HTMLParser(html)
-    assert meta.unlock in html
-    link = tree.css_first("a")
-    assert link is not None
-    assert link.attributes.get("href") == meta.fix_url
-    assert meta.fix_label in link.text()
+    html = _render_action("REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
+    assert meta.unlock in html, "unlock copy must appear in data-tooltip"
+    # Fix link is NOT inside locked_action — the tooltip is enough.
+    # (Users click the button's parent or navigate to capability page separately.)
+    button = HTMLParser(html).css_first("button[disabled]")
+    assert button is not None
 
 
 # ---------------------------------------------------------------------------
-# locked_field — placeholder naming a withheld value
+# locked_field — placeholder for withheld data values
 # ---------------------------------------------------------------------------
 
 
-def test_locked_field_names_the_field_without_emitting_a_value() -> None:
-    """The macro is handed the field NAME, never its value — it renders
-    the name + unlock path and nothing resembling live data."""
-    html = _render("locked_field", "REASON_EMAIL_UNVERIFIED", "Practice name")
-    tree = HTMLParser(html)
-    assert "Practice name" in html
-    link = tree.css_first("a.locked-field a, .locked-field a")
+def test_locked_field_renders_fix_link_with_correct_href() -> None:
+    """The fix link points at the capability page so the viewer knows
+    exactly what unlocks the field."""
+    html = _render_field("REASON_VIEW_UNVERIFIED")
+    link = HTMLParser(html).css_first(".locked-field a")
     assert link is not None
     assert link.attributes.get("href") == capabilities.fix_url_for(
-        capabilities.REASON_EMAIL_UNVERIFIED
+        capabilities.REASON_VIEW_UNVERIFIED
     )
-    # No interactive control: a field placeholder is read-only chrome.
-    assert tree.css_first("button") is None
+
+
+def test_locked_field_tooltip_carries_unlock_copy() -> None:
+    """Unlock text appears in the tooltip attribute, not inline."""
+    meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED)
+    html = _render_field("REASON_VIEW_UNVERIFIED")
+    assert meta.unlock in html
+    span = HTMLParser(html).css_first(".locked-field")
+    assert span is not None
+    assert span.attributes.get("data-tooltip") == meta.unlock
 
 
 def test_locked_field_unknown_reason_falls_back_not_raises() -> None:
@@ -97,7 +108,7 @@ def test_locked_field_unknown_reason_falls_back_not_raises() -> None:
     env = _make_env()
     template = (
         '{%- from "_shared/_locked.html" import locked_field -%}'
-        '{{ locked_field("totally-not-a-reason", "Some field") }}'
+        '{{ locked_field("totally-not-a-reason") }}'
     )
     html = env.from_string(template).render()
     link = HTMLParser(html).css_first(".locked-field a")
@@ -105,19 +116,7 @@ def test_locked_field_unknown_reason_falls_back_not_raises() -> None:
     assert link.attributes.get("href") == "/users/me"
 
 
-def test_locked_field_without_label_reads_just_hidden() -> None:
-    """Inside an already-labeled row (a `<dl>` `<dt>` names the field) the
-    placeholder omits the name and reads "Hidden — …" — no redundant
-    "<field> hidden". The fix link still renders."""
-    env = _make_env()
-    template = (
-        '{%- from "_shared/_locked.html" import locked_field -%}'
-        "{{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}"
-    )
-    html = env.from_string(template).render()
-    placeholder = HTMLParser(html).css_first(".locked-field")
-    assert placeholder is not None
-    text = placeholder.text(strip=True)
-    assert text.startswith("Hidden"), text
-    assert "hidden" not in text.replace("Hidden", "", 1).lower(), text
-    assert placeholder.css_first("a") is not None
+def test_locked_field_no_button_rendered() -> None:
+    """A field placeholder is read-only chrome — no interactive button."""
+    html = _render_field("REASON_VIEW_UNVERIFIED")
+    assert HTMLParser(html).css_first("button") is None

--- a/src/framework/test_capabilities.py
+++ b/src/framework/test_capabilities.py
@@ -67,6 +67,15 @@ def test_gate_empty_is_false():
 # ---------- CapabilityCheck ------------------------------------------------
 
 
+def test_capability_check_description_defaults_to_none():
+    assert CapabilityCheck(name="x", tree=_met()).description is None
+
+
+def test_capability_check_accepts_description():
+    check = CapabilityCheck(name="x", tree=_met(), description="Some text")
+    assert check.description == "Some text"
+
+
 def test_capability_check_granted_delegates_to_tree_met():
     check_granted = CapabilityCheck(name="x", tree=_met())
     assert check_granted.granted is True


### PR DESCRIPTION
## Summary

- Renames capability slug `network` → `provider-network` (label: "Provider network"); adds `description` field to `CapabilityCheck`; redesigns capability list view with article cards showing name, description, and status
- Extracts `locked_name(placeholder, fix_url)` macro for withheld identity names (clinician / org); updates `locked_field` and `locked_action` to use Pico CSS `data-tooltip` instead of inline unlock text
- Post detail footer: unverified viewers see a disabled "Email" button with lock icon + tooltip instead of a redirect link
- Post feed rows and post detail identity rows use `locked_name` with kind-appropriate placeholders ("Dr. J. Doe" / "Doe Health Group")
- `REASON_VIEW_UNVERIFIED` copy updated: tooltip text "Get provider network access to see this." / fix label "Get access"
- All checkboxes in capability requirements macro are `disabled` (not `readonly`)
- Fixes stale assertions across 4 test files

## Test plan

- [ ] `dev test` passes (2336 passed, 101 skipped)
- [ ] `dev lint` passes
- [ ] Verify `/users/me/access/capabilities` renders article cards with status badges
- [ ] Verify `/users/me/access/capabilities/provider-network` shows requirement tree with disabled checkboxes
- [ ] Verify post detail footer shows disabled Email button for unverified users
- [ ] Verify post feed row shows `🔒 Dr. J. Doe` / `🔒 Doe Health Group` for gated users
- [ ] Hover over any lock icon — Pico tooltip shows "Get provider network access to see this."

🤖 Generated with [Claude Code](https://claude.com/claude-code)