### PR TITLE
Always show viewer's own clinician on /clinicians

### DIFF
--- a/src/domain/logic/clinicians/repository.py
+++ b/src/domain/logic/clinicians/repository.py
@@ -51,34 +51,48 @@ class ClinicianRepository(BaseRepository):
         Never-verified clinicians are filtered out so the directory
         stays a curated index of verified providers — the chrome's
         capability gates already prevent them from posting, and listing
-        them would surface noise.
+        them would surface noise. **Exception:** the viewer's *own*
+        clinician rows are always included regardless of verification
+        state. A brand-new user's in-flight clinician (sitting in the
+        NPPES queue, not yet ``clinician_verified``) must remain
+        visible to its creator so they can find and edit it, even on
+        the unfiltered `/clinicians` page. The redaction layer keeps
+        other viewers from leaking the identity — the universe never
+        narrows for the owner.
 
         ``owner="me"`` scopes results to the viewer's own rows
-        (``Clinician.owner_id == self._requesting_user.id``) and
-        bypasses the verified-only directory filter so a brand-new
-        viewer can see the row they just created before its NPPES
-        verification settles. The viewer is the same id
+        (``Clinician.owner_id == self._requesting_user.id``) and drops
+        the verified-only filter entirely — useful when the picker
+        deep-links here. The viewer is the same id
         ``BaseRepository._requesting_user`` carries — stamped by
         ``handle_list`` so every list mount can resolve viewer-relative
         filters. Any other ``owner`` value is silently ignored (the
         only supported sentinel today).
         """
-        owner_self = (
-            owner == "me"
-            and self._requesting_user is not None
+        viewer_id = (
+            self._requesting_user.id
+            if self._requesting_user is not None
             and getattr(self._requesting_user, "id", None) is not None
+            else None
         )
+        owner_self = owner == "me" and viewer_id is not None
         if owner_self:
-            stmt = select(Clinician).filter(
-                Clinician.owner_id == self._requesting_user.id
-            )
+            stmt = select(Clinician).filter(Clinician.owner_id == viewer_id)
         else:
-            stmt = select(Clinician).filter(
-                sa.or_(
-                    Clinician.clinician_verified.is_(True),
-                    Clinician.ever_verified_at.is_not(None),
-                )
+            # Default directory: verified-only. The viewer's own rows
+            # bypass the gate so brand-new in-flight clinicians stay
+            # visible to their creator while NPPES verification is in
+            # progress.
+            verified_or_own = sa.or_(
+                Clinician.clinician_verified.is_(True),
+                Clinician.ever_verified_at.is_not(None),
             )
+            if viewer_id is not None:
+                verified_or_own = sa.or_(
+                    verified_or_own,
+                    Clinician.owner_id == viewer_id,
+                )
+            stmt = select(Clinician).filter(verified_or_own)
         if license_type or issuing_state:
             stmt = stmt.join(
                 ClinicianLicensure,

--- a/src/domain/logic/clinicians/test_repository.py
+++ b/src/domain/logic/clinicians/test_repository.py
@@ -404,6 +404,52 @@ async def test_list_clinicians_filters_out_never_verified(
         assert len(clinicians) == 1
 
 
+async def test_list_clinicians_includes_viewers_own_never_verified_row(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Without ``?owner=me``, the unfiltered directory normally hides
+    never-verified rows (``test_list_clinicians_filters_out_never_verified``).
+    The viewer's own in-flight clinician is the documented exception:
+    a brand-new user who just submitted their clinician — and is
+    waiting on NPPES — must still see their row on ``/clinicians``
+    even before ``clinician_verified`` flips. Pinning the SQL-level
+    behavior so the bypass survives any future repo refactor.
+    """
+    viewer = await _seed_user(db_test_session_manager)
+    stranger = await _seed_user(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            # Stranger's never-verified row — must stay hidden.
+            stranger_cln = make_clinician_with_org(
+                owner_id=stranger.id,
+                practice_name="Stranger Clinic",
+                clinician_verified=False,
+                npi_match_status="none",
+            )
+            session.add(stranger_cln)
+            # Viewer's own never-verified row — must surface.
+            own_cln = make_clinician_with_org(
+                owner_id=viewer.id,
+                practice_name="My Clinic",
+                clinician_verified=False,
+                npi_match_status="none",
+            )
+            session.add(own_cln)
+
+    async with db_test_session_manager() as session:
+        repo = ClinicianRepository(session)
+        repo._requesting_user = viewer
+        clinicians = await repo.list_clinicians()
+
+    owner_ids = {c.owner_id for c in clinicians}
+    assert (
+        viewer.id in owner_ids
+    ), "viewer's own unverified row must show on /clinicians"
+    assert (
+        stranger.id not in owner_ids
+    ), "stranger's unverified row must stay hidden on /clinicians"
+
+
 async def test_list_clinicians_includes_once_verified_clinicians(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):


### PR DESCRIPTION
## Summary

The `/clinicians` directory's verified-only filter (`clinician_verified=True OR ever_verified_at IS NOT NULL`) was hiding a brand-new user's just-created clinician until NPPES finished. Owners need to find their own row regardless of state.

`ClinicianRepository.list_clinicians` now ORs in `owner_id == viewer.id` when `_requesting_user` is set (which `handle_list` stamps for every list mount, landed in #1287). Other never-verified rows still stay hidden; the redaction layer keeps identity private on the rows that do surface.

No spec or template change — the bypass is internal to the repo SQL. `?owner=me` continues to scope strictly to owned rows.

## Test plan

- [x] `dev test` passes (2238 passed, 101 skipped).
- [x] All lint checks pass.
- [x] New `test_list_clinicians_includes_viewers_own_never_verified_row` pins both halves: viewer's own unverified row surfaces, stranger's unverified row stays hidden.
- [ ] Manual smoke: sign up, create a clinician, immediately load `/clinicians` and confirm own row appears.

## Audit of other directories

- `/organizations` — no equivalent filter; viewer's own rows already show.
- `/posts` — no `exclude_self` declared; viewer's own posts show.
- `/users` — declares `list_exclude_self=True` deliberately ("the user-list page is for other users"). Left as-is; ping if that should change too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)