### PR TITLE
Verify solo clinicians on matched NPI alone

### DIFF
--- a/alembic/versions/9a4f1c7e0a21_backfill_clinician_verified_for_matched_npi.py
+++ b/alembic/versions/9a4f1c7e0a21_backfill_clinician_verified_for_matched_npi.py
@@ -1,0 +1,54 @@
+"""backfill clinician_verified for matched NPI
+
+Data backfill for the Claim-A rule change: previously
+``recompute_clinician_claim`` required matched NPI AND ≥1 active
+licensure. Solo clinicians with a matched NPI but no licensure stayed
+``clinician_verified=False``. The rule now requires only matched NPI,
+so flip the denorm cache for those rows and stamp the timestamps the
+recompute helper would have set.
+
+Schema-only migrations are the norm here (see alembic/README.md), but
+this is a denorm-cache realignment that has to ship with the code
+change — otherwise existing matched-NPI clinicians stay unverified
+until the next worker pass touches them.
+
+Revision ID: 9a4f1c7e0a21
+Revises: 43c694311395
+Create Date: 2026-06-09
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "9a4f1c7e0a21"
+down_revision: Union[str, None] = "43c694311395"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Set ``clinician_verified=True`` (+ timestamps) for every
+    clinician whose ``npi_match_status`` is ``matched`` but whose denorm
+    cache is still False. Idempotent: rows already True are untouched.
+    """
+    op.execute(sa.text("""
+            UPDATE clinicians
+            SET clinician_verified = 1,
+                verified_at = COALESCE(verified_at, CURRENT_TIMESTAMP),
+                ever_verified_at = COALESCE(ever_verified_at, CURRENT_TIMESTAMP)
+            WHERE npi_match_status = 'matched'
+              AND clinician_verified = 0
+            """))
+
+
+def downgrade() -> None:
+    """Data-only migration: leave the cache as-is on downgrade. Reverting
+    the cache to the old rule would require re-joining licensures and
+    re-running the predicate; in practice the code rollback alone is
+    enough since the next recompute under the old rule will correct
+    any row whose state actually changed.
+    """

--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -5,7 +5,7 @@ into the same predicates so the visible UI affordance and the server-side
 gate cannot disagree.
 
 The two-claim model: a `User` may hold **Claim A** (verified clinician —
-NPPES Type-1 + active license) and/or **Claim B** (verified org rep —
+NPPES Type-1 name match) and/or **Claim B** (verified org rep —
 NPPES Type-2 + authority proven), per (user, org). Capabilities derive
 from claim state; "solo / group / coordinator" labels are emergent, never
 stored.
@@ -141,11 +141,11 @@ def email_verified(user: Any) -> bool:
 
 
 def clinician_verified(user: Any) -> bool:
-    """Claim A: NPPES Type-1 name-matched + ≥1 active license. Reads the
+    """Claim A: NPPES Type-1 name-matched. Reads the
     `Clinician.clinician_verified` denorm cache so the predicate doesn't
-    re-derive from `npi_match_status` + licensure status per call. The
-    cache is recomputed by `recompute_clinician_claim(...)` on every
-    transition that touches its inputs."""
+    re-derive from `npi_match_status` per call. The cache is recomputed
+    by `recompute_clinician_claim(...)` on every transition that touches
+    its inputs."""
     if not email_verified(user):
         return False
     clinicians = getattr(user, "clinicians", None) or ()

--- a/src/domain/logic/verifications/events.py
+++ b/src/domain/logic/verifications/events.py
@@ -41,24 +41,19 @@ def _now() -> datetime:
 def recompute_clinician_claim(clinician: Clinician) -> None:
     """Compute `Clinician.clinician_verified` + the timestamp triplet
     (`verified_at`, `ever_verified_at`, regression detection) from the
-    current `npi_match_status` + the licensure set, then mutate the
-    clinician in place. The caller is responsible for committing the
-    enclosing transaction.
+    current `npi_match_status`, then mutate the clinician in place. The
+    caller is responsible for committing the enclosing transaction.
 
-    Claim A requires:
-      1. `npi_match_status == 'matched'`
-      2. at least one `ClinicianLicensure` with `status == 'active'`
+    Claim A requires only an NPPES Type-1 name match
+    (`npi_match_status == 'matched'`). Licensures and affiliations are
+    tracked for display and credentialing but do not gate the claim —
+    a solo practitioner with a matched NPI is fully verified.
 
     `ever_verified_at` is set on the first transition to True and
     preserved on regression — that's what powers the once-verified feed
     retention rule (handoff §7.1).
     """
