### PR TITLE
Refactor /users/me cards to reuse picker macro

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -457,7 +457,7 @@ async def test_users_me_access_card_links_to_access_page(
     tree = HTMLParser(response.text)
     headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
     assert "Access" in headings, "/users/me is missing the Access card"
-    access_link = tree.css_first("a.picker-option[href$='/users/me/access']")
+    access_link = tree.css_first("article.picker-option a[href$='/users/me/access']")
     assert (
         access_link is not None
     ), "Access card is missing the link to /users/me/access"
@@ -478,7 +478,7 @@ async def test_users_me_email_card_links_to_email_form(
     tree = HTMLParser(response.text)
     headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
     assert "Email" in headings, "/users/me is missing the Email card"
-    email_link = tree.css_first("a.picker-option[href$='/users/me/email/form']")
+    email_link = tree.css_first("article.picker-option a[href$='/users/me/email/form']")
     assert (
         email_link is not None
     ), "Email card is missing the link to /users/me/email/form"
@@ -498,7 +498,7 @@ async def test_users_me_email_card_not_shown_for_other_users(
     response = await authenticated_client.get(f"/users/{target.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    email_link = tree.css_first("a.picker-option[href$='/email/form']")
+    email_link = tree.css_first("article.picker-option a[href$='/email/form']")
     assert email_link is None, "Email card must not appear on another user's profile"
 
 

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -441,10 +441,7 @@ async def test_detail_no_inline_clinicians_section(
     response = await authenticated_client.get("/users/me")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    headings = [
-        el.text(strip=True)
-        for el in tree.css("section.entity-card header.entity-header strong")
-    ]
+    headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
     assert "Clinicians" not in headings
     return None
 
@@ -458,12 +455,9 @@ async def test_users_me_access_card_links_to_access_page(
     response = await authenticated_client.get("/users/me")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    headings = [
-        el.text(strip=True)
-        for el in tree.css("section.entity-card header.entity-header strong")
-    ]
+    headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
     assert "Access" in headings, "/users/me is missing the Access card"
-    access_link = tree.css_first("section.entity-card a[href$='/users/me/access']")
+    access_link = tree.css_first("a.picker-option[href$='/users/me/access']")
     assert (
         access_link is not None
     ), "Access card is missing the link to /users/me/access"
@@ -482,12 +476,9 @@ async def test_users_me_email_card_links_to_email_form(
     response = await authenticated_client.get("/users/me")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    headings = [
-        el.text(strip=True)
-        for el in tree.css("section.entity-card header.entity-header strong")
-    ]
+    headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
     assert "Email" in headings, "/users/me is missing the Email card"
-    email_link = tree.css_first("section.entity-card a[href$='/users/me/email/form']")
+    email_link = tree.css_first("a.picker-option[href$='/users/me/email/form']")
     assert (
         email_link is not None
     ), "Email card is missing the link to /users/me/email/form"
@@ -507,7 +498,7 @@ async def test_users_me_email_card_not_shown_for_other_users(
     response = await authenticated_client.get(f"/users/{target.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    email_link = tree.css_first("section.entity-card a[href$='/email/form']")
+    email_link = tree.css_first("a.picker-option[href$='/email/form']")
     assert email_link is None, "Email card must not appear on another user's profile"
 
 
@@ -526,10 +517,7 @@ async def test_users_me_verification_card_not_shown_for_other_users(
     response = await authenticated_client.get(f"/users/{target.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    headings = [
-        el.text(strip=True)
-        for el in tree.css("section.entity-card header.entity-header strong")
-    ]
+    headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
     assert (
         "Verification" not in headings
     ), "Verification card unexpectedly shown on another user's profile"
@@ -551,10 +539,7 @@ async def test_detail_no_inline_clinicians_section_for_other_user(
     response = await authenticated_client.get(f"/users/{target.id}")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    headings = [
-        el.text(strip=True)
-        for el in tree.css("section.entity-card header.entity-header strong")
-    ]
+    headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
     assert "Clinicians" not in headings
 
 

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -1,5 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/sections.html" import fact -%}
+{%- from "_shared/_picker.html" import picker -%}
 {% block resource_label %}Users{% endblock %}
 {% block current_label %}{{ target_user.username }}{% endblock %}
 {% block actions %}
@@ -22,77 +23,54 @@
   {% endif %}
   {% include "users/_admin_actions.html" %}
 {% endblock %}
-{# User detail: identity card (email/active) + Favorites + Access. #}
+{# User detail: identity facts (email/active) + navigational picker
+ (Email, Favorites, Access). The picker species here is a *dispatching
+ picker* — each card points OUT to a self-sub-page where the user
+ actually manages that surface. Headers + descriptions read as a
+ self-explanatory dashboard; whole-card click is the affordance.
+ The identity-facts article above stays plain-data (not a picker
+ option) because it shows the email value rather than navigating. #}
 {% block content %}
-  <section class="entity-card">
-    {# Private rows (email, active) are gated by `can_view_private`,
-     computed in handle_get_user_detail as `is_self OR is_admin(viewer)`.
-     The handler also omits these fields from the `target_user`
-     projection for non-authorized viewers, so a forgotten guard here
-     cannot re-leak.
+  {# Private rows (email, active) are gated by `can_view_private`,
+   computed in handle_get_user_detail as `is_self OR is_admin(viewer)`.
+   The handler also omits these fields from the `target_user`
+   projection for non-authorized viewers, so a forgotten guard here
+   cannot re-leak.
 
-     The Active row is an admin signal — it makes sense to an admin
-     auditing someone else's account, not to the user themselves (#597).
-     Hide it on the self-view; an admin viewing another user still sees
-     it. Email stays for self since users routinely glance at it to
-     confirm which account they're signed in as.
+   The Active row is an admin signal — it makes sense to an admin
+   auditing someone else's account, not to the user themselves (#597).
+   Hide it on the self-view; an admin viewing another user still sees
+   it. Email stays for self since users routinely glance at it to
+   confirm which account they're signed in as.
 
-     `is_verified` removed in #696 — no verification flow exists and
-     every account is permanently False; showing it was misleading.
-     Verification status and the resend action live at
-     /users/me/email/form (linked in the Email card below). #}
-    {% if can_view_private %}
-      <section class="entity-facts">
-        <dl>
-          {{ fact('email', 'Email', target_user.email) }}
-          {% if not is_self %}{{ fact('active', 'Active', "Yes" if target_user.is_active else "No") }}{% endif %}
-        </dl>
-      </section>
-    {% endif %}
-  </section>
-  {# Email — self-only card linking to the email management page where
-   the user can check verification status and resend the verification
-   email. #}
-  {% if is_self %}
-    <section class="entity-card">
-      <header class="entity-header">
-        <strong>Email</strong>
-      </header>
-      <footer class="entity-footer">
-        <a href="{{ entity_url('user', id='me') }}/email/form"
-           role="button"
-           class="outline">Manage email</a>
-      </footer>
-    </section>
+   `is_verified` removed in #696 — no verification flow exists and
+   every account is permanently False; showing it was misleading.
+   Verification status and the resend action live at
+   /users/me/email/form (linked in the Email card below). #}
+  {% if can_view_private %}
+    <article>
+      <dl>
+        {{ fact('email', 'Email', target_user.email) }}
+        {% if not is_self %}{{ fact('active', 'Active', "Yes" if target_user.is_active else "No") }}{% endif %}
+      </dl>
+    </article>
   {% endif %}
-  {# Favorites — self-only navigation to the viewer's private favorites
-   list. Lives in the body, not the toolbar: toolbar is reserved for
-   Actions (Sign out, admin Deactivate/Delete), and viewing someone
-   else's profile must not expose their private favorites. #}
+  {# Self-only navigation. Each option dispatches to a sub-page where
+   the user actually manages that surface — Email verification, the
+   private Favorites list, the capability tree. Order is identity →
+   content → access: Email is closest to the identity card above; the
+   capability tree is the most "settings"-flavored and sits last. #}
   {% if is_self %}
-    <section class="entity-card">
-      <header class="entity-header">
-        <strong>Favorites</strong>
-      </header>
-      <footer class="entity-footer">
-        <a href="{{ entity_url('user_favorite') }}"
-           role="button"
-           class="outline">View favorites</a>
-      </footer>
-    </section>
-  {% endif %}
-  {# Access — self-only. Links to the access overview where the user
-   can inspect their capability status. #}
-  {% if is_self %}
-    <section class="entity-card">
-      <header class="entity-header">
-        <strong>Access</strong>
-      </header>
-      <footer class="entity-footer">
-        <a href="{{ entity_url('user', id='me') }}/access"
-           role="button"
-           class="outline">View access</a>
-      </footer>
-    </section>
+    {{ picker([
+        {"href": entity_url('user', id='me') + "/email/form",
+    "heading": "Email",
+    "description": "Manage your email address and verification."},
+    {"href": entity_url('user_favorite'),
+    "heading": "Favorites",
+    "description": "Posts you've saved to revisit."},
+    {"href": entity_url('user', id='me') + "/access",
+    "heading": "Access",
+    "description": "Review your account's capabilities and what's gated."},
+    ]) }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- The Email / Favorites / Access cards on the self-view are "choose where to go" navigation — the same shape as the posts form picker. Replace per-card `<section class=\"entity-card\">` chrome with `_shared/_picker.html` so each card carries a heading + one-line description and the whole card is the click target.
- Wrap the identity-facts block (email row) in a plain `<article>` so it picks up Pico's card chrome without custom CSS.
- Update the `test_users.py` selectors that targeted `section.entity-card header.entity-header strong` to point at `.picker-option h2` / `a.picker-option[href$=…]`.

## Test plan
- [x] \`dev test\` (2395 passed, 101 skipped)
- [x] \`dev lint\` (all checks green)
- [ ] Eyeball \`/users/me\` to confirm the three cards render with heading + description and the identity card shows the email row

🤖 Generated with [Claude Code](https://claude.com/claude-code)