### PR TITLE
Remove org type-picker — go straight to the create form

### DIFF
--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -296,48 +296,6 @@ async def test_get_organizations_form_resolves(
     assert response.status_code == 200
 
 
-# --- Type picker (issue #704) -------------------------------------------
-
-
-async def test_get_organizations_form_no_type_shows_picker(
-    authenticated_client: AsyncClient,
-    logged_in_user: User,
-):
-    """``GET /organizations/form`` (no ``?type=``) shows the type-picker,
-    not the create form.  Each card links to ``?type=<value>``."""
-    response = await authenticated_client.get("/organizations/form")
-    assert response.status_code == 200
-    tree = HTMLParser(response.text)
-    # Picker links: one per org type.
-    hrefs = {a.attributes.get("href") for a in tree.css("a[href*='?type=']")}
-    assert "/organizations/form?type=solo_practice" in hrefs
-    assert "/organizations/form?type=group_practice" in hrefs
-    assert "/organizations/form?type=clinic" in hrefs
-    assert "/organizations/form?type=health_system" in hrefs
-    assert "/organizations/form?type=other" in hrefs
-    # No org create form — the picker should not render it.
-    assert tree.css_first('form[hx-post="/organizations"]') is None
-
-
-async def test_get_organizations_form_with_type_shows_form(
-    authenticated_client: AsyncClient,
-    logged_in_user: User,
-):
-    """``GET /organizations/form?type=solo_practice`` skips the picker and
-    renders the create form with the Type field pre-selected."""
-    response = await authenticated_client.get("/organizations/form?type=solo_practice")
-    assert response.status_code == 200
-    tree = HTMLParser(response.text)
-    # Form is rendered.
-    assert tree.css_first("form") is not None
-    # Type dropdown pre-selects solo_practice.
-    selected = tree.css_first('select[name="type"] option[selected]')
-    assert selected is not None
-    assert selected.attributes.get("value") == "solo_practice"
-    # Parent-org picker present.
-    assert tree.css_first('select[name="parent_org_id"]') is not None
-
-
 # --- Parent-Org picker (issue #581) --------------------------------------
 
 
@@ -363,8 +321,6 @@ async def test_form_new_renders_parent_org_select_with_root_option(
     name="parent_org_id">`` with a "(no parent)" default option plus
     one ``<option>`` per Org visible to the requesting user.
 
-    ``?type=solo_practice`` is required to bypass the type-picker and
-    render the create form (issue #704).
     """
     mine_a = await _seed_org(
         db_test_session_manager, owner_id=logged_in_user.id, name="Mine A"
@@ -373,7 +329,7 @@ async def test_form_new_renders_parent_org_select_with_root_option(
         db_test_session_manager, owner_id=logged_in_user.id, name="Mine B"
     )
 
-    response = await authenticated_client.get("/organizations/form?type=solo_practice")
+    response = await authenticated_client.get("/organizations/form")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     select = tree.css_first('select[name="parent_org_id"]')
@@ -400,8 +356,6 @@ async def test_form_new_scopes_to_owned_orgs(
 ):
     """Non-superusers see only Orgs they own in the picker — same scope
     as the Clinician/Program form pickers (see ``_orgs_visible_to``).
-
-    ``?type=solo_practice`` bypasses the type-picker (issue #704).
     """
     mine = await _seed_org(
         db_test_session_manager, owner_id=logged_in_user.id, name="Mine"
@@ -414,7 +368,7 @@ async def test_form_new_scopes_to_owned_orgs(
         db_test_session_manager, owner_id=other.id, name="Other's"
     )
 
-    response = await authenticated_client.get("/organizations/form?type=solo_practice")
+    response = await authenticated_client.get("/organizations/form")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     values = {

--- a/src/domain/templates/organizations/_form_new_fragment.html
+++ b/src/domain/templates/organizations/_form_new_fragment.html
@@ -3,9 +3,7 @@
 
    Rendered in two contexts:
 
-   1. Included by `organizations/form_new.html` when the user has
-      passed `?type=<value>` (the type-picker has been resolved to a
-      specific organization type and the form should appear).
+   1. Included by `organizations/form_new.html`.
    2. Standalone by `mount_create._render_form_with_errors` on a
       validation-failure re-render. The path-derivation convention
       (`<dir>/_<name>_fragment.html`) requires this file's name.

--- a/src/domain/templates/organizations/form_new.html
+++ b/src/domain/templates/organizations/form_new.html
@@ -1,12 +1,4 @@
-{# Create-organization entry point.
-
-When no `?type=` query param is present the user sees a type-picker — one
-card per organization type, each linking to the same URL with `?type=<value>`
-appended.  Clicking a card (or following a deep link with `?type=` already
-set) skips the picker and renders the full create form with that type
-pre-selected in the Type dropdown.
-
-This mirrors the `/posts/form` picker pattern (issue #704).
+{# Create-organization page.
 
 The actual form lives in `_form_new_fragment.html` so the framework's
 error-rerender path (`mount_create._render_form_with_errors`) can
@@ -15,33 +7,7 @@ the path-derivation convention (`<dir>/_<name>_fragment.html`) requires
 a sibling file with that exact name. The full page below includes it.
 #}
 {% extends "views/form_new.html" %}
-{%- from "_shared/_picker.html" import picker -%}
 {% block resource_label %}Organizations{% endblock %}
 {% block form_content %}
-  {%- set selected_type = request.query_params.get('type', '') -%}
-  {% if not selected_type %}
-    {# Type picker: shown when no ?type= param is present.  Each card links
-   to the same URL with ?type=<value> so the form renders with the Type
-   field pre-filled.  Deep links (?type=solo_practice) skip the picker
-   and land directly on the form. #}
-    {{ picker([
-        {"href": entity_form_url('organization') + "?type=solo_practice",
-    "heading": "Solo practice",
-    "description": "Just you — a single clinician running their own practice."},
-    {"href": entity_form_url('organization') + "?type=group_practice",
-    "heading": "Group practice",
-    "description": "Multiple clinicians under one roof or brand."},
-    {"href": entity_form_url('organization') + "?type=clinic",
-    "heading": "Clinic, IOP, or inpatient program",
-    "description": "A facility offering structured or intensive programming."},
-    {"href": entity_form_url('organization') + "?type=health_system",
-    "heading": "Health system",
-    "description": "A network of clinics or hospitals."},
-    {"href": entity_form_url('organization') + "?type=other",
-    "heading": "Other",
-    "description": "Doesn't fit the above."},
-    ]) }}
-  {% else %}
-    {% include "organizations/_form_new_fragment.html" %}
-  {% endif %}
+  {% include "organizations/_form_new_fragment.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- Drops the intermediate type-picker step at `/organizations/form`; the URL now renders the create form directly
- The Type dropdown on the form already covers the selection — the picker was redundant
- Removes two picker-specific tests; strips the `?type=solo_practice` bypass comment from two parent-org picker tests (no longer needed)

## Test plan

- [ ] `GET /organizations/form` renders the create form (name, type dropdown, NPI, parent org)
- [ ] Type dropdown still accepts all valid org types
- [ ] Validation errors still re-render the form fragment with errors inline
- [ ] `dev test src/domain/routes/test_organizations.py` passes (19 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)