### PR TITLE
Drop dead claims context vars; collapse can_post into can_access_network

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -9,7 +9,7 @@ These tests assert:
 1. `/home` shows no per-page finish-setup card for a no-claim user — the
    post-action row is suppressed entirely and the only nudge is the chrome
    `#onboarding-banner`.
-2. Post CTAs on `/home` are gated on `can_post` (`can_access_network` — Claim A or Claim B).
+2. Post CTAs on `/home` are gated on `can_access_network` (clinician or org rep).
 3. The global `#onboarding-banner` is currently disabled (absent on all pages).
 """
 
@@ -70,8 +70,8 @@ async def test_home_renders_post_ctas_when_claim_a_verified(
     logged_in_user,
 ):
     """A verified clinician sees the post CTAs on /home. The chrome gates
-    on `can_post` (`can_access_network`), so any network-verified user
-    (Claim A or Claim B) gets the active create links."""
+    on `can_access_network`, so any network-verified user gets the active
+    create links."""
     from tests.helpers import make_clinician_with_org
 
     clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
@@ -105,10 +105,9 @@ async def test_home_shows_active_post_actions_for_claim_b_org_rep(
     db_test_session_manager,
     logged_in_user,
 ):
-    """A Claim-B org rep (verified org representative, no Claim A) now gets
-    full posting chrome — `can_post` equals `can_access_network`, so Claim B
-    is sufficient. Pins: active create links appear in the toolbar (not
-    disabled buttons), same as a Claim-A user."""
+    """A verified org rep (no clinician profile) gets full posting chrome —
+    `can_access_network` is the single gate. Pins: active create links appear
+    in the toolbar (not disabled buttons), same as a verified clinician."""
     from src.domain.models.org_representations.org_representation import (
         OrgRepresentation,
     )

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -589,9 +589,8 @@ async def test_list_shows_create_cta_for_claim_b_org_rep(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """A Claim-B org rep (verified org representative, no Claim A) must see the
-    `/posts` toolbar Create CTA — `can_post` now equals `can_access_network`
-    (Claim A or Claim B)."""
+    """A verified org rep (no clinician profile) must see the `/posts` toolbar
+    Create CTA — `can_access_network` is the single gate for posting."""
     org = make_organization_row(owner_id=logged_in_user.id)
     rep = OrgRepresentation(
         user_id=logged_in_user.id,

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -5,14 +5,12 @@
 {%- macro _no_poster_row(post) %}{{ post_feed_row(post, show_poster=False) }}{%- endmacro -%}
   {% block title %}Home{% endblock %}
   {# Home title + post actions ride the unified page-header toolbar. The
-     active create links appear for any network-verified user (`can_post`
-     equals `can_access_network` — Claim A or Claim B). An unverified user
-     gets neither: the chrome `#onboarding-banner` (base.html) is their
-     finish-setup nudge. `can_post` is derived once in `base_context()` —
-     don't re-derive here. #}
+     active create links appear for any network-verified user
+     (`can_access_network`). An unverified user gets neither: the chrome
+     `#onboarding-banner` (base.html) is their finish-setup nudge. #}
   {% block toolbar %}
     {% call page_toolbar(heading="Home") %}
-      {% if can_post %}
+      {% if can_access_network %}
         <li>
           <a href="{{ entity_form_url('post') }}?kind=referral"
              role="button"
@@ -27,7 +25,7 @@
     {% endcall %}
   {% endblock %}
   {% block content %}
-    {% if can_post %}
+    {% if can_access_network %}
       <section>
         <header style="display: flex;
                        justify-content: space-between;

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -7,7 +7,7 @@
 {% block resource_label %}Posts{% endblock %}
 {% block toolbar %}
   {% call page_toolbar(heading="Posts") %}
-    {% if can_post %}
+    {% if can_access_network %}
       <li>
         <a href="{{ entity_form_url('post') }}" role="button">{{ entity_create_label("post") }}</a>
       </li>

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -38,22 +38,12 @@ def base_context(user: Actor | None) -> dict:
     (see `src.auth_config.UserManager.on_after_register`) so the
     banner is silent for the seed flow.
 
-    `claims`, `claim_a_lapsed`, `claim_b_lapsed_orgs`, `any_claim_lapsed`
-    power the claim-aware chrome (`_verify_banner.html`, the profile-hub
-    mode header, the `/home` "Finish setup" / "Action needed" sub-states).
-    They flow through `claim_state(...)` in `src.domain.logic.capabilities`
-    so the single-source-of-truth predicate set computes them once per
-    request. The import is lazy to keep this framework module from taking
-    a hard `domain/` import.
-
-    `can_post` is the chrome-level "show a Create Post CTA" gate. It equals
-    `can_access_network` — any verified user (Claim A or Claim B) may post.
-    Templates gate on `can_post` so they all share the same definition
-    without re-deriving it.
+    `can_access_network` is the single chrome gate for both feed access
+    and the Create Post CTA — any network-verified user (clinician or
+    org rep) gets both.
     """
-    from src.domain.logic.capabilities import can_access_network, claim_state
+    from src.domain.logic.capabilities import can_access_network
 
-    state = claim_state(user)
     return {
         "is_authenticated": user is not None,
         "is_admin": is_admin(user),
@@ -63,15 +53,6 @@ def base_context(user: Actor | None) -> dict:
         "current_user_is_verified": (
             True if user is None else bool(getattr(user, "is_verified", True))
         ),
-        "claims": {"a": state.a, "b": list(state.b)},
-        "can_post": can_access_network(user),
-        "claim_a_lapsed": False,
-        "claim_b_lapsed_orgs": [],
-        "any_claim_lapsed": bool(state.lapsed),
-        # `can_access_network` is the chrome-level feed-teaser gate
-        # (handoff §7.1: full feed once verified, retained after lapse
-        # via `ever_verified_at`). Anonymous viewers always see the
-        # teaser (predicate returns False for `user=None`).
         "can_access_network": can_access_network(user),
     }
 

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -28,14 +28,7 @@ def test_base_context_anonymous():
         # Anonymous users don't get the verify nag — default True so
         # the banner stays silent.
         "current_user_is_verified": True,
-        # Claim-aware chrome (claim-based verification rollout) — anon
-        # holds no claims and has no lapsed claims.
-        "claims": {"a": False, "b": []},
-        "claim_a_lapsed": False,
-        "claim_b_lapsed_orgs": [],
-        "any_claim_lapsed": False,
         "can_access_network": False,
-        "can_post": False,
     }
 
 
@@ -51,22 +44,13 @@ def test_base_context_regular_user():
         "current_user_id": user_id,
         "has_clinician_profile": False,
         "current_user_is_verified": True,
-        # No clinicians on this stub → Claim A is False; OrgRepresentation
-        # placeholders keep `b` empty.
-        "claims": {"a": False, "b": []},
-        "claim_a_lapsed": False,
-        "claim_b_lapsed_orgs": [],
-        "any_claim_lapsed": False,
         "can_access_network": False,
-        "can_post": False,
     }
 
 
-def test_base_context_claim_a_verified_user():
-    """A user with a `clinician_verified=True` cache on at least one
-    `Clinician` flips `claims.a` to True. Pins the wiring between
-    `base_context()` and `capabilities.claim_state()` — Phase 5's
-    profile-hub mode dispatcher reads this same shape."""
+def test_base_context_can_access_network_true_for_verified_clinician():
+    """A verified clinician gets `can_access_network` True — gates both the
+    Create Post CTA and full feed access."""
     user = SimpleNamespace(
         id=uuid.uuid4(),
         username="alice",
@@ -81,33 +65,12 @@ def test_base_context_claim_a_verified_user():
         ],
         org_representations=[],
     )
-    ctx = base_context(user)
-    assert ctx["claims"] == {"a": True, "b": []}
-    assert ctx["any_claim_lapsed"] is False
-
-
-def test_base_context_can_access_network_true_for_verified_clinician():
-    """The chrome scalar `can_access_network` powers `home.html`'s
-    network-feed blur — pinned here so a regression in `base_context`
-    can't silently re-blur every authed user's feed."""
-    user = SimpleNamespace(
-        id=uuid.uuid4(),
-        username="bob",
-        is_superuser=False,
-        is_verified=True,
-        clinicians=[
-            SimpleNamespace(
-                npi="1234567890", clinician_verified=True, ever_verified_at=None
-            )
-        ],
-        org_representations=[],
-    )
     assert base_context(user)["can_access_network"] is True
 
 
-def test_base_context_claim_b_coordinator():
-    """A program coordinator (no clinician profile) with a verified
-    OrgRepresentation gets `claims.b` populated with the org id."""
+def test_base_context_can_access_network_true_for_org_rep():
+    """A verified org rep (no clinician profile) gets `can_access_network`
+    True — org reps are network-verified and may post."""
     org_id = uuid.uuid4()
     user = SimpleNamespace(
         id=uuid.uuid4(),
@@ -123,47 +86,7 @@ def test_base_context_claim_b_coordinator():
             )
         ],
     )
-    ctx = base_context(user)
-    assert ctx["claims"]["a"] is False
-    assert ctx["claims"]["b"] == [org_id]
-
-
-def test_base_context_can_post_true_for_claim_a():
-    """`can_post` is True when Claim A is held — Claim A users see the chrome post CTA."""
-    user = SimpleNamespace(
-        id=uuid.uuid4(),
-        username="alice",
-        is_superuser=False,
-        is_verified=True,
-        clinicians=[
-            SimpleNamespace(
-                npi="1234567890", clinician_verified=True, ever_verified_at=None
-            )
-        ],
-        org_representations=[],
-    )
-    assert base_context(user)["can_post"] is True
-
-
-def test_base_context_can_post_true_for_claim_b_only():
-    """`can_post` is True when only Claim B is held — org reps have a chrome post CTA
-    because `can_post` now equals `can_access_network` (Claim A or Claim B)."""
-    org_id = uuid.uuid4()
-    user = SimpleNamespace(
-        id=uuid.uuid4(),
-        username="dana",
-        is_superuser=False,
-        is_verified=True,
-        clinicians=[],
-        org_representations=[
-            SimpleNamespace(
-                org_id=org_id, authority_status="verified", archived_at=None
-            )
-        ],
-    )
-    ctx = base_context(user)
-    assert ctx["can_post"] is True
-    assert ctx["claims"]["b"] == [org_id]
+    assert base_context(user)["can_access_network"] is True
 
 
 def test_base_context_unverified_user_surfaces_for_nag_banner():

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -41,10 +41,10 @@ async def test_home_page_shows_post_buttons_when_claim_a_verified(
     logged_in_user,
 ):
     """The home page renders kind-specific CTAs linking to the unified
-    `/posts/form` URL when the user holds Claim A. Per Phase-6
-    rollout the CTAs are gated on `claims.a` from `base_context()` —
-    same predicate the route's `write_authz` consults — so the visible
-    button and the server-side block can't disagree."""
+    `/posts/form` URL when the user is network-verified. CTAs are gated
+    on `can_access_network` from `base_context()` — same
+    predicate the route's `write_authz` consults — so the visible button
+    and the server-side block can't disagree."""
     from tests.helpers import make_clinician_with_org
 
     clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")


### PR DESCRIPTION
## Summary

Follows #1209 (already merged).

- `base_context()` was computing `claims`, `claim_a_lapsed`, `claim_b_lapsed_orgs`, `any_claim_lapsed`, and a redundant `can_post` on every request — no template read any of them
- Removes all five keys; the single surviving chrome gate is `can_access_network`
- Templates (`home.html`, `posts/list.html`) updated to reference `can_access_network` directly instead of the `can_post` alias
- 3 test consolidations (duplicate coverage collapsed)

## Test plan

- [ ] `dev test` passes (2333 passing)
- [ ] Verified clinician: active Create CTAs on `/home` and `/posts`
- [ ] Verified org rep: active Create CTAs on `/home` and `/posts`
- [ ] Unverified user: locked Create button on `/posts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)