### PR TITLE
Superusers bypass all capability checks

### DIFF
--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -110,3 +110,24 @@ async def test_capability_detail_unauthenticated_redirected(test_client: AsyncCl
         follow_redirects=False,
     )
     assert response.status_code != 200
+
+
+async def test_capabilities_index_superuser_shows_bypass_label(
+    superuser_client: AsyncClient,
+):
+    """Superusers see 'Available (superuser)' on the capabilities list."""
+    response = await superuser_client.get("/users/me/access/capabilities")
+    assert response.status_code == 200
+    assert "Available (superuser)" in response.text
+
+
+async def test_capability_detail_superuser_shows_bypass_note(
+    superuser_client: AsyncClient,
+):
+    """Superusers see a bypass note on the capability detail page."""
+    response = await superuser_client.get(
+        "/users/me/access/capabilities/provider-network"
+    )
+    assert response.status_code == 200
+    assert "Superuser" in response.text
+    assert "Available" in response.text

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -15,4 +15,11 @@
   {% call page_toolbar(heading=check.tree.label_active) %}
   {% endcall %}
 {% endblock %}
-{% block content %}{{ capability_requirements_panel(check.tree, check.granted, check.description) }}{% endblock %}
+{% block content %}
+  {% if check.bypass %}
+    <p>
+      <small>Superuser — access granted regardless of requirements below.</small>
+    </p>
+  {% endif %}
+  {{ capability_requirements_panel(check.tree, check.granted, check.description) }}
+{% endblock %}

--- a/src/domain/templates/users/access/capabilities/index.html
+++ b/src/domain/templates/users/access/capabilities/index.html
@@ -24,7 +24,9 @@
               {% if check.description %}<p>{{ check.description }}</p>{% endif %}
             </hgroup>
             <small data-state="{{ 'unlocked' if check.granted else 'locked' }}">
-              {% if check.granted %}
+              {% if check.bypass %}
+                <i class="icon-check" aria-hidden="true"></i>Available (superuser)
+              {% elif check.granted %}
                 <i class="icon-check" aria-hidden="true"></i>Available
               {% else %}
                 <i class="icon-lock" aria-hidden="true"></i>Not available yet

--- a/src/framework/access/capabilities/capabilities.py
+++ b/src/framework/access/capabilities/capabilities.py
@@ -12,6 +12,7 @@ evaluation logic and the route-mount plumbing.
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -67,15 +68,21 @@ class Gate:
 
 @dataclass(frozen=True)
 class CapabilityCheck:
-    """Evaluated capability tree for a specific user."""
+    """Evaluated capability tree for a specific user.
+
+    When `bypass` is True (set by the framework for superusers), `granted`
+    returns True regardless of the tree's met state. The tree itself is
+    preserved so templates can still show the real requirement state.
+    """
 
     name: str
     tree: Any  # Condition | Bundle | Gate
     description: str | None = None
+    bypass: bool = False
 
     @property
     def granted(self) -> bool:
-        return self.tree.met
+        return self.bypass or self.tree.met
 
 
 def mount_capability_routes(
@@ -131,6 +138,11 @@ def mount_capability_routes(
         user: Any = Depends(current_active_user),
     ):
         evaluated = {name: fn(user) for name, fn in checks.items()}
+        if user.is_superuser:
+            evaluated = {
+                name: dataclasses.replace(check, bypass=True)
+                for name, check in evaluated.items()
+            }
         return APIResponse.html_response(
             template_name=capabilities_list_template,
             context={
@@ -152,6 +164,8 @@ def mount_capability_routes(
         if fn is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         check = fn(user)
+        if user.is_superuser:
+            check = dataclasses.replace(check, bypass=True)
         return APIResponse.html_response(
             template_name=detail_template,
             context={

--- a/src/framework/access/capabilities/test_capabilities.py
+++ b/src/framework/access/capabilities/test_capabilities.py
@@ -109,6 +109,28 @@ def test_capability_check_granted_uses_gate_met():
     assert CapabilityCheck(name="x", tree=tree_fail).granted is False
 
 
+def test_capability_check_bypass_defaults_false():
+    assert CapabilityCheck(name="x", tree=_unmet()).bypass is False
+
+
+def test_capability_check_bypass_overrides_unmet_tree():
+    """bypass=True grants access even when every condition is unmet."""
+    check = CapabilityCheck(name="x", tree=_unmet(), bypass=True)
+    assert check.granted is True
+
+
+def test_capability_check_bypass_preserves_tree():
+    """The tree's own met state is unchanged when bypass is set — templates
+    can still render the real requirement state."""
+    check = CapabilityCheck(name="x", tree=_unmet(), bypass=True)
+    assert check.tree.met is False
+
+
+def test_capability_check_bypass_false_still_uses_tree():
+    assert CapabilityCheck(name="x", tree=_met(), bypass=False).granted is True
+    assert CapabilityCheck(name="x", tree=_unmet(), bypass=False).granted is False
+
+
 # ---------- nested tree evaluation ----------------------------------------
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -174,6 +174,39 @@ async def authenticated_client(
 
 
 @pytest.fixture(scope="function")
+async def superuser_client(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    test_app: FastAPI,
+) -> AsyncGenerator[AsyncClient, None]:
+    from src.auth_config import get_user_manager
+
+    user_data = UserCreate(
+        email="superuser@example.com",
+        password="password123",
+        username="superuser",
+        is_superuser=True,
+    )
+
+    await create_test_user(db_test_session_manager, user_data, get_user_manager)
+
+    login_data = {
+        "username": user_data.email,
+        "password": user_data.password,
+    }
+    res = await test_client.post("/auth/jwt/login", data=login_data)
+
+    cookie = res.headers["Set-Cookie"]
+    access_token = cookie.split(";")[0].split("=")[1]
+
+    test_client.headers["Cookie"] = f"fastapiusersauth={access_token}"
+
+    yield test_client
+
+    del test_client.headers["Cookie"]
+
+
+@pytest.fixture(scope="function")
 async def logged_in_user(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],


### PR DESCRIPTION
## Summary

- Adds `bypass: bool = False` to `CapabilityCheck`; `granted` short-circuits to `True` when set, regardless of the tree's met state
- `mount_capability_routes` wraps each evaluated check with `bypass=True` for superusers — framework layer, no domain changes needed
- Templates show "Available (superuser)" on the list page and a note above the requirement tree on the detail page; the real requirement tree remains visible so superusers can see what normal users need

## Test plan

- [ ] Log in as `admin@example.com` on devbox, visit `/users/me/access/capabilities` — all capabilities show "Available (superuser)"
- [ ] Visit `/users/me/access/capabilities/provider-network` — shows bypass note above the (possibly unmet) requirement tree
- [ ] Log in as a regular user — behavior unchanged, no "superuser" labels visible
- [ ] `dev test src/framework/access/capabilities/test_capabilities.py src/domain/routes/test_access.py` passes (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)