### PR TITLE
Redirect to /home after signup; logo links to /home

### DIFF
--- a/src/domain/routes/auth_routes.py
+++ b/src/domain/routes/auth_routes.py
@@ -110,7 +110,7 @@ async def register_request_handler(
         # Mirrors the pattern in src/domain/routes/dev_auth.py.
         login_response = await auth_backend.login(get_strategy(), created_user)
         login_response.status_code = 200
-        login_response.headers["HX-Redirect"] = "/users/me"
+        login_response.headers["HX-Redirect"] = "/home"
         return login_response
 
     return created_user

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -95,7 +95,7 @@ async def test_register_via_htmx_sets_cookie_and_redirects(test_client: AsyncCli
         headers={"HX-Request": "true", "Content-Type": "application/json"},
     )
     assert response.status_code == 200
-    assert response.headers.get("HX-Redirect") == "/users/me"
+    assert response.headers.get("HX-Redirect") == "/home"
     # A session cookie must be set so the redirect lands authenticated.
     assert (
         "fastapiusersauth" in response.cookies

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -24,11 +24,12 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """Authenticated pages render a primary nav with a brand link on the
-    left and a <details>/<summary> collapsible menu containing four
-    destination links: Home, Posts, Profile, and Sign out. The <details>
-    pattern supports a mobile hamburger toggle at narrow widths while
-    keeping all links visible inline on desktop via CSS.
+    """Authenticated pages render a primary nav with a brand link (the
+    logo) on the left that navigates to /home, and a <details>/<summary>
+    collapsible menu containing three destination links: Posts, Profile,
+    and Sign out. The <details> pattern supports a mobile hamburger
+    toggle at narrow widths while keeping all links visible inline on
+    desktop via CSS.
 
     The "Create clinician" chrome CTA was removed in #697 — the
     /users/me detail page is the discoverable entry point."""
@@ -39,17 +40,17 @@ async def test_base_template_renders_primary_nav_when_authenticated(
     # "Create clinician" button no longer lives in the nav (#697).
     cta_items = tree.css("#primary-nav a[href='/clinicians/form']")
     assert len(cta_items) == 0, "Create-clinician CTA should be removed from nav (#697)"
-    # Brand link is a direct child of the nav element.
-    assert tree.css_first('#primary-nav > a[href="/"]') is not None
+    # Brand link is a direct child of the nav element, pointing at /home.
+    assert tree.css_first('#primary-nav > a[href="/home"]') is not None
     # Profile link points at /users/me.
     assert tree.css_first('#primary-nav a[href="/users/me"]') is not None
-    # The four authed-chrome destinations render in this exact order
+    # The three authed-chrome menu destinations render in this exact order
     # inside #nav-menu. Sign-out is the `#` placeholder href on the
-    # `<a hx-post>` that drives the HTMX POST.
+    # `<a hx-post>` that drives the HTMX POST. "Home" is the logo, not a
+    # menu item.
     nav_items = tree.css("#nav-menu ul li a")
     nav_hrefs = [a.attributes.get("href") for a in nav_items]
     assert nav_hrefs == [
-        "/home",
         "/posts",
         "/users/me",
         "#",
@@ -91,8 +92,8 @@ async def test_base_template_renders_primary_nav_for_anonymous_visitors(
     tree = HTMLParser(response.text)
     nav = tree.css_first('nav[aria-label="Primary"]')
     assert nav is not None
-    # Brand link is present.
-    brand = nav.css_first('a[href="/"]')
+    # Brand link is present and points at /home.
+    brand = nav.css_first('a[href="/home"]')
     assert brand is not None
     # No profile link, no Login link, no Login indicator.
     assert tree.css_first('#primary-nav a[href="/users/me"]') is None

--- a/src/framework/templates/_shared/_page_header.html
+++ b/src/framework/templates/_shared/_page_header.html
@@ -15,7 +15,8 @@ identical across pages at one size.
 `base.html` captures the breadcrumb / toolbar block output into context
 vars and this partial renders them as pre-rendered HTML. The partial
 inherits the caller's context, so `_on_home` / `_on_posts` /
-`_on_profile` / `is_authenticated` resolve normally.
+`_on_profile` / `is_authenticated` resolve normally. `_on_home` marks
+the brand logo with `aria-current="page"` when the viewer is on /home.
 
 The band's lower rows (breadcrumb + toolbar + rule) render only when
 there's app chrome to show — any breadcrumb or toolbar content, or an
@@ -33,7 +34,7 @@ and the constant-boundary rationale (one source of truth).
 #}
 <header class="container page-header">
   <nav aria-label="Primary" id="primary-nav">
-    <a href="/"><strong>Bedlam Connect</strong></a>
+    <a href="/home" {% if _on_home %}aria-current="page"{% endif %}><strong>Bedlam Connect</strong></a>
     {% if is_authenticated %}
       <details id="nav-menu">
         <summary class="nav-menu-toggle" aria-label="Menu">
@@ -41,9 +42,6 @@ and the constant-boundary rationale (one source of truth).
           <i class="icon-x nav-menu-close-icon"></i>
         </summary>
         <ul>
-          <li>
-            <a href="/home" {% if _on_home %}aria-current="page"{% endif %}>Home</a>
-          </li>
           <li>
             <a href="{{ entity_url('post') }}"
                {% if _on_posts %}aria-current="page"{% endif %}>Posts</a>


### PR DESCRIPTION
## Summary

- After HTMX registration, redirect to `/home` instead of `/users/me` — the home feed is the right landing spot for a new user
- Remove the separate "Home" nav link; the "Bedlam Connect" brand logo now navigates to `/home` (with `aria-current="page"` when on that route)

## Test plan

- [x] `test_register_via_htmx_sets_cookie_and_redirects` updated to assert `HX-Redirect: /home`
- [x] All 43 auth route tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)