### PR TITLE
Replace post mailto button with in-app message form

### DIFF
--- a/src/domain/logic/posts/emails.py
+++ b/src/domain/logic/posts/emails.py
@@ -1,0 +1,66 @@
+"""Post-message transactional email — render + send.
+
+Domain-layer wrapper around `src.framework.email.send_email`. Mirrors
+`domain/logic/auth/emails.py` for the in-app "message the poster" flow
+hung off `POST /posts/{post_id}/message`: a sender writes a body via
+the form on the post detail page, we render the
+`emails/post_message.{html,txt}` pair, and send it to the post owner
+with the sender's email on the `Reply-To:` header so the poster can
+respond off-platform.
+
+The route handler in `domain/routes/posts.py` is the only caller —
+keeps Jinja rendering and link construction out of the route file and
+in one place per email type.
+"""
+
+from __future__ import annotations
+
+from src.domain.models import Post, User
+from src.framework.config import settings
+from src.framework.email import send_email
+from src.framework.rendering.templating import templates
+
+
+def _absolute_url(path: str) -> str:
+    """Join `APP_BASE_URL` with a path. Mirrors
+    `domain/logic/auth/emails._absolute_url` — kept local rather than
+    extracted because the auth helper is private and a second copy is
+    cheaper than promoting one helper to a shared module just for two
+    callers."""
+    base = settings.APP_BASE_URL.rstrip("/")
+    return f"{base}/{path.lstrip('/')}"
+
+
+def _render(template_name: str, **context: object) -> str:
+    template = templates.env.get_template(f"emails/{template_name}")
+    return template.render(**context)
+
+
+async def send_post_message_email(*, post: Post, sender: User, body: str) -> None:
+    """Deliver an in-app message to a post owner.
+
+    Recipient: `post.owner.email` (the poster). `Reply-To` is the
+    sender's email — the whole point of the flow is to let the poster
+    continue the conversation off-platform in their own mail client,
+    so their "Reply" must land on the sender, not on `EMAIL_FROM`'s
+    no-reply mailbox.
+
+    Sender identity in the body is `sender.username` (display name —
+    the email address is in the headers, not duplicated in the body
+    prose). The link back to the post lets the poster re-anchor on
+    what was being asked about.
+    """
+    post_url = _absolute_url(f"/posts/{post.id}")
+    context = {
+        "sender_username": sender.username,
+        "sender_email": sender.email,
+        "body": body,
+        "post_url": post_url,
+    }
+    await send_email(
+        to=post.owner.email,
+        subject="New message about your post on Bedlam Connect",
+        html=_render("post_message.html", **context),
+        text=_render("post_message.txt", **context),
+        reply_to=sender.email,
+    )

