### PR TITLE
Add "check your email" CTA after register and resend-verify

### DIFF
--- a/src/domain/logic/auth/email_providers.py
+++ b/src/domain/logic/auth/email_providers.py
@@ -1,0 +1,65 @@
+"""Webmail-provider smart-link lookup for the "check your email" CTA.
+
+Stripe-style: when we recognize the email's domain as a webmail provider
+that supports a URL-driven inbox search, return an "Open Gmail" / "Open
+Yahoo Mail" deep link pre-filtered to messages from our verify sender.
+When we don't, return ``(None, None)`` — the page falls back to a plain
+"check your inbox" sentence with no link.
+
+The table is deliberately conservative: only providers whose URL search
+syntax is publicly documented and stable land here. Providers without
+URL-driven search (Outlook, iCloud, AOL, Proton) fall back to the plain
+sentence rather than ship a misleading "Open X" button that lands on
+the inbox root.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+from urllib.parse import quote
+
+
+def _gmail_search_url(from_address: str) -> str:
+    # Gmail honors `#search/<query>` on its hash route. The query is the
+    # same syntax shown in the search box, so `from:<addr>` filters by
+    # sender. quote(safe="") encodes ":" and "@" so the URL fragment
+    # survives intact across clients.
+    query = quote(f"from:{from_address}", safe="")
+    return f"https://mail.google.com/mail/u/0/#search/{query}"
+
+
+def _yahoo_search_url(from_address: str) -> str:
+    query = quote(f"from:{from_address}", safe="")
+    return f"https://mail.yahoo.com/d/search/keyword={query}"
+
+
+_PROVIDERS: dict[str, tuple[str, Callable[[str], str]]] = {
+    "gmail.com": ("Gmail", _gmail_search_url),
+    "googlemail.com": ("Gmail", _gmail_search_url),
+    "yahoo.com": ("Yahoo Mail", _yahoo_search_url),
+    "yahoo.co.uk": ("Yahoo Mail", _yahoo_search_url),
+}
+
+
+def email_provider_search_url(
+    email: str, from_address: str
+) -> tuple[str | None, str | None]:
+    """Return ``(provider_label, search_url)`` for a recognized webmail
+    provider, or ``(None, None)`` when the domain isn't in the table.
+
+    ``provider_label`` is the human-readable name used in CTA copy
+    ("Open Gmail"). ``search_url`` opens that provider's inbox
+    pre-filtered to messages from ``from_address``.
+    """
+    if "@" not in email:
+        return None, None
+    local, _, domain = email.rpartition("@")
+    local = local.strip()
+    domain = domain.strip().lower()
+    if not local or not domain:
+        return None, None
+    entry = _PROVIDERS.get(domain)
+    if entry is None:
+        return None, None
+    label, builder = entry
+    return label, builder(from_address)

--- a/src/domain/logic/auth/test_email_providers.py
+++ b/src/domain/logic/auth/test_email_providers.py
@@ -1,0 +1,94 @@
+"""Tests for `src/domain/logic/auth/email_providers.py`.
+
+Pin the URL shape for every supported provider so a silent drift in the
+table (or a botched URL-encode of the ``from`` address) trips a test
+rather than ships a broken "Open Gmail" button.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.domain.logic.auth.email_providers import email_provider_search_url
+
+FROM = "no-reply@bedlamconnect.com"
+ENCODED_QUERY = "from%3Ano-reply%40bedlamconnect.com"
+
+
+@pytest.mark.parametrize(
+    "email,expected_label,expected_url",
+    [
+        (
+            "alice@gmail.com",
+            "Gmail",
+            f"https://mail.google.com/mail/u/0/#search/{ENCODED_QUERY}",
+        ),
+        (
+            "ALICE@GMAIL.COM",
+            "Gmail",
+            f"https://mail.google.com/mail/u/0/#search/{ENCODED_QUERY}",
+        ),
+        (
+            "bob@googlemail.com",
+            "Gmail",
+            f"https://mail.google.com/mail/u/0/#search/{ENCODED_QUERY}",
+        ),
+        (
+            "carol@yahoo.com",
+            "Yahoo Mail",
+            f"https://mail.yahoo.com/d/search/keyword={ENCODED_QUERY}",
+        ),
+        (
+            "dave@yahoo.co.uk",
+            "Yahoo Mail",
+            f"https://mail.yahoo.com/d/search/keyword={ENCODED_QUERY}",
+        ),
+    ],
+)
+def test_known_provider_returns_label_and_search_url(
+    email: str, expected_label: str, expected_url: str
+):
+    label, url = email_provider_search_url(email, FROM)
+    assert label == expected_label
+    assert url == expected_url
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        # Providers without a documented URL-driven search → fall back
+        # to the plain sentence rather than ship a misleading button.
+        "alice@outlook.com",
+        "alice@hotmail.com",
+        "alice@icloud.com",
+        "alice@aol.com",
+        "alice@proton.me",
+        # Custom / unknown domains.
+        "alice@example.com",
+        "alice@somecompany.io",
+    ],
+)
+def test_unknown_provider_returns_none(email: str):
+    label, url = email_provider_search_url(email, FROM)
+    assert label is None
+    assert url is None
+
+
+@pytest.mark.parametrize("malformed", ["", "noatsign", "alice@", "@gmail.com"])
+def test_malformed_email_returns_none(malformed: str):
+    label, url = email_provider_search_url(malformed, FROM)
+    assert label is None
+    assert url is None
+
+
+def test_from_address_is_url_encoded():
+    """A from address with characters that need encoding (`+`, spaces)
+    must still produce a valid URL fragment."""
+    label, url = email_provider_search_url(
+        "alice@gmail.com", "no-reply+verify@bedlamconnect.com"
+    )
+    assert label == "Gmail"
+    # `+` must be percent-encoded (Gmail's hash-search treats `+` as
+    # operator-ish in some clients; safer to encode).
+    assert "%2B" in url
+    assert "no-reply%2Bverify%40bedlamconnect.com" in url

