### PR TITLE
Verify on POST + auto-login on success

### DIFF
--- a/scripts/dev/contract_form_coverage_check.py
+++ b/scripts/dev/contract_form_coverage_check.py
@@ -81,6 +81,17 @@ FORMS_WITHOUT_PAIRS: dict[str, str] = {
         "Empty-body endpoint that reads the user from the session and "
         "re-mints a verify token. Nothing to pin beyond the path."
     ),
+    "POST /auth/verify": (
+        "Single hidden `token` field round-tripped from the email-link "
+        "GET render (see `src/domain/routes/auth_pages.py::post_verify` "
+        "for the GET→POST split rationale). Same wire shape as "
+        "fastapi-users' built-in `POST /auth/verify` which our wrapper "
+        "shadows — no new JSON contract surface. Response shape "
+        "(200 + HTML on already_verified/error; 204 + HX-Redirect or "
+        "302 + Location on success with the session cookie set) is "
+        "pinned by route tests in "
+        "`src/domain/routes/test_auth_routes.py`."
+    ),
     "POST /org_representations": (
         "The Profile Hub's `_add_claim.html` submits to the bespoke "
         "create handler that dispatches on authority_method. Body shape "

--- a/src/domain/logic/auth/emails.py
+++ b/src/domain/logic/auth/emails.py
@@ -43,9 +43,10 @@ async def send_verification_email(user: User, token: str) -> None:
 
     `token` is fastapi-users' verification JWT. The link lands on
     `GET /auth/verify?token=...` (the page route in `auth_pages.py`),
-    which calls `user_manager.verify` server-side and renders a
-    success/error page — keeps the user out of HTMX-only territory
-    since the click comes from an email client.
+    which renders a confirm-button page; the user's click POSTs to
+    the sibling handler that actually consumes the token and signs
+    them in. GET deliberately does NOT mutate — see
+    `auth_pages.py:get_verify_page` for why (link prefetchers).
     """
     verify_url = _absolute_url(f"/auth/verify?token={token}")
     context = {

--- a/src/domain/routes/auth_pages.py
+++ b/src/domain/routes/auth_pages.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Body, Depends, Request
+from fastapi import APIRouter, Body, Depends, Form, Request
 from fastapi.responses import Response
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import exceptions as fa_users_exceptions
@@ -455,43 +455,105 @@ async def get_reset_password_page(request: Request, token: str):
 
 
 @router.get("/verify", name="auth_pages:verify")
-async def get_verify_page(
-    request: Request,
-    user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
-):
-    """Consume the verify token from the email link.
+async def get_verify_page(request: Request):
+    """Render the "click to verify" confirm page.
 
-    The email contains `GET /auth/verify?token=...`. Calling
-    `user_manager.verify(token)` server-side keeps the user out of any
-    HTMX/JS ceremony — the click comes from an email client, which may
-    not run JS at all. Renders one of three states:
+    The email contains `GET /auth/verify?token=...`. The GET handler
+    deliberately does NOT consume the token — it just renders a page
+    with a button that POSTs to the sibling handler. Two reasons:
 
-      - `status="success"`: token consumed, account verified.
-      - `status="already_verified"`: token valid but `is_verified`
-        already True. Treated as success in the UI; explicit branch so
-        a future "the link doesn't seem to work" copy can differentiate.
-      - `status="error"`: token missing / expired / malformed. The page
-        offers a "resend" link back to the nag banner (`/users/me`).
+      - Link prefetchers (corporate AV, Outlook Safe Links, Gmail
+        preview crawlers) issue GETs against email URLs and would burn
+        the token before the user clicks. POST sidesteps every one of
+        them.
+      - GET is supposed to be safe / idempotent. Mutating user state
+        on GET is the kind of accident that makes auditors itch.
+
+    Token validation (expired, malformed, already used) happens at POST
+    time — keeps the GET path stateless and the GET response cacheable.
+    Missing `?token=` is the one case GET catches: a broken URL renders
+    the error state immediately instead of a confirm button that's
+    guaranteed to fail.
     """
     token = request.query_params.get("token", "")
-    if not token:
-        status = "error"
-    else:
-        try:
-            await user_manager.verify(token, request)
-            status = "success"
-        except fa_users_exceptions.UserAlreadyVerified:
-            status = "already_verified"
-        except (
-            fa_users_exceptions.InvalidVerifyToken,
-            fa_users_exceptions.UserNotExists,
-        ):
-            status = "error"
     return APIResponse.html_response(
         template_name="auth/verify.html",
-        context={"status": status},
+        context={"token": token, "status": "error" if not token else None},
         request=request,
     )
+
+
+@router.post("/verify", name="auth_pages:post_verify")
+async def post_verify(
+    request: Request,
+    token: str = Form(""),
+    user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+    strategy: Strategy[models.UP, models.ID] = Depends(auth_backend.get_strategy),
+):
+    """Consume the verify token, auto-login on success, redirect to /.
+
+    Sole mutation point for the verify flow — GET just hosts the
+    button. Three outcomes:
+
+      - Success → mint the session cookie via `auth_backend.login`
+        (same path `/auth/login` uses); HX-Redirect (or 302 + Location
+        for non-HTMX) to the post-login home, mirroring `post_login`'s
+        HTMX-vs-browser branch. The user is logged in by the response
+        the browser hands back.
+      - `UserAlreadyVerified` → render the `already_verified` state
+        with a login link. Deliberately NOT auto-login — a second
+        click against an already-consumed token could be from a leaked
+        post-use URL (browser history on a shared machine, log
+        scraping, etc.), and convenience here is not worth the risk.
+      - Missing token, `InvalidVerifyToken`, `UserNotExists` → render
+        the error state.
+    """
+    if not token:
+        return APIResponse.html_response(
+            template_name="auth/verify.html",
+            context={"token": "", "status": "error"},
+            request=request,
+        )
+    try:
+        user = await user_manager.verify(token, request)
+    except fa_users_exceptions.UserAlreadyVerified:
+        return APIResponse.html_response(
+            template_name="auth/verify.html",
+            context={"token": "", "status": "already_verified"},
+            request=request,
+        )
+    except (
+        fa_users_exceptions.InvalidVerifyToken,
+        fa_users_exceptions.UserNotExists,
+    ):
+        return APIResponse.html_response(
+            template_name="auth/verify.html",
+            context={"token": "", "status": "error"},
+            request=request,
+        )
+
+    # Success: mint the cookie + redirect, same dual-mode shape as
+    # post_login (HTMX → 204 + HX-Redirect; plain browser POST → 302
+    # + Location). Cookie is preserved on either branch — it's set
+    # by the response `auth_backend.login` returns, which we mutate
+    # in place rather than replace.
+    #
+    # Destination is the clinician-create form, NOT `on_after_login`'s
+    # default (/posts?kind=referral). #1302 routes verify-success into
+    # the create-clinician funnel — the intended next step for a
+    # freshly-verified new user — and that intent persists across the
+    # GET-render / POST-confirm split.
+    from src.framework.rendering.route_urls import entity_form_url
+
+    next_url = entity_form_url("clinician")
+    response = await auth_backend.login(strategy, user)
+    if request.headers.get("HX-Request") == "true":
+        response.headers["HX-Redirect"] = next_url
+        response.status_code = 204
+    else:
+        response.headers["Location"] = next_url
+        response.status_code = 302
+    return response
 
 
 @router.post("/resend-verify", name="auth_pages:resend_verify")

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -2,7 +2,6 @@ import pytest
 from fastapi_users.db import SQLAlchemyUserDatabase
 from httpx import AsyncClient
 from pydantic import BaseModel
-from selectolax.parser import HTMLParser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -655,60 +654,44 @@ async def test_card_chrome_only_applies_to_article_list_items(
         )
 
 
-async def test_get_verify_page_without_token_returns_error(test_client: AsyncClient):
-    """Missing `?token=` query param → error state. Page still
-    renders 200 (this is the email-link landing, not an API endpoint
-    — the user shouldn't see a JSON 422)."""
-    response = await test_client.get("/auth/verify")
-    assert response.status_code == 200
-    assert "text/html" in response.headers["content-type"]
-    assert "didn't work" in response.text.lower() or "error" in response.text.lower()
+# --- /auth/verify --------------------------------------------------------
+#
+# The email-link flow is split GET (render confirm page, NO token
+# consumption) + POST (consume + auto-login + redirect). This shape
+# defends against email-link prefetchers (corporate AV, Outlook Safe
+# Links, Gmail preview) burning the token before the user clicks —
+# prefetchers issue GETs, not POSTs. See `auth_pages.py:get_verify_page`
+# for the full rationale.
 
 
-async def test_get_verify_page_with_invalid_token_returns_error(
-    test_client: AsyncClient,
-):
-    """An obviously-bad token (not a valid JWT) renders the error
-    state, never raises a 500. The page route swallows
-    `InvalidVerifyToken` and routes to the error template."""
-    response = await test_client.get("/auth/verify?token=not.a.real.jwt")
-    assert response.status_code == 200
-    assert "didn't work" in response.text.lower() or "error" in response.text.lower()
-
-
-async def test_get_verify_page_with_valid_token_verifies_user(
-    test_client: AsyncClient,
+async def _mint_verify_token(
     db_test_session_manager: async_sessionmaker[AsyncSession],
-    logged_in_user: User,
-):
-    """A valid verification token flips `is_verified` to True, the
-    landing page renders the success state, and the footer CTA points
-    into the clinician-create flow (the intended next step after
-    confirming email — pins the template's success-path link)."""
+    user_id,
+) -> str:
+    """Helper: mint a real fastapi-users verify JWT for a user by routing
+    through `request_verify` (the same path the email send uses) and
+    capturing the token off the send hook.
+
+    fastapi-users doesn't expose a public `make_verify_token` so this
+    is the supported way to obtain one in tests.
+    """
     from src.auth_config import get_user_manager
     from src.db import get_user_db
 
-    # Mint a real verify token by calling `request_verify` through the
-    # manager — same path the email-link generation uses.
     async with db_test_session_manager() as session:
         user_db_gen = get_user_db(session)
         user_db = await anext(user_db_gen)
         manager_gen = get_user_manager(user_db)
         manager = await anext(manager_gen)
-        # Pull a fresh user row from this session so the manager can
-        # operate on it without touching a closed session.
+
         from sqlalchemy import select
 
         fresh_user = (
-            await session.execute(select(User).where(User.id == logged_in_user.id))
+            await session.execute(select(User).where(User.id == user_id))
         ).scalar_one()
-        # Mark unverified so the verify call has work to do (the dev
-        # auto-verify pathway leaves users at True; reset to False here).
+        # Reset to unverified so request_verify works (dev auto-verify
+        # leaves new users at True).
         await user_db.update(fresh_user, {"is_verified": False})
-        # Mint the token via the manager. fastapi-users doesn't expose
-        # a `make_verify_token` helper but `request_verify` produces
-        # one and triggers `on_after_request_verify` — we capture the
-        # token from there.
 
         captured: dict = {}
 
@@ -724,27 +707,155 @@ async def test_get_verify_page_with_valid_token_verifies_user(
         finally:
             emails_module.send_verification_email = original
 
-    token = captured["token"]
+    return captured["token"]
+
+
+async def test_get_verify_page_without_token_renders_error(
+    test_client: AsyncClient,
+):
+    """Missing `?token=` query param → error state. The page renders
+    200 (this is the email-link landing, not an API endpoint — the
+    user shouldn't see a JSON 422)."""
+    response = await test_client.get("/auth/verify")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "didn't work" in response.text.lower()
+
+
+async def test_get_verify_page_renders_confirm_form_without_mutating(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """GET with any token renders the confirm-button form and leaves
+    `is_verified` untouched. The whole point of the GET/POST split is
+    that prefetcher GETs don't burn the token."""
+    token = await _mint_verify_token(db_test_session_manager, logged_in_user.id)
 
     response = await test_client.get(f"/auth/verify?token={token}")
     assert response.status_code == 200
-    assert "verified" in response.text.lower()
-    # Footer CTA on the success state routes into the clinician-create
-    # flow, not /users/me. The failure / already-verified states still
-    # land on the profile (see the template).
-    tree = HTMLParser(response.text)
-    cta = tree.css_first("section.auth-page footer a[role='button']")
-    assert cta is not None, "verify-success page is missing the footer CTA"
-    assert cta.attributes.get("href") == "/clinicians/form"
+    # Confirm form is rendered and the token is round-tripped into the
+    # hidden field for the POST.
+    body = response.text
+    assert '<form action="/auth/verify"' in body
+    assert 'name="token"' in body
+    assert token in body
+    assert "Verify and sign in" in body
 
-    # Confirm the DB column actually flipped.
+    # And the GET did NOT flip the column — POST is the mutation.
+    from sqlalchemy import select
+
     async with db_test_session_manager() as session:
-        from sqlalchemy import select
+        user = (
+            await session.execute(select(User).where(User.id == logged_in_user.id))
+        ).scalar_one()
+        assert user.is_verified is False
 
+
+async def test_post_verify_with_valid_token_verifies_and_auto_logs_in(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Valid token at POST: `is_verified` flips, a session cookie is
+    set, and the response steers the browser into the clinician-create
+    funnel (#1302 — the intended next step for a freshly-verified
+    user)."""
+    token = await _mint_verify_token(db_test_session_manager, logged_in_user.id)
+
+    response = await test_client.post(
+        "/auth/verify",
+        data={"token": token},
+        follow_redirects=False,
+    )
+    # Non-HTMX POST → 302 + Location to the clinician-create form
+    # (NOT `on_after_login`'s default `/posts?kind=referral`).
+    assert response.status_code == 302
+    assert response.headers["location"] == "/clinicians/form"
+    # Session cookie was minted.
+    assert (
+        "fastapiusersauth" in response.headers.get("set-cookie", "")
+        or "fastapiusersauth" in response.cookies
+    )
+
+    # DB column actually flipped.
+    from sqlalchemy import select
+
+    async with db_test_session_manager() as session:
         user = (
             await session.execute(select(User).where(User.id == logged_in_user.id))
         ).scalar_one()
         assert user.is_verified is True
+
+
+async def test_post_verify_htmx_redirects_via_hx_header(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """HTMX POST gets `HX-Redirect` + 204 so HTMX does a full
+    navigation (mirrors `post_login`'s HTMX branch). Cookie is still
+    set on the same response."""
+    token = await _mint_verify_token(db_test_session_manager, logged_in_user.id)
+
+    response = await test_client.post(
+        "/auth/verify",
+        data={"token": token},
+        headers={"HX-Request": "true"},
+    )
+    assert response.status_code == 204
+    assert response.headers.get("HX-Redirect") == "/clinicians/form"
+    # `Location` is not set on the HTMX branch — HTMX navigates via
+    # the `HX-Redirect` header instead.
+    assert "location" not in {k.lower() for k in response.headers.keys()}
+
+
+async def test_post_verify_without_token_renders_error(test_client: AsyncClient):
+    """Empty `token` form field → error state. No 422, no 500."""
+    response = await test_client.post("/auth/verify", data={"token": ""})
+    assert response.status_code == 200
+    assert "didn't work" in response.text.lower()
+    # No cookie set.
+    assert "set-cookie" not in {k.lower() for k in response.headers.keys()}
+
+
+async def test_post_verify_with_invalid_token_renders_error(test_client: AsyncClient):
+    """Malformed token → error state. fastapi-users raises
+    `InvalidVerifyToken`; the route swallows it and routes to the
+    error template. Never auto-logs in."""
+    response = await test_client.post("/auth/verify", data={"token": "not.a.real.jwt"})
+    assert response.status_code == 200
+    assert "didn't work" in response.text.lower()
+    assert "set-cookie" not in {k.lower() for k in response.headers.keys()}
+
+
+async def test_post_verify_with_already_used_token_does_not_auto_login(
+    test_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Second POST with an already-consumed token renders the
+    already_verified state WITHOUT auto-login. A second click could be
+    from a leaked-after-use URL (shared browser history, log scraping);
+    the convenience of auto-login isn't worth the risk on this branch."""
+    token = await _mint_verify_token(db_test_session_manager, logged_in_user.id)
+
+    # First POST: consumes the token, auto-logs in.
+    first = await test_client.post(
+        "/auth/verify", data={"token": token}, follow_redirects=False
+    )
+    assert first.status_code == 302
+
+    # Drop the cookie the first POST set so the second POST is a fresh
+    # anonymous click (the realistic "leaked URL replayed by someone
+    # else" scenario).
+    test_client.cookies.clear()
+
+    second = await test_client.post("/auth/verify", data={"token": token})
+    assert second.status_code == 200
+    assert "already verified" in second.text.lower()
+    # NO cookie minted on the already_verified branch.
+    assert "set-cookie" not in {k.lower() for k in second.headers.keys()}
 
 
 async def test_post_resend_verify_unauthenticated_returns_401(test_client: AsyncClient):

--- a/src/domain/templates/auth/verify.html
+++ b/src/domain/templates/auth/verify.html
@@ -1,32 +1,50 @@
 {% extends "base.html" %}
 {% block content %}
   <section class="auth-page">
-    <header>
-      {% if status == "success" %}
-        <h1>Email verified</h1>
-        <p>Thanks — your email is confirmed. The nag banner will go away on your next page load.</p>
-      {% elif status == "already_verified" %}
+    {# Three render states. `status=None` (default) is the confirm-page
+       branch the GET handler hits when a token is present — clicking
+       the button POSTs to `/auth/verify`, which is where the token
+       is actually consumed (see auth_pages.py:post_verify for why GET
+       doesn't mutate). The success branch isn't a template state —
+       the POST handler redirects (via on_after_login + override) into
+       the clinician-create flow, preserving the funnel intent from
+       #1302. #}
+    {% if status == "already_verified" %}
+      <header>
         <h1>Already verified</h1>
-        <p>This email was already confirmed. Nothing more to do.</p>
-      {% else %}
+        <p>This email was already confirmed. Log in to continue.</p>
+      </header>
+      <footer>
+        <p>
+          <a href="/auth/login" role="button">Log in</a>
+        </p>
+      </footer>
+    {% elif status == "error" %}
+      <header>
         <h1>Verification link didn't work</h1>
         <p>
           The link may have expired, been used already, or been mis-copied. Sign in and use the resend link in the banner at the top of the page.
         </p>
-      {% endif %}
-    </header>
-    <footer>
-      {# On success, route the user into the clinician-create flow — the
-         intended next step after confirming email. The two other states
-         (already-verified / link-failed) still bounce to /users/me, where
-         the user can resend or self-manage. #}
-      <p>
-        {% if status == "success" %}
-          <a href="{{ entity_form_url('clinician') }}" role="button">{{ entity_create_label("clinician") }}</a>
-        {% else %}
-          <a href="{{ entity_url('user', id='me') }}" role="button">Go to your profile</a>
-        {% endif %}
-      </p>
-    </footer>
+      </header>
+      <footer>
+        <p>
+          <a href="/auth/login" role="button">Log in</a>
+        </p>
+      </footer>
+    {% else %}
+      <header>
+        <h1>Verify your email</h1>
+        <p>Click the button below to confirm your email and sign in.</p>
+      </header>
+      {# Plain form POST — no HTMX. The page is the landing for an
+         email link, so we can't assume HTMX is mounted and the
+         browser-native form submit + 302 follow is the simpler path.
+         (The POST handler still honors `HX-Request: true` if a
+         future HTMX caller wants the 204 + HX-Redirect shape.) #}
+      <form action="/auth/verify" method="post">
+        <input type="hidden" name="token" value="{{ token }}">
+        <button type="submit">Verify and sign in</button>
+      </form>
+    {% endif %}
   </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- `GET /auth/verify?token=...` no longer consumes the token — it renders a "Verify and sign in" confirm page with the token in a hidden form field. `POST /auth/verify` is the new mutation point: consumes the token, mints a session cookie, and redirects.
- Defends against email link-prefetchers (corporate AV, Outlook Safe Links, Gmail preview) that GET email links and burn the token before the user can click. Prefetchers don't POST.
- Success redirects to `/clinicians/form` — preserves #1302's intent that verified users land in the create-clinician funnel.
- `UserAlreadyVerified` on POST deliberately does NOT auto-login (second click could be from a leaked-after-use URL); renders the existing "already verified" page with a Log in link.

## Test plan
- [x] `dev test` (2460 passed)
- [x] `dev test contract` (40 passed)
- [x] `dev lint`
- [x] Manual: GET with token → confirm button; POST with real token → cookie set, redirected to `/clinicians/form` (Sign out in nav confirms session); replay used token without cookie → "Already verified" + Log in CTA, no cookie; bogus token → error page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)