### PR TITLE
Add git town set-parent main to dev worktree add

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -763,6 +763,19 @@ class WorktreeCommands:
         root_env = self.runner.project_root / ".env"
         if root_env.exists():
             shutil.copy(root_env, path / ".env")
+        # Register the parent branch so `git town sync` works non-interactively.
+        town_result = subprocess.run(
+            ["git", "town", "set-parent", "main"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if town_result.returncode != 0:
+            print(
+                "⚠️  git town set-parent main failed (git-town not installed?). "
+                "Run it manually so `git town sync` works."
+            )
         print(f"✅ Worktree ready: {path}")
         print(f"   Branch: {branch}")
         print(f"   App port: {app_port}  →  http://localhost:{app_port}")

--- a/scripts/test_dev_cli_worktree.py
+++ b/scripts/test_dev_cli_worktree.py
@@ -8,9 +8,12 @@ contract we care about — there's nothing useful to mock here.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 from typing import List, Optional
+
+import pytest
 
 from scripts.dev_cli import WorktreeCommands
 
@@ -171,3 +174,23 @@ def test_gc_never_removes_the_main_checkout(tmp_path: Path) -> None:
     assert rc == 0
     assert (repo / ".git").exists()
     assert (repo / "pyproject.toml").exists()
+
+
+@pytest.mark.skipif(
+    shutil.which("git-town") is None,
+    reason="git-town not installed",
+)
+def test_add_sets_git_town_parent(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    # Give git-town the minimum config it needs to run non-interactively.
+    _git(repo, "config", "git-town.main-branch", "main")
+    cmd = WorktreeCommands(_FakeRunner(repo))
+    assert cmd.add("707", base="origin/main") == 0
+    result = subprocess.run(
+        ["git", "config", "git-town-branch.fix/707.parent"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.stdout.strip() == "main"


### PR DESCRIPTION
## Summary

- `dev worktree add` now runs `git town set-parent main` in the new worktree after creation
- This registers the parent branch in git-town's config so `git town sync` works non-interactively (no terminal prompt)
- If git-town isn't installed, a warning is printed but the command still succeeds
- New test `test_add_sets_git_town_parent` verifies the config is set (skipped when git-town is absent)

Closes #1230

## Test plan

- [x] `dev test scripts/test_dev_cli_worktree.py` — all 12 tests pass including the new one
- [x] `dev lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)