### PR TITLE
Drop dead claim A/B/affiliation reason codes from capabilities

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -51,11 +51,6 @@ from src.framework.access.capabilities.capabilities import (  # noqa: F401
 # `fix_url_for(...)`. Closed vocab: any new reason must be added here and
 # given a `ReasonMeta` entry in `_REASON_META` below.
 REASON_EMAIL_UNVERIFIED = "email_unverified"
-REASON_CLAIM_A_UNVERIFIED = "claim_a_unverified"
-REASON_CLAIM_B_UNVERIFIED = "claim_b_unverified"
-REASON_CLAIM_A_LAPSED = "claim_a_lapsed"
-REASON_CLAIM_B_LAPSED = "claim_b_lapsed"
-REASON_AFFILIATION_MISSING = "affiliation_missing"
 # Network-access gate: the user hasn't cleared verification, so both
 # read-side details (contact info, identity) and write-side affordances
 # (create post CTA) are locked. Fixed by completing any verification
@@ -98,36 +93,6 @@ _REASON_META = {
         unlock="Verify your email to unlock this.",
         fix_label="Verify email",
         fix_url="/users/me/email/form",
-    ),
-    REASON_CLAIM_A_UNVERIFIED: ReasonMeta(
-        title="Clinician identity",
-        unlock="Add a verified clinician profile to unlock this.",
-        fix_label="Complete clinician setup",
-        fix_url="/users/me",
-    ),
-    REASON_CLAIM_A_LAPSED: ReasonMeta(
-        title="Clinician identity",
-        unlock="Re-attest your license to resume this.",
-        fix_label="Re-verify license",
-        fix_url="/users/me",
-    ),
-    REASON_CLAIM_B_UNVERIFIED: ReasonMeta(
-        title="Organization representation",
-        unlock="Become a verified organization representative to unlock this.",
-        fix_label="Complete organization setup",
-        fix_url="/users/me",
-    ),
-    REASON_CLAIM_B_LAPSED: ReasonMeta(
-        title="Organization representation",
-        unlock="Re-verify your authority to resume this.",
-        fix_label="Re-verify authority",
-        fix_url="/users/me",
-    ),
-    REASON_AFFILIATION_MISSING: ReasonMeta(
-        title="Clinician affiliation",
-        unlock="Add a clinician affiliation to unlock this.",
-        fix_label="Manage affiliations",
-        fix_url="/users/me",
     ),
     REASON_NETWORK_UNVERIFIED: ReasonMeta(
         title="Provider network",

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -462,21 +462,9 @@ def test_claim_state_b_set_is_frozenset():
 
 
 def test_fix_url_for_onboarding_reasons_route_to_step_subroutes():
-    # The email reason points at the email form subresource; identity
-    # and additive / lapsed reasons all point at /users/me.
     assert (
         capabilities.fix_url_for(capabilities.REASON_EMAIL_UNVERIFIED)
         == "/users/me/email/form"
-    )
-    assert (
-        capabilities.fix_url_for(capabilities.REASON_CLAIM_A_UNVERIFIED) == "/users/me"
-    )
-    assert capabilities.fix_url_for(capabilities.REASON_CLAIM_A_LAPSED) == "/users/me"
-    assert (
-        capabilities.fix_url_for(capabilities.REASON_CLAIM_B_UNVERIFIED) == "/users/me"
-    )
-    assert (
-        capabilities.fix_url_for(capabilities.REASON_AFFILIATION_MISSING) == "/users/me"
     )
 
 
@@ -512,26 +500,13 @@ def test_reason_meta_known_reason_carries_full_copy():
     """A known reason resolves to a title, non-empty unlock copy, a fix
     label, and the same deep-link `fix_url_for` returns — one source for
     every display string."""
-    meta = capabilities.reason_meta(capabilities.REASON_CLAIM_A_UNVERIFIED)
+    meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED)
     assert meta.title
     assert meta.unlock
     assert meta.fix_label
-    assert meta.fix_url == "/users/me"
     assert meta.fix_url == capabilities.fix_url_for(
-        capabilities.REASON_CLAIM_A_UNVERIFIED
+        capabilities.REASON_NETWORK_UNVERIFIED
     )
-
-
-def test_reason_meta_lapsed_reasons_carry_resume_copy():
-    """Both lapsed reasons (A and the newly-added B) resolve to a section
-    title + a re-verify CTA — the re-verify card reads entirely from this,
-    so a missing B entry would have rendered a raw reason code."""
-    a = capabilities.reason_meta(capabilities.REASON_CLAIM_A_LAPSED)
-    b = capabilities.reason_meta(capabilities.REASON_CLAIM_B_LAPSED)
-    assert a.title == "Clinician identity"
-    assert b.title == "Organization representation"
-    assert a.fix_label == "Re-verify license"
-    assert b.fix_label == "Re-verify authority"
 
 
 def test_reason_meta_network_unverified_points_at_capability_page():

--- a/src/domain/logic/users/view.py
+++ b/src/domain/logic/users/view.py
@@ -70,7 +70,7 @@ def onboarding_readiness(user: Any) -> OnboardingReadiness:
         next_href = capabilities.fix_url_for(capabilities.REASON_EMAIL_UNVERIFIED)
     elif not can_post:
         next_label = "Verify your identity to start posting"
-        next_href = capabilities.fix_url_for(capabilities.REASON_CLAIM_A_UNVERIFIED)
+        next_href = "/users/me"
     else:
         next_label = None
         next_href = None

--- a/src/framework/templates/_shared/test_locked.py
+++ b/src/framework/templates/_shared/test_locked.py
@@ -67,7 +67,7 @@ def _render_field(reason: str) -> str:
 
 
 def test_locked_action_renders_disabled_button_with_label() -> None:
-    html = _render_action("REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
     button = HTMLParser(html).css_first("button")
     assert button is not None, "expected a <button> for the gated action"
     assert "disabled" in button.attributes, "gated action must be disabled"
@@ -77,8 +77,8 @@ def test_locked_action_renders_disabled_button_with_label() -> None:
 def test_locked_action_tooltip_carries_unlock_copy() -> None:
     """Unlock copy is in the tooltip wrapper, not inline — so a refactor
     can't silently drop it or hard-code copy that drifts from the single source."""
-    meta = capabilities.reason_meta(capabilities.REASON_CLAIM_A_UNVERIFIED)
-    html = _render_action("REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
+    meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED)
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
     assert meta.unlock in html, "unlock copy must appear in data-tooltip"
     # Fix link is NOT inside locked_action — the tooltip is enough.
     # (Users click the button's parent or navigate to capability page separately.)

--- a/src/framework/templates/_shared/test_locked.py
+++ b/src/framework/templates/_shared/test_locked.py
@@ -157,7 +157,7 @@ def test_locked_action_extra_class_appended_to_outline() -> None:
 
 def test_locked_action_no_icon_by_default() -> None:
     """Without icon= the button contains no <i> element."""
-    html = _render_action("REASON_CLAIM_A_UNVERIFIED", "+ Post a referral")
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
     button = HTMLParser(html).css_first("button")
     assert button is not None
     assert button.css_first("i") is None


### PR DESCRIPTION
## Summary

- Removes 5 dead `REASON_*` constants (`CLAIM_A_UNVERIFIED`, `CLAIM_B_UNVERIFIED`, `CLAIM_A_LAPSED`, `CLAIM_B_LAPSED`, `AFFILIATION_MISSING`) and their `_REASON_META` entries — none had production callers
- Replaces the one live use of `REASON_CLAIM_A_UNVERIFIED` in `users/view.py` with a direct `/users/me` href; no remaining reason code cleanly maps to "complete either claim A or B"
- Updates all test references to use `REASON_NETWORK_UNVERIFIED`, which is the only non-email reason code that remains

## Test plan

- [ ] `dev test src/domain/logic/test_capabilities.py src/domain/logic/users/ src/framework/templates/_shared/test_locked.py` — 69 passed
- [ ] `dev lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)