### PR TITLE
Require Clinician first_name and last_name (NOT NULL)

### DIFF
--- a/alembic/versions/d1e2f3a4b5c6_require_clinician_first_last_name.py
+++ b/alembic/versions/d1e2f3a4b5c6_require_clinician_first_last_name.py
@@ -1,0 +1,32 @@
+"""Require clinician first_name and last_name (NOT NULL)
+
+Revision ID: d1e2f3a4b5c6
+Revises: c4d5e6f7a8b9
+Create Date: 2026-06-06 00:00:00.000000
+
+`Clinician.first_name` and `Clinician.last_name` were nullable at creation
+but are always required in practice — every clinician-authored post kind
+surfaces the provider's name. Existing NULL rows (dev/test data) are
+backfilled with 'Unknown' before the constraint is applied.
+"""
+
+from alembic import op
+
+revision = "d1e2f3a4b5c6"
+down_revision = "c4d5e6f7a8b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE clinicians SET first_name = 'Unknown' WHERE first_name IS NULL")
+    op.execute("UPDATE clinicians SET last_name = 'Unknown' WHERE last_name IS NULL")
+    with op.batch_alter_table("clinicians") as batch_op:
+        batch_op.alter_column("first_name", nullable=False)
+        batch_op.alter_column("last_name", nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("clinicians") as batch_op:
+        batch_op.alter_column("first_name", nullable=True)
+        batch_op.alter_column("last_name", nullable=True)

--- a/scripts/dev/seed/overrides/clinicians.py
+++ b/scripts/dev/seed/overrides/clinicians.py
@@ -56,11 +56,10 @@ async def generate_clinicians(
         row = Clinician(
             id=cid,
             owner_id=users[i % len(users)].id,
-            # All three are nullable per the model. Exercise the NULL
-            # path so the nullable-coverage test has both samples.
+            # npi is still nullable (not yet required at schema level).
             npi=(None if rng.bool(0.4) else COLUMN_VOCAB["npi"](rng, i)),
-            first_name=(None if rng.bool(0.1) else COLUMN_VOCAB["first_name"](rng, i)),
-            last_name=(None if rng.bool(0.1) else COLUMN_VOCAB["last_name"](rng, i)),
+            first_name=COLUMN_VOCAB["first_name"](rng, i),
+            last_name=COLUMN_VOCAB["last_name"](rng, i),
             npi_match_status=match_status,
             npi_verified_at=verified_ts,
             clinician_verified=clinician_verified,

--- a/src/domain/logic/clinician_affiliations/test_repository.py
+++ b/src/domain/logic/clinician_affiliations/test_repository.py
@@ -83,6 +83,8 @@ async def test_repository_creates_and_fetches_affiliation(session):
     clinician = Clinician(
         owner_id=user_id,
         org_id=org_a_id,
+        first_name="Jane",
+        last_name="Smith",
         location_city="Brooklyn",
         location_state="NY",
         location_zip="11201",

--- a/src/domain/logic/clinicians/schema.py
+++ b/src/domain/logic/clinicians/schema.py
@@ -204,11 +204,9 @@ class ClinicianRead(FlatLocationSchema, ReadProjection):
     # verification pipeline to look up the clinician in NPPES. No UNIQUE
     # constraint at the DB layer yet.
     npi: str | None = None
-    # Legal first / last name — surfaced via `from_attributes` through
-    # `Clinician.first_name` / `last_name`. Optional on read because
-    # backfill is operator-driven.
-    first_name: str | None = None
-    last_name: str | None = None
+    # Legal first / last name — required on the model (NOT NULL).
+    first_name: str
+    last_name: str
     # `(city, state, zip)` arrive flat — from ORM attributes via
     # ``from_attributes`` or from a flat dict — and dump flat (JSON
     # responses still expose ``location_city`` / ``location_state`` /
@@ -262,15 +260,12 @@ class ClinicianCreate(FlatLocationSchema, WirePayload):
             raise ValueError("org_id is required unless solo_practice is True")
         return self
 
-    # Optional on create; backfill is operator-driven. Empty input
-    # normalizes to `None` so an unfilled form field doesn't 422.
+    # Optional on create; empty input normalizes to `None`.
     npi: NpiText = None
-    # Legal first / last name — both optional, both normalize empty
-    # string to `None` via `StrippedOptionalText` so an unfilled form
-    # field doesn't persist `""`. Forwarded to the linked Clinician
-    # via `Clinician.__init__`'s kwarg peeling.
-    first_name: StrippedOptionalText = None
-    last_name: StrippedOptionalText = None
+    # Legal first / last name — required; empty input fails validation.
+    # Forwarded to the linked Clinician via `Clinician.__init__`'s kwarg peeling.
+    first_name: StrippedText
+    last_name: StrippedText
     location: Location | None = None
     in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] = "yes"
     virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] = "yes"
@@ -307,12 +302,11 @@ class ClinicianUpdate(FlatLocationSchema, PartialUpdate):
     # Patch the NPI by writing a 10-digit string or empty (→ `None`,
     # clearing the field). Same validator as :class:`ClinicianCreate`.
     npi: NpiText = None
-    # Patch the linked Clinician's first / last name. Empty input
-    # normalizes to `None` so submitting a blank field clears the
-    # column; absent fields pass through `exclude_unset=True` and
-    # don't touch the persisted value.
-    first_name: StrippedOptionalText = None
-    last_name: StrippedOptionalText = None
+    # Patch the linked Clinician's first / last name. Empty input raises
+    # a 422 (cannot clear to NULL); absent fields pass through
+    # `exclude_unset=True` and don't touch the persisted value.
+    first_name: StrippedText | None = None
+    last_name: StrippedText | None = None
     location: LocationPartial | None = None
     in_person_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None
     virtual_sessions: Literal[*LOCATION_AVAILABILITY_OPTIONS] | None = None

--- a/src/domain/logic/clinicians/test_handlers.py
+++ b/src/domain/logic/clinicians/test_handlers.py
@@ -146,6 +146,8 @@ async def _seed_org(
 def _clinician_create_payload(*, org_id: uuid.UUID, **overrides) -> ClinicianCreate:
     base = dict(
         org_id=org_id,
+        first_name="Jane",
+        last_name="Smith",
         location_city="Springfield",
         location_state="IL",
         location_zip="62701",
@@ -986,6 +988,8 @@ async def test_after_create_clinician_verification_no_npi_records_skipped(
             clinician = Clinician(
                 owner_id=user.id,
                 org_id=org_id,
+                first_name="Jane",
+                last_name="Smith",
                 location_city="Springfield",
                 location_state="IL",
                 location_zip="62701",

--- a/src/domain/logic/clinicians/test_schema.py
+++ b/src/domain/logic/clinicians/test_schema.py
@@ -56,6 +56,8 @@ def _clinician_create_kwargs(**overrides):
     """
     base = {
         "org_id": uuid.uuid4(),
+        "first_name": "Jane",
+        "last_name": "Smith",
         "location_city": "Boise",
         "location_state": "ID",
         "location_zip": "83702",
@@ -298,6 +300,8 @@ def test_clinician_read_round_trips_npi():
             "org_id": uuid.uuid4(),
             "org_name": "Sunrise",
             "npi": "1234567890",
+            "first_name": "Jane",
+            "last_name": "Smith",
             "location_city": "Boise",
             "location_state": "ID",
             "location_zip": "83702",
@@ -414,6 +418,8 @@ def test_clinician_read_validates_from_nested_dict():
         "updated_at": now,
         "org_id": org_id,
         "org_name": "Sunrise",
+        "first_name": "Jane",
+        "last_name": "Smith",
         "location_city": "Boise",
         "location_state": "ID",
         "location_zip": "83702",

--- a/src/domain/logic/verifications/test_events.py
+++ b/src/domain/logic/verifications/test_events.py
@@ -116,7 +116,9 @@ def test_recompute_clinician_claim_preserves_ever_verified_at_on_regression():
     expired) must keep `ever_verified_at` set — that's what the
     `can_access_network` retention rule reads."""
     historic = datetime(2025, 6, 1, tzinfo=timezone.utc)
-    clinician = Clinician(id=uuid4(), owner_id=uuid4())
+    clinician = Clinician(
+        id=uuid4(), owner_id=uuid4(), first_name="Eva", last_name="Stone"
+    )
     clinician.npi_match_status = "matched"
     clinician.clinician_verified = True
     clinician.verified_at = historic

--- a/src/domain/logic/verifications/test_handlers.py
+++ b/src/domain/logic/verifications/test_handlers.py
@@ -81,8 +81,8 @@ async def _seed_clinician(
     *,
     npi: str | None = None,
     username: str = "owner",
-    first_name: str | None = None,
-    last_name: str | None = None,
+    first_name: str = "Jane",
+    last_name: str = "Smith",
 ) -> tuple[Clinician, User]:
     owner = create_test_user(username=f"{username}-{uuid4()}")
     async with db_test_session_manager() as session:

--- a/src/domain/models/clinician_affiliations/test_clinician_affiliation.py
+++ b/src/domain/models/clinician_affiliations/test_clinician_affiliation.py
@@ -40,6 +40,8 @@ def _make_clinician(*, owner: User, org: Organization, **overrides) -> Clinician
     defaults = dict(
         owner_id=owner.id,
         org_id=org.id,
+        first_name="Jane",
+        last_name="Smith",
         in_person_sessions="yes",
         virtual_sessions="please_contact",
         accepts_out_of_network=True,

--- a/src/domain/models/clinicians/clinician.py
+++ b/src/domain/models/clinicians/clinician.py
@@ -56,8 +56,8 @@ class Clinician(BaseModel):
     user = relationship("User", lazy="selectin", foreign_keys=[owner_id])
 
     npi = Column(Text, nullable=True)
-    first_name = Column(Text, nullable=True)
-    last_name = Column(Text, nullable=True)
+    first_name = Column(Text, nullable=False)
+    last_name = Column(Text, nullable=False)
 
     # NPPES Type-1 match state. Source-of-truth field for Claim A: the
     # `verifications` table is the event log; this column is the cache

--- a/src/domain/models/clinicians/test_clinician.py
+++ b/src/domain/models/clinicians/test_clinician.py
@@ -47,6 +47,8 @@ def _make_clinician(
     return Clinician(
         owner_id=owner.id,
         org_id=org.id,
+        first_name="Jane",
+        last_name="Smith",
         npi=npi,
         in_person_sessions="yes",
         virtual_sessions="please_contact",
@@ -106,6 +108,8 @@ async def test_clinician_construct_with_existing_affiliation_skips_auto_create()
     )
     clinician = Clinician(
         owner_id=user.id,
+        first_name="Jane",
+        last_name="Smith",
         npi="9876543210",
         clinician_affiliations=[existing],
     )
@@ -134,7 +138,9 @@ async def test_setting_clinician_npi_persists(session):
 async def test_clinician_npi_check_constraint_rejects_non_ten_digits(session):
     """The CHECK constraint on ``clinicians.npi`` — defense-in-
     depth behind the Pydantic ``_validate_npi``."""
-    clinician = Clinician(npi="12345")  # 5 digits, not 10
+    clinician = Clinician(
+        first_name="Jane", last_name="Smith", npi="12345"
+    )  # 5 digits, not 10
     session.add(clinician)
     with pytest.raises(IntegrityError):
         await session.flush()

--- a/src/domain/models/clinicians/test_clinician_models.py
+++ b/src/domain/models/clinicians/test_clinician_models.py
@@ -34,6 +34,8 @@ def _make_clinician(user, **overrides) -> Clinician:
     defaults = dict(
         owner_id=user.id,
         org_id=org.id,
+        first_name="Jane",
+        last_name="Smith",
         location_city="Springfield",
         location_state="IL",
         location_zip="62701",

--- a/src/domain/models/favorites/test_user_favorite_models.py
+++ b/src/domain/models/favorites/test_user_favorite_models.py
@@ -25,6 +25,8 @@ async def _seed_user_and_clinician(
     clinician = Clinician(
         owner_id=owner.id,
         org_id=org.id,
+        first_name="Jane",
+        last_name="Smith",
         in_person_sessions="yes",
         virtual_sessions="no",
         location_city="Springfield",

--- a/src/domain/models/verifications/test_verification.py
+++ b/src/domain/models/verifications/test_verification.py
@@ -31,6 +31,8 @@ async def _seed_clinician(
     clinician = Clinician(
         owner_id=user.id,
         org_id=org.id,
+        first_name="Jane",
+        last_name="Smith",
         in_person_sessions="yes",
         virtual_sessions="no",
         location_city="Springfield",

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -24,8 +24,8 @@
     {# Person-level fields (name, NPI) — these live on the Clinician row,
      so they follow the person across affiliations. #}
     {% call form_section("Clinician") %}
-      {{ text_field("first_name", "First name", current=clinician.first_name, required=false, maxlength=120) }}
-      {{ text_field("last_name", "Last name", current=clinician.last_name, required=false, maxlength=120) }}
+      {{ text_field("first_name", "First name", current=clinician.first_name, maxlength=120) }}
+      {{ text_field("last_name", "Last name", current=clinician.last_name, maxlength=120) }}
       {{ text_field("npi", "NPI", current=clinician.npi, required=false, pattern="\\d{10}", maxlength=10, help=npi_help() ) }}
     {% endcall %}
     {% call form_section("Practice location") %}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -231,6 +231,8 @@ def make_opening_detail(*, clinician_id: UUID, **overrides: Any) -> OpeningDetai
 # instead of a `NOT NULL` violation at flush time.
 
 _CLINICIAN_DEFAULTS: dict[str, Any] = {
+    "first_name": "Jane",
+    "last_name": "Smith",
     "location_city": "Springfield",
     "location_state": "IL",
     "location_zip": "62701",

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -241,12 +241,13 @@ def _setup_clinician_edit_form_stub(app: FastAPI) -> None:
             # `orgs` context var to render options.
             org_id=org_id,
             org=org,
-            # `first_name`, `last_name`, and `npi` are empty optional
-            # text inputs on the stub. They live in the "Clinician"
-            # fieldset which renders first, so the form serializes them
+            # `first_name` and `last_name` are required (NOT NULL) so
+            # the stub supplies values that will pre-fill the form inputs
+            # and round-trip in the PATCH body. `npi` remains optional.
+            # The "Clinician" fieldset renders first, so these serialize
             # ahead of `org_id` in the encoded body.
-            first_name=None,
-            last_name=None,
+            first_name="Jane",
+            last_name="Doe",
             npi=None,
             location_city="Brooklyn",
             location_state="NY",

--- a/tests/test_contract/tests/consumer/test_clinician_create_form.py
+++ b/tests/test_contract/tests/consumer/test_clinician_create_form.py
@@ -55,23 +55,24 @@ async def test_consumer_clinician_create_form_submits(
     expected_request_headers = {
         "Content-Type": Like("application/x-www-form-urlencoded")
     }
-    # `first_name`, `last_name`, `npi`, and `cost` are empty text
-    # inputs — the browser includes empty-valued text inputs in the
-    # form body. The `accepts_out_of_network` checkbox is pre-checked
-    # by the template (`current=true`); `sliding_scale` is not
-    # pre-checked. Both render via `checkbox_field`, which emits a
-    # sibling `<input type="hidden" value="false">` before each
-    # checkbox so default-true booleans round-trip — checked submits
-    # both `false` and `true` (last wins at the parser; see
-    # `src/framework/http/forms.py`), unchecked submits just `false`.
-    # The carrier multi-select is empty. `org_id` carries the
-    # Organization picked from the dropdown (#524); the stub server
-    # seeds one Org. The "Clinician" fieldset holds the person-level
-    # fields and renders first, so `first_name`, `last_name`, `npi`
-    # serialize ahead of `org_id`.
+    # `first_name` and `last_name` are required by `ClinicianCreate` —
+    # the template renders them with the HTML `required` attribute so the
+    # browser won't submit without values. The test fills them explicitly.
+    # `npi` and `cost` remain optional empty text inputs. The
+    # `accepts_out_of_network` checkbox is pre-checked by the template
+    # (`current=true`); `sliding_scale` is not pre-checked. Both render
+    # via `checkbox_field`, which emits a sibling `<input type="hidden"
+    # value="false">` before each checkbox so default-true booleans
+    # round-trip — checked submits both `false` and `true` (last wins at
+    # the parser; see `src/framework/http/forms.py`), unchecked submits
+    # just `false`. The carrier multi-select is empty. `org_id` carries the
+    # Organization picked from the dropdown (#524); the stub server seeds
+    # one Org. The "Clinician" fieldset holds the person-level fields and
+    # renders first, so `first_name`, `last_name`, `npi` serialize ahead
+    # of `org_id`.
     expected_request_body = (
-        "first_name="
-        "&last_name="
+        "first_name=Jane"
+        "&last_name=Doe"
         "&npi="
         "&org_id=66666666-6666-6666-6666-666666666666"
         "&location_city=Brooklyn"
@@ -111,6 +112,8 @@ async def test_consumer_clinician_create_form_submits(
     with pact:
         await page.goto(form_page_url)
         await page.wait_for_selector('select[name="org_id"]')
+        await page.locator('input[name="first_name"]').fill("Jane")
+        await page.locator('input[name="last_name"]').fill("Doe")
         await page.locator('select[name="org_id"]').select_option(
             "66666666-6666-6666-6666-666666666666"
         )

--- a/tests/test_contract/tests/consumer/test_clinician_edit_form.py
+++ b/tests/test_contract/tests/consumer/test_clinician_edit_form.py
@@ -77,11 +77,11 @@ async def test_consumer_clinician_edit_form_submits(
     # selection so it doesn't appear in the encoded form body. The
     # "Clinician" fieldset holds the person-level fields (first/last
     # name and npi) and renders first, so they serialize ahead of
-    # `org_id`. `first_name`, `last_name`, and `npi` are empty optional
-    # text inputs on the stub.
+    # `org_id`. `first_name` and `last_name` are required fields pre-filled
+    # from the stub clinician; `npi` is optional and empty.
     expected_request_body = (
-        "first_name="
-        "&last_name="
+        "first_name=Jane"
+        "&last_name=Doe"
         "&npi="
         "&org_id=55555555-5555-5555-5555-555555555555"
         "&location_city=Bayside"

--- a/tests/test_contract/tests/shared/mock_data_factory.py
+++ b/tests/test_contract/tests/shared/mock_data_factory.py
@@ -381,6 +381,10 @@ class MockDataFactory:
             owner_id=UUID("00000000-0000-0000-0000-000000000004"),
             created_at=now,
             updated_at=now,
+            # `first_name` and `last_name` are required (NOT NULL) on
+            # `ClinicianRead` after #1207.
+            first_name="Jane",
+            last_name="Doe",
             # `org_id` + `org_name` replace the former `practice_name`
             # (#524). `ClinicianRead.model_validate` reads `org_name` off
             # this stub via `from_attributes`.


### PR DESCRIPTION
## Summary

- Adds Alembic migration (`d1e2f3a4b5c6`) that backfills any NULL `first_name`/`last_name` rows with `'Unknown'` then applies `NOT NULL` constraints (via `batch_alter_table` for SQLite compat)
- Tightens the `Clinician` ORM columns to `nullable=False`
- `ClinicianCreate` now requires both names (was `Optional`, defaulted to `None`)
- `ClinicianUpdate` uses `StrippedText | None = None` — absent = skip, empty string = 422
- `ClinicianRead` removes `Optional` from both name fields
- Updates all test fixtures, `tests/helpers.py` `_CLINICIAN_DEFAULTS`, and the seed generator to always supply names

Closes #1204.

## Test plan

- [x] `dev test` — 2323 passed, 101 skipped
- [x] `dev test contract` — passed
- [x] `dev lint` — passed