### PR TITLE
Remove inline styles from templates

### DIFF
--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -292,3 +292,8 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 /* ── Capability requirements panel (users/access/capabilities/detail.html) ── */
 .cap-reqs { list-style: none; margin: 0; padding: 0; }
 .cap-reqs li { list-style: none; }
+
+/* ── Home page (home.html) ─────────────────────────────────────── */
+.home-section-header { display: flex; justify-content: space-between; align-items: baseline; }
+.home-empty-msg { color: var(--pico-muted-color); }
+.home-network-blurb { font-size: 0.875rem; color: var(--pico-muted-color); margin-bottom: 1rem; }

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -102,6 +102,10 @@ it's dev-only chrome that should never ship to production. #}
     margin-top: var(--pico-spacing);
     margin-bottom: calc(var(--pico-spacing) * 0.25);
   }
+  .gallery-h3-lg { margin-top: 1.5rem; }
+  .gallery-h3 { margin-top: 1rem; }
+  .gallery-form-preview { max-width: var(--form-max-width); }
+  .gallery-panel-preview { max-width: 420px; }
   </style>
 {% endblock %}
 {% block toolbar %}
@@ -342,7 +346,7 @@ it's dev-only chrome that should never ship to production. #}
         {% endmacro %}
         <h3>With items + pagination</h3>
         {{ item_list(fixture_item_list_items, gallery_item_row, "gallery-item-list", pager=fixture_pager) }}
-        <h3 style="margin-top:1.5rem">
+        <h3 class="gallery-h3-lg">
           Empty state (<code>empty_msg</code>)
         </h3>
         {{ item_list([], gallery_item_row, "gallery-item-list-empty", empty_msg="No items found.") }}
@@ -361,7 +365,7 @@ it's dev-only chrome that should never ship to production. #}
             <a href="{{ entity_form_url('clinician') }}" role="button">Create clinician</a>
           </li>
         {% endcall %}
-        <h3 style="margin-top:1rem">Detail toolbar (heading + edit)</h3>
+        <h3 class="gallery-h3">Detail toolbar (heading + edit)</h3>
         {% call page_toolbar(heading="Dr. Jane Smith") %}
           <li>
             <a href="{{ entity_form_url('clinician', id=1) }}"
@@ -448,7 +452,7 @@ it's dev-only chrome that should never ship to production. #}
             {{ textarea_field("notes", "Notes", current="Sample notes text.", required=False, help="Any additional context.") }}
           </form>
         </div>
-        <h3 style="margin-top:1.5rem">Error state</h3>
+        <h3 class="gallery-h3-lg">Error state</h3>
         <div class="entity-form-page">
           <form>
             {{ text_field("email", "Email", current="not-an-email", error="Enter a valid email address.", invalid=True) }}
@@ -468,11 +472,11 @@ it's dev-only chrome that should never ship to production. #}
           <small>Rendered via <code>_shared/actions.html</code> → <code>actions()</code>. <code>wrapper="form"</code> for create/edit; <code>wrapper="toolbar"</code> for detail pages.</small>
         </p>
         <h3>Form mode (save + cancel + delete)</h3>
-        <div style="max-width:var(--form-max-width)">
+        <div class="gallery-form-preview">
           {{ actions("Save changes", cancel_url="/example", delete_url="/example/1", delete_confirm="Delete this item?") }}
         </div>
-        <h3 style="margin-top:1rem">Form mode (save + cancel only)</h3>
-        <div style="max-width:var(--form-max-width)">
+        <h3 class="gallery-h3">Form mode (save + cancel only)</h3>
+        <div class="gallery-form-preview">
           {{ actions("Create clinician", cancel_url=entity_url('clinician') ) }}
         </div>
       </section>
@@ -749,7 +753,7 @@ it's dev-only chrome that should never ship to production. #}
               }
             ]
           } %}
