### PR TITLE
Rebuild locked affordances: native popover + CSS anchor positioning

### DIFF
--- a/deployment/droplet-files/deploy.sh
+++ b/deployment/droplet-files/deploy.sh
@@ -56,8 +56,10 @@ cleanup_containers() {
     fi
 }
 
-# Derive the nginx site config name from APP_BASE_URL, falling back to bedlamconnect.com.
-APP_DOMAIN="$(echo "${APP_BASE_URL:-https://bedlamconnect.com}" | sed 's|https\?://||' | sed 's|/.*||')"
+# Derive the bare domain (no www.) from APP_BASE_URL for nginx server_name/cert paths.
+# The template adds www.${APP_DOMAIN} itself, so strip any www. prefix here to avoid
+# producing "www.www.bedlamconnect.com" when APP_BASE_URL includes www.
+APP_DOMAIN="$(echo "${APP_BASE_URL:-https://bedlamconnect.com}" | sed 's|https\?://||' | sed 's|/.*||' | sed 's|^www\.||')"
 
 # Function to update nginx upstream
 update_nginx_upstream() {

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -541,7 +541,13 @@ async def test_list_has_no_inline_verify_notice_for_unverified(
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     assert "posts-verify-notice" not in response.text
-    assert "Get access" not in response.text
+    # No inline locked placeholder in the list body — locked affordances only
+    # appear in the toolbar (locked_action for Create) and globally in the
+    # locked-cta popovers rendered by base.html.
+    tree = HTMLParser(response.text)
+    main = tree.css_first("main")
+    assert main is not None
+    assert main.css_first("button.locked-ghost-btn") is None
 
 
 # --- Toolbar Create CTA gate (posting-capable claim) -------------------------
@@ -692,18 +698,13 @@ async def test_detail_redacts_identity_rows_as_locked_placeholders_for_unverifie
         dd = tree.css_first(f'div[data-fact="{fact_key}"] dd')
         assert dd is not None, f"{fact_key} row should still render when redacted"
         assert (
-            dd.css_first("span.locked-field") is not None
+            dd.css_first("button.locked-ghost-btn") is not None
         ), f"{fact_key} should render a locked placeholder"
-        assert (
-            dd.css_first("a").attributes.get("href")
-            == "/users/me/access/capabilities/provider-network"
-        )
 
     # ...but the real navigable links + the address value are withheld.
     assert tree.css_first(f"a[href='/clinicians/{clinician.id}']") is None
     assert tree.css_first(f"a[href='/organizations/{org_id}']") is None
     assert "Springfield, IL" not in response.text
-    assert "Get access" in response.text
 
 
 async def test_detail_shows_identity_rows_for_verified_viewer(
@@ -735,4 +736,4 @@ async def test_detail_shows_identity_rows_for_verified_viewer(
 
     assert tree.css_first(f"a[href='/clinicians/{clinician.id}']") is not None
     assert "Springfield, IL" in response.text
-    assert tree.css_first("span.locked-field") is None
+    assert tree.css_first("button.locked-ghost-btn") is None

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -20,6 +20,7 @@ it's dev-only chrome that should never ship to production. #}
 {%- from "_shared/_item_list.html" import item_list -%}
 {%- from "_shared/_picker.html" import picker -%}
 {%- from "_shared/_capability_requirements.html" import capability_requirements_panel -%}
+{%- from "_shared/_locked.html" import locked_action, locked_link, locked_name, locked_field -%}
 {% extends "base.html" %}
 {% block head %}
   <style>
@@ -88,6 +89,18 @@ it's dev-only chrome that should never ship to production. #}
   @media (max-width: 640px) {
     .gallery-layout { grid-template-columns: 1fr; }
     .gallery-layout > aside { position: static; }
+  }
+  .gallery-specimen-label {
+    display: block;
+    margin-bottom: calc(var(--pico-spacing) * 0.25);
+    color: var(--pico-muted-color);
+  }
+  .gallery-section-subheading {
+    font-size: var(--pico-font-size);
+    font-weight: 600;
+    color: var(--pico-muted-color);
+    margin-top: var(--pico-spacing);
+    margin-bottom: calc(var(--pico-spacing) * 0.25);
   }
   </style>
 {% endblock %}
@@ -193,6 +206,9 @@ it's dev-only chrome that should never ship to production. #}
               <li>
                 <span class="gallery-nav-subgroup">Access</span>
                 <ul>
+                  <li>
+                    <a href="#locked-affordances">Locked affordances</a>
+                  </li>
                   <li>
                     <a href="#capability-requirements">Capability requirements</a>
                   </li>
@@ -624,6 +640,74 @@ it's dev-only chrome that should never ship to production. #}
       {# ═══════════════════════════════════════════════════════════ #}
       {# DOMAIN: ACCESS                                               #}
       {# ═══════════════════════════════════════════════════════════ #}
+      <section class="gallery-section" id="locked-affordances">
+        <h2>Locked affordances</h2>
+        <p>
+          <small>Four variants for "you can't do/see this yet" UI. Each carries a
+            <code>data-locked-cta="{reason}"</code> attribute. Clicking opens a native
+            <code>&lt;popover&gt;</code> CTA card anchored via CSS anchor positioning
+            (<code>position-try-fallbacks</code> keeps it on-screen near the trigger).
+          Copy and fix-URL come from <code>capabilities.reason_meta(reason)</code>.</small>
+        </p>
+        {# locked_action — disabled-looking button (write affordances) #}
+        <h3 class="gallery-section-subheading">locked_action</h3>
+        <p>
+          <small>Rendered in place of a create/submit button the user doesn't have access to. Looks disabled; clicking opens the CTA popover.</small>
+        </p>
+        <div class="gallery-row">
+          <div>
+            <small class="gallery-specimen-label">Default</small>
+            {{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, "+ Post a referral") }}
+          </div>
+          <div>
+            <small class="gallery-specimen-label">extra_class="secondary"</small>
+            {{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, "Email", extra_class="secondary") }}
+          </div>
+          <div>
+            <small class="gallery-specimen-label">email reason</small>
+            {{ locked_action(capabilities.REASON_EMAIL_UNVERIFIED, "Submit") }}
+          </div>
+        </div>
+        {# locked_link — disabled-looking inline navigation link #}
+        <h3 class="gallery-section-subheading">locked_link</h3>
+        <p>
+          <small>Rendered in place of an <code>&lt;a&gt;</code> the user can't navigate to yet. Muted, not-allowed cursor, opens CTA popover.</small>
+        </p>
+        <div class="gallery-row">
+          <div>{{ locked_link(capabilities.REASON_NETWORK_UNVERIFIED, "View full profile") }}</div>
+          <div>{{ locked_link(capabilities.REASON_EMAIL_UNVERIFIED, "Continue") }}</div>
+        </div>
+        {# locked_name — withheld identity placeholder #}
+        <h3 class="gallery-section-subheading">locked_name</h3>
+        <p>
+          <small>Rendered where a clinician or org name would appear. The placeholder communicates "a real name exists here." Always uses <code>REASON_NETWORK_UNVERIFIED</code>.</small>
+        </p>
+        <div class="gallery-row">
+          <div>
+            <small class="gallery-specimen-label">clinician</small>
+            <small>{{ locked_name("Dr. J. Doe") }}</small>
+          </div>
+          <div>
+            <small class="gallery-specimen-label">org / program</small>
+            <small>{{ locked_name("Doe Health Group") }}</small>
+          </div>
+        </div>
+        {# locked_field — withheld data value (address, contact) #}
+        <h3 class="gallery-section-subheading">locked_field</h3>
+        <p>
+          <small>Rendered where a withheld data value (full address, phone) would appear. The redacted dots signal content exists; the lock icon signals it's gated.</small>
+        </p>
+        <div class="gallery-row">
+          <div>
+            <small class="gallery-specimen-label">network_unverified</small>
+            {{ locked_field(capabilities.REASON_NETWORK_UNVERIFIED) }}
+          </div>
+          <div>
+            <small class="gallery-specimen-label">email_unverified</small>
+            {{ locked_field(capabilities.REASON_EMAIL_UNVERIFIED) }}
+          </div>
+        </div>
+      </section>
       <section class="gallery-section" id="capability-requirements">
         <h2>Capability requirements</h2>
         <p>

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -36,7 +36,7 @@
              role="button"
              class="secondary outline">Email</a>
         {% else %}
-          {{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, "Email", icon="icon-lock", extra_class="secondary") }}
+          {{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, "Email", extra_class="secondary") }}
         {% endif %}
       </footer>
     </section>

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -622,28 +622,71 @@ body {
   display: grid;
   grid-template-rows: auto 1fr auto;
 }
-/* Locked affordances rendered by `_shared/_locked.html`. A gated *action*
-   stays visible but disabled, stacked above a muted unlock line; a gated
-   *field* renders a muted italic placeholder where the withheld value
-   would be. Both carry an `icon-lock` glyph and a deep-link to the fix.
-   See the macro header for the action-vs-field contract. */
-.locked-action {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-.locked-action button[disabled] {
-  width: auto;
+/* Locked affordances rendered by `_shared/_locked.html`.
+   Four trigger shapes + one CTA popover card:
+
+   locked_action   — button, aria-disabled, not-allowed cursor
+   locked_link     — anchor, aria-disabled, not-allowed cursor
+   locked_name     — ghost button, muted italic inline text + lock icon
+   locked_field    — ghost button, muted lock icon + redacted dots
+
+   The CTA popover (.locked-cta) is a native <div popover> positioned via
+   CSS anchor positioning. JS (base.html) sets `position-anchor` and
+   `anchor-name` dynamically on each click so the card appears near the
+   element that was triggered. position-try-fallbacks keeps it on-screen
+   when the trigger is near an edge. */
+
+/* CTA popover card — anchor positioning is the only non-Pico CSS here.
+   Typography, spacing, and color inherit from Pico via <p>, <small>,
+   <strong>, and <a role="button"> semantics in the popover HTML. */
+.locked-cta[popover] {
+  inset: unset;
   margin: 0;
+  margin-bottom: var(--pico-spacing);
+  position: fixed;
+  position-area: top center;
+  position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+  position-visibility: anchors-visible;
+  max-width: 260px;
+  width: max-content;
+  padding: var(--pico-spacing);
+  border-radius: var(--pico-border-radius);
+  background: var(--pico-card-background-color);
+  border: 1px solid var(--pico-muted-border-color);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+.locked-cta p { margin-bottom: calc(var(--pico-spacing) * 0.5); }
+.locked-cta a[role="button"] { width: 100%; }
+
+/* Disabled-looking action buttons and links */
+button[aria-disabled="true"],
+a.locked-link[aria-disabled="true"] {
+  opacity: 0.5;
   cursor: not-allowed;
 }
-.locked-reason {
-  color: var(--pico-muted-color);
-  font-size: 0.875rem;
-}
-.locked-field {
+
+/* Ghost button for inline locked names and fields */
+.locked-ghost-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
   color: var(--pico-muted-color);
   font-style: italic;
+  cursor: pointer;
+  text-decoration: none;
+}
+.locked-ghost-btn .icon-lock {
+  font-style: normal;
+}
+
+/* Redacted content placeholder (used by locked_field) */
+.locked-redacted {
+  letter-spacing: 0.1em;
 }
 /* Pagination nav — centered horizontally, Lucide chevrons for prev/next.
    Pico renders `nav` as a flex container; `justify-content: center` centers

--- a/src/framework/templates/_shared/_locked.html
+++ b/src/framework/templates/_shared/_locked.html
@@ -1,47 +1,79 @@
 {# Consistent "you can't do/see this yet" affordances, driven by the
-   closed `capabilities.REASON_*` vocab. Three treatments:
+   closed `capabilities.REASON_*` vocab. Four trigger macros + one
+   popover-renderer:
 
-   - `locked_action(reason, label, icon=none, extra_class=none)` — for
-     write affordances (buttons, create links). Renders the control
-     DISABLED inside a tooltip wrapper. `icon` prepends a `<i class="...">`,
-     `extra_class` appends to the button's default `"outline"` class.
-     Safe to render: the server re-checks authz on submit.
+   Trigger macros (each renders a [data-locked-cta="{reason}"] element
+   that the locked-affordance JS uses to anchor and show the CTA card):
 
-   - `locked_field(reason)` — for withheld DATA values (full address).
-     Renders a lock icon + fix link inside a tooltip wrapper. The caller
-     never passes the real value — withholding is the VIEW layer's job.
+   - `locked_action(reason, label, extra_class=none)` — a write-affordance
+     button that LOOKS disabled (aria-disabled + muted opacity + not-allowed
+     cursor) but is still clickable to open the CTA popover. `extra_class`
+     appends to the default `"outline"` Pico class.
 
-   - `locked_name(placeholder)` — for withheld identity names (clinician
-     name, org name). Always uses `REASON_NETWORK_UNVERIFIED`; derives
-     the fix URL from that reason internally. Renders the placeholder as
-     a link inside a tooltip wrapper.
+   - `locked_link(reason, label)` — an inline navigation link that looks
+     disabled. Use in place of an `<a>` the user doesn't have access to yet.
 
-   Tooltip text + fix link come from `capabilities.reason_meta(reason)`.
-   `capabilities` is a Jinja global (registered in
-   `src/domain/template_globals.py`), so these macros need no `with
-   context`. Add or change reason copy in
-   `src/domain/logic/capabilities.py` — never inline here. #}
-{% macro locked_action(reason, label, icon=none, extra_class=none) -%}
-  {%- set meta = capabilities.reason_meta(reason) -%}
+   - `locked_name(placeholder)` — for withheld identity names (clinician /
+     org). Always uses REASON_NETWORK_UNVERIFIED. Renders as a muted italic
+     ghost button with a lock icon so the viewer knows a real name exists.
+
+   - `locked_field(reason)` — for withheld data values (address, contact).
+     Renders as a muted ghost button with a lock icon and redacted dots.
+
+   Popover macro (render once per page, e.g. in base.html):
+
+   - `locked_popovers()` — renders one <div popover> per known reason.
+     Content (title, unlock copy, fix link) comes from
+     `capabilities.reason_meta(reason)`. The JS in base.html dynamically
+     sets `position-anchor` on the right popover and calls showPopover().
+
+   Copy lives in `src/domain/logic/capabilities.py` — never inline here.
+   CSS lives in `src/framework/static/css/framework.css` under "Locked
+affordances". JS lives inline in `src/framework/templates/base.html`. #}
+{% macro locked_action(reason, label, extra_class=none) -%}
   {%- set _cls = "outline " ~ extra_class if extra_class else "outline" -%}
-  <span data-tooltip="{{ meta.unlock }}">
-    <button type="button" class="{{ _cls }}" disabled aria-disabled="true">
-      {%- if icon %}<i class="{{ icon }}" aria-hidden="true"></i>{% endif %}
+  <button type="button"
+          class="{{ _cls }}"
+          aria-disabled="true"
+          data-locked-cta="{{ reason }}">
+    <i class="icon-lock" aria-hidden="true"></i>
     {{ label }}
   </button>
-</span>
+{%- endmacro %}
+{% macro locked_link(reason, label) -%}
+  <a class="locked-link"
+     aria-disabled="true"
+     tabindex="0"
+     data-locked-cta="{{ reason }}">
+    <i class="icon-lock" aria-hidden="true"></i>
+    {{ label }}
+  </a>
 {%- endmacro %}
 {% macro locked_name(placeholder) -%}
-  {%- set _meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED) -%}
-  <span class="locked-field" data-tooltip="{{ _meta.unlock }}">
-    <i class="icon-lock" aria-hidden="true"></i>
-    <a href="{{ _meta.fix_url }}">{{ placeholder }}</a>
-  </span>
+  <button class="locked-ghost-btn"
+          data-locked-cta="{{ capabilities.REASON_NETWORK_UNVERIFIED }}">
+    <i class="icon-lock" aria-hidden="true"></i>{{ placeholder }}
+  </button>
 {%- endmacro %}
 {% macro locked_field(reason) -%}
-  {%- set meta = capabilities.reason_meta(reason) -%}
-  <span class="locked-field" data-tooltip="{{ meta.unlock }}">
-    <i class="icon-lock" aria-hidden="true"></i>
-    <a href="{{ meta.fix_url }}">{{ meta.fix_label }}</a>
-  </span>
+  <button class="locked-ghost-btn" data-locked-cta="{{ reason }}">
+    <i class="icon-lock" aria-hidden="true"></i><span class="locked-redacted" aria-hidden="true">••••••</span>
+  </button>
+{%- endmacro %}
+{% macro locked_popovers() -%}
+  {%- set _all = [
+    capabilities.REASON_EMAIL_UNVERIFIED,
+    capabilities.REASON_NETWORK_UNVERIFIED,
+    ] -%}
+  {%- for reason in _all -%}
+    {%- set meta = capabilities.reason_meta(reason) -%}
+    <div popover id="locked-cta-{{ reason }}" class="locked-cta">
+      <p>
+        <strong>{{ meta.title }}</strong>
+        <br>
+        <small>{{ meta.unlock }}</small>
+      </p>
+      <a href="{{ meta.fix_url }}" role="button" class="secondary">{{ meta.fix_label }}</a>
+    </div>
+  {%- endfor %}
 {%- endmacro %}

--- a/src/framework/templates/_shared/test_locked.py
+++ b/src/framework/templates/_shared/test_locked.py
@@ -1,18 +1,22 @@
 """Tests for the locked-affordance macros in ``_shared/_locked.html``.
 
-Three macros render the consistent "you can't do/see this yet" chrome
-driven by the closed ``capabilities.REASON_*`` vocab:
+Four trigger macros render "you can't do/see this yet" chrome driven by the
+closed ``capabilities.REASON_*`` vocab.  All four carry a
+``data-locked-cta="{reason}"`` attribute; the locked-affordance JS in
+``base.html`` uses that attribute to anchor and open the matching
+``<div popover>``.
 
-- ``locked_action`` — a *disabled, visible* control wrapped in a Pico
-  tooltip. The tooltip carries the unlock copy; the button is non-submittable.
-- ``locked_field`` — a lock icon + fix link in a tooltip wrapper, rendered
-  in place of a withheld data value (e.g. full address).
-- ``locked_name`` — a lock icon + placeholder name as a link in a tooltip
-  wrapper, rendered in place of a withheld identity name.
+- ``locked_action`` — aria-disabled button for write affordances.
+- ``locked_link``   — aria-disabled anchor for locked navigation links.
+- ``locked_name``   — ghost button replacing a withheld identity name.
+- ``locked_field``  — ghost button replacing a withheld data value.
+
+``locked_popovers()`` renders one ``<div popover>`` per known reason;
+this is tested to confirm IDs and fix-URL links wire up correctly.
 
 The real ``capabilities`` module is registered as the ``capabilities``
-Jinja global so the assertions exercise the actual copy wiring, exactly
-as a page render would.
+Jinja global so assertions exercise the actual copy wiring exactly as a
+page render would.
 """
 
 from __future__ import annotations
@@ -28,88 +32,221 @@ from src.domain.logic import capabilities
 
 def _make_env() -> Environment:
     stub = DictLoader({})
-    framework = FileSystemLoader(
-        str(Path(__file__).resolve().parents[1])
-    )  # src/framework/templates
+    framework = FileSystemLoader(str(Path(__file__).resolve().parents[1]))
     env = Environment(loader=ChoiceLoader([stub, framework]))
     env.globals["capabilities"] = capabilities
     return env
 
 
+def _render(snippet: str) -> str:
+    return _make_env().from_string(snippet).render()
+
+
 def _render_action(reason: str, label: str, **kwargs) -> str:
     kwarg_str = "".join(f", {k}={v!r}" for k, v in kwargs.items())
-    template = textwrap.dedent(f"""\
+    return _render(textwrap.dedent(f"""\
         {{%- from "_shared/_locked.html" import locked_action -%}}
         {{{{ locked_action(capabilities.{reason}, {label!r}{kwarg_str}) }}}}
-        """)
-    return _make_env().from_string(template).render()
+        """))
+
+
+def _render_link(reason: str, label: str) -> str:
+    return _render(textwrap.dedent(f"""\
+        {{%- from "_shared/_locked.html" import locked_link -%}}
+        {{{{ locked_link(capabilities.{reason}, {label!r}) }}}}
+        """))
 
 
 def _render_name(placeholder: str) -> str:
-    template = textwrap.dedent(f"""\
+    return _render(textwrap.dedent(f"""\
         {{%- from "_shared/_locked.html" import locked_name -%}}
         {{{{ locked_name({placeholder!r}) }}}}
-        """)
-    return _make_env().from_string(template).render()
+        """))
 
 
 def _render_field(reason: str) -> str:
-    template = textwrap.dedent(f"""\
+    return _render(textwrap.dedent(f"""\
         {{%- from "_shared/_locked.html" import locked_field -%}}
         {{{{ locked_field(capabilities.{reason}) }}}}
-        """)
-    return _make_env().from_string(template).render()
+        """))
 
 
-# ---------------------------------------------------------------------------
-# locked_action — disabled control in tooltip wrapper
-# ---------------------------------------------------------------------------
-
-
-def test_locked_action_renders_disabled_button_with_label() -> None:
-    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
-    button = HTMLParser(html).css_first("button")
-    assert button is not None, "expected a <button> for the gated action"
-    assert "disabled" in button.attributes, "gated action must be disabled"
-    assert button.text(strip=True) == "+ Post a referral"
-
-
-def test_locked_action_tooltip_carries_unlock_copy() -> None:
-    """Unlock copy is in the tooltip wrapper, not inline — so a refactor
-    can't silently drop it or hard-code copy that drifts from the single source."""
-    meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED)
-    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
-    assert meta.unlock in html, "unlock copy must appear in data-tooltip"
-    # Fix link is NOT inside locked_action — the tooltip is enough.
-    # (Users click the button's parent or navigate to capability page separately.)
-    button = HTMLParser(html).css_first("button[disabled]")
-    assert button is not None
-
-
-# ---------------------------------------------------------------------------
-# locked_field — placeholder for withheld data values
-# ---------------------------------------------------------------------------
-
-
-def test_locked_field_renders_fix_link_with_correct_href() -> None:
-    """The fix link points at the capability page so the viewer knows
-    exactly what unlocks the field."""
-    html = _render_field("REASON_NETWORK_UNVERIFIED")
-    link = HTMLParser(html).css_first(".locked-field a")
-    assert link is not None
-    assert link.attributes.get("href") == capabilities.fix_url_for(
-        capabilities.REASON_NETWORK_UNVERIFIED
+def _render_popovers() -> str:
+    return _render(
+        '{%- from "_shared/_locked.html" import locked_popovers -%}'
+        "{{ locked_popovers() }}"
     )
 
 
-def test_locked_field_tooltip_carries_unlock_copy() -> None:
-    """Unlock text appears in the tooltip attribute, not inline."""
-    meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED)
+# ---------------------------------------------------------------------------
+# locked_action
+# ---------------------------------------------------------------------------
+
+
+def test_locked_action_renders_button_with_label() -> None:
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None
+    assert "+ Post a referral" in button.text()
+
+
+def test_locked_action_is_aria_disabled_not_html_disabled() -> None:
+    """Uses aria-disabled so keyboard users can still focus and trigger the
+    popover — html disabled removes the element from tab order entirely."""
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None
+    assert button.attributes.get("aria-disabled") == "true"
+    assert "disabled" not in button.attributes
+
+
+def test_locked_action_carries_data_locked_cta() -> None:
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None
+    assert (
+        button.attributes.get("data-locked-cta")
+        == capabilities.REASON_NETWORK_UNVERIFIED
+    )
+
+
+def test_locked_action_always_has_lock_icon() -> None:
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None
+    assert button.css_first("i.icon-lock") is not None
+
+
+def test_locked_action_extra_class_appended_to_outline() -> None:
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "Email", extra_class="secondary")
+    button = HTMLParser(html).css_first("button")
+    assert button is not None
+    cls = button.attributes.get("class", "")
+    assert "outline" in cls
+    assert "secondary" in cls
+
+
+def test_locked_action_no_tooltip_wrapper() -> None:
+    """CTA is now a popover, not a data-tooltip — no wrapper span."""
+    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
+    assert "data-tooltip" not in html
+
+
+# ---------------------------------------------------------------------------
+# locked_link
+# ---------------------------------------------------------------------------
+
+
+def test_locked_link_renders_anchor_with_label() -> None:
+    html = _render_link("REASON_NETWORK_UNVERIFIED", "View full profile")
+    a = HTMLParser(html).css_first("a.locked-link")
+    assert a is not None
+    assert "View full profile" in a.text()
+
+
+def test_locked_link_is_aria_disabled() -> None:
+    html = _render_link("REASON_NETWORK_UNVERIFIED", "View full profile")
+    a = HTMLParser(html).css_first("a.locked-link")
+    assert a is not None
+    assert a.attributes.get("aria-disabled") == "true"
+
+
+def test_locked_link_carries_data_locked_cta() -> None:
+    html = _render_link("REASON_NETWORK_UNVERIFIED", "View full profile")
+    a = HTMLParser(html).css_first("a.locked-link")
+    assert a is not None
+    assert a.attributes.get("data-locked-cta") == capabilities.REASON_NETWORK_UNVERIFIED
+
+
+def test_locked_link_has_lock_icon() -> None:
+    html = _render_link("REASON_NETWORK_UNVERIFIED", "View full profile")
+    a = HTMLParser(html).css_first("a.locked-link")
+    assert a is not None
+    assert a.css_first("i.icon-lock") is not None
+
+
+def test_locked_link_has_no_href() -> None:
+    """No href — the popover is the action; navigating to '#' would be wrong."""
+    html = _render_link("REASON_NETWORK_UNVERIFIED", "View full profile")
+    a = HTMLParser(html).css_first("a.locked-link")
+    assert a is not None
+    assert "href" not in a.attributes
+
+
+# ---------------------------------------------------------------------------
+# locked_name
+# ---------------------------------------------------------------------------
+
+
+def test_locked_name_renders_ghost_button_with_placeholder() -> None:
+    html = _render_name("Dr. J. Doe")
+    btn = HTMLParser(html).css_first("button.locked-ghost-btn")
+    assert btn is not None
+    assert "Dr. J. Doe" in btn.text()
+
+
+def test_locked_name_data_locked_cta_is_network_unverified() -> None:
+    """Hardwired to REASON_NETWORK_UNVERIFIED — the caller doesn't choose."""
+    html = _render_name("Dr. J. Doe")
+    btn = HTMLParser(html).css_first("button.locked-ghost-btn")
+    assert btn is not None
+    assert (
+        btn.attributes.get("data-locked-cta") == capabilities.REASON_NETWORK_UNVERIFIED
+    )
+
+
+def test_locked_name_has_lock_icon() -> None:
+    html = _render_name("Dr. J. Doe")
+    btn = HTMLParser(html).css_first("button.locked-ghost-btn")
+    assert btn is not None
+    assert btn.css_first("i.icon-lock") is not None
+
+
+def test_locked_name_no_href_link() -> None:
+    """Name no longer renders a fix-URL link — the popover carries the CTA."""
+    html = _render_name("Dr. J. Doe")
+    assert HTMLParser(html).css_first("a") is None
+
+
+# ---------------------------------------------------------------------------
+# locked_field
+# ---------------------------------------------------------------------------
+
+
+def test_locked_field_renders_ghost_button() -> None:
     html = _render_field("REASON_NETWORK_UNVERIFIED")
-    assert meta.unlock in html
-    span = HTMLParser(html).css_first(".locked-field")
+    btn = HTMLParser(html).css_first("button.locked-ghost-btn")
+    assert btn is not None
+
+
+def test_locked_field_carries_data_locked_cta() -> None:
+    html = _render_field("REASON_NETWORK_UNVERIFIED")
+    btn = HTMLParser(html).css_first("button.locked-ghost-btn")
+    assert btn is not None
+    assert (
+        btn.attributes.get("data-locked-cta") == capabilities.REASON_NETWORK_UNVERIFIED
+    )
+
+
+def test_locked_field_has_lock_icon() -> None:
+    html = _render_field("REASON_NETWORK_UNVERIFIED")
+    btn = HTMLParser(html).css_first("button.locked-ghost-btn")
+    assert btn is not None
+    assert btn.css_first("i.icon-lock") is not None
+
+
+def test_locked_field_shows_redacted_placeholder() -> None:
+    """Renders the redacted-dots span, not the raw fix_label."""
+    html = _render_field("REASON_NETWORK_UNVERIFIED")
+    span = HTMLParser(html).css_first(".locked-redacted")
     assert span is not None
-    assert span.attributes.get("data-tooltip") == meta.unlock
+    assert "•" in span.text()
+
+
+def test_locked_field_no_href_link() -> None:
+    """Field no longer renders a fix-URL link — the popover carries the CTA."""
+    html = _render_field("REASON_NETWORK_UNVERIFIED")
+    assert HTMLParser(html).css_first("a") is None
 
 
 def test_locked_field_unknown_reason_falls_back_not_raises() -> None:
@@ -120,78 +257,48 @@ def test_locked_field_unknown_reason_falls_back_not_raises() -> None:
         '{{ locked_field("totally-not-a-reason") }}'
     )
     html = env.from_string(template).render()
-    link = HTMLParser(html).css_first(".locked-field a")
-    assert link is not None
-    assert link.attributes.get("href") == "/users/me"
-
-
-def test_locked_field_no_button_rendered() -> None:
-    """A field placeholder is read-only chrome — no interactive button."""
-    html = _render_field("REASON_NETWORK_UNVERIFIED")
-    assert HTMLParser(html).css_first("button") is None
+    btn = HTMLParser(html).css_first("button.locked-ghost-btn")
+    assert btn is not None
+    assert btn.attributes.get("data-locked-cta") == "totally-not-a-reason"
 
 
 # ---------------------------------------------------------------------------
-# locked_action — optional icon and extra_class params
+# locked_popovers
 # ---------------------------------------------------------------------------
 
 
-def test_locked_action_icon_prepended_when_provided() -> None:
-    """An icon class renders as a `<i>` before the label."""
-    html = _render_action("REASON_NETWORK_UNVERIFIED", "Email", icon="icon-lock")
-    button = HTMLParser(html).css_first("button")
-    assert button is not None
-    icon = button.css_first("i.icon-lock")
-    assert icon is not None, "icon element must be inside the button"
+def test_locked_popovers_renders_one_per_known_reason() -> None:
+    html = _render_popovers()
+    tree = HTMLParser(html)
+    for reason in (
+        capabilities.REASON_EMAIL_UNVERIFIED,
+        capabilities.REASON_NETWORK_UNVERIFIED,
+    ):
+        div = tree.css_first(f"#locked-cta-{reason}")
+        assert div is not None, f"missing popover for {reason}"
+        assert "popover" in div.attributes
 
 
-def test_locked_action_extra_class_appended_to_outline() -> None:
-    """extra_class appends to the default 'outline' class."""
-    html = _render_action("REASON_NETWORK_UNVERIFIED", "Email", extra_class="secondary")
-    button = HTMLParser(html).css_first("button")
-    assert button is not None
-    cls = button.attributes.get("class", "")
-    assert "outline" in cls
-    assert "secondary" in cls
+def test_locked_popovers_contain_fix_url_links() -> None:
+    html = _render_popovers()
+    tree = HTMLParser(html)
+    for reason in (
+        capabilities.REASON_EMAIL_UNVERIFIED,
+        capabilities.REASON_NETWORK_UNVERIFIED,
+    ):
+        meta = capabilities.reason_meta(reason)
+        div = tree.css_first(f"#locked-cta-{reason}")
+        assert div is not None
+        link = div.css_first("a")
+        assert link is not None
+        assert link.attributes.get("href") == meta.fix_url
 
 
-def test_locked_action_no_icon_by_default() -> None:
-    """Without icon= the button contains no <i> element."""
-    html = _render_action("REASON_NETWORK_UNVERIFIED", "+ Post a referral")
-    button = HTMLParser(html).css_first("button")
-    assert button is not None
-    assert button.css_first("i") is None
-
-
-# ---------------------------------------------------------------------------
-# locked_name — withheld identity placeholder
-# ---------------------------------------------------------------------------
-
-
-def test_locked_name_renders_placeholder_as_link() -> None:
-    """The placeholder text appears as a link so the viewer knows a real
-    name exists and can navigate to unlock it."""
-    html = _render_name("Dr. J. Doe")
-    link = HTMLParser(html).css_first(".locked-field a")
-    assert link is not None
-    assert link.text(strip=True) == "Dr. J. Doe"
-
-
-def test_locked_name_fix_url_comes_from_network_unverified_reason() -> None:
-    """The fix URL is derived from REASON_NETWORK_UNVERIFIED, not passed
-    by the caller — pins that the macro is self-contained."""
-    html = _render_name("Dr. J. Doe")
-    link = HTMLParser(html).css_first(".locked-field a")
-    assert link is not None
-    assert link.attributes.get("href") == capabilities.fix_url_for(
-        capabilities.REASON_NETWORK_UNVERIFIED
-    )
-
-
-def test_locked_name_tooltip_carries_network_unlock_copy() -> None:
-    """Unlock text from REASON_NETWORK_UNVERIFIED appears in the tooltip."""
-    meta = capabilities.reason_meta(capabilities.REASON_NETWORK_UNVERIFIED)
-    html = _render_name("Dr. J. Doe")
-    span = HTMLParser(html).css_first(".locked-field")
-    assert span is not None
-    assert span.attributes.get("data-tooltip") == meta.unlock
+def test_locked_popovers_contain_unlock_copy() -> None:
+    html = _render_popovers()
+    for reason in (
+        capabilities.REASON_EMAIL_UNVERIFIED,
+        capabilities.REASON_NETWORK_UNVERIFIED,
+    ):
+        meta = capabilities.reason_meta(reason)
+        assert meta.unlock in html

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -190,5 +190,33 @@
         <small>&copy; 2026 Bedlam Health &middot; <a href="mailto:support@bedlamhealth.com">support@bedlamhealth.com</a></small>
       {% endblock %}
     </footer>
+    {# Locked-affordance CTA popovers. One <div popover> per reason, rendered
+       once here so every page has them. The locked-affordance JS below
+       dynamically anchors the active popover to whichever trigger was clicked
+       via CSS anchor positioning (`position-anchor` inline style). #}
+    {%- from "_shared/_locked.html" import locked_popovers -%}
+    {{ locked_popovers() }}
+    {# Locked-affordance JS. Uses event delegation so it works for any
+       [data-locked-cta] element added by the locked_* macros. Per click:
+       1. Assigns a fresh CSS anchor-name to the trigger element.
+       2. Points the corresponding popover's position-anchor at that name.
+       3. Opens the popover (showPopover handles closing any other open one). #}
+    <script>
+    ;(function () {
+      var seq = 0
+      document.addEventListener('click', function (e) {
+        var trigger = e.target.closest('[data-locked-cta]')
+        if (!trigger) return
+        e.preventDefault()
+        var reason = trigger.dataset.lockedCta
+        var popover = document.getElementById('locked-cta-' + reason)
+        if (!popover) return
+        var anchorName = '--locked-' + (++seq)
+        trigger.style.anchorName = anchorName
+        popover.style.positionAnchor = anchorName
+        popover.showPopover()
+      })
+    }())
+    </script>
   </body>
 </html>

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -46,6 +46,7 @@ def _make_env() -> Environment:
         loader=ChoiceLoader([stub_loader, framework_loader]),
         autoescape=select_autoescape(["html", "xml"]),
     )
+    from src.domain.logic import capabilities
     from src.framework.rendering.labels import (
         entity_create_label,
         entity_filter_label,
@@ -56,6 +57,7 @@ def _make_env() -> Environment:
     env.globals["entity_form_url"] = entity_form_url
     env.globals["entity_create_label"] = entity_create_label
     env.globals["entity_filter_label"] = entity_filter_label
+    env.globals["capabilities"] = capabilities
     return env
 
 
@@ -180,12 +182,11 @@ _BANNER_CTX: dict[str, object] = dict(
 
 
 def test_body_top_level_children_are_header_main_footer_only() -> None:
-    """The body scaffold emits exactly three top-level elements —
-    `<header>`, `<main>`, `<footer>`, the three rows of the body grid — and
-    nothing else. Pinned with the incomplete-profile banner SHOWING, which
-    is the case that would regress: the banner must be a child of `<main>`,
-    never a fourth top-level `<aside>` band. Checked across both generic
-    view types since every full page composes one of them via `base.html`."""
+    """The body scaffold emits `<header>`, `<main>`, `<footer>` as the three
+    layout rows (the body grid), followed by locked-CTA `<div popover>`
+    elements and an init `<script>` from `base.html`.  The banner must be a
+    child of `<main>`, never a fourth top-level band.  The locked-CTA popovers
+    and JS script are utility chrome intentionally placed after `<footer>`."""
     env = _make_env()
     _add_child(env, "liststub.html", _LIST_STUB)
     _add_child(env, "detailstub.html", _DETAIL_STUB)
@@ -194,7 +195,14 @@ def test_body_top_level_children_are_header_main_footer_only() -> None:
         # Banner temporarily disabled — assert absent and structure still holds.
         assert tree.css_first("#onboarding-banner") is None, name
         top_level = [n.tag for n in tree.css("body > *")]
-        assert top_level == ["header", "main", "footer"], f"{name}: {top_level}"
+        # Layout rows must be the first three children and in order.
+        assert top_level[:3] == ["header", "main", "footer"], f"{name}: {top_level}"
+        # Remaining children are only locked-CTA popovers and the init script.
+        assert all(
+            t in ("div", "script") for t in top_level[3:]
+        ), f"{name}: unexpected body tail elements: {top_level[3:]}"
+        for div in tree.css("body > div"):
+            assert "popover" in div.attributes, f"{name}: non-popover div in body"
 
 
 def test_onboarding_banner_is_first_child_of_main() -> None:

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -45,6 +45,7 @@ def _make_env() -> Environment:
     # Jinja globals registered in production by
     # `src.framework.rendering.templating`. Mirror them here so the
     # chrome renders without needing a full app boot.
+    from src.domain.logic import capabilities
     from src.framework.rendering.labels import (
         entity_create_label,
         entity_filter_label,
@@ -55,6 +56,7 @@ def _make_env() -> Environment:
     env.globals["entity_form_url"] = entity_form_url
     env.globals["entity_create_label"] = entity_create_label
     env.globals["entity_filter_label"] = entity_filter_label
+    env.globals["capabilities"] = capabilities
     return env
 
 

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -76,22 +76,23 @@ async def test_home_page_no_post_actions_for_no_claim_user(
     assert tree.css_first("#finish-setup-card") is None
     # My posts section always renders
     assert "My posts" in response.text
-    # Empty-state CTA is a disabled button, not a live link
+    # Empty-state CTA is a locked_action button (aria-disabled, not disabled),
+    # not a live link
     assert "No posts yet." in response.text
-    assert tree.css_first("button[disabled]") is not None
+    assert tree.css_first('button[aria-disabled="true"]') is not None
     assert tree.css_first('a[href="/posts/form"]') is None
 
 
 async def test_home_page_empty_my_posts_shows_locked_cta_when_unverified(
     authenticated_client: AsyncClient,
 ):
-    """An unverified user with no posts sees a disabled Create a post button
-    (locked_action pattern) rather than a live link."""
+    """An unverified user with no posts sees a locked_action Create a post button
+    (aria-disabled, clickable for popover) rather than a live link."""
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert "No posts yet." in response.text
-    btn = tree.css_first("button[disabled]")
+    btn = tree.css_first('button[aria-disabled="true"]')
     assert btn is not None
     assert "Create a post" in btn.text()
 
@@ -116,7 +117,7 @@ async def test_home_page_empty_my_posts_shows_active_cta_when_verified(
     tree = HTMLParser(response.text)
     assert "No posts yet." in response.text
     assert tree.css_first('a[href="/posts/form"]') is not None
-    assert tree.css_first("button[disabled]") is None
+    assert tree.css_first('button[aria-disabled="true"]') is None
 
 
 async def test_home_page_no_blur_element(authenticated_client: AsyncClient):


### PR DESCRIPTION
## Summary

- Replaces Pico `data-tooltip` wrappers with native `<div popover>` CTA cards anchored via CSS anchor positioning. Clicking any locked element opens a card near the trigger; `position-try-fallbacks` handles viewport edges automatically — no JS needed for placement once the anchor name is set.
- Adds four well-categorized trigger macros: `locked_action` (disabled-looking button), `locked_link` (disabled-looking nav link, new), `locked_name` (inline ghost button for withheld identity), `locked_field` (inline ghost button with redacted `••••••` dots for withheld data).
- 12-line event-delegation script in `base.html` assigns a fresh `--locked-N` CSS anchor-name to the clicked trigger and points the popover's `position-anchor` at it before calling `showPopover()`.
- CTA popovers rendered globally once in `base.html` via `locked_popovers()` — no per-page wiring needed.
- CSS is mostly Pico-inherited (`<p>`, `<small>`, `<strong>`, `<a role="button">`); only anchor positioning and ghost-button reset are custom. All spacing uses Pico tokens.
- Dev component gallery gains a "Locked affordances" section covering all four variants with specimen labels.

## Test plan

- [ ] All 2363 tests pass (`dev test`)
- [ ] Visit `/dev/components#locked-affordances` — confirm all four variants render and clicking each opens the popover anchored near the element
- [ ] Visit `/posts` as unverified user — confirm "Create post" button looks disabled, clicking opens network-unverified CTA card
- [ ] Visit a post detail as unverified user — confirm identity rows show ghost-button placeholders, address shows redacted dots; clicking opens the card
- [ ] Resize viewport so a locked element is near an edge — confirm `position-try-fallbacks` flips the card to stay on-screen
- [ ] Test on mobile (touch) — confirm popover opens on tap (no hover dependency)
- [ ] Keyboard: tab to a locked button, press Enter — confirm popover opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)