### PR TITLE
Replace multi_select_field <select multiple> with scrollable checkbox list

### DIFF
--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -1456,9 +1456,8 @@ async def test_get_clinician_form_renders(
     )
     assert tree.css_first('input[type="checkbox"][name="sliding_scale"]') is not None
     assert tree.css_first('input[name="cost"]') is not None
-    carrier_select = tree.css_first('select[name="in_network_carriers"][multiple]')
-    assert carrier_select is not None
-    assert len(carrier_select.css("option")) == 11
+    carrier_boxes = tree.css('input[type="checkbox"][name="in_network_carriers"]')
+    assert len(carrier_boxes) == 11
 
 
 async def test_get_clinician_form_scopes_org_dropdown_to_user(

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -389,9 +389,11 @@ async def test_clinician_opening_create_form_error_render_is_wired(
     )
     assert response.status_code == 422, response.text
     assert response.headers["content-type"].startswith("text/html")
-    assert 'name="age_groups"' in response.text
-    age_block_start = response.text.index('name="age_groups"')
-    age_block = response.text[max(0, age_block_start - 200) : age_block_start + 200]
+    # `multi_select_field` renders a `<div role="group" id="age_groups">`
+    # wrapper; the aria-invalid lives on the group, not on each checkbox.
+    assert 'id="age_groups"' in response.text
+    group_start = response.text.index('id="age_groups"')
+    age_block = response.text[max(0, group_start - 200) : group_start + 200]
     assert 'aria-invalid="true"' in age_block, age_block
     # Fragment-only response: the re-render returns just the `<form>`,
     # not the full `new_clinician_opening.html` page (which extends
@@ -422,9 +424,11 @@ async def test_referral_create_form_error_render_is_wired(
     )
     assert response.status_code == 422, response.text
     assert response.headers["content-type"].startswith("text/html")
-    assert 'name="age_groups"' in response.text
-    age_block_start = response.text.index('name="age_groups"')
-    age_block = response.text[max(0, age_block_start - 200) : age_block_start + 200]
+    # `multi_select_field` renders a `<div role="group" id="age_groups">`
+    # wrapper; the aria-invalid lives on the group, not on each checkbox.
+    assert 'id="age_groups"' in response.text
+    group_start = response.text.index('id="age_groups"')
+    age_block = response.text[max(0, group_start - 200) : group_start + 200]
     assert 'aria-invalid="true"' in age_block, age_block
     assert "<!DOCTYPE" not in response.text
     assert "<html" not in response.text

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -234,6 +234,44 @@ dd { margin: 0; }
 .entity-form-page form .form-field > select,
 .entity-form-page form .form-field > textarea,
 .entity-form-page form .form-field > .form-field-control { margin: 0; min-width: 0; }
+/* Multi-selection rendered as a scrollable checkbox list (replaces the
+   old `<select multiple>` listbox — see `multi_select_field` in
+   `_shared/form_fields.html`). The max-height cap is the whole point:
+   long controlled vocabularies (50 US states, the carrier list) used
+   to grow the form unboundedly; this caps the visual envelope at
+   ~14rem and scrolls the overflow. Short vocabularies (3–4 genders)
+   render shorter than the cap and don't gain a scrollbar.
+
+   The container reads as a single visual control — bordered like an
+   input, padded inside so the option-label text doesn't kiss the
+   scrollbar gutter. Each option is a flex row so the checkbox and the
+   text baseline-align even when the label wraps. */
+.checkbox-list {
+  max-height: 14rem;
+  overflow-y: auto;
+  border: 1px solid var(--pico-form-element-border-color);
+  border-radius: var(--pico-border-radius);
+  background: var(--pico-form-element-background-color);
+  padding: 0.375rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+.checkbox-list-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  cursor: pointer;
+}
+.checkbox-list-option > input[type="checkbox"] {
+  margin: 0;
+  flex: 0 0 auto;
+}
+.checkbox-list[aria-invalid="true"],
+.form-field[aria-invalid="true"] > .checkbox-list {
+  border-color: var(--pico-form-element-invalid-border-color);
+}
 .entity-form-page form .form-field > small {
   grid-column: 2;
   margin: 0;
@@ -501,17 +539,31 @@ td > menu > li > [role="button"] {
    option per line so short choice sets (Age groups, Languages)
    read top-to-bottom. Long sets opt into `.search-checkbox-grid`
    which lays the options out in 2–3 responsive columns so a
-   50-state list doesn't stretch the form to 50 rows tall. */
+   50-state list doesn't stretch the form to 50 rows tall — and
+   the option list is wrapped in a scrollable container with a
+   max-height cap so even the single-column fallback (narrow
+   viewports) doesn't grow the filter sidebar unboundedly. The
+   legend sits OUTSIDE that scroll viewport so the field label
+   stays pinned while the options scroll. */
 .search-checkbox-fieldset {
   margin-block-start: var(--pico-spacing);
 }
-.search-checkbox-fieldset > label {
+/* `.search-checkbox-options` is the scrollable inner viewport — the
+   legend stays pinned outside it (always visible above the option
+   list) while the options scroll if there are more than fit in the
+   14rem cap. Short choice sets render shorter and don't gain a
+   scrollbar. */
+.search-checkbox-options {
+  max-height: 14rem;
+  overflow-y: auto;
+}
+.search-checkbox-options > label {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   margin-block: 0.125rem;
 }
-.search-checkbox-fieldset > label > input[type="checkbox"] {
+.search-checkbox-options > label > input[type="checkbox"] {
   margin: 0;
   flex: 0 0 auto;
 }
@@ -520,9 +572,6 @@ td > menu > li > [role="button"] {
   grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
   column-gap: var(--pico-spacing);
   row-gap: 0.125rem;
-}
-.search-checkbox-grid > legend {
-  grid-column: 1 / -1;
 }
 @media (max-width: 540px) {
   .search-checkbox-grid {

--- a/src/framework/templates/_shared/_filter_field.html
+++ b/src/framework/templates/_shared/_filter_field.html
@@ -33,17 +33,19 @@
      threshold (>12) keeps short multi-selects — Age groups, Languages —
      as a single column where each option already reads cleanly. #}
       {%- set grid_class = " search-checkbox-grid" if f.choices|length > 12 else "" -%}
-      <fieldset class="search-checkbox-fieldset{{ grid_class }}">
+      <fieldset class="search-checkbox-fieldset">
         <legend>{{ f.display_label }}</legend>
-        {%- for v, l in f.choices %}
-          <label>
-            <input type="checkbox"
-                   name="{{ f.name }}"
-                   value="{{ v }}"
-                   {% if v in selected %}checked{% endif %} />
-            {{ l }}
-          </label>
-        {%- endfor %}
+        <div class="search-checkbox-options{{ grid_class }}">
+          {%- for v, l in f.choices %}
+            <label>
+              <input type="checkbox"
+                     name="{{ f.name }}"
+                     value="{{ v }}"
+                     {% if v in selected %}checked{% endif %} />
+              {{ l }}
+            </label>
+          {%- endfor %}
+        </div>
       </fieldset>
     {%- elif f.radio -%}
       <fieldset class="toggle-radio">

--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -207,19 +207,28 @@ emitted attribute string. #}
     {{- _help_small(name, help, error) }}
   </label>
 {%- endmacro %}
-{# `<select multiple>` driven by a controlled-vocabulary tuple. One
-   option per value; selected ones get `selected`. Multi selections
-   serialize as repeated `name=v` pairs under
-   application/x-www-form-urlencoded; under htmx's `json-enc` the
-   extension emits an array for 2+ selections, scalar for 1, absent for
-   0 — the schema's `_scalar_to_list` `BeforeValidator` re-wraps the
-   scalar back into a list. Used today for create/edit forms; the
-   search-form variant is `.search-checkbox-fieldset` (one checkbox per
-   value), not this macro. #}
-{# Multi-select: `required=False` by default because the canonical
-   semantic is "any subset, including the empty set" (no in-network
-   carriers, no featured services). Callers can pass `required=True`
-   to force at least one selection. #}
+{# Multi-selection rendered as a scrollable list of checkboxes. One
+   `<input type="checkbox" name="<name>">` per controlled-vocab value;
+   the shared `name` makes the browser submit each checked value
+   independently, identical to the wire shape of the old
+   `<select multiple>`: repeated `name=v` pairs under
+   application/x-www-form-urlencoded; under htmx's `json-enc` an array
+   for 2+ checks, scalar for 1, absent for 0 — the schema's
+   `_scalar_to_list` `BeforeValidator` re-wraps the scalar back into a
+   list.
+
+   Markup is a `<div class="form-field" role="group">` (not a `<label>`,
+   because a single `<label>` can't be the accessible label for many
+   inputs — `aria-labelledby` on the wrapping group does the job) with a
+   `<div class="checkbox-list">` holding the options. The list has a CSS
+   `max-height` and `overflow-y: auto`, so a 50-state vocabulary scrolls
+   inside a fixed envelope instead of growing the form unboundedly.
+
+   Required: `required=False` by default ("any subset, including the
+   empty set" is the canonical semantic — no in-network carriers, no
+   featured services). Callers can pass `required=True` to surface the
+   `(optional)` marker is hidden, but HTML can't natively require "at
+   least one of these checkboxes" — server-side validation owns that. #}
 {% macro multi_select_field(name, label, options, labels=None, current=None, required=False, help=None, invalid=None, error=None) -%}
   {%- set _form_errors = form_errors|default({}, true) -%}
   {%- set _form_values = form_values|default({}, true) -%}
@@ -227,20 +236,26 @@ emitted attribute string. #}
   {%- set current = _form_values[name] if name in _form_values else current -%}
   {%- set selected = current or [] -%}
   {%- set aria_invalid = true if error else invalid -%}
-  <label class="form-field" for="{{ name }}">
-    <span class="form-field-label">{{ _field_label(label, required) }}</span>
-    <select id="{{ name }}"
-            name="{{ name }}"
-            multiple
-            size="{{ [options|length, 8]|min }}"
-            {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
-            {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>
+  <div class="form-field"
+       role="group"
+       id="{{ name }}"
+       aria-labelledby="{{ name }}-label"
+       {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
+       {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>
+    <span class="form-field-label" id="{{ name }}-label">{{ _field_label(label, required) }}</span>
+    <div class="checkbox-list form-field-control">
       {%- for v in options %}
-        <option value="{{ v }}"{% if v in selected %} selected{% endif %}>{{ labels[v] if labels else v }}</option>
+        <label class="checkbox-list-option">
+          <input type="checkbox"
+                 name="{{ name }}"
+                 value="{{ v }}"
+                 {% if v in selected %}checked{% endif %} />
+          <span>{{ labels[v] if labels else v }}</span>
+        </label>
       {%- endfor %}
-    </select>
+    </div>
     {{- _help_small(name, help, error) }}
-  </label>
+  </div>
 {%- endmacro %}
 {# `<select>` populated from a list of entity rows — the canonical
    foreign-key picker (`org_id` on Clinician/Program forms, `parent_org_id`

--- a/src/framework/templates/_shared/test_form_fields.py
+++ b/src/framework/templates/_shared/test_form_fields.py
@@ -196,17 +196,53 @@ def test_select_field_placeholder_emits_disabled_option_when_no_current() -> Non
 # --- multi_select_field ---------------------------------------------------
 
 
-def test_multi_select_field_with_help_links_each_via_aria() -> None:
-    """`<select multiple>` carries `aria-describedby` on the select
-    itself; the `<small>` lives inside the label after the select."""
+def test_multi_select_field_renders_checkbox_list_with_one_input_per_option() -> None:
+    """Multi-selection renders as a scrollable `.checkbox-list` of
+    `<input type="checkbox">` controls — one per controlled-vocab value,
+    all sharing the field `name` so repeated submissions deserialize as
+    a list. Replaces the old `<select multiple>` listbox."""
+    html = _render(
+        _make_env(),
+        '{{ multi_select_field("tags", "Tags", ("a", "b")) }}',
+    )
+    tree = HTMLParser(html)
+    # No `<select>` anywhere — that's the regression guard.
+    assert tree.css_first("select") is None
+    boxes = tree.css('input[type="checkbox"][name="tags"]')
+    assert [b.attributes.get("value") for b in boxes] == ["a", "b"]
+    # The scrollable container is what caps height for long vocabularies.
+    assert tree.css_first(".checkbox-list") is not None
+
+
+def test_multi_select_field_with_help_links_group_via_aria() -> None:
+    """The wrapping `[role=group]` carries `aria-describedby`; the
+    `<small>` lives inside the group so screen readers announce it as
+    part of the group's accessible description."""
     html = _render(
         _make_env(),
         '{{ multi_select_field("tags", "Tags", ("a", "b"), help="Pick any.") }}',
     )
     tree = HTMLParser(html)
-    sel = tree.css_first('select[name="tags"][multiple]')
-    assert sel.attributes.get("aria-describedby") == "tags-helper"
+    group = tree.css_first('[role="group"][id="tags"]')
+    assert group is not None
+    assert group.attributes.get("aria-describedby") == "tags-helper"
     assert tree.css_first("small#tags-helper") is not None
+
+
+def test_multi_select_field_marks_current_values_checked() -> None:
+    """`current=` is an iterable of selected values; each matching
+    checkbox carries `checked`, the rest don't."""
+    html = _render(
+        _make_env(),
+        '{{ multi_select_field("tags", "Tags", ("a", "b", "c"), current=["a", "c"]) }}',
+    )
+    tree = HTMLParser(html)
+    checked = {
+        b.attributes.get("value")
+        for b in tree.css('input[type="checkbox"][name="tags"]')
+        if "checked" in b.attributes
+    }
+    assert checked == {"a", "c"}
 
 
 # --- entity_select_field --------------------------------------------------
@@ -569,7 +605,7 @@ _INPUT_MACROS = [
     (
         "multi_select_field",
         '{{ multi_select_field("x", "X", ("a", "b"), error="bad") }}',
-        "select",
+        '[role="group"][id="x"]',
     ),
     (
         "entity_select_field",
@@ -756,7 +792,7 @@ _AUTO_RESOLVE_MACROS = [
     (
         "multi_select_field",
         '{{ multi_select_field("x", "X", ("a", "b")) }}',
-        "select",
+        '[role="group"][id="x"]',
     ),
     (
         "entity_select_field",
@@ -858,6 +894,18 @@ def _checkbox_checked_check(expected: bool):
     return check
 
 
+def _checkbox_list_checked_check(values: list[str]):
+    def check(tree: HTMLParser) -> tuple[bool, str]:
+        checked = [
+            b.attributes.get("value")
+            for b in tree.css('input[type="checkbox"][name="x"]')
+            if "checked" in b.attributes
+        ]
+        return checked == values, f"expected checked={values!r}, got {checked!r}"
+
+    return check
+
+
 _AUTO_RESOLVE_VALUE_CASES = [
     ("text_field", '{{ text_field("x", "X") }}', "typed", _input_value_check("typed")),
     (
@@ -876,7 +924,7 @@ _AUTO_RESOLVE_VALUE_CASES = [
         "multi_select_field",
         '{{ multi_select_field("x", "X", ("a", "b")) }}',
         ["a", "b"],
-        _select_selected_check(["a", "b"]),
+        _checkbox_list_checked_check(["a", "b"]),
     ),
     (
         "entity_select_field",


### PR DESCRIPTION
## Summary

- `multi_select_field` macro now renders a `<div role=\"group\">` wrapping a `.checkbox-list` of single-click `<input type=\"checkbox\">` controls, capped at a 14rem max-height with overflow-y: auto. Wire shape is unchanged (each checkbox shares the field `name`; `_scalar_to_list` still re-wraps the 1-check scalar).
- Same scroll cap applied to `.search-checkbox-fieldset` on the search/filter sidebar — the 50-state filter had the same infinite-tall failure mode on narrow viewports.
- Test updates: form-fields macro tests now pin the checkbox-list shape; `test_clinicians.py` updated to count checkboxes instead of `<option>`s; `test_posts.py` error-render smoke now keys off the group's `id` attribute instead of `name=` on the underlying control (aria-invalid now lives on the wrapping group, not on each checkbox).

## Test plan

- [x] `dev test` (2397 passed, 101 skipped)
- [x] `dev test contract` (40 passed)
- [x] `dev lint`
- [ ] Visual check on `/dev/components` (renders Services multi-select as scrollable checkbox list)
- [ ] Visual check on a clinician edit page (in-network carriers picker scrolls instead of growing the form)
- [ ] Visual check on `/posts/search` state filter (50-state list scrolls inside its 14rem envelope on narrow viewports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)