### PR TITLE
Remove dead post-feed-row and article CSS rules

### DIFF
--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -97,20 +97,13 @@ table.post-rows td:nth-last-child(2) {
    Container is <ul class="post-feed-list">; each item is
    <li><article class="post-feed-row">. The <ul>/<li> reset removes
    browser list chrome without affecting the accessibility tree —
-   screen readers still announce "list of N items". Each row is a
-   vertical flex column: header line, headline link, meta strip. */
+   screen readers still announce "list of N items". */
 ul.post-feed-list {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 ul.post-feed-list > li { list-style: none; padding: 0; }
-.post-feed-row {
-  display: flex;
-  flex-direction: column;
-  border-top: 1px solid var(--pico-muted-border-color);
-}
-.post-feed-list > li:first-child > .post-feed-row { border-top: none; }
 /* Header line — pill · poster · timestamp */
 .post-feed-header {
   display: flex;

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -41,10 +41,6 @@ h1 { font-size: 1.5rem; font-weight: 600; }
 h2 { font-size: 1.25rem; font-weight: 500; }
 h3 { font-size: 1.0625rem; font-weight: 500; }
 h4, h5, h6 { font-size: 1rem; font-weight: 500; }
-/* Pico defines --pico-card-box-shadow independently from --pico-box-shadow
-   and may set it via higher-specificity selectors in its theme rules.
-   Belt-and-suspenders: kill the shadow directly on the element. */
-article { box-shadow: none; margin-bottom: 0; }
 /* Entity list — <ul class="entity-list"> wraps every list of entity
    cards. Resets remove browser list chrome while keeping the <ul>/<li>
    in the accessibility tree so screen readers announce "list of N items".


### PR DESCRIPTION
## Summary

- Removes `.post-feed-row` flex/border-top rules and the first-child `border-top: none` override from `domain.css`
- Removes `article { box-shadow: none; margin-bottom: 0; }` from `framework.css`
- Updates the Feed rows comment block to drop the stale "vertical flex column" description

## Test plan
- [ ] Visual check: feed pages (home, posts list) render correctly without the removed styles
- [ ] `dev lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)