### PR TITLE
Tighten locked-affordance macros: icon/extra_class params, self-contained locked_name

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -285,12 +285,16 @@ def can_access_network(user: Any) -> bool:
 
 
 def can_post_referral(user: Any) -> bool:
-    """Posting a referral as oneself requires Claim A (handoff §4.3)."""
+    """Self-path gate: posting a referral as the owning clinician requires
+    Claim A (handoff §4.3). The org-rep authority path in
+    `_assert_post_payload_authz` bypasses this check."""
     return clinician_verified(user)
 
 
 def can_post_opening(user: Any) -> bool:
-    """Posting a clinician opening requires Claim A (handoff §4.3)."""
+    """Self-path gate: posting a clinician opening as the owning clinician
+    requires Claim A (handoff §4.3). The org-rep authority path in
+    `_assert_post_payload_authz` bypasses this check."""
     return clinician_verified(user)
 
 

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -121,7 +121,6 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
         compact card omits — practice/program identity, full address,
         scheduling, and per-kind insurance details. -#}
                 {%- if expanded %}
-                  {%- set _fix_url = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED).fix_url -%}
                   {%- set _name_placeholder = "Doe Health Group" if view.kind == "program_intake" else "Dr. J. Doe" -%}
                   {%- if view.ages and view.kind == "referral" %}
                     {#- Referral expanded-only Age row: the headline already carries
@@ -136,7 +135,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- if view.practice_link %}
                       {%- call fact('practice', 'Practice') %}
                         {% if redacted %}
-                          {{ locked_name(_name_placeholder, _fix_url) }}
+                          {{ locked_name(_name_placeholder) }}
                         {% else %}
                           <a href="{{ entity_url('clinician', id=view.practice_link.id) }}">{{ view.practice_link.name }}</a>
                         {% endif %}
@@ -145,7 +144,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- if view.program_link %}
                       {%- call fact('program', 'Program') %}
                         {% if redacted %}
