### PR TITLE
Raise loudly on per-affiliation writes to unaffiliated clinicians

### DIFF
--- a/src/domain/models/clinicians/README.md
+++ b/src/domain/models/clinicians/README.md
@@ -28,3 +28,9 @@ This `Clinician` class is the **directory entry**: the row that `/clinicians/...
 ## Why a separate cluster
 
 A `Clinician` is *the person*; an `ClinicianAffiliation` is *the person's role at one practice*. Separating them lets credentials live with the person (so adding a second affiliation doesn't fragment a license list) and lets per-(clinician × org) attributes vary independently across affiliations.
+
+## Per-affiliation proxy setters require a primary affiliation
+
+`Clinician` exposes proxy `@property`/setter pairs for the per-affiliation columns (`org_id`, `location_city`/`_state`/`_zip`, `in_person_sessions`, `virtual_sessions`, `accepts_out_of_network`, `in_network_carriers`, `sliding_scale`, `cost` — the `_PER_ROLE_ATTRS` tuple). They proxy reads from / writes to `primary_clinician_affiliation` (`clinician_affiliations[0]`). When no affiliation exists the **setters raise `ValueError`** rather than silently dropping the write — this catches the prod regression where an unaffiliated clinician's edit form returned 200 but persisted nothing. The readers still return `None` for backwards compatibility with templates that may render an unaffiliated row.
+
+Auto-creation of a primary affiliation for solo clinicians lives in the verification handler (see `src/domain/logic/clinicians/handlers.py`), not in the setter — silently materializing rows from inside a setattr would re-introduce the same kind of invisible behavior we're trying to surface.

--- a/src/domain/models/clinicians/clinician.py
+++ b/src/domain/models/clinicians/clinician.py
@@ -139,6 +139,28 @@ class Clinician(BaseModel):
     def primary_clinician_affiliation(self):
         return self.clinician_affiliations[0] if self.clinician_affiliations else None
 
+    def _require_primary_affiliation(self, attr_name: str):
+        """Setter guard for every per-affiliation proxy below.
+
+        Per-affiliation fields (location, availability, insurance posture,
+        cost, org_id) live on :class:`ClinicianAffiliation`, not on this
+        row. Writing through the proxy when no affiliation exists used to
+        silently no-op — :class:`Clinician` accepted the write and dropped
+        it, which surfaced in production as "the edit form returned 200
+        but nothing saved" once create-time affiliation became optional.
+        The cure is to refuse the write loudly: callers must give the
+        clinician an affiliation first (PR-2 auto-creates a stub for solo
+        clinicians) or write directly to the target affiliation.
+        """
+        aff = self.primary_clinician_affiliation
+        if aff is None:
+            raise ValueError(
+                f"cannot set {attr_name!r} on a Clinician with no "
+                "ClinicianAffiliation; per-affiliation fields require a "
+                "primary affiliation"
+            )
+        return aff
+
     @property
     def org_id(self):
         aff = self.primary_clinician_affiliation
@@ -146,8 +168,7 @@ class Clinician(BaseModel):
 
     @org_id.setter
     def org_id(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.org_id = value
+        self._require_primary_affiliation("org_id").org_id = value
 
     @property
     def org(self):
@@ -156,8 +177,7 @@ class Clinician(BaseModel):
 
     @org.setter
     def org(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.org = value
+        self._require_primary_affiliation("org").org = value
 
     @property
     def org_name(self) -> str | None:
@@ -171,8 +191,7 @@ class Clinician(BaseModel):
 
     @location_city.setter
     def location_city(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.location_city = value
+        self._require_primary_affiliation("location_city").location_city = value
 
     @property
     def location_state(self) -> str | None:
@@ -181,8 +200,7 @@ class Clinician(BaseModel):
 
     @location_state.setter
     def location_state(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.location_state = value
+        self._require_primary_affiliation("location_state").location_state = value
 
     @property
     def location_zip(self) -> str | None:
@@ -191,8 +209,7 @@ class Clinician(BaseModel):
 
     @location_zip.setter
     def location_zip(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.location_zip = value
+        self._require_primary_affiliation("location_zip").location_zip = value
 
     @property
     def in_person_sessions(self) -> str | None:
@@ -201,8 +218,9 @@ class Clinician(BaseModel):
 
     @in_person_sessions.setter
     def in_person_sessions(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.in_person_sessions = value
+        self._require_primary_affiliation("in_person_sessions").in_person_sessions = (
+            value
+        )
 
     @property
     def virtual_sessions(self) -> str | None:
@@ -211,8 +229,7 @@ class Clinician(BaseModel):
 
     @virtual_sessions.setter
     def virtual_sessions(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.virtual_sessions = value
+        self._require_primary_affiliation("virtual_sessions").virtual_sessions = value
 
     @property
     def accepts_out_of_network(self) -> bool | None:
@@ -221,8 +238,9 @@ class Clinician(BaseModel):
 
     @accepts_out_of_network.setter
     def accepts_out_of_network(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.accepts_out_of_network = value
+        self._require_primary_affiliation(
+            "accepts_out_of_network"
+        ).accepts_out_of_network = value
 
     @property
     def in_network_carriers(self) -> list:
@@ -233,8 +251,9 @@ class Clinician(BaseModel):
 
     @in_network_carriers.setter
     def in_network_carriers(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.in_network_carriers = value
+        self._require_primary_affiliation("in_network_carriers").in_network_carriers = (
+            value
+        )
 
     @property
     def sliding_scale(self) -> bool | None:
@@ -243,8 +262,7 @@ class Clinician(BaseModel):
 
     @sliding_scale.setter
     def sliding_scale(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.sliding_scale = value
+        self._require_primary_affiliation("sliding_scale").sliding_scale = value
 
     @property
     def cost(self) -> str | None:
@@ -253,5 +271,4 @@ class Clinician(BaseModel):
 
     @cost.setter
     def cost(self, value) -> None:
-        if self.primary_clinician_affiliation is not None:
-            self.primary_clinician_affiliation.cost = value
+        self._require_primary_affiliation("cost").cost = value

--- a/src/domain/models/clinicians/test_clinician.py
+++ b/src/domain/models/clinicians/test_clinician.py
@@ -202,6 +202,59 @@ async def test_setting_clinician_names_persists(session):
     assert clinician.last_name == "Hart"
 
 
+# --- Per-affiliation proxy setters ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setting_per_affiliation_field_with_no_affiliation_raises():
+    """Per-affiliation fields (location, availability, insurance posture,
+    cost, org_id) live on :class:`ClinicianAffiliation`. Writing through
+    the proxy when no affiliation exists used to silently drop the write
+    — the canonical "edit form returned 200 but nothing saved" prod bug
+    once create-time affiliation became optional. The setter must now
+    refuse the write loudly so the failure is visible."""
+    user = _make_user("solo")
+    clinician = Clinician(
+        owner_id=user.id,
+        first_name="Solo",
+        last_name="Practitioner",
+        npi="1234567890",
+    )
+    assert clinician.primary_clinician_affiliation is None
+    for attr, value in (
+        ("org_id", uuid.uuid4()),
+        ("location_city", "Brooklyn"),
+        ("location_state", "NY"),
+        ("location_zip", "11201"),
+        ("in_person_sessions", "yes"),
+        ("virtual_sessions", "please_contact"),
+        ("accepts_out_of_network", True),
+        ("in_network_carriers", []),
+        ("sliding_scale", False),
+        ("cost", "$150"),
+    ):
+        with pytest.raises(ValueError, match=f"cannot set '{attr}'"):
+            setattr(clinician, attr, value)
+
+
+@pytest.mark.asyncio
+async def test_setting_per_affiliation_field_with_affiliation_writes_through():
+    """When a primary affiliation exists the proxy setter writes through
+    to it — the path the clinician edit form takes for any clinician
+    that has one."""
+    user = _make_user("affd")
+    org = _make_org("Acme", user.id)
+    clinician = _make_clinician(owner=user, org=org)
+    assert clinician.primary_clinician_affiliation is not None
+
+    clinician.location_city = "Queens"
+    clinician.in_person_sessions = "no"
+    clinician.cost = "$200"
+    assert clinician.primary_clinician_affiliation.location_city == "Queens"
+    assert clinician.primary_clinician_affiliation.in_person_sessions == "no"
+    assert clinician.primary_clinician_affiliation.cost == "$200"
+
+
 # --- Claim A verification columns -----------------------------------------
 
 


### PR DESCRIPTION
## Summary

- The per-affiliation `@property` setters on `Clinician` (`org_id`, `location_*`, `in_person_sessions`, `virtual_sessions`, `accepts_out_of_network`, `in_network_carriers`, `sliding_scale`, `cost`) used to silently no-op when no primary `ClinicianAffiliation` existed. After #1296 made create-time affiliation optional, that path went live for solo clinicians: the edit form returned 200 OK while every per-affiliation write vanished.
- Setters now raise `ValueError` so the failure surfaces in Sentry and the user sees an actual error instead of "form refreshed, nothing saved." Readers still return `None` for backwards compat.
- Dedup'd the guard into one `_require_primary_affiliation(attr_name)` helper rather than repeating the raise nine times.

This is PR 1 of 5 in a sequence that straightens out the Clinician / Organization / Affiliation modelling after #1296 loosened the "always has an affiliation" invariant. PR 2 will auto-create a stub affiliation on verify + backfill existing solo rows so the raise becomes unreachable in practice; PR 3-5 move posture editing onto the affiliation, fix the referral/opening picker labels, and relabel "affiliation" to "practice" in solo UI contexts.

## Test plan

- [x] `dev test` — 2462 passed
- [x] `dev test contract` — 40 passed
- [x] `dev lint`
- [x] New colocated tests in `src/domain/models/clinicians/test_clinician.py` covering both branches (raise when no affiliation; write-through when one exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)