### PR TITLE
Fix nginx www.www double-prefix in deploy.sh

### DIFF
--- a/deployment/droplet-files/deploy.sh
+++ b/deployment/droplet-files/deploy.sh
@@ -56,8 +56,10 @@ cleanup_containers() {
     fi
 }
 
-# Derive the nginx site config name from APP_BASE_URL, falling back to bedlamconnect.com.
-APP_DOMAIN="$(echo "${APP_BASE_URL:-https://bedlamconnect.com}" | sed 's|https\?://||' | sed 's|/.*||')"
+# Derive the bare domain (no www.) from APP_BASE_URL for nginx server_name/cert paths.
+# The template adds www.${APP_DOMAIN} itself, so strip any www. prefix here to avoid
+# producing "www.www.bedlamconnect.com" when APP_BASE_URL includes www.
+APP_DOMAIN="$(echo "${APP_BASE_URL:-https://bedlamconnect.com}" | sed 's|https\?://||' | sed 's|/.*||' | sed 's|^www\.||')"
 
 # Function to update nginx upstream
 update_nginx_upstream() {


### PR DESCRIPTION
## Summary
- When `APP_BASE_URL` is set to `https://www.bedlamconnect.com`, `deploy.sh` extracted `www.bedlamconnect.com` as `APP_DOMAIN`
- The nginx template adds `www.${APP_DOMAIN}` itself, so `server_name` became `www.bedlamconnect.com www.www.bedlamconnect.com`
- One extra `sed 's|^www\.||'` strips any `www.` prefix after extraction — now works regardless of whether the secret includes `www.`

## Test plan
- [ ] Deploy to prod and confirm nginx `server_name` reads `bedlamconnect.com www.bedlamconnect.com`
- [ ] Confirm SSL cert resolves at `/etc/letsencrypt/live/bedlamconnect.com/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)