-                          {{ locked_name(_name_placeholder, _fix_url) }}{# title-case-ignore: placeholder org name #}
+                          {{ locked_name(_name_placeholder) }}{# title-case-ignore: placeholder org name #}
                         {% else %}
                           <a href="{{ entity_url('program', id=view.program_link.id) }}">{{ view.program_link.name }}</a>
                         {% endif %}
@@ -154,7 +153,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                     {%- if view.organization_link %}
                       {%- call fact('organization', 'Organization') %}
                         {% if redacted %}
-                          {{ locked_name(_name_placeholder, _fix_url) }}{# title-case-ignore: placeholder org name #}
+                          {{ locked_name(_name_placeholder) }}{# title-case-ignore: placeholder org name #}
                         {% else %}
                           <a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a>
                         {% endif %}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -2,6 +2,7 @@
 {%- from "posts/_shared/_modality_chips.html" import modality_chips -%}
 {%- from "posts/_shared/_facts_block.html" import facts_block -%}
 {%- from "posts/_shared/_how_to_refer.html" import how_to_refer -%}
+{%- from "_shared/_locked.html" import locked_action -%}
 {%- set view = post_card_view(post) -%}
 {% block resource_label %}Posts{% endblock %}
 {# The toolbar H1 is the subject when set; falls back to the
@@ -35,12 +36,7 @@
              role="button"
              class="secondary outline">Email</a>
         {% else %}
-          {%- set _meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED) -%}
-          <span data-tooltip="{{ _meta.unlock }}">
-            <button type="button" disabled aria-disabled="true" class="secondary outline">
-              <i class="icon-lock" aria-hidden="true"></i> Email
-            </button>
-          </span>
+          {{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, "Email", icon="icon-lock", extra_class="secondary") }}
         {% endif %}
       </footer>
     </section>

--- a/src/framework/templates/_shared/_feed_row.html
+++ b/src/framework/templates/_shared/_feed_row.html
@@ -41,11 +41,10 @@ under the "Feed rows" section. #}
 <small>{{ view.poster_name }}</small>
 {%- endif -%}
 {%- else -%}
-{%- set _fix_url = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED).fix_url -%}
 {%- if post.kind == "program_intake" -%}
-<small>{{ locked_name("Doe Health Group", _fix_url) }}</small>{# title-case-ignore: placeholder org name #}
+<small>{{ locked_name("Doe Health Group") }}</small>{# title-case-ignore: placeholder org name #}
 {%- else -%}
-<small>{{ locked_name("Dr. J. Doe", _fix_url) }}</small>
+<small>{{ locked_name("Dr. J. Doe") }}</small>
 {%- endif -%}
 {%- endif -%}
 {%- endif -%}

--- a/src/framework/templates/_shared/_locked.html
+++ b/src/framework/templates/_shared/_locked.html
@@ -1,35 +1,41 @@
 {# Consistent "you can't do/see this yet" affordances, driven by the
    closed `capabilities.REASON_*` vocab. Three treatments:
 
-   - `locked_action(reason, label)` — for write affordances (buttons,
-     create links). Renders the control DISABLED inside a tooltip wrapper.
+   - `locked_action(reason, label, icon=none, extra_class=none)` — for
+     write affordances (buttons, create links). Renders the control
+     DISABLED inside a tooltip wrapper. `icon` prepends a `<i class="...">`,
+     `extra_class` appends to the button's default `"outline"` class.
      Safe to render: the server re-checks authz on submit.
 
    - `locked_field(reason)` — for withheld DATA values (full address).
      Renders a lock icon + fix link inside a tooltip wrapper. The caller
      never passes the real value — withholding is the VIEW layer's job.
 
-   - `locked_name(placeholder, fix_url)` — for withheld identity names
-     (clinician name, org name). Renders the placeholder as a link inside
-     a tooltip wrapper, so the viewer knows there's a real name and how to
-     unlock it.
+   - `locked_name(placeholder)` — for withheld identity names (clinician
+     name, org name). Always uses `REASON_NETWORK_UNVERIFIED`; derives
+     the fix URL from that reason internally. Renders the placeholder as
+     a link inside a tooltip wrapper.
 
    Tooltip text + fix link come from `capabilities.reason_meta(reason)`.
    `capabilities` is a Jinja global (registered in
    `src/domain/template_globals.py`), so these macros need no `with
    context`. Add or change reason copy in
    `src/domain/logic/capabilities.py` — never inline here. #}
-{% macro locked_action(reason, label) -%}
+{% macro locked_action(reason, label, icon=none, extra_class=none) -%}
   {%- set meta = capabilities.reason_meta(reason) -%}
+  {%- set _cls = "outline " ~ extra_class if extra_class else "outline" -%}
   <span data-tooltip="{{ meta.unlock }}">
-    <button type="button" class="outline" disabled aria-disabled="true">{{ label }}</button>
-  </span>
+    <button type="button" class="{{ _cls }}" disabled aria-disabled="true">
+      {%- if icon %}<i class="{{ icon }}" aria-hidden="true"></i>{% endif %}
+    {{ label }}
+  </button>
+</span>
 {%- endmacro %}
-{% macro locked_name(placeholder, fix_url) -%}
+{% macro locked_name(placeholder) -%}
   {%- set _meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED) -%}
   <span class="locked-field" data-tooltip="{{ _meta.unlock }}">
     <i class="icon-lock" aria-hidden="true"></i>
-    <a href="{{ fix_url }}">{{ placeholder }}</a>
+    <a href="{{ _meta.fix_url }}">{{ placeholder }}</a>
   </span>
 {%- endmacro %}
 {% macro locked_field(reason) -%}

--- a/src/framework/templates/_shared/test_locked.py
+++ b/src/framework/templates/_shared/test_locked.py
@@ -36,10 +36,19 @@ def _make_env() -> Environment:
     return env
 
 
-def _render_action(reason: str, label: str) -> str:
+def _render_action(reason: str, label: str, **kwargs) -> str:
+    kwarg_str = "".join(f", {k}={v!r}" for k, v in kwargs.items())
     template = textwrap.dedent(f"""\
         {{%- from "_shared/_locked.html" import locked_action -%}}
-        {{{{ locked_action(capabilities.{reason}, {label!r}) }}}}
+        {{{{ locked_action(capabilities.{reason}, {label!r}{kwarg_str}) }}}}
+        """)
+    return _make_env().from_string(template).render()
+
+
+def _render_name(placeholder: str) -> str:
+    template = textwrap.dedent(f"""\
+        {{%- from "_shared/_locked.html" import locked_name -%}}
+        {{{{ locked_name({placeholder!r}) }}}}
         """)
     return _make_env().from_string(template).render()
 
@@ -120,3 +129,69 @@ def test_locked_field_no_button_rendered() -> None:
     """A field placeholder is read-only chrome — no interactive button."""
     html = _render_field("REASON_NETWORK_UNVERIFIED")
     assert HTMLParser(html).css_first("button") is None
+
+
+# ---------------------------------------------------------------------------
+# locked_action — optional icon and extra_class params
+# ---------------------------------------------------------------------------
+
+
+def test_locked_action_icon_prepended_when_provided() -> None:
+    """An icon class renders as a `<i>` before the label."""
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "Email", icon="icon-lock")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None
+    icon = button.css_first("i.icon-lock")
+    assert icon is not None, "icon element must be inside the button"
+
+
+def test_locked_action_extra_class_appended_to_outline() -> None:
+    """extra_class appends to the default 'outline' class."""
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "Email", extra_class="secondary")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None
+    cls = button.attributes.get("class", "")
+    assert "outline" in cls
+    assert "secondary" in cls
+
+
+def test_locked_action_no_icon_by_default() -> None:
+    """Without icon= the button contains no <i> element."""
+    html = _render_action("REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None
+    assert button.css_first("i") is None
+
+
+# ---------------------------------------------------------------------------
+# locked_name — withheld identity placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_locked_name_renders_placeholder_as_link() -> None:
+    """The placeholder text appears as a link so the viewer knows a real
+    name exists and can navigate to unlock it."""
+    html = _render_name("Dr. J. Doe")
+    link = HTMLParser(html).css_first(".locked-field a")
+    assert link is not None
+    assert link.text(strip=True) == "Dr. J. Doe"
+
+
+def test_locked_name_fix_url_comes_from_network_unverified_reason() -> None:
+    """The fix URL is derived from REASON_NETWORK_UNVERIFIED, not passed
+    by the caller — pins that the macro is self-contained."""
+    html = _render_name("Dr. J. Doe")
+    link = HTMLParser(html).css_first(".locked-field a")
+    assert link is not None
+    assert link.attributes.get("href") == capabilities.fix_url_for(
+        capabilities.REASON_NETWORK_UNVERIFIED
+    )
+
+
+def test_locked_name_tooltip_carries_network_unlock_copy() -> None:
+    """Unlock text from REASON_NETWORK_UNVERIFIED appears in the tooltip."""
+    meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED)
+    html = _render_name("Dr. J. Doe")
+    span = HTMLParser(html).css_first(".locked-field")
+    assert span is not None
+    assert span.attributes.get("data-tooltip") == meta.unlock


### PR DESCRIPTION
## Summary

- `locked_action` gains optional `icon=` and `extra_class=` params, eliminating the one call site (`detail.html` email button) that was inlining a duplicate locked-button pattern just to attach an icon.
- `locked_name` drops its `fix_url` param and derives the URL internally from `REASON_NETWORK_UNVERIFIED`. Every caller was computing `reason_meta(...).fix_url` and passing it back in — the macro can own that lookup.
- `_facts_block.html` and `_feed_row.html` remove their local `_fix_url` intermediary and call `locked_name` with a single arg.
- 6 new tests in `test_locked.py` pin the new params and the self-contained `locked_name` contract.

Stacked on `fix/drop-dead-claims-context` (#1211).

## Test plan
- [ ] `dev test src/framework/templates/_shared/test_locked.py` — 12 pass
- [ ] `dev test` — full suite green (2339 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)