### PR TITLE
Use can_access_network as the single post-creation gate (Claim A or B)

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -56,11 +56,11 @@ REASON_CLAIM_B_UNVERIFIED = "claim_b_unverified"
 REASON_CLAIM_A_LAPSED = "claim_a_lapsed"
 REASON_CLAIM_B_LAPSED = "claim_b_lapsed"
 REASON_AFFILIATION_MISSING = "affiliation_missing"
-# Read-side gate (not a write affordance): the viewer hasn't cleared
-# verification, so contact/identity details on a post detail are withheld
-# (`can_access_network` is False). Distinct from the claim-to-*post*
-# reasons above — this one fixes by completing any verification path.
-REASON_VIEW_UNVERIFIED = "view_unverified"
+# Network-access gate: the user hasn't cleared verification, so both
+# read-side details (contact info, identity) and write-side affordances
+# (create post CTA) are locked. Fixed by completing any verification
+# path (Claim A or Claim B).
+REASON_NETWORK_UNVERIFIED = "network_unverified"
 
 
 @dataclass(frozen=True)
@@ -129,9 +129,9 @@ _REASON_META = {
         fix_label="Manage affiliations",
         fix_url="/users/me",
     ),
-    REASON_VIEW_UNVERIFIED: ReasonMeta(
-        title="Contact details",
-        unlock="Get provider network access to see this.",
+    REASON_NETWORK_UNVERIFIED: ReasonMeta(
+        title="Provider network",
+        unlock="Get provider network access to unlock this.",
         fix_label="Get access",
         fix_url="/users/me/access/capabilities/provider-network",
     ),

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -534,11 +534,11 @@ def test_reason_meta_lapsed_reasons_carry_resume_copy():
     assert b.fix_label == "Re-verify authority"
 
 
-def test_reason_meta_view_unverified_is_the_read_side_gate():
-    """The redaction reason (withheld post-detail contact/identity rows)
+def test_reason_meta_network_unverified_points_at_capability_page():
+    """The network-access reason (withheld post detail + locked create CTA)
     carries verification-oriented copy and points at the capability detail
-    page where the viewer can see exactly what needs to change."""
-    meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED)
+    page where the user can see exactly what needs to change."""
+    meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED)
     assert "Get access" == meta.fix_label
     assert meta.fix_url == "/users/me/access/capabilities/provider-network"
     assert meta.unlock

--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -9,7 +9,7 @@ These tests assert:
 1. `/home` shows no per-page finish-setup card for a no-claim user — the
    post-action row is suppressed entirely and the only nudge is the chrome
    `#onboarding-banner`.
-2. Post CTAs on `/home` are gated on `claims.a` being populated.
+2. Post CTAs on `/home` are gated on `can_post` (`can_access_network` — Claim A or Claim B).
 3. The global `#onboarding-banner` is currently disabled (absent on all pages).
 """
 
@@ -69,10 +69,9 @@ async def test_home_renders_post_ctas_when_claim_a_verified(
     db_test_session_manager,
     logged_in_user,
 ):
-    """A verified clinician sees the post CTAs on /home. The chrome's
-    `claims.a` scalar is the gate — same predicate the route's
-    write_authz consults, so visible button and server-side block
-    can't disagree."""
+    """A verified clinician sees the post CTAs on /home. The chrome gates
+    on `can_post` (`can_access_network`), so any network-verified user
+    (Claim A or Claim B) gets the active create links."""
     from tests.helpers import make_clinician_with_org
 
     clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
