### PR TITLE
Always show 'Recent in the network' section with empty state

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -41,6 +41,18 @@ async def test_new_user_sees_no_finish_setup_card_on_home(
     assert tree.css_first("#onboarding-banner") is None
 
 
+async def test_home_shows_network_section_with_empty_state_when_no_recent_posts(
+    authenticated_client: AsyncClient,
+):
+    """The 'Recent in the network' section is always rendered, even when no
+    posts exist in the last 7 days — the header and an empty-state message
+    appear instead of the section being hidden."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    assert "Recent in the network" in response.text
+    assert "No activity in the last 7 days." in response.text
+
+
 async def test_home_shows_empty_my_posts_section_when_no_active_posts(
     authenticated_client: AsyncClient,
     db_test_session_manager,

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -44,14 +44,14 @@
         {% endif %}
       {% endif %}
     </section>
-    {% if network_posts %}
-      <section>
-        <header style="display: flex;
-                       justify-content: space-between;
-                       align-items: baseline">
-          <h2>Recent in the network</h2>
-          <a href="{{ entity_url('post') }}">See all</a>
-        </header>
+    <section>
+      <header style="display: flex;
+                     justify-content: space-between;
+                     align-items: baseline">
+        <h2>Recent in the network</h2>
+        <a href="{{ entity_url('post') }}">See all</a>
+      </header>
+      {% if network_posts %}
         <p style="font-size: 0.875rem;
                   color: var(--pico-muted-color);
                   margin-bottom: 1rem">
@@ -67,6 +67,8 @@
            explains verification unlocks the full view — no per-feed
            notice repeats it. #}
         {{ item_list(network_posts, post_feed_row, "network-posts-list", "post-feed-list") }}
-      </section>
-    {% endif %}
+      {% else %}
+        <p style="color: var(--pico-muted-color)">No activity in the last 7 days.</p>
+      {% endif %}
+    </section>
   {% endblock %}


### PR DESCRIPTION
## Summary
- The section was previously hidden entirely when no posts existed in the last 7 days, leaving users (including unverified ones) with a blank page
- Now the header and a "No activity in the last 7 days." message always render
- New test pins the empty-state behavior

## Test plan
- [ ] Load `/home` with no recent posts from other users — confirm "Recent in the network" header and empty-state message appear
- [ ] Load `/home` with recent network posts — confirm list renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)