### PR TITLE
Center pagination nav and use Lucide chevron icons

### DIFF
--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -649,6 +649,13 @@ body {
   color: var(--pico-muted-color);
   font-style: italic;
 }
+/* Pagination nav — centered horizontally, Lucide chevrons for prev/next.
+   Pico renders `nav` as a flex container; `justify-content: center` centers
+   the single `<ul>` child. The trailing chevron-right (after "Next") needs
+   start margin instead of the default end margin the icon rule gives every
+   icon — override both here, scoped to this nav. */
+.pagination-nav { justify-content: center; }
+.pagination-nav .icon-chevron-right { margin-inline-end: 0; margin-inline-start: 0.25em; }
 /* Picker rendered by `_shared/_picker.html`. A "choose your path" card
    grid that funnels the user to a kind- or type-specific sub-form. Each
    option is a bordered card so the chooser reads as the primary action on

--- a/src/framework/templates/_shared/pagination.html
+++ b/src/framework/templates/_shared/pagination.html
@@ -23,16 +23,16 @@ The handler is responsible for building `paginator_base_query`; see
 {% macro pagination(page_meta, paginator_base_query="") -%}
   {%- if page_meta.has_prev or page_meta.has_next -%}
     {%- set sep = "&" if paginator_base_query else "" -%}
-    <nav aria-label="Pagination">
+    <nav class="pagination-nav" aria-label="Pagination">
       <ul>
         {%- if page_meta.has_prev %}
           <li>
             <a href="?{{ paginator_base_query }}{{ sep }}page={{ page_meta.prev_page }}"
-               rel="prev">&laquo; Prev</a>
+               rel="prev"><i class="icon-chevron-left"></i>Prev</a>
           </li>
         {%- else %}
           <li>
-            <span aria-disabled="true">&laquo; Prev</span>
+            <span aria-disabled="true"><i class="icon-chevron-left"></i>Prev</span>
           </li>
         {%- endif %}
         <li>
@@ -41,11 +41,11 @@ The handler is responsible for building `paginator_base_query`; see
         {%- if page_meta.has_next %}
           <li>
             <a href="?{{ paginator_base_query }}{{ sep }}page={{ page_meta.next_page }}"
-               rel="next">Next &raquo;</a>
+               rel="next">Next<i class="icon-chevron-right"></i></a>
           </li>
         {%- else %}
           <li>
-            <span aria-disabled="true">Next &raquo;</span>
+            <span aria-disabled="true">Next<i class="icon-chevron-right"></i></span>
           </li>
         {%- endif %}
       </ul>

--- a/src/framework/templates/_shared/test_pagination.py
+++ b/src/framework/templates/_shared/test_pagination.py
@@ -1,0 +1,151 @@
+"""Tests for the pagination macro in ``_shared/pagination.html``.
+
+Pins the structural contract: when to emit the nav, which icons appear,
+which links are active vs disabled, and rel attributes — so a refactor
+can't silently break the rendered output.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from jinja2 import ChoiceLoader, DictLoader, Environment, FileSystemLoader
+from selectolax.parser import HTMLParser
+
+from src.framework.dispatch.pagination import Page
+
+
+def _make_env() -> Environment:
+    stub = DictLoader({})
+    framework = FileSystemLoader(str(Path(__file__).resolve().parents[1]))
+    return Environment(loader=ChoiceLoader([stub, framework]))
+
+
+def _render(page: Page, base_query: str = "") -> str:
+    snippet = textwrap.dedent(f"""\
+        {{%- from "_shared/pagination.html" import pagination -%}}
+        {{{{ pagination(page_meta, {base_query!r}) }}}}
+        """)
+    return _make_env().from_string(snippet).render(page_meta=page)
+
+
+def _page(**kwargs) -> Page:
+    defaults = dict(page=1, per_page=15, has_prev=False, has_next=False)
+    return Page(**{**defaults, **kwargs})
+
+
+# ---------------------------------------------------------------------------
+# Visibility
+# ---------------------------------------------------------------------------
+
+
+def test_single_page_emits_nothing() -> None:
+    assert _render(_page(has_prev=False, has_next=False)).strip() == ""
+
+
+def test_emits_nav_when_has_prev() -> None:
+    html = _render(_page(page=2, has_prev=True))
+    assert HTMLParser(html).css_first("nav") is not None
+
+
+def test_emits_nav_when_has_next() -> None:
+    html = _render(_page(has_next=True))
+    assert HTMLParser(html).css_first("nav") is not None
+
+
+# ---------------------------------------------------------------------------
+# CSS class for centering
+# ---------------------------------------------------------------------------
+
+
+def test_nav_carries_pagination_nav_class() -> None:
+    html = _render(_page(has_next=True))
+    nav = HTMLParser(html).css_first("nav")
+    assert nav is not None
+    assert "pagination-nav" in (nav.attributes.get("class") or "")
+
+
+# ---------------------------------------------------------------------------
+# Lucide chevron icons
+# ---------------------------------------------------------------------------
+
+
+def test_prev_link_has_chevron_left_icon() -> None:
+    html = _render(_page(page=2, has_prev=True))
+    prev_link = HTMLParser(html).css_first("a[rel='prev']")
+    assert prev_link is not None
+    assert prev_link.css_first("i.icon-chevron-left") is not None
+
+
+def test_prev_disabled_has_chevron_left_icon() -> None:
+    html = _render(_page(has_next=True))
+    disabled = HTMLParser(html).css_first("span[aria-disabled='true']")
+    assert disabled is not None
+    assert disabled.css_first("i.icon-chevron-left") is not None
+
+
+def test_next_link_has_chevron_right_icon() -> None:
+    html = _render(_page(has_next=True))
+    next_link = HTMLParser(html).css_first("a[rel='next']")
+    assert next_link is not None
+    assert next_link.css_first("i.icon-chevron-right") is not None
+
+
+def test_next_disabled_has_chevron_right_icon() -> None:
+    html = _render(_page(page=2, has_prev=True))
+    # last li span is the disabled next
+    disabled_spans = HTMLParser(html).css("span[aria-disabled='true']")
+    assert any(s.css_first("i.icon-chevron-right") for s in disabled_spans)
+
+
+def test_no_guillemet_entities_in_output() -> None:
+    html = _render(_page(page=2, has_prev=True, has_next=True))
+    assert "«" not in html
+    assert "»" not in html
+    assert "&laquo;" not in html
+    assert "&raquo;" not in html
+
+
+# ---------------------------------------------------------------------------
+# Links and rel attributes
+# ---------------------------------------------------------------------------
+
+
+def test_prev_link_points_to_previous_page() -> None:
+    html = _render(_page(page=3, has_prev=True))
+    a = HTMLParser(html).css_first("a[rel='prev']")
+    assert a is not None
+    assert "page=2" in (a.attributes.get("href") or "")
+
+
+def test_next_link_points_to_next_page() -> None:
+    html = _render(_page(page=1, has_next=True))
+    a = HTMLParser(html).css_first("a[rel='next']")
+    assert a is not None
+    assert "page=2" in (a.attributes.get("href") or "")
+
+
+def test_base_query_preserved_in_prev_link() -> None:
+    html = _render(_page(page=2, has_prev=True), base_query="kind=referral")
+    a = HTMLParser(html).css_first("a[rel='prev']")
+    assert a is not None
+    href = a.attributes.get("href") or ""
+    assert "kind=referral" in href
+    assert "page=1" in href
+
+
+def test_base_query_preserved_in_next_link() -> None:
+    html = _render(_page(page=1, has_next=True), base_query="kind=referral")
+    a = HTMLParser(html).css_first("a[rel='next']")
+    assert a is not None
+    href = a.attributes.get("href") or ""
+    assert "kind=referral" in href
+    assert "page=2" in href
+
+
+def test_current_page_number_shown() -> None:
+    html = _render(_page(page=5, has_next=True))
+    span = HTMLParser(html).css_first("span[aria-current='page']")
+    assert span is not None
+    assert "5" in span.text()


### PR DESCRIPTION
## Summary

- Replaces `«`/`»` guillemet entities in the pagination macro with Lucide `icon-chevron-left` / `icon-chevron-right` glyphs (consistent with breadcrumb and other icon usage across the app)
- Adds `.pagination-nav` class to the `<nav>` and a CSS rule (`justify-content: center`) so the prev/page/next row is horizontally centered in every list view
- Scopes a `margin-inline-start` override on the trailing chevron-right so spacing reads correctly on both sides
- The pagination macro was already in the component library (`/dev/components#pagination`) — no gallery change needed

## Test plan

- [ ] 14 new template unit tests in `src/framework/templates/_shared/test_pagination.py` — all pass (`dev test` clean)
- [ ] `dev lint` clean
- [ ] Visually confirm at `/dev/components#pagination` and on any list view (e.g. `/clinicians`) that pagination is centered and shows chevrons

🤖 Generated with [Claude Code](https://claude.com/claude-code)