### PR TITLE
Hide redundant email row on self user-detail view

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -171,7 +171,7 @@ async def test_login_success(test_client: AsyncClient, logged_in_user: User):
     auth_header = {"Cookie": f"fastapiusersauth={access_token}"}
     me_response = await test_client.get("/users/me", headers=auth_header)
     assert me_response.status_code == 200
-    assert logged_in_user.email in me_response.text
+    assert logged_in_user.username in me_response.text
 
 
 async def test_login_failure_wrong_password(

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -315,21 +315,21 @@ async def test_detail_hides_private_fields_from_strangers(
     assert "<dt>Verified</dt>" not in body
 
 
-async def test_detail_shows_email_but_hides_admin_fields_for_self(
+async def test_detail_hides_identity_facts_for_self(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
     """The user viewing their own profile (via /users/me or
-    /users/<own-id>) sees their email but NOT the Active or Verified
-    rows — those are admin signals (#597). Admins viewing someone
-    else still see all three (see
+    /users/<own-id>) sees no top-level identity facts. Email lives in
+    the Email card (which links to /users/me/email/form); Active and
+    Verified are admin signals not shown on the self-view (#597).
+    Admins viewing someone else still see Email + Active (see
     ``test_detail_shows_private_fields_to_admin``)."""
     response = await authenticated_client.get("/users/me")
 
     assert response.status_code == 200
     body = response.text
-    assert logged_in_user.email in body
-    assert "<dt>Email</dt>" in body
+    assert "<dt>Email</dt>" not in body
     assert "<dt>Active</dt>" not in body
     assert "<dt>Verified</dt>" not in body
 

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -59,18 +59,20 @@
    The Active row is an admin signal — it makes sense to an admin
    auditing someone else's account, not to the user themselves (#597).
    Hide it on the self-view; an admin viewing another user still sees
-   it. Email stays for self since users routinely glance at it to
-   confirm which account they're signed in as.
+   it. Email is hidden on the self-view too — it's already reachable
+   via the Email card below, which links to /users/me/email/form
+   where the value lives next to the verification controls. Admins
+   viewing someone else still see the email row.
 
    `is_verified` removed in #696 — no verification flow exists and
    every account is permanently False; showing it was misleading.
    Verification status and the resend action live at
    /users/me/email/form (linked in the Email card below). #}
-  {% if can_view_private %}
+  {% if can_view_private and not is_self %}
     <article>
       <dl>
         {{ fact('email', 'Email', target_user.email) }}
-        {% if not is_self %}{{ fact('active', 'Active', "Yes" if target_user.is_active else "No") }}{% endif %}
+        {{ fact('active', 'Active', "Yes" if target_user.is_active else "No") }}
       </dl>
     </article>
   {% endif %}


### PR DESCRIPTION
## Summary
- The self-view of `/users/<id>` showed a top-level Email fact and an Email picker card linking to `/users/me/email/form` — the value was redundant.
- Drop the top-level email row on the self-view; the Email card remains the entry point to the value + verification controls.
- Admins viewing another user still see Email + Active in the identity-facts article.

## Test plan
- [x] Updated `test_detail_hides_identity_facts_for_self` (replaces `test_detail_shows_email_but_hides_admin_fields_for_self`) to pin the new behavior.
- [x] `test_detail_shows_private_fields_to_admin` still passes (admin viewing other still sees Email).
- [x] `test_detail_hides_private_fields_from_strangers` still passes (non-admin viewing other still hides Email).
- [x] `pytest src/domain/routes/test_users.py` — 46 passed.