### PR TITLE
Drop ul/li wrapping on /users/me/access/capabilities

### DIFF
--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -59,6 +59,16 @@ async def test_capabilities_index_shows_granted_or_denied(
     assert "Available" in response.text or "Not available yet" in response.text
 
 
+async def test_capabilities_index_renders_articles_without_list(
+    authenticated_client: AsyncClient,
+):
+    """Capabilities render as bare <article>s — no <ul>/<li> wrapping."""
+    response = await authenticated_client.get("/users/me/access/capabilities")
+    assert response.status_code == 200
+    assert "<article>" in response.text
+    assert "capability-list" not in response.text
+
+
 async def test_capability_detail_network_returns_200(
     authenticated_client: AsyncClient,
 ):

--- a/src/domain/templates/users/access/capabilities/index.html
+++ b/src/domain/templates/users/access/capabilities/index.html
@@ -14,28 +14,24 @@
   {% endcall %}
 {% endblock %}
 {% block content %}
-  <ul class="capability-list">
-    {% for name, check in checks.items() %}
-      <li>
-        <article>
-          <header>
-            <hgroup>
-              <h3>{{ check.tree.label_active }}</h3>
-              {% if check.description %}<p>{{ check.description }}</p>{% endif %}
-            </hgroup>
-            <small data-state="{{ 'unlocked' if check.granted else 'locked' }}">
-              {% if check.bypass %}
-                <i class="icon-check" aria-hidden="true"></i>Available (superuser)
-              {% elif check.granted %}
-                <i class="icon-check" aria-hidden="true"></i>Available
-              {% else %}
-                <i class="icon-lock" aria-hidden="true"></i>Not available yet
-              {% endif %}
-            </small>
-          </header>
-          <a href="{{ capability_base_url }}/{{ name }}">View requirements →</a>
-        </article>
-      </li>
-    {% endfor %}
-  </ul>
+  {% for name, check in checks.items() %}
+    <article>
+      <header>
+        <hgroup>
+          <h3>{{ check.tree.label_active }}</h3>
+          {% if check.description %}<p>{{ check.description }}</p>{% endif %}
+        </hgroup>
+        <small data-state="{{ 'unlocked' if check.granted else 'locked' }}">
+          {% if check.bypass %}
+            <i class="icon-check" aria-hidden="true"></i>Available (superuser)
+          {% elif check.granted %}
+            <i class="icon-check" aria-hidden="true"></i>Available
+          {% else %}
+            <i class="icon-lock" aria-hidden="true"></i>Not available yet
+          {% endif %}
+        </small>
+      </header>
+      <a href="{{ capability_base_url }}/{{ name }}">View requirements →</a>
+    </article>
+  {% endfor %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Render capabilities as bare `<article>` elements instead of `<ul>`/`<li>`-wrapped cards.
- Add a test pinning that the `capability-list` wrapper is gone.

## Test plan
- [x] `pytest src/domain/routes/test_access.py` passes (12/12).
- [ ] Visual check at `/users/me/access/capabilities`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)