### PR TITLE
Inline NPPES mock into routes conftest

### DIFF
--- a/src/domain/routes/conftest.py
+++ b/src/domain/routes/conftest.py
@@ -1,20 +1,52 @@
 """Pytest fixtures scoped to the route-test directory.
 
-`mock_nppes_default_match` (defined in `tests/fixtures.py`) is wired in
-as autouse for every test under `src/domain/routes/test_*.py` so the
+`_autouse_mock_nppes` patches NPPES to return a verified-match response
+for every test under `src/domain/routes/test_*.py`. Without it, the
 inline-create gate on `POST /clinicians` and `POST /organizations`
-doesn't block the happy path with a real NPPES round-trip. The
-verification-cluster tests under `src/domain/logic/verifications/`
-exercise the real `nppes_lookup` against a mocked HTTP transport and
-must not be affected — keeping the autouse scope to this directory
-preserves that.
+(which now raises `BadRequestError` on any non-verified NPPES outcome
+— see `src/domain/logic/clinicians/handlers.py` and the verifications
+README) would block the happy path in every route-level integration
+test with a real NPPES round-trip.
+
+The mock lives here, not in `tests/fixtures.py`, on purpose: making it
+autouse globally would break the verification-cluster tests under
+`src/domain/logic/verifications/test_handlers.py`, which exercise the
+real `nppes_lookup` against a mocked HTTP transport. Pytest's conftest
+discovery scopes this autouse to the directory tree the file lives in,
+so the verification tests stay untouched.
+
+The defaults align with the wire defaults used by route-level tests:
+`tests.helpers.clinician_payload()` (Jane / Smith) and the org-create
+tests' `_org_payload()` (Acme Health). A test that needs a failure-mode
+lookup (NPI not found, name mismatch, OIG hit) re-patches the two
+symbols locally with a higher-precedence `monkeypatch.setattr`.
 """
+
+from unittest.mock import AsyncMock
 
 import pytest
 
+from src.domain.logic.verifications.nppes import NppesOrgResult, NppesResult
+
 
 @pytest.fixture(autouse=True)
-def _autouse_mock_nppes(mock_nppes_default_match):
-    """Resolve the named fixture so it runs automatically for tests
-    in this directory."""
-    yield
+def _autouse_mock_nppes(monkeypatch):
+    monkeypatch.setattr(
+        "src.domain.logic.verifications.handlers.nppes_lookup",
+        AsyncMock(
+            return_value=NppesResult(
+                found=True, first_name="Jane", last_name="Smith", raw={}
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "src.domain.logic.verifications.handlers.nppes_lookup_type2",
+        AsyncMock(
+            return_value=NppesOrgResult(
+                found=True,
+                org_name="Acme Health",
+                authorized_official_name=None,
+                raw={},
+            )
+        ),
+    )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -31,47 +31,6 @@ def _enable_sqlite_foreign_keys(dbapi_connection, connection_record):
     cursor.close()
 
 
-@pytest.fixture
-def mock_nppes_default_match(monkeypatch):
-    """Patch NPPES to return a verified-match response by default,
-    aligned with the wire defaults used by `tests.helpers.clinician_payload()`
-    (Jane / Smith) and the org-create tests (Acme Health). Route-level
-    tests use this so the inline-create hook (which now raises
-    `BadRequestError` on any non-verified NPPES outcome — see
-    `src/domain/logic/clinicians/handlers.py` and the verifications
-    README) doesn't block the happy path. Tests that need a failure-mode
-    lookup re-patch the two symbols locally.
-
-    Wired in as an autouse fixture only for the route-test directories
-    via `src/domain/routes/conftest.py` so the verification-cluster
-    tests — which exercise the real `nppes_lookup` against a mocked
-    HTTP transport — aren't affected.
-    """
-    from unittest.mock import AsyncMock
-
-    from src.domain.logic.verifications.nppes import NppesOrgResult, NppesResult
-
-    monkeypatch.setattr(
-        "src.domain.logic.verifications.handlers.nppes_lookup",
-        AsyncMock(
-            return_value=NppesResult(
-                found=True, first_name="Jane", last_name="Smith", raw={}
-            )
-        ),
-    )
-    monkeypatch.setattr(
-        "src.domain.logic.verifications.handlers.nppes_lookup_type2",
-        AsyncMock(
-            return_value=NppesOrgResult(
-                found=True,
-                org_name="Acme Health",
-                authorized_official_name=None,
-                raw={},
-            )
-        ),
-    )
-
-
 @pytest.fixture(scope="session", autouse=True)
 async def _db_schema() -> AsyncGenerator[None, None]:
     """Create the schema once per pytest session — every


### PR DESCRIPTION
## Summary

- The autouse NPPES mock added in #1281 was split across two files: the fixture body in `tests/fixtures.py` and a wrapper autouse fixture in `src/domain/routes/conftest.py` that resolved the named fixture. The indirection paid for nothing — no other directory uses the named fixture, and "this only affects route tests" was readable in two places that could drift.
- Inline the patch body directly into the routes conftest as a single autouse fixture. One file owns the scoping decision; the verifications cluster's HTTP-stub tests remain untouched.

## Test plan

- [x] `dev lint` passes
- [x] `dev test` — 2451 passed, 101 skipped (same numbers as the parent PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)