@@ -101,18 +100,15 @@ async def test_home_renders_post_ctas_when_claim_a_verified(
     assert cta_labels == {"+ Post a referral", "+ Post an opening"}
 
 
-async def test_home_shows_locked_post_actions_for_claim_b_only_org_rep(
+async def test_home_shows_active_post_actions_for_claim_b_org_rep(
     authenticated_client: AsyncClient,
     db_test_session_manager,
     logged_in_user,
 ):
-    """A Claim-B-only org rep (verified org representative, no Claim A)
-    can't post as themselves, but the chrome no longer hides the actions —
-    it renders them DISABLED with the unlock path (`locked_action` →
-    `_shared/_locked.html`). Pins: the buttons render disabled (not as
-    active create links), and the unlock copy comes from
-    `capabilities.reason_meta`, not inline text."""
-    from src.domain.logic import capabilities
+    """A Claim-B org rep (verified org representative, no Claim A) now gets
+    full posting chrome — `can_post` equals `can_access_network`, so Claim B
+    is sufficient. Pins: active create links appear in the toolbar (not
+    disabled buttons), same as a Claim-A user."""
     from src.domain.models.org_representations.org_representation import (
         OrgRepresentation,
     )
@@ -135,26 +131,24 @@ async def test_home_shows_locked_post_actions_for_claim_b_only_org_rep(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    # Claim-B-only → has a claim, so NOT the no-claim finish-setup card.
+    # Claim-B → has network access, so NOT the no-claim finish-setup card.
     assert "Finish setting up" not in response.text
 
-    # Both post actions render as DISABLED buttons, not active create links.
-    disabled_labels = {
-        b.text(strip=True)
+    # Active create links appear in the toolbar — no disabled buttons.
+    assert (
+        tree.css_first("a[href*='kind=referral']") is not None
+    ), "Claim-B org rep must get the active post-a-referral toolbar link"
+    assert (
+        tree.css_first("a[href*='kind=clinician_opening']") is not None
+    ), "Claim-B org rep must get the active post-an-opening toolbar link"
+    disabled_post_buttons = [
+        b
         for b in tree.css("button[disabled]")
         if b.text(strip=True).startswith("+ Post")
-    }
-    assert "+ Post a referral" in disabled_labels
-    assert "+ Post an opening" in disabled_labels
+    ]
     assert (
-        tree.css_first("a[href*='kind=referral']") is None
-    ), "Claim-B-only rep must not get an active post-create link"
-
-    # Unlock copy is the single-source string, not inline-authored here.
-    assert (
-        capabilities.reason_meta(capabilities.REASON_CLAIM_A_UNVERIFIED).unlock
-        in response.text
-    )
+        disabled_post_buttons == []
+    ), "No disabled post buttons expected for a network-verified user"
 
 
 async def test_onboarding_banner_shown_off_profile_for_incomplete_user(

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -584,17 +584,14 @@ async def test_list_shows_create_cta_for_claim_a_user(
     ), "Claim-A user should be offered the toolbar Create CTA"
 
 
-async def test_list_hides_create_cta_for_claim_b_only_org_rep(
+async def test_list_shows_create_cta_for_claim_b_org_rep(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """A Claim-B-only org rep (verified org representative, no Claim A) must NOT
-    see the `/posts` toolbar Create CTA.
-
-    The server's `_assert_post_payload_authz` still authorises org reps to post;
-    the chrome is deliberately narrower. This test pins that invariant so nobody
-    accidentally widens the gate back to `claims.a or claims.b`."""
+    """A Claim-B org rep (verified org representative, no Claim A) must see the
+    `/posts` toolbar Create CTA — `can_post` now equals `can_access_network`
+    (Claim A or Claim B)."""
     org = make_organization_row(owner_id=logged_in_user.id)
     rep = OrgRepresentation(
         user_id=logged_in_user.id,
@@ -612,8 +609,8 @@ async def test_list_hides_create_cta_for_claim_b_only_org_rep(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert (
-        tree.css_first("a[href='/posts/form'][role='button']") is None
-    ), "Claim-B-only org rep must not be offered the toolbar Create CTA"
+        tree.css_first("a[href='/posts/form'][role='button']") is not None
+    ), "Claim-B org rep must be offered the toolbar Create CTA"
 
 
 async def test_detail_hides_email_and_shows_cta_for_unverified(

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,20 +1,15 @@
 {% extends "base.html" %}
 {%- from "_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {%- from "_shared/_item_list.html" import item_list -%}
-{%- from "_shared/_locked.html" import locked_action -%}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
 {%- macro _no_poster_row(post) %}{{ post_feed_row(post, show_poster=False) }}{%- endmacro -%}
   {% block title %}Home{% endblock %}
   {# Home title + post actions ride the unified page-header toolbar. The
-     active create links appear only for a posting-capable user (`can_post`).
-     A Claim-B-only org rep (holds a claim but can't post yet) keeps the
-     DISABLED locked controls — but those are a two-line affordance that
-     can't sit in the single-row band, so they stay in `{% block content %}`
-     below. A *no-claim* user gets neither: the chrome `#onboarding-banner`
-     (base.html) is their one finish-setup nudge. The server's
-     `_assert_post_payload_authz` is the real gate; a disabled button leaks
-     nothing. `can_post` is derived once in `base_context()` — don't
-     re-derive from raw `claims.*`. #}
+     active create links appear for any network-verified user (`can_post`
+     equals `can_access_network` — Claim A or Claim B). An unverified user
+     gets neither: the chrome `#onboarding-banner` (base.html) is their
+     finish-setup nudge. `can_post` is derived once in `base_context()` —
+     don't re-derive here. #}
   {% block toolbar %}
     {% call page_toolbar(heading="Home") %}
       {% if can_post %}
@@ -32,16 +27,6 @@
     {% endcall %}
   {% endblock %}
   {% block content %}
-    {# Claim-B-only org rep: the locked create controls are their only
-       signal (the chrome banner is silent once onboarding is complete).
-       Suppressed for a posting-capable user (actions are in the toolbar
-       above) and for a no-claim user (covered by the chrome banner). #}
-    {% if (claims.a or claims.b) and not can_post %}
-      <section style="display: flex; gap: 1rem; flex-wrap: wrap;">
-        {{ locked_action(capabilities.REASON_CLAIM_A_UNVERIFIED, "+ Post a referral") }}
-        {{ locked_action(capabilities.REASON_CLAIM_A_UNVERIFIED, "+ Post an opening") }}
-      </section>
-    {% endif %}
     {% if can_post %}
       <section>
         <header style="display: flex;

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -121,7 +121,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
         compact card omits — practice/program identity, full address,
         scheduling, and per-kind insurance details. -#}
                 {%- if expanded %}
-                  {%- set _fix_url = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED).fix_url -%}
+                  {%- set _fix_url = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED).fix_url -%}
                   {%- set _name_placeholder = "Doe Health Group" if view.kind == "program_intake" else "Dr. J. Doe" -%}
                   {%- if view.ages and view.kind == "referral" %}
                     {#- Referral expanded-only Age row: the headline already carries
@@ -162,7 +162,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- endif %}
                     {%- if view.full_address %}
                       {% if redacted %}
-                        {%- call fact('address', 'Address', icon='map-pin') %}{{ locked_field(capabilities.REASON_VIEW_UNVERIFIED) }}
+                        {%- call fact('address', 'Address', icon='map-pin') %}{{ locked_field(capabilities.REASON_NETWORK_UNVERIFIED) }}
                         {% endcall %}
                       {% else %}
                         {{ fact('address', 'Address', view.full_address, icon='map-pin') }}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -35,7 +35,7 @@
              role="button"
              class="secondary outline">Email</a>
         {% else %}
-          {%- set _meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED) -%}
+          {%- set _meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED) -%}
           <span data-tooltip="{{ _meta.unlock }}">
             <button type="button" disabled aria-disabled="true" class="secondary outline">
               <i class="icon-lock" aria-hidden="true"></i> Email

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -3,20 +3,16 @@
 {%- from "posts/_shared/_filter_form.html" import filter_form -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
+{%- from "_shared/_locked.html" import locked_action -%}
 {% block resource_label %}Posts{% endblock %}
 {% block toolbar %}
   {% call page_toolbar(heading="Posts") %}
-    {# Create CTA gates on `can_post` (Claim A only) — narrower than the
-       server's `_assert_post_payload_authz`, which also accepts verified
-       org reps (Claim B). The org-rep posting path (#1128) has no chrome
-       entry point by design; it's reachable by direct URL or a future
-       org-context surface. Do not widen this back to `claims.b` without
-       also adding a scoped org-context CTA for reps.
-       `can_post` is derived once in `base_context()` — don't re-derive here. #}
     {% if can_post %}
       <li>
         <a href="{{ entity_form_url('post') }}" role="button">{{ entity_create_label("post") }}</a>
       </li>
+    {% else %}
+      <li>{{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, entity_create_label("post") ) }}</li>
     {% endif %}
   {% endcall %}
 {% endblock %}

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -47,10 +47,9 @@ def base_context(user: Actor | None) -> dict:
     a hard `domain/` import.
 
     `can_post` is the chrome-level "show a Create Post CTA" gate. It equals
-    Claim A only — deliberately narrower than the server's `_assert_post_payload_authz`,
-    which also accepts verified org reps (Claim B). Org-rep posting has no
-    chrome entry point by design; templates gate on `can_post` so they all
-    use the same definition instead of re-deriving `claims.a`.
+    `can_access_network` — any verified user (Claim A or Claim B) may post.
+    Templates gate on `can_post` so they all share the same definition
+    without re-deriving it.
     """
     from src.domain.logic.capabilities import can_access_network, claim_state
 
@@ -65,7 +64,7 @@ def base_context(user: Actor | None) -> dict:
             True if user is None else bool(getattr(user, "is_verified", True))
         ),
         "claims": {"a": state.a, "b": list(state.b)},
-        "can_post": state.a,
+        "can_post": can_access_network(user),
         "claim_a_lapsed": False,
         "claim_b_lapsed_orgs": [],
         "any_claim_lapsed": bool(state.lapsed),

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -145,10 +145,9 @@ def test_base_context_can_post_true_for_claim_a():
     assert base_context(user)["can_post"] is True
 
 
-def test_base_context_can_post_false_for_claim_b_only():
-    """`can_post` is False when only Claim B is held — org reps have no chrome post CTA.
-    The server (`_assert_post_payload_authz`) still authorizes them; the chrome
-    is deliberately narrower."""
+def test_base_context_can_post_true_for_claim_b_only():
+    """`can_post` is True when only Claim B is held — org reps have a chrome post CTA
+    because `can_post` now equals `can_access_network` (Claim A or Claim B)."""
     org_id = uuid.uuid4()
     user = SimpleNamespace(
         id=uuid.uuid4(),
@@ -163,7 +162,7 @@ def test_base_context_can_post_false_for_claim_b_only():
         ],
     )
     ctx = base_context(user)
-    assert ctx["can_post"] is False
+    assert ctx["can_post"] is True
     assert ctx["claims"]["b"] == [org_id]
 
 

--- a/src/framework/templates/_shared/_feed_row.html
+++ b/src/framework/templates/_shared/_feed_row.html
@@ -41,7 +41,7 @@ under the "Feed rows" section. #}
 <small>{{ view.poster_name }}</small>
 {%- endif -%}
 {%- else -%}
-{%- set _fix_url = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED).fix_url -%}
+{%- set _fix_url = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED).fix_url -%}
 {%- if post.kind == "program_intake" -%}
 <small>{{ locked_name("Doe Health Group", _fix_url) }}</small>{# title-case-ignore: placeholder org name #}
 {%- else -%}

--- a/src/framework/templates/_shared/_locked.html
+++ b/src/framework/templates/_shared/_locked.html
@@ -26,7 +26,7 @@
   </span>
 {%- endmacro %}
 {% macro locked_name(placeholder, fix_url) -%}
-  {%- set _meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED) -%}
+  {%- set _meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED) -%}
   <span class="locked-field" data-tooltip="{{ _meta.unlock }}">
     <i class="icon-lock" aria-hidden="true"></i>
     <a href="{{ fix_url }}">{{ placeholder }}</a>

--- a/src/framework/templates/_shared/test_locked.py
+++ b/src/framework/templates/_shared/test_locked.py
@@ -85,18 +85,18 @@ def test_locked_action_tooltip_carries_unlock_copy() -> None:
 def test_locked_field_renders_fix_link_with_correct_href() -> None:
     """The fix link points at the capability page so the viewer knows
     exactly what unlocks the field."""
-    html = _render_field("REASON_VIEW_UNVERIFIED")
+    html = _render_field("REASON_NETWORK_UNVERIFIED")
     link = HTMLParser(html).css_first(".locked-field a")
     assert link is not None
     assert link.attributes.get("href") == capabilities.fix_url_for(
-        capabilities.REASON_VIEW_UNVERIFIED
+        capabilities.REASON_NETWORK_UNVERIFIED
     )
 
 
 def test_locked_field_tooltip_carries_unlock_copy() -> None:
     """Unlock text appears in the tooltip attribute, not inline."""
-    meta = capabilities.reason_meta(capabilities.REASON_VIEW_UNVERIFIED)
-    html = _render_field("REASON_VIEW_UNVERIFIED")
+    meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED)
+    html = _render_field("REASON_NETWORK_UNVERIFIED")
     assert meta.unlock in html
     span = HTMLParser(html).css_first(".locked-field")
     assert span is not None
@@ -118,5 +118,5 @@ def test_locked_field_unknown_reason_falls_back_not_raises() -> None:
 
 def test_locked_field_no_button_rendered() -> None:
     """A field placeholder is read-only chrome — no interactive button."""
-    html = _render_field("REASON_VIEW_UNVERIFIED")
+    html = _render_field("REASON_NETWORK_UNVERIFIED")
     assert HTMLParser(html).css_first("button") is None


### PR DESCRIPTION
## Summary

- `can_post` previously equaled Claim A only, narrower than `_assert_post_payload_authz` which already accepted Claim B org reps
- `can_post` now equals `can_access_network` — any network-verified user (Claim A or Claim B) gets the active Create CTA on `/home` and `/posts`
- `/posts` now shows a **locked Create button** with a tooltip CTA for users without network access (instead of hiding the button entirely)
- `REASON_VIEW_UNVERIFIED` renamed to `REASON_NETWORK_UNVERIFIED` — it now correctly covers both read-side (contact details) and write-side (create CTA) locked affordances
- Removed the dead locked-action block from `home.html` (was only shown for Claim-B users, now they get the active toolbar links)

## Test plan

- [ ] Claim-A user: active Create button on `/posts` and `/home` toolbar
- [ ] Claim-B org rep: active Create button on `/posts` and `/home` toolbar (new behavior)
- [ ] Unverified user: locked disabled Create button on `/posts` with tooltip "Get provider network access to unlock this."
- [ ] Post detail: locked Email button tooltip still reads correctly
- [ ] `dev test` passes (2336 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)