### PR TITLE
Lock organizations behind network capability + extract NETWORK_GATED_READ_POLICY

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -46,6 +46,7 @@ from src.framework.access.capabilities.capabilities import (  # noqa: F401
     Condition,
     Gate,
 )
+from src.framework.dispatch.entity_spec import ReadPolicy
 
 # Reason codes used by the `_shared/_locked.html` macros and
 # `fix_url_for(...)`. Closed vocab: any new reason must be added here and
@@ -245,22 +246,58 @@ def check_network(user: Any) -> CapabilityCheck:
 
 
 def can_access_network(user: Any) -> bool:
-    """Feed-teaser gate: delegates to `check_network`."""
+    """Feed-teaser gate: superuser bypass, otherwise delegates to
+    `check_network`.
+
+    Symmetric with `assert_can_access_network` — both forms grant
+    superusers full read access regardless of claim state, so the
+    route-level guard and the template-level affordance can't
+    disagree about what a superuser sees. Without the bypass here,
+    a superuser navigating around would clear the route's 403 check
+    yet still see locked-popover affordances in templates that read
+    `{% if can_access_network %}` or render `entity_link(...)` for
+    a gated entity — a contradictory UX where the chrome treats the
+    viewer as locked while the underlying page is open.
+    """
+    if getattr(user, "is_superuser", False):
+        return True
     return check_network(user).granted
 
 
 def assert_can_access_network(user: Any) -> None:
-    """Raising form of `can_access_network`. Superusers bypass.
+    """Raising form of `can_access_network`. Superuser bypass
+    delegates to the predicate, which short-circuits first.
 
     Used as `ReadPolicy.assert_can_read` on entities whose data is
     restricted to verified network members (e.g. clinicians).
     """
-    if getattr(user, "is_superuser", False):
-        return
     if not can_access_network(user):
         from src.framework.http.exceptions import ForbiddenError
 
         raise ForbiddenError(detail="Provider network access required.")
+
+
+# Pre-built `ReadPolicy` for the network gate. Specs that want
+# "verified-clinician-or-org-rep can read; everyone else 403s and sees a
+# locked-link popover" set `read_policy=NETWORK_GATED_READ_POLICY` rather
+# than re-declaring the same three-field `ReadPolicy(...)` block. Today's
+# members: USER_ENTITY, CLINICIAN_ENTITY, ORGANIZATION_ENTITY (every
+# directory entity whose rows reveal a real person / practice / org).
+#
+# Why a constant here and not a `network_gated()` factory or a flag on
+# `EntitySpec`: ReadPolicy is structurally a tuple of (raiser, predicate,
+# reason_code), and the three callables it bundles are themselves named
+# domain facts (`assert_can_access_network`, `can_access_network`,
+# `REASON_NETWORK_UNVERIFIED`). A frozen instance is the cheapest binding
+# that points all three at the same gate; a factory would just be
+# `lambda: ReadPolicy(...)` over the same args, and a flag would push
+# this domain-specific tuple into the framework which doesn't otherwise
+# know about Claim A/B.
+NETWORK_GATED_READ_POLICY: ReadPolicy = ReadPolicy(
+    assert_can_read=assert_can_access_network,
+    can_read=can_access_network,
+    lock_reason=REASON_NETWORK_UNVERIFIED,
+)
 
 
 def can_post_referral(user: Any) -> bool:

--- a/src/domain/routes/test_organizations.py
+++ b/src/domain/routes/test_organizations.py
@@ -333,3 +333,40 @@ async def test_get_org_intakes_404_for_missing_org(
 ):
     response = await authenticated_client.get(f"/organizations/{uuid.uuid4()}/intakes")
     assert response.status_code == 404
+
+
+# --- Network gate (read_policy) ---------------------------------------------
+
+
+async def test_list_403_for_unverified_viewer(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """`/organizations` is gated behind `can_access_network` via the
+    spec's `read_policy`. A claimless viewer (no verified clinician,
+    no verified org rep) gets 403 — symmetric with the clinician
+    list. The list-mount calls `_check_read` before issuing the
+    underlying SQL, so this fires at the repo layer rather than in
+    the template."""
+    response = await authenticated_client.get("/organizations")
+    assert response.status_code == 403
+
+
+async def test_list_200_for_verified_viewer(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Self-registering an organization grants the creator a verified
+    `OrgRepresentation` (`authority_status='verified'`), which flips
+    `can_access_network` to True — the same user can now list orgs.
+    Pins the network-bootstrap path: a brand-new user becomes Claim-B
+    by completing the canonical create flow."""
+    create = await authenticated_client.post(
+        "/organizations", data=_org_payload(name="Gateway Org")
+    )
+    assert create.status_code == 201
+
+    response = await authenticated_client.get("/organizations")
+    assert response.status_code == 200
+    assert "Gateway Org" in response.text