--- a/src/domain/logic/posts/test_emails.py
+++ b/src/domain/logic/posts/test_emails.py
@@ -1,0 +1,156 @@
+"""Tests for `src/domain/logic/posts/emails.py`.
+
+Pin the recipient / reply-to / link-shape contract for the post-message
+email. The framework's `send_email` is mocked — these tests don't
+exercise the transport layer (covered in
+`src/framework/email/test_sender.py`)."""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.domain.logic.posts.emails import send_post_message_email
+
+
+def _post(owner_email: str = "poster@example.com"):
+    """Minimal stand-in for a `Post` row — only the fields the email
+    module reads. `SimpleNamespace` keeps the test off the DB."""
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        owner=SimpleNamespace(email=owner_email),
+    )
+
+
+def _sender(email: str = "sender@example.com", username: str = "sender"):
+    return SimpleNamespace(id=uuid.uuid4(), email=email, username=username)
+
+
+@pytest.mark.asyncio
+async def test_recipient_is_post_owner_email(monkeypatch):
+    """The recipient is the post's owner, not the sender — the whole
+    point of the flow is to deliver a message to the poster."""
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
+
+    await send_post_message_email(
+        post=_post(owner_email="poster@example.com"),
+        sender=_sender(),
+        body="hello there",
+    )
+
+    kwargs = send_email_mock.call_args.kwargs
+    assert kwargs["to"] == "poster@example.com"
+
+
+@pytest.mark.asyncio
+async def test_reply_to_is_sender_email(monkeypatch):
+    """`Reply-To` carries the sender's email so the poster's "Reply"
+    in their mail client goes back to the real human, not to
+    `EMAIL_FROM` (the no-reply mailbox). This is the load-bearing
+    behavior of the whole feature — the conversation continues
+    off-platform."""
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
+
+    await send_post_message_email(
+        post=_post(),
+        sender=_sender(email="alice@example.com"),
+        body="hi",
+    )
+
+    assert send_email_mock.call_args.kwargs["reply_to"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_body_appears_in_both_parts(monkeypatch):
+    """The user-supplied body lands verbatim in both the HTML and
+    plain-text parts. Autoescape on the `.html` template handles HTML
+    safety — the `.txt` template is plain text."""
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
+
+    await send_post_message_email(
+        post=_post(),
+        sender=_sender(),
+        body="I have a referral that matches",
+    )
+
+    kwargs = send_email_mock.call_args.kwargs
+    assert "I have a referral that matches" in kwargs["text"]
+    assert "I have a referral that matches" in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_body_is_html_escaped_in_html_part(monkeypatch):
+    """The `.html` template autoescapes by extension — user-supplied
+    body must not survive as raw HTML."""
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
+
+    await send_post_message_email(
+        post=_post(),
+        sender=_sender(),
+        body="<script>alert(1)</script>",
+    )
+
+    kwargs = send_email_mock.call_args.kwargs
+    assert "<script>" not in kwargs["html"]
+    assert "&lt;script&gt;" in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_email_includes_absolute_post_url(monkeypatch):
+    """The "View the post" link must be absolute (`APP_BASE_URL` +
+    `/posts/{id}`) — email clients can't resolve relative paths since
+    they aren't running in the request scope."""
+    monkeypatch.setattr(
+        "src.domain.logic.posts.emails.settings.APP_BASE_URL",
+        "https://app.example.com",
+    )
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
+
+    post = _post()
+    await send_post_message_email(post=post, sender=_sender(), body="hi")
+
+    kwargs = send_email_mock.call_args.kwargs
+    expected_url = f"https://app.example.com/posts/{post.id}"
+    assert expected_url in kwargs["text"]
+    assert expected_url in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_sender_username_and_email_surface_in_body(monkeypatch):
+    """Both display name (`username`) and the actual reply address
+    (`email`) appear in body prose — the recipient should be able to
+    read the message on a client that hides `Reply-To` and still know
+    who to write back to and at what address."""
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
+
+    await send_post_message_email(
+        post=_post(),
+        sender=_sender(email="alice@example.com", username="alice"),
+        body="hi",
+    )
+
+    text = send_email_mock.call_args.kwargs["text"]
+    assert "alice" in text
+    assert "alice@example.com" in text
+
+
+@pytest.mark.asyncio
+async def test_renders_both_html_and_text_parts(monkeypatch):
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
+
+    await send_post_message_email(post=_post(), sender=_sender(), body="hi")
+
+    kwargs = send_email_mock.call_args.kwargs
+    assert kwargs["html"].strip().startswith("<")
+    assert "<html" in kwargs["html"]
+    assert "<" not in kwargs["text"]

--- a/src/domain/routes/posts.py
+++ b/src/domain/routes/posts.py
@@ -1,6 +1,18 @@
+from uuid import UUID
+
+from fastapi import Depends, Request
+from pydantic import BaseModel, Field, field_validator
+
+from src.auth_config import current_active_user
+from src.domain.logic.capabilities import can_access_network
+from src.domain.logic.posts.emails import send_post_message_email
+from src.domain.logic.posts.repository import PostRepository, get_post_repository
+from src.domain.models import Post, User
 from src.domain.specs import POST_ENTITY
 from src.framework import register_entity
 from src.framework.dispatch.resource_routes import mount_entity
+from src.framework.http.exceptions import ForbiddenError, NotFoundError
+from src.framework.http.responses import APIResponse
 
 router = register_entity(POST_ENTITY)
 
@@ -10,3 +22,72 @@ router = register_entity(POST_ENTITY)
 # template at `GET /posts/form`; the discriminated-union body adapter
 # dispatches POST/PATCH bodies by their declared `kind`.
 mount_entity(router, POST_ENTITY)
+
+
+# Maximum body length — chosen to comfortably fit "I have a referral
+# that matches; here's a few sentences about availability" without
+# becoming an entire email's worth of free text. The cap exists to
+# bound the outbound transactional-email size, not to be a UX limit
+# the user is meant to feel; bumping it later is cheap.
+_MESSAGE_BODY_MAX_LEN = 2000
+
+
+class _PostMessageBody(BaseModel):
+    """Wire shape for `POST /posts/{post_id}/message` — a sender's
+    free-text body. The body is rendered as plain text (escaped in
+    the HTML part) into the outbound email; there is no DB row.
+
+    Field validators strip surrounding whitespace and reject
+    empty-after-strip submissions, matching the implicit contract a
+    `<textarea required>` carries on the client side."""
+
+    body: str = Field(..., max_length=_MESSAGE_BODY_MAX_LEN)
+
+    @field_validator("body")
+    @classmethod
+    def _non_blank(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("body must not be empty")
+        return stripped
+
+
+@router.post("/{post_id}/message", name="post:message_send")
+async def send_post_message(
+    post_id: UUID,
+    body_in: _PostMessageBody,
+    request: Request,
+    post_repo: PostRepository = Depends(get_post_repository),
+    requesting_user: User = Depends(current_active_user),
+):
+    """In-app "message the poster" event endpoint.
+
+    Event-shaped (RESOURCE_GRAMMAR § "POST /<r>/{id}/<event>") — fires
+    an outbound transactional email to the post owner with the
+    sender's email on `Reply-To`, persists nothing. The whole point of
+    the flow is to let the poster continue the conversation off-platform
+    in their own mail client, so any history we'd persist would only
+    diverge from what actually happened.
+
+    Authz: the sender must clear `can_access_network` — the same gate
+    that controlled visibility of the prior `mailto:` Email button on
+    the post detail/list cards. Tightening this to `can_message`
+    (clinician-only, per `domain/logic/capabilities.py`) is a separate
+    concern; the new endpoint preserves the prior CTA's visibility
+    rule so this change is mechanism-only, not also a permission
+    change.
+
+    Returns an HTML fragment HTMX swaps over the form in place.
+    """
+    if not can_access_network(requesting_user):
+        raise ForbiddenError(detail="Provider network access required.")
+    post = await post_repo.get_by_model_id(Post, post_id)
+    if post is None:
+        raise NotFoundError(detail="Post not found")
+    await send_post_message_email(post=post, sender=requesting_user, body=body_in.body)
+    return APIResponse.html_response(
+        template_name="posts/_message_sent.html",
+        context={"post": post},
+        request=request,
+        current_user=requesting_user,
+    )

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -619,13 +619,16 @@ async def test_list_shows_create_cta_for_claim_b_org_rep(
     ), "Claim-B org rep must be offered the toolbar Create CTA"
 
 
-async def test_detail_hides_email_and_shows_cta_for_unverified(
+async def test_detail_hides_message_form_and_shows_cta_for_unverified(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """Unverified users see a disabled Email button (not a mailto link) on
-    post detail — contact info is not sent to the browser."""
+    """Unverified users see a locked Message CTA (no form, no contact
+    info) on post detail — the inline form is not rendered, and the
+    poster's email address is not sent to the browser. Replaces the
+    prior `mailto:`-button assertion: the same `can_access_network`
+    gate now hides the form instead of disabling a button."""
     author = create_test_user(
         username=f"detail-author-{uuid.uuid4()}",
         email=f"detail-author-{uuid.uuid4()}@example.com",
@@ -638,19 +641,22 @@ async def test_detail_hides_email_and_shows_cta_for_unverified(
 
     response = await authenticated_client.get(f"/posts/{post.id}")
     assert response.status_code == 200
-    assert f"mailto:{author.email}" not in response.text
     assert author.email not in response.text
-    assert "disabled" in response.text
-    assert "Email" in response.text
+    tree = HTMLParser(response.text)
+    assert tree.css_first(f"form[hx-post='/posts/{post.id}/message']") is None
+    assert "Message" in response.text
 
 
-async def test_detail_shows_email_for_verified(
+async def test_detail_shows_message_form_for_verified(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """Verified users (Claim A active) see the poster's email button on the
-    post detail page."""
+    """Verified users (Claim A active) see the inline message form on
+    the post detail page — POSTs to `/posts/{id}/message`, which
+    dispatches the transactional email server-side. The poster's raw
+    email address is never sent to the browser; the form route
+    resolves the recipient from the post row."""
     clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
     clinician.npi_match_status = "matched"
     clinician.clinician_verified = True
@@ -668,7 +674,11 @@ async def test_detail_shows_email_for_verified(
 
     response = await authenticated_client.get(f"/posts/{post.id}")
     assert response.status_code == 200
-    assert f"mailto:{author_email}" in response.text
+    assert author_email not in response.text
+    tree = HTMLParser(response.text)
+    form = tree.css_first(f"form[hx-post='/posts/{post.id}/message']")
+    assert form is not None
+    assert form.css_first("textarea[name='body']") is not None
 
 
 async def test_detail_redacts_identity_rows_as_locked_placeholders_for_unverified(
@@ -738,3 +748,131 @@ async def test_detail_shows_identity_rows_for_verified_viewer(
     assert tree.css_first(f"a[href='/clinicians/{clinician.id}']") is not None
     assert "Springfield, IL" in response.text
     assert tree.css_first("button.locked-ghost-btn") is None
+
+
+# --- POST /posts/{id}/message (in-app contact form) --------------------------
+
+
+async def test_message_send_unverified_user_is_forbidden(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+    monkeypatch,
+):
+    """A claimless viewer can't see the form (existing visibility gate),
+    so the route must also reject the request server-side. Mirrors the
+    `can_access_network` gate that hid the prior `mailto:` button."""
+    send_mock = pytest.importorskip("unittest.mock").AsyncMock()
+    monkeypatch.setattr("src.domain.routes.posts.send_post_message_email", send_mock)
+
+    author = create_test_user(username=f"author-{uuid.uuid4()}")
+    post = _referral_post(owner_id=author.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.post(
+        f"/posts/{post.id}/message", json={"body": "hello"}
+    )
+    assert response.status_code == 403
+    assert send_mock.call_count == 0
+
+
+async def test_message_send_verified_user_dispatches_email(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+    monkeypatch,
+):
+    """Verified-network viewer (`can_access_network=True`) reaches the
+    handler and we hand the post + sender + body to the domain email
+    wrapper. Tests for `Reply-To`, recipient, and link shape live in
+    `src/domain/logic/posts/test_emails.py` — this test only pins the
+    handoff."""
+    from unittest.mock import AsyncMock
+
+    send_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.routes.posts.send_post_message_email", send_mock)
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    author = create_test_user(username=f"author-{uuid.uuid4()}")
+    post = _referral_post(owner_id=author.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.post(
+        f"/posts/{post.id}/message",
+        json={"body": "I have a referral that matches"},
+    )
+    assert response.status_code == 200
+    assert "Message sent" in response.text
+    assert send_mock.call_count == 1
+    kwargs = send_mock.call_args.kwargs
+    assert kwargs["post"].id == post.id
+    assert kwargs["sender"].id == logged_in_user.id
+    assert kwargs["body"] == "I have a referral that matches"
+
+
+async def test_message_send_404_when_post_missing(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+    monkeypatch,
+):
+    """Unknown post id returns 404 — even for an authorized sender.
+    The `can_access_network` check fires first, so the user must clear
+    that gate before the missing-post path is reachable."""
+    from unittest.mock import AsyncMock
+
+    send_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.routes.posts.send_post_message_email", send_mock)
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.post(
+        f"/posts/{uuid.uuid4()}/message", json={"body": "hi"}
+    )
+    assert response.status_code == 404
+    assert send_mock.call_count == 0
+
+
+async def test_message_send_rejects_blank_body(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+    monkeypatch,
+):
+    """Empty / whitespace-only bodies are 422 — no point shipping a
+    blank email."""
+    from unittest.mock import AsyncMock
+
+    send_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.routes.posts.send_post_message_email", send_mock)
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    clinician.npi_match_status = "matched"
+    clinician.clinician_verified = True
+    author = create_test_user(username=f"author-{uuid.uuid4()}")
+    post = _referral_post(owner_id=author.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+            session.add(author)
+            session.add(post)
+
+    response = await authenticated_client.post(
+        f"/posts/{post.id}/message", json={"body": "   "}
+    )
+    assert response.status_code == 422
+    assert send_mock.call_count == 0

--- a/src/domain/templates/emails/post_message.html
+++ b/src/domain/templates/emails/post_message.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+{# Self-contained email body — no `{% extends %}`. See README in this dir. #}
+<html>
+  <body style="font-family: -apple-system, system-ui, sans-serif;
+               max-width: 560px;
+               margin: 2rem auto;
+               line-height: 1.5">
+    <p>{{ sender_username }} sent you a message about your post on Bedlam Connect.</p>
+    <blockquote style="border-left: 3px solid #ccc;
+                       margin: 1rem 0;
+                       padding: 0.25rem 0 0.25rem 1rem;
+                       color: #333;
+                       white-space: pre-wrap">
+      {{ body }}
+    </blockquote>
+    <p>
+      Reply directly to this email to respond to {{ sender_username }} at
+      <a href="mailto:{{ sender_email }}">{{ sender_email }}</a>.
+    </p>
+    <p>
+      <a href="{{ post_url }}">View the post</a>
+    </p>
+    <p>— Bedlam Connect</p>
+  </body>
+</html>

--- a/src/domain/templates/emails/post_message.txt
+++ b/src/domain/templates/emails/post_message.txt
@@ -1,0 +1,11 @@
+{{ sender_username }} sent you a message about your post on Bedlam Connect.
+
+---
+{{ body }}
+---
+
+Reply directly to this email to respond to {{ sender_username }} at {{ sender_email }}.
+
+View the post: {{ post_url }}
+
+— Bedlam Connect

--- a/src/domain/templates/posts/_message_sent.html
+++ b/src/domain/templates/posts/_message_sent.html
@@ -1,0 +1,8 @@
+{# Returned by `POST /posts/{post_id}/message` and HTMX-swapped over
+   the message form in place. The `id="post-message"` matches the
+   form's wrapper id so a follow-up swap (if the user sends a second
+   message after reloading) targets the same DOM node. #}
+<aside role="status" id="post-message">
+  <strong>Message sent.</strong>
+  The poster will see your email on their reply.
+</aside>

--- a/src/domain/templates/posts/_shared/_item.html
+++ b/src/domain/templates/posts/_shared/_item.html
@@ -18,7 +18,7 @@ Layout per card:
   │ Insurance    …                               │
   │ Modality     …                               │
   │                                              │
-  │ <footer>  [✉ Email]                          │
+  │ <footer>  [✉ Message]                        │
   └──────────────────────────────────────────────┘
 
 The card is `<article>` with `<header>`, a body block, and
@@ -31,8 +31,10 @@ each item is its own element rather than a hardcoded join string.
 The body is one `<dl>` from `_facts_block` whose first row carries
 the services (`Seeking` / `Providing` verb + `icon_list` of
 services); subsequent rows carry the demographic facts. The footer
-carries one element — the Email CTA — in the default left-aligned
-footer flow.
+carries one element — the Message CTA, a button-link to the post's
+detail page where the inline contact form (`POST /posts/{id}/message`)
+lives. The list card never exposes the poster's email address; the
+form route resolves the recipient server-side.
 
 Per-kind branching and field selection live in
 `src.domain.logic.posts.view.post_card_view`, which collapses CR /
@@ -60,17 +62,17 @@ post's kind. #}
   subtitle=subtitle,
   data_kind=post.kind) -%}
   {{ facts_block(view) }}
-  {#- Footer carries just the Email CTA — Pico-styled `role="button"
-    class="secondary outline"` with the label "Email". The raw
-    address lives only in the `href`. `target="_blank" rel="noopener
-    noreferrer"` is harmless on `mailto:` URLs and matches the pattern
-    used for the PA `website` link on the detail page. -#}
+  {#- Footer carries the Message CTA — a button-link to the post's
+    detail page where the inline contact form lives. We don't put
+    the form itself in the list card (a textarea per row would be
+    heavy and the per-card recipient would still need a server
+    round-trip); deferring to detail keeps the list scan-shaped.
+    Network-access gating happens on the detail page where the form
+    actually appears. -#}
   <footer>
-    <a href="mailto:{{ post.owner.email }}"
-       target="_blank"
-       rel="noopener noreferrer"
+    <a href="{{ entity_url(entity_name, id=post.id) }}"
        role="button"
-       class="secondary outline">Email</a>
+       class="secondary outline">Message</a>
   </footer>
 {%- endcall %}
 {%- endmacro %}

--- a/src/domain/templates/posts/_shared/_message_form.html
+++ b/src/domain/templates/posts/_shared/_message_form.html
@@ -1,0 +1,34 @@
+{# Inline "message the poster" form on the post detail page.
+
+   Replaces the prior `mailto:` Email button (which dumped the
+   poster's address into the browser and handed the user off to their
+   mail client). The form posts to `POST /posts/{id}/message`; the
+   server renders the message into a transactional email with the
+   sender's email on `Reply-To` so the poster's reply lands back in
+   the sender's inbox and the conversation continues off-platform.
+
+   The `id="post-message"` wrapper matches the swap target the
+   success fragment (`posts/_message_sent.html`) returns, so the
+   form's `<form>` element is replaced in place on a successful send.
+   Errors target the same node so 4xx rerenders also stay local.
+
+   Gating: rendered only when the viewer clears `can_access_network`
+   (the post detail template applies the gate); the route handler
+   enforces the same predicate server-side. #}
+<form id="post-message"
+      hx-post="{{ entity_url(entity_name, id=post.id, subresource='message') }}"
+      hx-target="this"
+      hx-swap="outerHTML"
+      hx-target-4xx="this"
+      hx-swap-4xx="outerHTML"
+      hx-ext="json-enc">
+  <label>
+    Message to the poster
+    <textarea name="body"
+              rows="5"
+              maxlength="2000"
+              required
+              placeholder="Introduce yourself and ask whatever you'd like — the poster will get your message by email and can reply to you directly."></textarea>
+  </label>
+  <button type="submit">Send message</button>
+</form>

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -30,13 +30,9 @@
     {%- if view.referral %}{{ how_to_refer(view) }}{%- endif %}
       <footer>
         {% if can_access_network %}
-          <a href="mailto:{{ post.owner.email }}"
-             target="_blank"
-             rel="noopener noreferrer"
-             role="button"
-             class="secondary outline">Email</a>
+          {% include "posts/_shared/_message_form.html" %}
         {% else %}
-          {{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, "Email", extra_class="secondary") }}
+          {{ locked_action(capabilities.REASON_NETWORK_UNVERIFIED, "Message", extra_class="secondary") }}
         {% endif %}
       </footer>
     </section>

--- a/src/framework/email/README.md
+++ b/src/framework/email/README.md
@@ -31,6 +31,7 @@ await send_email(
     subject="Verify your email",
     html="<p>…</p>",
     text="…",
+    reply_to=None,  # optional; see below
 )
 ```
 
@@ -38,6 +39,14 @@ Both `html` and `text` parts are required — text/plain is what keeps
 the spam score down at deliverability-strict providers. Callers
 render both from the same template pair (see
 `src/domain/templates/emails/`).
+
+`reply_to` is the optional address a recipient's "Reply" goes to
+when it differs from the sending `EMAIL_FROM` address (e.g. an
+in-app message-the-poster flow where the conversation should
+continue between the two real users, not loop back to a no-reply
+mailbox). Omit it (the default `None`) when replies should bounce
+or land in `EMAIL_FROM`'s inbox — the Resend payload simply won't
+carry the key.
 
 ## Why provider-shaped
 

--- a/src/framework/email/sender.py
+++ b/src/framework/email/sender.py
@@ -24,13 +24,27 @@ from src.framework.config import settings
 EmailBackend = Literal["console", "file", "resend"]
 
 
-async def send_email(*, to: str, subject: str, html: str, text: str) -> None:
+async def send_email(
+    *,
+    to: str,
+    subject: str,
+    html: str,
+    text: str,
+    reply_to: str | None = None,
+) -> None:
     """Send a transactional email via the configured backend.
 
     Both `html` and `text` parts are required — text/plain is what keeps
     the spam score down at deliverability-strict providers. Callers
     render both from the same template pair (see
     `domain/templates/emails/`).
+
+    `reply_to` is the optional address a recipient's "Reply" goes to
+    when it differs from the sending `EMAIL_FROM` address (e.g. an
+    in-app message-the-poster flow where the conversation should
+    continue between the two real users, not loop back to a no-reply
+    mailbox). Omit it for the common case where replies should bounce
+    or land in `EMAIL_FROM`'s inbox.
 
     Errors propagate. Email send is best-effort by design — fastapi-users
     hooks don't expose a retry surface and adding one would be the wrong
@@ -40,11 +54,13 @@ async def send_email(*, to: str, subject: str, html: str, text: str) -> None:
     backend: EmailBackend = settings.EMAIL_BACKEND  # type: ignore[assignment]
 
     if backend == "console":
-        _send_console(to=to, subject=subject, html=html, text=text)
+        _send_console(to=to, subject=subject, html=html, text=text, reply_to=reply_to)
     elif backend == "file":
-        _send_file(to=to, subject=subject, html=html, text=text)
+        _send_file(to=to, subject=subject, html=html, text=text, reply_to=reply_to)
     elif backend == "resend":
-        await _send_resend(to=to, subject=subject, html=html, text=text)
+        await _send_resend(
+            to=to, subject=subject, html=html, text=text, reply_to=reply_to
+        )
     else:
         raise ValueError(
             f"Unknown EMAIL_BACKEND={backend!r}; expected one of "
@@ -52,17 +68,23 @@ async def send_email(*, to: str, subject: str, html: str, text: str) -> None:
         )
 
 
-def _send_console(*, to: str, subject: str, html: str, text: str) -> None:
+def _send_console(
+    *, to: str, subject: str, html: str, text: str, reply_to: str | None
+) -> None:
     print("=" * 60, file=sys.stderr)
     print(f"[email:console] To: {to}", file=sys.stderr)
     print(f"[email:console] From: {settings.EMAIL_FROM}", file=sys.stderr)
+    if reply_to is not None:
+        print(f"[email:console] Reply-To: {reply_to}", file=sys.stderr)
     print(f"[email:console] Subject: {subject}", file=sys.stderr)
     print("-" * 60, file=sys.stderr)
     print(text, file=sys.stderr)
     print("=" * 60, file=sys.stderr)
 
 
-def _send_file(*, to: str, subject: str, html: str, text: str) -> None:
+def _send_file(
+    *, to: str, subject: str, html: str, text: str, reply_to: str | None
+) -> None:
     out_dir = Path(".mail")
     out_dir.mkdir(exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -70,9 +92,11 @@ def _send_file(*, to: str, subject: str, html: str, text: str) -> None:
     # collapse runs, cap length. Avoids surprises on Windows-friendly checkouts.
     slug = re.sub(r"[^A-Za-z0-9_-]+", "-", subject).strip("-")[:50] or "email"
     path = out_dir / f"{ts}-{slug}.eml"
+    reply_to_header = f"Reply-To: {reply_to}\n" if reply_to is not None else ""
     body = (
         f"To: {to}\n"
         f"From: {settings.EMAIL_FROM}\n"
+        f"{reply_to_header}"
         f"Subject: {subject}\n"
         f"Content-Type: multipart/alternative\n"
         f"\n"
@@ -82,7 +106,9 @@ def _send_file(*, to: str, subject: str, html: str, text: str) -> None:
     path.write_text(body, encoding="utf-8")
 
 
-async def _send_resend(*, to: str, subject: str, html: str, text: str) -> None:
+async def _send_resend(
+    *, to: str, subject: str, html: str, text: str, reply_to: str | None
+) -> None:
     """Resend HTTP API call.
 
     Imported lazily so the `resend` package is only required when this
@@ -102,13 +128,17 @@ async def _send_resend(*, to: str, subject: str, html: str, text: str) -> None:
     # keeps the caller async without pulling in an async HTTP client.
     import asyncio
 
-    await asyncio.to_thread(
-        resend.Emails.send,
-        {
-            "from": settings.EMAIL_FROM,
-            "to": [to],
-            "subject": subject,
-            "html": html,
-            "text": text,
-        },
-    )
+    payload: dict[str, object] = {
+        "from": settings.EMAIL_FROM,
+        "to": [to],
+        "subject": subject,
+        "html": html,
+        "text": text,
+    }
+    if reply_to is not None:
+        # Resend accepts `reply_to` as a string or list-of-strings; pass
+        # the single address as a string to match what we accept on the
+        # public surface (one reply target per send, not a list).
+        payload["reply_to"] = reply_to
+
+    await asyncio.to_thread(resend.Emails.send, payload)

--- a/src/framework/email/test_sender.py
+++ b/src/framework/email/test_sender.py
@@ -154,6 +154,118 @@ async def test_resend_backend_calls_resend_sdk(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_console_backend_includes_reply_to_when_set(capsys, monkeypatch):
+    """`reply_to` is the conversation-routing knob for sender-to-poster
+    flows (post messages) — the recipient's "Reply" should land in the
+    sender's inbox, not the `EMAIL_FROM` no-reply mailbox. The console
+    backend surfaces it as a `Reply-To:` line so dev sends visibly carry
+    the header."""
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "console")
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.EMAIL_FROM", "no-reply@example.com"
+    )
+
+    await send_email(
+        to="alice@example.com",
+        subject="Hello",
+        html="<p>Hi</p>",
+        text="Hi",
+        reply_to="bob@example.com",
+    )
+
+    err = capsys.readouterr().err
+    assert "Reply-To: bob@example.com" in err
+
+
+@pytest.mark.asyncio
+async def test_file_backend_includes_reply_to_when_set(tmp_path, monkeypatch):
+    """The `.eml`-shaped file emits a `Reply-To:` header — same rule
+    as the console backend, but on disk so the dev can inspect the
+    saved headers."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "file")
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.EMAIL_FROM", "no-reply@example.com"
+    )
+
+    await send_email(
+        to="poster@example.com",
+        subject="New message",
+        html="<p>HTML</p>",
+        text="Plain",
+        reply_to="sender@example.com",
+    )
+
+    files = list(Path(".mail").glob("*.eml"))
+    assert len(files) == 1
+    body = files[0].read_text(encoding="utf-8")
+    assert "Reply-To: sender@example.com" in body
+
+
+@pytest.mark.asyncio
+async def test_resend_backend_forwards_reply_to(monkeypatch):
+    """When set, `reply_to` lands in the Resend payload as a single
+    string (Resend accepts string-or-list; we pass a string to match
+    the public surface's single-address shape)."""
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "resend")
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.RESEND_API_KEY", "test-key"
+    )
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.EMAIL_FROM", "no-reply@example.com"
+    )
+
+    fake_resend = type(sys)("resend")
+    fake_resend.api_key = None
+    fake_resend.Emails = type(sys)("Emails")
+    from unittest.mock import Mock
+
+    send_mock = Mock(return_value={"id": "msg_123"})
+    fake_resend.Emails.send = send_mock
+
+    with patch.dict(sys.modules, {"resend": fake_resend}):
+        await send_email(
+            to="poster@example.com",
+            subject="New message",
+            html="<p>m</p>",
+            text="m",
+            reply_to="sender@example.com",
+        )
+
+    payload = send_mock.call_args[0][0]
+    assert payload["reply_to"] == "sender@example.com"
+
+
+@pytest.mark.asyncio
+async def test_resend_backend_omits_reply_to_when_unset(monkeypatch):
+    """The default-None case must NOT add a `reply_to` key to the
+    Resend payload — pinning this prevents an `{"reply_to": None}`
+    regression that some SDK versions would forward as a literal
+    `null` header."""
+    monkeypatch.setattr("src.framework.email.sender.settings.EMAIL_BACKEND", "resend")
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.RESEND_API_KEY", "test-key"
+    )
+    monkeypatch.setattr(
+        "src.framework.email.sender.settings.EMAIL_FROM", "no-reply@example.com"
+    )
+
+    fake_resend = type(sys)("resend")
+    fake_resend.api_key = None
+    fake_resend.Emails = type(sys)("Emails")
+    from unittest.mock import Mock
+
+    send_mock = Mock(return_value={"id": "msg_123"})
+    fake_resend.Emails.send = send_mock
+
+    with patch.dict(sys.modules, {"resend": fake_resend}):
+        await send_email(to="x@example.com", subject="s", html="h", text="t")
+
+    payload = send_mock.call_args[0][0]
+    assert "reply_to" not in payload
+
+
+@pytest.mark.asyncio
 async def test_unknown_backend_raises(monkeypatch):
     """An unknown `EMAIL_BACKEND` value is a config typo — better to
     fail fast at first send than swallow it and lose mail."""


### PR DESCRIPTION
## Summary

- Verified viewers on a post detail page see an inline message form (`<textarea>` + Send) instead of the prior `mailto:` button. Submit → `POST /posts/{id}/message` → server renders a transactional email to `post.owner.email` with `Reply-To: sender.email` and a link back to the post → form swaps to a "Message sent" confirmation.
- List cards now link to detail instead of exposing `post.owner.email` in a `mailto:` href.
- Fire-and-forget: no `PostMessage` entity, no DB row. The poster's reply continues off-platform in their own mail client.

The whole point of `Reply-To` is to let the conversation continue between the two real users instead of looping back to the `EMAIL_FROM` no-reply mailbox.

## Architectural notes

- **Event-shaped subresource** per RESOURCE_GRAMMAR § "POST /<r>/{id}/<event>" — no parent schema change, no new entity to register.
- **`reply_to` is a new optional param on `send_email`** — default `None` preserves prior behavior, no current callers depend on it. Threaded through console / file / resend backends.
- **Authz gate held identical** (`can_access_network`). A `can_message` predicate exists in `domain/logic/capabilities.py` and the docstring suggests tighter scoping is intended; that's a separate behavior change, not bundled here.
- **No `mailto:` in markup any more on posts** — list cards used to leak `post.owner.email` to anyone with network access.

## Test plan

- [x] Transport: 4 new tests cover `reply_to` for console, file, resend, and the unset-default case (`src/framework/email/test_sender.py`).
- [x] Domain email: 7 new tests pin recipient / reply-to / HTML-escape / absolute link shape (`src/domain/logic/posts/test_emails.py`).
- [x] Route: 4 new tests for `POST /posts/{id}/message` — 403 for unverified, 200 + email dispatched for verified, 404 for missing post, 422 for blank body (`src/domain/routes/test_posts.py`).
- [x] Template: existing post-detail tests updated to assert the form (instead of `mailto:`) for verified, locked CTA for unverified — neither path leaks the poster's email to the browser.
- [x] `dev test` (2420 passed, 101 skipped) and `dev test contract` (40 passed) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)