### PR TITLE
Point verify-success CTA into the clinician-create flow

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi_users.db import SQLAlchemyUserDatabase
 from httpx import AsyncClient
 from pydantic import BaseModel
+from selectolax.parser import HTMLParser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -680,8 +681,10 @@ async def test_get_verify_page_with_valid_token_verifies_user(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """A valid verification token flips `is_verified` to True and the
-    landing page renders the success state."""
+    """A valid verification token flips `is_verified` to True, the
+    landing page renders the success state, and the footer CTA points
+    into the clinician-create flow (the intended next step after
+    confirming email — pins the template's success-path link)."""
     from src.auth_config import get_user_manager
     from src.db import get_user_db
 
@@ -726,6 +729,13 @@ async def test_get_verify_page_with_valid_token_verifies_user(
     response = await test_client.get(f"/auth/verify?token={token}")
     assert response.status_code == 200
     assert "verified" in response.text.lower()
+    # Footer CTA on the success state routes into the clinician-create
+    # flow, not /users/me. The failure / already-verified states still
+    # land on the profile (see the template).
+    tree = HTMLParser(response.text)
+    cta = tree.css_first("section.auth-page footer a[role='button']")
+    assert cta is not None, "verify-success page is missing the footer CTA"
+    assert cta.attributes.get("href") == "/clinicians/form"
 
     # Confirm the DB column actually flipped.
     async with db_test_session_manager() as session:

--- a/src/domain/templates/auth/verify.html
+++ b/src/domain/templates/auth/verify.html
@@ -16,8 +16,16 @@
       {% endif %}
     </header>
     <footer>
+      {# On success, route the user into the clinician-create flow — the
+         intended next step after confirming email. The two other states
+         (already-verified / link-failed) still bounce to /users/me, where
+         the user can resend or self-manage. #}
       <p>
-        <a href="{{ entity_url('user', id='me') }}" role="button">Go to your profile</a>
+        {% if status == "success" %}
+          <a href="{{ entity_form_url('clinician') }}" role="button">{{ entity_create_label("clinician") }}</a>
+        {% else %}
+          <a href="{{ entity_url('user', id='me') }}" role="button">Go to your profile</a>
+        {% endif %}
       </p>
     </footer>
   </section>


### PR DESCRIPTION
## Summary
- After a user clicks the email-verification link and lands on the success state, the footer CTA now routes to `/clinicians/form` (the create-clinician form) instead of `/users/me`. That's the intended next step in the new-user funnel.
- The `already_verified` and `error` states still route to `/users/me`, where the user can resend or self-manage.

## Test plan
- [x] Extended `test_get_verify_page_with_valid_token_verifies_user` to assert the footer CTA's href is `/clinicians/form`.
- [x] `pytest` (full suite) — 2456 passed.
- [x] `dev lint` — clean.