--- a/src/domain/specs/clinician.py
+++ b/src/domain/specs/clinician.py
@@ -16,11 +16,7 @@ Read by:
 
 from typing import Final
 
-from src.domain.logic.capabilities import (
-    REASON_NETWORK_UNVERIFIED,
-    assert_can_access_network,
-    can_access_network,
-)
+from src.domain.logic.capabilities import NETWORK_GATED_READ_POLICY
 from src.domain.logic.clinicians.repository import (
     ClinicianRepository,
     get_clinician_repository,
@@ -52,7 +48,6 @@ from src.framework.dispatch.entity_spec import (
     AUTHENTICATED,
     OWNER_OR_ADMIN,
     EntitySpec,
-    ReadPolicy,
     RelatedListSubresource,
     RouteSet,
     StateAxis,
@@ -90,11 +85,7 @@ CLINICIAN_ENTITY: Final[EntitySpec] = EntitySpec(
     repo_dep=get_clinician_repository,
     auth_deps=AUTHENTICATED,
     auth_policy=OWNER_OR_ADMIN,
-    read_policy=ReadPolicy(
-        assert_can_read=assert_can_access_network,
-        can_read=can_access_network,
-        lock_reason=REASON_NETWORK_UNVERIFIED,
-    ),
+    read_policy=NETWORK_GATED_READ_POLICY,
     create_adapter=ClinicianCreate,
     update_adapter=ClinicianUpdate,
     read_schema=ClinicianRead,

--- a/src/domain/specs/organization.py
+++ b/src/domain/specs/organization.py
@@ -4,6 +4,7 @@ practices, health systems, and solo-practice shells.
 
 from typing import Final
 
+from src.domain.logic.capabilities import NETWORK_GATED_READ_POLICY
 from src.domain.logic.org_representations.repository import (
     OrgRepresentationRepository,
 )
@@ -53,6 +54,7 @@ ORGANIZATION_ENTITY: Final[EntitySpec] = EntitySpec(
     repo_dep=get_organization_repository,
     auth_deps=AUTHENTICATED,
     auth_policy=OWNER_OR_ADMIN,
+    read_policy=NETWORK_GATED_READ_POLICY,
     create_adapter=OrganizationCreate,
     update_adapter=OrganizationUpdate,
     read_schema=OrganizationRead,

--- a/src/domain/specs/user.py
+++ b/src/domain/specs/user.py
@@ -19,11 +19,7 @@ A1 documented (`api/common -> api/routes`) is resolved.
 from typing import Final
 
 from src.auth_config import current_active_user
-from src.domain.logic.capabilities import (
-    REASON_NETWORK_UNVERIFIED,
-    assert_can_access_network,
-    can_access_network,
-)
+from src.domain.logic.capabilities import NETWORK_GATED_READ_POLICY
 from src.domain.logic.clinicians.repository import ClinicianRepository
 from src.domain.logic.users.repository import get_user_repository
 from src.domain.logic.users.schema import (
@@ -38,7 +34,6 @@ from src.framework.audit.core import AuditAction
 from src.framework.dispatch.entity_spec import (
     ADMIN_FOR_WRITE,
     EntitySpec,
-    ReadPolicy,
     RelatedListSubresource,
     RouteSet,
     StateAxis,
@@ -62,11 +57,7 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
     display_label_fn=lambda u: u.username,
     repo_dep=get_user_repository,
     auth_deps=ADMIN_FOR_WRITE,
-    read_policy=ReadPolicy(
-        assert_can_read=assert_can_access_network,
-        can_read=can_access_network,
-        lock_reason=REASON_NETWORK_UNVERIFIED,
-    ),
+    read_policy=NETWORK_GATED_READ_POLICY,
     audit_snapshot=UserAuditSnapshot,
     private_fields=("email", "is_active"),
     private_field_predicate=is_self_or_admin,

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -54,7 +54,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
 `DESIRED_TIME_SLOT_LABELS`, `REFERRAL_SERVICE_LABELS`,
 `TREATMENT_SETTINGS_LABELS`) are Jinja globals. #}
 {%- from "_shared/sections.html" import fact -%}
-{%- from "_shared/_locked.html" import locked_field, locked_name -%}
+{%- from "_shared/_locked.html" import entity_link, locked_field, locked_name -%}
 {% macro facts_block(view, expanded=False, redacted=False) -%}
   <section class="entity-facts">
     <dl>
@@ -155,7 +155,7 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                         {% if redacted %}
                           {{ locked_name(_name_placeholder) }}{# title-case-ignore: placeholder org name #}
                         {% else %}
-                          <a href="{{ entity_url('organization', id=view.organization_link.id) }}">{{ view.organization_link.name }}</a>
+                          {{ entity_link('organization', view.organization_link.name, id=view.organization_link.id) }}
                         {% endif %}
                       {% endcall %}
                     {%- endif %}

--- a/src/domain/templates/programs/detail.html
+++ b/src/domain/templates/programs/detail.html
@@ -1,6 +1,7 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions -%}
 {%- from "_shared/sections.html" import fact -%}
+{%- from "_shared/_locked.html" import entity_link -%}
 {% block resource_label %}Programs{% endblock %}
 {% block current_label %}{{ program.name }}{% endblock %}
 {% block actions %}
@@ -24,13 +25,13 @@
     {%- if program.description %}<p class="entity-description">{{ program.description }}</p>{%- endif %}
     <section class="entity-facts">
       <dl>
-        {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a>
-      {% endcall %}
-      {%- if program.state_preference %}{{ fact('state_served', 'State served', program.state_preference) }}{%- endif %}
-        {%- if program.start_date %}{{ fact('start_date', 'Start date', program.start_date) }}{%- endif %}
-          {%- if program.end_date %}{{ fact('end_date', 'End date', program.end_date) }}{%- endif %}
-            {{ fact('accepting_referrals', 'Accepting referrals', "Yes" if program.accepting_referrals else "No") }}
-          </dl>
+        {%- call fact('organization', 'Organization') %}{{ entity_link('organization', program.organization.name, id=program.org_id) }}
+        {% endcall %}
+        {%- if program.state_preference %}{{ fact('state_served', 'State served', program.state_preference) }}{%- endif %}
+          {%- if program.start_date %}{{ fact('start_date', 'Start date', program.start_date) }}{%- endif %}
+            {%- if program.end_date %}{{ fact('end_date', 'End date', program.end_date) }}{%- endif %}
+              {{ fact('accepting_referrals', 'Accepting referrals', "Yes" if program.accepting_referrals else "No") }}
+            </dl>
+          </section>
         </section>
-      </section>
-    {% endblock %}
+      {% endblock %}

--- a/src/domain/templates/programs/list.html
+++ b/src/domain/templates/programs/list.html
@@ -2,6 +2,7 @@
 {%- from "_shared/_card.html" import card -%}
 {%- from "_shared/sections.html" import fact -%}
 {%- from "_shared/_item_list.html" import item_list -%}
+{%- from "_shared/_locked.html" import entity_link -%}
 {% block actions %}
   <li>
     <a href="{{ entity_form_url('program') }}" role="button">{{ entity_create_label("program") }}</a>
@@ -19,11 +20,11 @@
     subtitle=subtitle) -%}
     <section class="entity-facts">
       <dl>
-        {%- call fact('organization', 'Organization') %}<a href="{{ entity_url('organization', id=program.org_id) }}">{{ program.organization.name }}</a>
-      {% endcall %}
-    </dl>
-  </section>
-{%- endcall %}
+        {%- call fact('organization', 'Organization') %}{{ entity_link('organization', program.organization.name, id=program.org_id) }}
+        {% endcall %}
+      </dl>
+    </section>
+  {%- endcall %}
 {%- endmacro %}
 {% block list_body %}
   {%- set _empty %}

--- a/src/framework/rendering/test_route_urls.py
+++ b/src/framework/rendering/test_route_urls.py
@@ -181,9 +181,10 @@ def test_entity_lock_reason_none_when_viewer_passes_gate():
 
 
 def test_entity_lock_reason_none_for_entity_without_read_policy():
-    """`organization` declares no `read_policy` — listing is open, so
-    there's no lock affordance to render regardless of viewer."""
-    assert entity_lock_reason("organization", _Unverified()) is None
+    """`post` declares no `read_policy` — posting is intentionally open
+    so the feed teaser can render to unverified viewers, and there's
+    no lock affordance to surface regardless of viewer."""
+    assert entity_lock_reason("post", _Unverified()) is None
 
 
 def test_entity_lock_reason_unknown_entity_raises():
@@ -224,9 +225,10 @@ def test_breadcrumb_entity_item_label_override_replaces_default():
 def test_breadcrumb_entity_item_for_entity_without_read_policy():
     """An ungated entity (no `read_policy` set) always produces
     `lock_reason=None` — the back link is a plain `<a>` regardless of
-    viewer."""
-    item = breadcrumb_entity_item("organization", _Unverified())
-    assert item == ("Organizations", "/organizations", None)
+    viewer. `post` is the canonical open example: posting is public
+    so the feed teaser can render to unverified viewers."""
+    item = breadcrumb_entity_item("post", _Unverified())
+    assert item == ("Posts", "/posts", None)
 
 
 def test_breadcrumb_entity_item_unknown_entity_raises():

--- a/src/framework/templates/_shared/_clinician_card.html
+++ b/src/framework/templates/_shared/_clinician_card.html
@@ -23,6 +23,7 @@
 #}
 {%- from "_shared/_card.html" import card -%}
 {%- from "_shared/sections.html" import fact -%}
+{%- from "_shared/_locked.html" import entity_link -%}
 {% macro clinician_card(clinician) -%}
   {%- set view = clinician_card_view(clinician) -%}
   {%- set affiliations = clinician.clinician_affiliations | list -%}
@@ -61,7 +62,7 @@
         {%- call fact('practice', 'Practice', dd_class='meta') -%}
           {%- if affiliations -%}
             {%- for aff in affiliations -%}
-              <a href="{{ entity_url('organization', id=aff.org_id) }}">{{ aff.org.name }}</a>
+              {{ entity_link('organization', aff.org.name, id=aff.org_id) }}
             {%- endfor -%}
           {%- else -%}
             &mdash;

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -234,24 +234,24 @@ def test_list_view_renders_actions_block_in_toolbar_right() -> None:
 def test_detail_view_renders_back_affordance_and_actions() -> None:
     """``views/detail.html`` builds the single-segment breadcrumb via
     `breadcrumb_entity_item(entity_name)` and the breadcrumb macro
-    renders it as `<a class="breadcrumb-back" href="/organizations">…</a>`.
+    renders it as `<a class="breadcrumb-back" href="/posts">…</a>`.
     Actions land inside the shared two-zone toolbar — empty left zone
     (no search link), and a `<menu class="toolbar-right">` carrying
     the `<li>` commands. Pins the "detail actions land at the same
     right edge as list-page actions" rule (no per-view-type toolbar
-    shape). Uses `organization` (no `read_policy`) so the back link
-    stays an unlocked `<a>` for the chrome assertion; the locked
-    branch is pinned by `test_breadcrumb.py` / route-level tests."""
+    shape). Uses `post` (no `read_policy`) so the back link stays an
+    unlocked `<a>` for the chrome assertion; the locked branch is
+    pinned by `test_breadcrumb.py` / route-level tests."""
     env = _make_env()
     _add_child(
         env,
         "stub.html",
         """
         {% extends "views/detail.html" %}
-        {% set entity_name = "organization" %}
-        {% block resource_label %}Organizations{% endblock %}
-        {% block current_label %}Sunrise Therapy{% endblock %}
-        {% block actions %}<li><a id="edit" href="/organizations/1/form">Edit</a></li>{% endblock %}
+        {% set entity_name = "post" %}
+        {% block resource_label %}Posts{% endblock %}
+        {% block current_label %}A referral{% endblock %}
+        {% block actions %}<li><a id="edit" href="/posts/1/form">Edit</a></li>{% endblock %}
         {% block content %}body{% endblock %}
         """,
     )
@@ -264,15 +264,15 @@ def test_detail_view_renders_back_affordance_and_actions() -> None:
 
     tree = HTMLParser(html)
     back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
-    assert back is not None and back.attributes.get("href") == "/organizations"
+    assert back is not None and back.attributes.get("href") == "/posts"
     label = back.css_first("span.breadcrumb-back-label")
-    assert label is not None and label.text(strip=True) == "Organizations"
-    assert "Sunrise Therapy" in html
+    assert label is not None and label.text(strip=True) == "Posts"
+    assert "A referral" in html
     assert '<div class="toolbar">' in html
     assert '<menu class="toolbar-right">' in html
     # No search link on detail pages — left zone stays empty.
     assert 'class="toolbar-filter-link"' not in html
-    assert '<li><a id="edit" href="/organizations/1/form">Edit</a></li>' in html
+    assert '<li><a id="edit" href="/posts/1/form">Edit</a></li>' in html
 
 
 def test_form_new_view_renders_create_heading_from_context() -> None:
@@ -280,9 +280,9 @@ def test_form_new_view_renders_create_heading_from_context() -> None:
     handler-supplied context and renders it as the toolbar `<h1>`.
     The handler computes it via `create_label_for(spec, kind=...)`,
     the same helper every "Create X" CTA reads from, so the page
-    title can't drift from the button that opened it. Uses
-    `organization` (no `read_policy`) so the chrome assertion stays
-    a plain unlocked back link — the locked branch is covered by
+    title can't drift from the button that opened it. Uses `post`
+    (no `read_policy`) so the chrome assertion stays a plain unlocked
+    back link — the locked branch is covered by
     `test_breadcrumb.py`."""
     env = _make_env()
     _add_child(
@@ -290,8 +290,8 @@ def test_form_new_view_renders_create_heading_from_context() -> None:
         "stub.html",
         """
         {% extends "views/form_new.html" %}
-        {% set entity_name = "organization" %}
-        {% block resource_label %}Organizations{% endblock %}
+        {% set entity_name = "post" %}
+        {% block resource_label %}Posts{% endblock %}
         {% block content %}<form id="x"></form>{% endblock %}
         """,
     )
@@ -300,15 +300,15 @@ def test_form_new_view_renders_create_heading_from_context() -> None:
         request=_request_stub(),
         is_authenticated=False,
         is_development=False,
-        create_heading="Create organization",
+        create_heading="Create post",
     )
 
     tree = HTMLParser(html)
     back = tree.css_first('nav[aria-label="breadcrumb"] a.breadcrumb-back')
-    assert back is not None and back.attributes.get("href") == "/organizations"
+    assert back is not None and back.attributes.get("href") == "/posts"
     label = back.css_first("span.breadcrumb-back-label")
-    assert label is not None and label.text(strip=True) == "Organizations"
-    assert "<h1>Create organization</h1>" in html
+    assert label is not None and label.text(strip=True) == "Posts"
+    assert "<h1>Create post</h1>" in html
     assert '<form id="x"></form>' in html
 
 


### PR DESCRIPTION
## Summary

- **Gates organization reads** behind `can_access_network` via `EntitySpec.read_policy`. `/organizations` list/search now 403s for viewers without a verified clinician or org-rep claim — symmetric with the existing clinician and user gates. The list-mount calls `_check_read` before issuing SQL so the guard fires at the repo layer.
- **Refactors the policy declaration** out of the per-spec boilerplate. The same three-field `ReadPolicy(assert_can_read=assert_can_access_network, can_read=can_access_network, lock_reason=REASON_NETWORK_UNVERIFIED)` was repeated verbatim in `user.py` and `clinician.py`, and would have been the third copy in `organization.py`. Now it lives once as `NETWORK_GATED_READ_POLICY` in `domain/logic/capabilities.py` and each spec opts in with one import + `read_policy=NETWORK_GATED_READ_POLICY`. Future gating is a one-line change.
- **Fixes a superuser asymmetry**: `assert_can_access_network` short-circuited for `is_superuser`, but the predicate form `can_access_network` did not. A superuser cleared the route's 403 yet the chrome's `{% if can_access_network %}` branches and `entity_link` helpers still rendered locked popovers. Both now agree.
- **Swaps four bare `<a href="{{ entity_url('organization', …) }}">` anchors** to `entity_link('organization', name, id=…)` so the locked-link popover lights up for unverified viewers on the affected templates (`posts/_shared/_facts_block.html`, `programs/list.html`, `programs/detail.html`, `framework/templates/_shared/_clinician_card.html`). The `template_route_check.py` lint enforces this once org is in the gated set.

## Contract-surface check

| Surface | Change | Compatibility |
|---|---|---|
| `GET /organizations`, `GET /organizations/search` | 200 → 403 for unverified | Breaking — intentional |
| `GET /organizations/{id}` | Unchanged (detail uses `_get_by_id`, which the framework deliberately doesn't gate — same rule applies to clinician detail) | Compatible |
| Templates linking to orgs | Now consult `entity_lock_reason("organization", viewer)` and may render a locked-popover button instead of an `<a>` | Visible to unverified viewers only |
| Persisted shape, request body shape | Untouched | — |

## Test plan

- [x] 2 new tests pin the gate at the route layer (`test_list_403_for_unverified_viewer`, `test_list_200_for_verified_viewer` — the canonical create flow bootstraps the verified `OrgRepresentation`).
- [x] Framework tests that previously used "organization" as the ungated example switched to "post" (the canonical open entity — posting is intentionally open for the feed teaser).
- [x] `pytest` (2444 passed, 101 skipped) and `dev test contract` (40 passed) clean.
- [x] `dev lint` clean — the bare-anchor lint catches any future regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)