-    matched = clinician.npi_match_status == "matched"
-    licensures = getattr(clinician, "licensures", None) or ()
-    has_active_license = any(
-        getattr(lic, "status", None) == "active" for lic in licensures
-    )
-    is_verified_now = matched and has_active_license
+    is_verified_now = clinician.npi_match_status == "matched"
 
     if is_verified_now:
         if not clinician.clinician_verified:

--- a/src/domain/logic/verifications/test_events.py
+++ b/src/domain/logic/verifications/test_events.py
@@ -40,8 +40,9 @@ from tests.helpers import (
 # ---------- recompute_clinician_claim ------------------------------------
 
 
-def test_recompute_clinician_claim_requires_matched_npi_and_active_license():
-    """Matched NPI without any active license → False."""
+def test_recompute_clinician_claim_matched_npi_alone_verifies():
+    """Matched NPI alone is sufficient for Claim A — licensures and
+    affiliations are tracked separately but don't gate verification."""
     clinician = Clinician(
         id=uuid4(),
         owner_id=uuid4(),
@@ -51,21 +52,17 @@ def test_recompute_clinician_claim_requires_matched_npi_and_active_license():
     )
     clinician.npi_match_status = "matched"
     clinician.clinician_verified = False
-    clinician.licensures = [
-        ClinicianLicensure(
-            clinician_id=clinician.id,
-            license_type="lcsw",
-            license_number="X-1",
-            issuing_state="IL",
-            status="pending",
-        )
-    ]
+    clinician.verified_at = None
+    clinician.ever_verified_at = None
     recompute_clinician_claim(clinician)
-    assert clinician.clinician_verified is False
+    assert clinician.clinician_verified is True
+    assert clinician.verified_at is not None
+    assert clinician.ever_verified_at is not None
 
 
-def test_recompute_clinician_claim_active_license_without_matched_npi_false():
-    """Active license without matched NPI → False."""
+def test_recompute_clinician_claim_unmatched_npi_unverified():
+    """Without `npi_match_status='matched'` the claim is never granted,
+    regardless of how many active licensures exist."""
     clinician = Clinician(
         id=uuid4(), owner_id=uuid4(), first_name="Eva", last_name="Stone"
     )
@@ -84,54 +81,18 @@ def test_recompute_clinician_claim_active_license_without_matched_npi_false():
     assert clinician.clinician_verified is False
 
 
-def test_recompute_clinician_claim_happy_path():
-    clinician = Clinician(
-        id=uuid4(),
-        owner_id=uuid4(),
-        npi="1234567890",
-        first_name="Eva",
-        last_name="Stone",
-    )
-    clinician.npi_match_status = "matched"
-    clinician.clinician_verified = False
-    clinician.verified_at = None
-    clinician.ever_verified_at = None
-    clinician.licensures = [
-        ClinicianLicensure(
-            clinician_id=clinician.id,
-            license_type="lcsw",
-            license_number="X-1",
-            issuing_state="IL",
-            status="active",
-        )
-    ]
-    recompute_clinician_claim(clinician)
-    assert clinician.clinician_verified is True
-    assert clinician.verified_at is not None
-    assert clinician.ever_verified_at is not None
-
-
 def test_recompute_clinician_claim_preserves_ever_verified_at_on_regression():
-    """A clinician who was previously verified and now isn't (license
-    expired) must keep `ever_verified_at` set — that's what the
-    `can_access_network` retention rule reads."""
+    """A clinician who was previously verified and now isn't (e.g. admin
+    flipped to `mismatch`) must keep `ever_verified_at` set — that's
+    what the `can_access_network` retention rule reads."""
     historic = datetime(2025, 6, 1, tzinfo=timezone.utc)
     clinician = Clinician(
         id=uuid4(), owner_id=uuid4(), first_name="Eva", last_name="Stone"
     )
-    clinician.npi_match_status = "matched"
+    clinician.npi_match_status = "mismatch"
     clinician.clinician_verified = True
     clinician.verified_at = historic
     clinician.ever_verified_at = historic
-    clinician.licensures = [
-        ClinicianLicensure(
-            clinician_id=clinician.id,
-            license_type="lcsw",
-            license_number="X-1",
-            issuing_state="IL",
-            status="expired",
-        )
-    ]
     recompute_clinician_claim(clinician)
     assert clinician.clinician_verified is False
     assert clinician.ever_verified_at == historic

--- a/src/domain/logic/verifications/test_handlers_phase3.py
+++ b/src/domain/logic/verifications/test_handlers_phase3.py
@@ -32,7 +32,6 @@ from src.domain.logic.verifications.nppes import nppes_lookup_type2
 from src.domain.logic.verifications.repository import VerificationRepository
 from src.domain.models import (
     Clinician,
-    ClinicianLicensure,
     Organization,
 )
 from src.framework.audit.repository import AuditRepository
@@ -222,10 +221,10 @@ async def test_nppes_lookup_type2_rejects_type1_record():
 async def test_run_clinician_verification_writes_through_cache(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):
-    """After Phase 3, the pipeline writes `npi_match_status='matched'`
-    + `clinician_verified=True` when the score is `verified` AND the
-    clinician has an active license. Without an active license the
-    cache stays False even after a successful NPPES match."""
+    """The pipeline writes `npi_match_status='matched'` +
+    `clinician_verified=True` when the NPPES name match scores
+    `verified`. Licensures are not required — a solo clinician with a
+    matched NPI is fully verified."""
     owner = create_test_user()
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -243,18 +242,6 @@ async def test_run_clinician_verification_writes_through_cache(
             )
             session.add(clinician)
     clinician_id = clinician.id
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(
-                ClinicianLicensure(
-                    clinician_id=clinician_id,
-                    license_type="lcsw",
-                    license_number="X-1",
-                    issuing_state="IL",
-                    status="active",
-                )
-            )
 
     http = _mock_http(
         {

--- a/src/domain/models/clinicians/clinician.py
+++ b/src/domain/models/clinicians/clinician.py
@@ -73,8 +73,8 @@ class Clinician(BaseModel):
 
     # Denormalized cache of Claim A. Recomputed by
     # `recompute_clinician_claim(...)` on every transition that changes
-    # `npi_match_status` or any `ClinicianLicensure.status`. Lets the
-    # capabilities predicate run without joining licensures every read.
+    # `npi_match_status`. Lets the capabilities predicate run without
+    # re-reading the column on every check.
     clinician_verified = Column(
         Boolean, nullable=False, server_default="0", default=False
     )

--- a/src/domain/models/enums.py
+++ b/src/domain/models/enums.py
@@ -465,9 +465,9 @@ NPI_MATCH_STATUS_LABELS: Final[dict[str, str]] = NpiMatchStatus.labels()
 
 # Computed-and-stored status of a `ClinicianLicensure`. Derived on write
 # from `expiration_date` and `attested_active` (see Phase 8's nightly
-# expiry worker) and persisted for query-speed reasons: list views and
-# the directory-listing filter both restrict on "has an active license"
-# without recomputing per row.
+# expiry worker) and persisted for query-speed reasons: licensure list
+# views surface this directly without recomputing per row. Licensure
+# status no longer gates Claim A — see `recompute_clinician_claim`.
 class LicenseStatus(LabeledChoice):
     active = "active", "Active", "check"
     expired = "expired", "Expired", "x-circle"

--- a/src/domain/specs/clinician_licensure.py
+++ b/src/domain/specs/clinician_licensure.py
@@ -6,8 +6,10 @@ Owned subentity of `Clinician`: routes nest under
 `_credential.py` for the shared factory. License attestation is the
 only credential-specific addition: a state axis at
 ``PUT /clinicians/{clinician_id}/licensures/{licensure_id}/attestation``
-that flips `attested_active=True` + recomputes the owning clinician's
-Claim-A cache.
+that flips `attested_active=True`. The owning clinician's Claim-A
+cache is recomputed for symmetry with other licensure transitions,
+but licensure status no longer gates the claim — only `npi_match_status`
+does.
 
 Read by `src/domain/routes/clinicians.py` (derives `LICENSURE_SPEC` for
 the mount helpers).

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -22,21 +22,24 @@
    `entity_form_url('organization')` first. #}
   <form hx-patch="{{ entity_url('clinician', id=clinician.id) }}">
     {# Person-level fields (name, NPI) — these live on the Clinician row,
-     so they follow the person across affiliations. #}
+     so they follow the person across affiliations. First name, last
+     name, and NPI are the only required fields on a Clinician; every
+     per-affiliation field below is optional so a solo practitioner can
+     leave the practice/availability/insurance sections empty. #}
     {% call form_section("Clinician") %}
       {{ text_field("first_name", "First name", current=clinician.first_name, maxlength=120) }}
       {{ text_field("last_name", "Last name", current=clinician.last_name, maxlength=120) }}
-      {{ text_field("npi", "NPI", current=clinician.npi, required=false, pattern="\\d{10}", maxlength=10, help=npi_help() ) }}
+      {{ text_field("npi", "NPI", current=clinician.npi, pattern="\\d{10}", maxlength=10, help=npi_help() ) }}
     {% endcall %}
     {% call form_section("Practice location") %}
-      {{ entity_select_field("org_id", "Organization", orgs, current=clinician.org_id, help=org_picker_help() ) }}
-      {{ text_field("location_city", "City", current=clinician.location_city, maxlength=120) }}
-      {{ select_field("location_state", "State", US_STATES, current=clinician.location_state) }}
-      {{ text_field("location_zip", "ZIP", current=clinician.location_zip, pattern="\\d{5}", maxlength=5) }}
+      {{ entity_select_field("org_id", "Organization", orgs, current=clinician.org_id, required=false, blank_label="(no organization)", help=org_picker_help() ) }}
+      {{ text_field("location_city", "City", current=clinician.location_city, required=false, maxlength=120) }}
+      {{ select_field("location_state", "State", US_STATES, current=clinician.location_state, required=false, placeholder=true) }}
+      {{ text_field("location_zip", "ZIP", current=clinician.location_zip, required=false, pattern="\\d{5}", maxlength=5) }}
     {% endcall %}
     {% call form_section("Session availability") %}
-      {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=clinician.in_person_sessions) }}
-      {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=clinician.virtual_sessions) }}
+      {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=clinician.in_person_sessions, required=false, placeholder=true) }}
+      {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, current=clinician.virtual_sessions, required=false, placeholder=true) }}
     {% endcall %}
     {# Insurance & payment. Empty carrier list = no in-network. #}
     {% call form_section("Insurance & payment") %}

--- a/tests/test_contract/infrastructure/servers/consumer.py
+++ b/tests/test_contract/infrastructure/servers/consumer.py
@@ -247,14 +247,14 @@ def _setup_clinician_edit_form_stub(app: FastAPI) -> None:
             # `orgs` context var to render options.
             org_id=org_id,
             org=org,
-            # `first_name` and `last_name` are required (NOT NULL) so
-            # the stub supplies values that will pre-fill the form inputs
-            # and round-trip in the PATCH body. `npi` remains optional.
-            # The "Clinician" fieldset renders first, so these serialize
-            # ahead of `org_id` in the encoded body.
+            # `first_name`, `last_name`, and `npi` are the three required
+            # fields on the edit form — supply real values so the form
+            # submits and the round-tripped values appear in the PATCH
+            # body. The "Clinician" fieldset renders first, so these
+            # serialize ahead of `org_id` in the encoded body.
             first_name="Jane",
             last_name="Doe",
-            npi=None,
+            npi="1234567890",
             location_city="Brooklyn",
             location_state="NY",
             location_zip="11201",

--- a/tests/test_contract/tests/consumer/test_clinician_edit_form.py
+++ b/tests/test_contract/tests/consumer/test_clinician_edit_form.py
@@ -77,12 +77,12 @@ async def test_consumer_clinician_edit_form_submits(
     # selection so it doesn't appear in the encoded form body. The
     # "Clinician" fieldset holds the person-level fields (first/last
     # name and npi) and renders first, so they serialize ahead of
-    # `org_id`. `first_name` and `last_name` are required fields pre-filled
-    # from the stub clinician; `npi` is optional and empty.
+    # `org_id`. `first_name`, `last_name`, and `npi` are required —
+    # the stub pre-fills all three so the form submits.
     expected_request_body = (
         "first_name=Jane"
         "&last_name=Doe"
-        "&npi="
+        "&npi=1234567890"
         "&org_id=55555555-5555-5555-5555-555555555555"
         "&location_city=Bayside"
         "&location_state=NY"


### PR DESCRIPTION
## Summary

- Drop the active-licensure requirement from `recompute_clinician_claim`. A solo practitioner with a matched NPPES Type-1 record now holds Claim A. Licensures stay tracked for display and credentialing but no longer gate verification.
- Backfill `clinician_verified=True` (+ `verified_at` / `ever_verified_at`) for every existing row whose `npi_match_status='matched'` was previously stuck unverified.
- Make every per-affiliation field on the clinician edit form optional. First name, last name, and NPI are the only required fields. Org picker gains a "(no organization)" option so a previously-attached row can be cleared.

## Test plan

- [x] `dev test` — 2455 passed
- [x] `dev lint`
- [x] `dev migrate roundtrip`
- [ ] Manual: create a clinician with a known-good NPI, no licensure, no org → see "Verified" badge after the NPPES pass.
- [ ] Manual: edit an existing clinician, leave every section below "Clinician" blank → form submits without 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)