--- a/src/domain/routes/README.md
+++ b/src/domain/routes/README.md
@@ -32,7 +32,7 @@ The grammar fits resource-shaped CRUD. These stay hand-written:
 | Route(s) | File | Reason |
 |---|---|---|
 | `POST /auth/register` | `auth_routes.py` | Auth-flow protocol (token issuance, fastapi-users hooks). |
-| `GET /auth/{register,login,forgot-password,reset-password/{token}}` | `auth_pages.py` | Pure form rendering. |
+| `GET /auth/{register,login,forgot-password,reset-password/{token},check-email}` | `auth_pages.py` | Pure form / CTA rendering. |
 | `GET /users/me`, `GET /users/me/clinicians` | `users.py` | Singleton aliases — mounted via `singleton_alias=` on the existing `mount_detail` / `mount_related_list`. |
 | `POST/DELETE/GET /users/me/favorites[/{clinician_id}]` | `favorites.py` | M:N edge add/remove — no `mount_*` helper for edge mutations. |
 | `GET /users/me/access`, `GET /users/me/access/capabilities/{name}` | `access.py` | Derived read view — capability posture, no stored row. |

--- a/src/domain/routes/auth_pages.py
+++ b/src/domain/routes/auth_pages.py
@@ -8,6 +8,7 @@ from fastapi_users.manager import BaseUserManager
 from pydantic import BaseModel, EmailStr, ValidationError
 
 from src.auth_config import auth_backend, current_active_user, get_user_manager
+from src.domain.logic.auth.email_providers import email_provider_search_url
 from src.domain.models import User
 from src.domain.routes.dev_auth import DEV_SEED_USERS
 from src.framework import APIResponse, BaseRouter
@@ -494,6 +495,37 @@ async def get_verify_page(
     )
 
 
