### PR TITLE
Tighten provider-network capability requirement copy

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -216,24 +216,24 @@ def check_network(user: Any) -> CapabilityCheck:
             label_done="Provider network",
             children=(
                 Condition(
-                    label_active="Verify email",
+                    label_active="Verify your email",
                     label_done="Email verified",
                     met=_email_met,
                     fix_url="/users/me/email/form",
                 ),
                 Gate(
-                    label_active="Verify your status",
-                    label_done="Status verified",
+                    label_active="Verify a clinician or organization",
+                    label_done="Clinician or organization verified",
                     children=(
                         Condition(
-                            label_active="Verify clinician identity",
-                            label_done="Clinician identity verified",
+                            label_active="Verify a clinician",
+                            label_done="Clinician verified",
                             met=_clin_met,
                             fix_url="/clinicians/form",
                         ),
                         Condition(
-                            label_active="Verify organization rep",
-                            label_done="Organization rep verified",
+                            label_active="Verify your organization",
+                            label_done="Organization verified",
                             met=_org_met,
                             fix_url="/organizations/form",
                         ),

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -584,7 +584,7 @@ def test_check_network_clinician_verified_granted():
     assert check.granted is True
     gate = check.tree.children[1]
     clin_condition = gate.children[0]
-    assert clin_condition.label_done == "Clinician identity verified"
+    assert clin_condition.label_done == "Clinician verified"
     assert clin_condition.met is True
 
 
@@ -599,7 +599,7 @@ def test_check_network_org_rep_granted():
     assert check.granted is True
     gate = check.tree.children[1]
     org_condition = gate.children[1]
-    assert org_condition.label_done == "Organization rep verified"
+    assert org_condition.label_done == "Organization verified"
     assert org_condition.met is True
 
 

--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -71,14 +71,13 @@ async def test_capability_detail_network_returns_200(
     # Capability label_active appears in the page heading and breadcrumb.
     assert "Provider network" in response.text
     # Tree node labels appear — active form for unmet, done form for met.
-    assert "Verify email" in response.text or "Email verified" in response.text
+    assert "Verify your email" in response.text or "Email verified" in response.text
     assert (
-        "Verify clinician identity" in response.text
-        or "Clinician identity verified" in response.text
+        "Verify a clinician" in response.text or "Clinician verified" in response.text
     )
     assert (
-        "Verify organization rep" in response.text
-        or "Organization rep verified" in response.text
+        "Verify your organization" in response.text
+        or "Organization verified" in response.text
     )
 
 

--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -724,26 +724,26 @@ it's dev-only chrome that should never ship to production. #}
             "met": false,
             "children": [
               {
-                "label_active": "Verify email",
+                "label_active": "Verify your email",
                 "label_done": "Email verified",
                 "met": true,
                 "fix_url": "#"
               },
               {
-                "label_active": "Verify your status",
-                "label_done": "Status verified",
+                "label_active": "Verify a clinician or organization",
+                "label_done": "Clinician or organization verified",
                 "op": "any",
                 "met": false,
                 "children": [
                   {
-                    "label_active": "Verify clinician identity",
-                    "label_done": "Clinician identity verified",
+                    "label_active": "Verify a clinician",
+                    "label_done": "Clinician verified",
                     "met": false,
                     "fix_url": "#"
                   },
                   {
-                    "label_active": "Verify organization rep",
-                    "label_done": "Organization rep verified",
+                    "label_active": "Verify your organization",
+                    "label_done": "Organization verified",
                     "met": false,
                     "fix_url": "#"
                   }
@@ -760,26 +760,26 @@ it's dev-only chrome that should never ship to production. #}
             "met": true,
             "children": [
               {
-                "label_active": "Verify email",
+                "label_active": "Verify your email",
                 "label_done": "Email verified",
                 "met": true,
                 "fix_url": "#"
               },
               {
-                "label_active": "Verify your status",
-                "label_done": "Status verified",
+                "label_active": "Verify a clinician or organization",
+                "label_done": "Clinician or organization verified",
                 "op": "any",
                 "met": true,
                 "children": [
                   {
-                    "label_active": "Verify clinician identity",
-                    "label_done": "Clinician identity verified",
+                    "label_active": "Verify a clinician",
+                    "label_done": "Clinician verified",
                     "met": true,
                     "fix_url": "#"
                   },
                   {
-                    "label_active": "Verify organization rep",
-                    "label_done": "Organization rep verified",
+                    "label_active": "Verify your organization",
+                    "label_done": "Organization verified",
                     "met": false,
                     "fix_url": "#"
                   }


### PR DESCRIPTION
## Summary
- Replace jargon (\"status\", \"identity\", \"rep\") in the `provider-network` capability tree with concrete, user-facing verbs that mirror the email leaf's `Verify your email` / `Email verified` grammar.
- New labels at `/users/me/access/capabilities/provider-network`:
  - Email: `Verify your email` / `Email verified`
  - Gate: `Verify a clinician or organization` / `Clinician or organization verified`
  - Clinician leaf: `Verify a clinician` / `Clinician verified`
  - Org leaf: `Verify your organization` / `Organization verified`
- Matching updates in `test_capabilities.py`, `test_access.py`, and the styleguide demo at `templates/dev/components.html`.

## Test plan
- [x] `pytest src/domain/logic/test_capabilities.py src/domain/routes/test_access.py src/framework/access/capabilities/test_capabilities.py` (85 passed)
- [x] Full `pytest` (2395 passed, 101 skipped)
- [x] `dev lint` clean
- [ ] Manual: visit `/users/me/access/capabilities/provider-network` and confirm the new strings render

🤖 Generated with [Claude Code](https://claude.com/claude-code)