### PR TITLE
Always show My posts section on /home; lock CTA when unverified

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -59,8 +59,8 @@ async def test_home_shows_empty_my_posts_section_when_no_active_posts(
 
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
-    assert "My active posts" in response.text
-    assert "You have no active posts." in response.text
+    assert "My posts" in response.text
+    assert "No posts yet." in response.text
     assert "Create a post" in response.text
 
 

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -2,6 +2,7 @@
 {%- from "_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
+{%- from "_shared/_locked.html" import locked_action -%}
 {%- macro _no_poster_row(post) %}{{ post_feed_row(post, show_poster=False) }}{%- endmacro -%}
   {% block title %}Home{% endblock %}
   {# Home title + post actions ride the unified page-header toolbar. The
@@ -25,22 +26,24 @@
     {% endcall %}
   {% endblock %}
   {% block content %}
-    {% if can_access_network %}
-      <section>
-        <header style="display: flex;
-                       justify-content: space-between;
-                       align-items: baseline">
-          <h2>My active posts</h2>
-          <a href="{{ entity_url('post') }}">See all</a>
-        </header>
-        {% if my_posts %}
-          {{ item_list(my_posts, _no_poster_row, "my-posts-list", "post-feed-list") }}
-        {% else %}
-          <p style="color: var(--pico-muted-color)">You have no active posts.</p>
+    <section>
+      <header style="display: flex;
+                     justify-content: space-between;
+                     align-items: baseline">
+        <h2>My posts</h2>
+        {% if can_access_network %}<a href="{{ entity_url('post') }}">See all</a>{% endif %}
+      </header>
+      {% if my_posts %}
+        {{ item_list(my_posts, _no_poster_row, "my-posts-list", "post-feed-list") }}
+      {% else %}
+        <p style="color: var(--pico-muted-color)">No posts yet.</p>
+        {% if can_access_network %}
           <a href="{{ entity_form_url('post') }}" role="button" class="outline">Create a post</a>
+        {% else %}
+          {{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, "Create a post") }}
         {% endif %}
-      </section>
-    {% endif %}
+      {% endif %}
+    </section>
     {% if network_posts %}
       <section>
         <header style="display: flex;

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -64,16 +64,59 @@ async def test_home_page_shows_post_buttons_when_claim_a_verified(
 async def test_home_page_no_post_actions_for_no_claim_user(
     authenticated_client: AsyncClient,
 ):
-    """A no-claim user (the default dev fixture) gets no post-action row on
-    /home at all — neither an active create link nor a disabled locked
-    button. The single chrome `#onboarding-banner` is their one nudge, so
-    the page hosts no finish-setup card either."""
+    """A no-claim user gets the My posts section but no active toolbar CTAs.
+    The empty-state create button is disabled (locked_action) instead of a
+    live link. No finish-setup card is rendered — the chrome
+    `#onboarding-banner` is the single nudge."""
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert tree.css_first('a[href="/posts/form?kind=referral"]') is None
     assert "+ Post a referral" not in response.text
     assert tree.css_first("#finish-setup-card") is None
+    # My posts section always renders
+    assert "My posts" in response.text
+    # Empty-state CTA is a disabled button, not a live link
+    assert "No posts yet." in response.text
+    assert tree.css_first("button[disabled]") is not None
+    assert tree.css_first('a[href="/posts/form"]') is None
+
+
+async def test_home_page_empty_my_posts_shows_locked_cta_when_unverified(
+    authenticated_client: AsyncClient,
+):
+    """An unverified user with no posts sees a disabled Create a post button
+    (locked_action pattern) rather than a live link."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert "No posts yet." in response.text
+    btn = tree.css_first("button[disabled]")
+    assert btn is not None
+    assert "Create a post" in btn.text()
+
+
+async def test_home_page_empty_my_posts_shows_active_cta_when_verified(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """A verified user with no posts sees a live Create a post link."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert "No posts yet." in response.text
+    assert tree.css_first('a[href="/posts/form"]') is not None
+    assert tree.css_first("button[disabled]") is None
 
 
 async def test_home_page_no_blur_element(authenticated_client: AsyncClient):


### PR DESCRIPTION
## Summary
- The **My posts** section now renders for all authenticated users regardless of `can_access_network` — previously it was completely hidden for unverified users.
- Empty state shows **"No posts yet."** with a live **Create a post** link when the user is verified.
- When unverified, the create CTA uses `locked_action(REASON_NETWORK_UNVERIFIED, ...)` — same disabled-button-with-tooltip pattern as `posts/list.html`.
- The **"See all"** link in the section header still gated on `can_access_network` (no point linking unverified users to the full network feed).

## Test plan
- [ ] Unverified user hits `/home` → sees "My posts" section with "No posts yet." + disabled Create a post button (tooltip explains unlock path)
- [ ] Verified user with no posts hits `/home` → sees "My posts" section with "No posts yet." + live Create a post link
- [ ] Verified user with posts hits `/home` → sees their posts listed normally
- [ ] All 10 existing `/home` tests pass (`dev test src/test_main.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)