+@router.get("/check-email", name="auth_pages:check_email")
+async def get_check_email_page(
+    request: Request,
+    current_user: User = Depends(current_active_user),
+):
+    """Post-registration / post-resend CTA: "open your inbox" with a
+    smart link when we recognize the provider.
+
+    Both flows that send a verification email land here:
+
+      - `POST /auth/register` (HTMX) redirects here after auto-login.
+      - `POST /auth/resend-verify` redirects here with `?sent=1` so the
+        page renders a "just sent another email" status line.
+
+    The page reads the user's email from the session and the from
+    address from `settings.EMAIL_FROM`; the provider lookup is pure.
+    """
+    label, url = email_provider_search_url(current_user.email, settings.EMAIL_FROM)
+    return APIResponse.html_response(
+        template_name="auth/check_email.html",
+        context={
+            "email": current_user.email,
+            "from_address": settings.EMAIL_FROM,
+            "provider_label": label,
+            "provider_url": url,
+            "just_sent": request.query_params.get("sent") == "1",
+        },
+        request=request,
+    )
+
+
 @router.post("/resend-verify", name="auth_pages:resend_verify")
 async def post_resend_verify(
     request: Request,
@@ -508,21 +540,20 @@ async def post_resend_verify(
     the session cookie; calls `request_verify` which triggers
     `on_after_request_verify` → `send_verification_email`.
 
-    Returns the banner partial back to HTMX (`outerHTML` swap) so the
-    nag is replaced with a confirmation message inline.
+    Returns `HX-Redirect: /auth/check-email?sent=1` so the user lands
+    on the shared CTA page with a "just sent another email" status —
+    same UX surface as the post-registration flow.
     """
     try:
         await user_manager.request_verify(current_user, request)
     except fa_users_exceptions.UserAlreadyVerified:
         # Edge case: user verified in another tab between page load
-        # and the resend click. Render the same confirmation —
-        # nothing to do from the user's POV.
+        # and the resend click. The CTA page is harmless either way —
+        # let it render and the nag goes away on next reload.
         pass
-    return APIResponse.html_response(
-        template_name="_shared/_verify_banner_sent.html",
-        context={},
-        request=request,
-    )
+    response = Response(status_code=200)
+    response.headers["HX-Redirect"] = "/auth/check-email?sent=1"
+    return response
 
 
 @router.post("/sign-out", name="auth_pages:sign_out")

--- a/src/domain/routes/auth_routes.py
+++ b/src/domain/routes/auth_routes.py
@@ -106,11 +106,12 @@ async def register_request_handler(
     )
 
     if request.headers.get("HX-Request") == "true":
-        # HTMX submit: auto-login and redirect instead of returning raw JSON.
-        # Mirrors the pattern in src/domain/routes/dev_auth.py.
+        # HTMX submit: auto-login and redirect to the "check your email"
+        # CTA so the user is nudged to open their inbox and click the
+        # verify link. Mirrors the pattern in src/domain/routes/dev_auth.py.
         login_response = await auth_backend.login(get_strategy(), created_user)
         login_response.status_code = 200
-        login_response.headers["HX-Redirect"] = "/home"
+        login_response.headers["HX-Redirect"] = "/auth/check-email"
         return login_response
 
     return created_user

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -95,7 +95,9 @@ async def test_register_via_htmx_sets_cookie_and_redirects(test_client: AsyncCli
         headers={"HX-Request": "true", "Content-Type": "application/json"},
     )
     assert response.status_code == 200
-    assert response.headers.get("HX-Redirect") == "/home"
+    # Post-register HTMX flow lands on the "check your email" CTA so
+    # the user is nudged to open their inbox and click the verify link.
+    assert response.headers.get("HX-Redirect") == "/auth/check-email"
     # A session cookie must be set so the redirect lands authenticated.
     assert (
         "fastapiusersauth" in response.cookies
@@ -743,15 +745,15 @@ async def test_post_resend_verify_unauthenticated_returns_401(test_client: Async
     assert response.status_code == 401
 
 
-async def test_post_resend_verify_authenticated_returns_sent_banner(
+async def test_post_resend_verify_authenticated_redirects_to_check_email(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
     monkeypatch,
 ):
-    """Authed user can re-request the verify email. Response is the
-    `_verify_banner_sent.html` partial (HTMX swaps it over the
-    original banner via `outerHTML`)."""
+    """Authed user can re-request the verify email. Response is
+    `HX-Redirect: /auth/check-email?sent=1` so HTMX navigates to the
+    shared CTA page — same UX surface as the post-registration flow."""
     # Stub the actual send so the test doesn't print to stderr.
     from unittest.mock import AsyncMock
 
@@ -761,10 +763,77 @@ async def test_post_resend_verify_authenticated_returns_sent_banner(
 
     response = await authenticated_client.post("/auth/resend-verify")
     assert response.status_code == 200
+    assert response.headers.get("HX-Redirect") == "/auth/check-email?sent=1"
+
+
+async def test_check_email_page_unauthenticated_is_rejected(
+    test_client: AsyncClient,
+):
+    """`GET /auth/check-email` reads the user from the session — no
+    cookie means no page. Same posture as `/auth/resend-verify`."""
+    response = await test_client.get("/auth/check-email", follow_redirects=False)
+    assert response.status_code != 200
+
+
+async def test_check_email_page_renders_smart_link_for_gmail(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Gmail user sees an "Open Gmail" button whose href is a pre-filtered
+    search URL for the verify sender."""
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            user = await session.get(User, logged_in_user.id)
+            user.email = "alice@gmail.com"
+
+    response = await authenticated_client.get("/auth/check-email")
+    assert response.status_code == 200
+    assert "Open Gmail" in response.text
+    # The Gmail search URL is pinned in test_email_providers.py; here we
+    # just verify the template actually renders it.
+    assert "mail.google.com/mail/u/0/#search/" in response.text
+    assert "from%3Ano-reply%40bedlamconnect.com" in response.text
+    assert "alice@gmail.com" in response.text
+
+
+async def test_check_email_page_falls_back_for_unknown_domain(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """Unrecognized domain (the default fixture user is `@example.com`)
+    → no button, plain sentence referencing the from address."""
+    response = await authenticated_client.get("/auth/check-email")
+    assert response.status_code == 200
+    # No provider button rendered.
+    assert "Open Gmail" not in response.text
+    assert "mail.google.com" not in response.text
+    # The from address is named in the plain-sentence fallback.
+    assert "no-reply@bedlamconnect.com" in response.text
+    # The user's email is still surfaced so they know which address to check.
+    assert logged_in_user.email in response.text
+
+
+async def test_check_email_page_shows_just_sent_banner_with_query_flag(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`?sent=1` (set by the resend redirect) renders the "just sent"
+    status line."""
+    response = await authenticated_client.get("/auth/check-email?sent=1")
+    assert response.status_code == 200
     assert "Verification email sent" in response.text
-    # The partial keeps the original id so a future HTMX target=
-    # `#verify-banner` swap on the same page still works.
-    assert 'id="verify-banner"' in response.text
+
+
+async def test_check_email_page_omits_just_sent_banner_without_query_flag(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """The "just sent" status is opt-in via `?sent=1`; first-visit
+    (post-registration redirect) doesn't show it."""
+    response = await authenticated_client.get("/auth/check-email")
+    assert response.status_code == 200
+    assert "Verification email sent" not in response.text
 
 
 async def test_unauthorized_redirect_for_browser_requests(test_client: AsyncClient):

--- a/src/domain/templates/auth/check_email.html
+++ b/src/domain/templates/auth/check_email.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+  <section class="auth-page">
+    {% if just_sent %}
+      <aside role="status">
+        <strong>Verification email sent.</strong>
+        Check your inbox — the link expires in an hour.
+      </aside>
+    {% endif %}
+    <header>
+      <h1>Check your email</h1>
+      <p>
+        We sent a verification link to <strong>{{ email }}</strong>.
+      </p>
+      <p>Click it to finish setting up your account.</p>
+    </header>
+    {% if provider_url %}
+      <p>
+        <a href="{{ provider_url }}"
+           target="_blank"
+           rel="noopener"
+           role="button">Open {{ provider_label }}</a>
+      </p>
+      <p>
+        <small>We'll search your inbox for messages from <strong>{{ from_address }}</strong>.</small>
+      </p>
+    {% else %}
+      <p>
+        Look for a message from <strong>{{ from_address }}</strong>.
+      </p>
+    {% endif %}
+    <footer>
+      <p>
+        Didn't get it?
+        <button type="button"
+                hx-post="/auth/resend-verify"
+                hx-swap="none"
+                class="secondary">Resend verification email</button>
+      </p>
+    </footer>
+  </section>
+{% endblock %}

--- a/src/domain/templates/users/email_form.html
+++ b/src/domain/templates/users/email_form.html
@@ -11,9 +11,11 @@
   {% if not target_user.is_verified %}
     <aside role="alert" id="verify-banner">
       <p>Your email address has not been verified. Check your inbox for the verification link, or request a new one.</p>
-      <button hx-post="/auth/resend-verify"
-              hx-target="#verify-banner"
-              hx-swap="outerHTML">Resend verification email</button>
+      {# The POST returns `HX-Redirect: /auth/check-email?sent=1` so the
+         user lands on the shared CTA page with a "just sent" status —
+         same surface as the post-registration flow. `hx-swap="none"`
+         lets HTMX handle the redirect without trying to swap a body. #}
+      <button hx-post="/auth/resend-verify" hx-swap="none">Resend verification email</button>
     </aside>
   {% endif %}
 {% endblock %}

--- a/src/framework/templates/_shared/_verify_banner_sent.html
+++ b/src/framework/templates/_shared/_verify_banner_sent.html
@@ -1,8 +1,0 @@
-{# Returned by `POST /auth/resend-verify` and HTMX-swapped over the
-   nag banner. The `id="verify-banner"` matches the original so a
-   second resend on this page (if the user clicks again before
-   reloading) targets the same DOM node. #}
-<aside role="status" id="verify-banner">
-  <strong>Verification email sent.</strong>
-  Check your inbox — the link expires in an hour.
-</aside>


### PR DESCRIPTION
## Summary

- After registration (HTMX) and after `POST /auth/resend-verify`, both flows now `HX-Redirect` to a new `GET /auth/check-email` page.
- The page detects the user's webmail provider from the email domain and renders a Stripe-style smart link (e.g. "Open Gmail") whose href is a pre-filtered search for messages from `no-reply@bedlamconnect.com`. Currently recognized: `gmail.com`, `googlemail.com`, `yahoo.com`, `yahoo.co.uk`.
- Unknown providers (Outlook, iCloud, Proton, custom domains) fall back to a plain "Look for a message from …" sentence — no misleading button that lands on a raw inbox.
- The page does double duty: `?sent=1` (set by the resend redirect) renders a "Verification email sent" status line. The old inline `_verify_banner_sent.html` partial is removed — one UX surface.

## Test plan

- [x] `dev test` (2427 passed, 101 skipped)
- [x] `dev test contract` (40 passed)
- [x] `dev lint` (clean)
- [ ] Manual: register a `@gmail.com` user in non-dev mode → land on `/auth/check-email` with an "Open Gmail" button whose href is `https://mail.google.com/mail/u/0/#search/from%3Ano-reply%40bedlamconnect.com`.
- [ ] Manual: register a `@somecompany.io` user → land on the same page with no button and the plain-sentence fallback.
- [ ] Manual: while logged-in but unverified, click the nag-banner "Resend verification email" → land on `/auth/check-email?sent=1` with the status line visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)