-          <div style="max-width:420px">{{ capability_requirements_panel(locked_tree, false) }}</div>
+          <div class="gallery-panel-preview">{{ capability_requirements_panel(locked_tree, false) }}</div>
           {# Unlocked: 2 of 2 met — email + clinician identity both done. #}
           {% set unlocked_tree = {
             "label_active": "Read full feed",
@@ -785,7 +789,7 @@ it's dev-only chrome that should never ship to production. #}
               }
             ]
           } %}
-          <div style="max-width:420px">{{ capability_requirements_panel(unlocked_tree, true) }}</div>
+          <div class="gallery-panel-preview">{{ capability_requirements_panel(unlocked_tree, true) }}</div>
         </div>
       </section>
     </div>

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -476,9 +476,7 @@ it's dev-only chrome that should never ship to production. #}
           {{ actions("Save changes", cancel_url="/example", delete_url="/example/1", delete_confirm="Delete this item?") }}
         </div>
         <h3 class="gallery-h3">Form mode (save + cancel only)</h3>
-        <div class="gallery-form-preview">
-          {{ actions("Create clinician", cancel_url=entity_url('clinician') ) }}
-        </div>
+        <div class="gallery-form-preview">{{ actions("Create clinician", cancel_url=entity_url('clinician') ) }}</div>
       </section>
       {# ═══════════════════════════════════════════════════════════ #}
       {# DOMAIN: POSTS                                                #}

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -27,16 +27,14 @@
   {% endblock %}
   {% block content %}
     <section>
-      <header style="display: flex;
-                     justify-content: space-between;
-                     align-items: baseline">
+      <header class="home-section-header">
         <h2>My posts</h2>
         {% if can_access_network %}<a href="{{ entity_url('post') }}">See all</a>{% endif %}
       </header>
       {% if my_posts %}
         {{ item_list(my_posts, _no_poster_row, "my-posts-list", "post-feed-list") }}
       {% else %}
-        <p style="color: var(--pico-muted-color)">No posts yet.</p>
+        <p class="home-empty-msg">No posts yet.</p>
         {% if can_access_network %}
           <a href="{{ entity_form_url('post') }}" role="button" class="outline">Create a post</a>
         {% else %}
@@ -45,16 +43,12 @@
       {% endif %}
     </section>
     <section>
-      <header style="display: flex;
-                     justify-content: space-between;
-                     align-items: baseline">
+      <header class="home-section-header">
         <h2>Recent in the network</h2>
         <a href="{{ entity_url('post') }}">See all</a>
       </header>
       {% if network_posts %}
-        <p style="font-size: 0.875rem;
-                  color: var(--pico-muted-color);
-                  margin-bottom: 1rem">
+        <p class="home-network-blurb">
           {# djlint:off #}
         Last 7 days, filtered to your saved searches and practice profile
         {%- if network_filter_chips %} — {{ network_filter_chips | join(" · ") }}{% endif %}.
@@ -68,7 +62,7 @@
            notice repeats it. #}
         {{ item_list(network_posts, post_feed_row, "network-posts-list", "post-feed-list") }}
       {% else %}
-        <p style="color: var(--pico-muted-color)">No activity in the last 7 days.</p>
+        <p class="home-empty-msg">No activity in the last 7 days.</p>
       {% endif %}
     </section>
   {% endblock %}


### PR DESCRIPTION
## Summary

- Moves all `style=` attributes out of `home.html` and `dev/components.html` into named CSS classes
- Adds `.home-section-header`, `.home-empty-msg`, `.home-network-blurb` to `domain.css`
- Adds `.gallery-h3-lg`, `.gallery-h3`, `.gallery-form-preview`, `.gallery-panel-preview` to the gallery's inline `<style>` block in `components.html`
- Email templates (`verify.html`, `reset_password.html`) are exempt — mail clients require inline styles

## Test plan

- [ ] Home page renders correctly: section headers flex-spaced, empty state muted, network blurb styled
- [ ] Dev component gallery renders correctly at `/dev/components`
- [ ] `dev lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)