### PR TITLE
Label referral/opening pickers person-first, org as disambiguator

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -31,6 +31,7 @@ from src.domain.models import Clinician, Organization, Post, Program
 from src.domain.models.org_representations.org_representation import OrgRepresentation
 from tests.helpers import (
     create_test_user,
+    make_clinician,
     make_clinician_with_org,
     make_intake_detail,
     make_opening_detail,
@@ -525,6 +526,82 @@ async def test_create_form_preselects_first_clinician(
     assert str(affiliation_id) in (
         options[0].attributes.get("value") or ""
     ), "selected option value should be the first affiliation's id"
+
+
+@pytest.mark.parametrize("kind", ["referral", "clinician_opening"])
+async def test_create_form_picker_labels_person_first_with_org(
+    kind: str,
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The practice picker labels each affiliation **person first, org as
+    disambiguator** — `"<First Last> · <Org Name>"` when the affiliation
+    points at an organization. The label was just `<Org Name>` before
+    #1308 — that erased the person entirely when one user owned multiple
+    clinicians, and broke entirely once solo clinicians (whose
+    affiliation has `org_id` NULL) became a first-class state."""
+    clinician = make_clinician_with_org(
+        owner_id=logged_in_user.id,
+        practice_name="Brooklyn Therapy",
+        first_name="Jane",
+        last_name="Smith",
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+    affiliation_id = clinician.clinician_affiliations[0].id
+
+    response = await authenticated_client.get(f"/posts/form?kind={kind}")
+    assert response.status_code == 200
+
+    tree = HTMLParser(response.text)
+    select = tree.css_first(f'select[name="{_CLINICIAN_FIELD[kind]}"]')
+    assert select is not None
+    option = next(
+        o
+        for o in select.css("option")
+        if o.attributes.get("value") == str(affiliation_id)
+    )
+    assert option.text(strip=True) == "Jane Smith · Brooklyn Therapy"
+
+
+@pytest.mark.parametrize("kind", ["referral", "clinician_opening"])
+async def test_create_form_picker_labels_solo_with_name_only(
+    kind: str,
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """Solo clinician: the affiliation row has `org_id` NULL — the label
+    is just the clinician's name (no `" · …"` suffix), because there is
+    no organizational entity to disclose."""
+    from src.domain.models import ClinicianAffiliation
+
+    clinician = make_clinician(
+        owner_id=logged_in_user.id,
+        first_name="Janet",
+        last_name="Solo",
+    )
+    # Force a stub affiliation with no org — mirrors the PR 2 stub shape.
+    clinician.clinician_affiliations = [ClinicianAffiliation(clinician=clinician)]
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+    affiliation_id = clinician.clinician_affiliations[0].id
+
+    response = await authenticated_client.get(f"/posts/form?kind={kind}")
+    assert response.status_code == 200
+
+    tree = HTMLParser(response.text)
+    select = tree.css_first(f'select[name="{_CLINICIAN_FIELD[kind]}"]')
+    assert select is not None
+    option = next(
+        o
+        for o in select.css("option")
+        if o.attributes.get("value") == str(affiliation_id)
+    )
+    assert option.text(strip=True) == "Janet Solo"
 
 
 # --- Anonymization gate (can_access_network) ---------------------------------

--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -49,18 +49,22 @@ Field order:
   <form hx-{{ hx_method }}="{{ action }}" {{ _hx_attrs|safe }}>
     <input type="hidden" name="kind" value="clinician_opening" />
     {# Practice picker. A Clinician may carry multiple Affiliations
-     (clinician × org practice-role rows); the dropdown labels each
-     option by the affiliation's org name so a clinician who works at
-     two practices sees both. Each option's value is the *affiliation*
-     id — the server derives the opening's `clinician_id` from it
-     (`_resolve_affiliation_context`), so a two-affiliation clinician's
-     options no longer collapse onto one value. Uses
-     `composite_select_field` because the label is sourced from a nested
-     `affiliations` loop — mirrors `_form_referral.html`'s picker. #}
+     (clinician × org practice-role rows). The label is **person first,
+     org as disambiguator when present** — "Jane Smith" for a solo
+     clinician whose affiliation has `org_id` NULL, "Jane Smith · Acme
+     Counseling" when the affiliation points at an org. Each option's
+     value is the *affiliation* id — the server derives the opening's
+     `clinician_id` from it (`_resolve_affiliation_context`), so a
+     two-affiliation clinician's options no longer collapse onto one
+     value. Uses `composite_select_field` because the label is sourced
+     from a nested `affiliations` loop — mirrors `_form_referral.html`'s
+     picker. #}
     {%- set _practices = namespace(opts=[]) -%}
     {%- for c in current_user.clinicians -%}
+      {%- set _name = (c.first_name ~ " " ~ c.last_name)|trim -%}
       {%- for aff in c.clinician_affiliations -%}
-        {%- set _practices.opts = _practices.opts + [(aff.id, aff.org.name)] -%}
+        {%- set _label = (_name ~ " · " ~ aff.org.name) if aff.org else _name -%}
+        {%- set _practices.opts = _practices.opts + [(aff.id, _label)] -%}
       {%- endfor -%}
     {%- endfor -%}
     {{ composite_select_field("clinician_affiliation_id", "Which practice?", _practices.opts, current=d.clinician_affiliation_id if d else None, default_first=true) }}

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -47,15 +47,21 @@ which FastAPI/Pydantic parses as a list.
     <input type="hidden" name="kind" value="referral" />
     {# Referring clinician picker — required; populated from the current
        user's owned clinicians' affiliations. Each option value is the
-       *affiliation* id; the label is the affiliated org name. The server
+       *affiliation* id; the label is **person first, org as
+       disambiguator when present** — "Jane Smith" for a solo clinician
+       whose affiliation has `org_id` NULL, "Jane Smith · Acme
+       Counseling" when the affiliation points at an org. The server
        derives `referring_clinician_id` from the chosen affiliation
-       (`_resolve_affiliation_context`), so a clinician affiliated with
-       two orgs produces two distinct options instead of collapsing both
-       onto the same clinician id. Mirrors the PA form's practice picker. #}
+       (`_resolve_affiliation_context`), so a clinician with two
+       affiliations produces two distinct options instead of collapsing
+       both onto the same clinician id. Mirrors the PA form's practice
+       picker. #}
     {%- set _practices = namespace(opts=[]) -%}
     {%- for c in current_user.clinicians -%}
+      {%- set _name = (c.first_name ~ " " ~ c.last_name)|trim -%}
       {%- for aff in c.clinician_affiliations -%}
-        {%- set _practices.opts = _practices.opts + [(aff.id, aff.org.name)] -%}
+        {%- set _label = (_name ~ " · " ~ aff.org.name) if aff.org else _name -%}
+        {%- set _practices.opts = _practices.opts + [(aff.id, _label)] -%}
       {%- endfor -%}
     {%- endfor -%}
     {{ composite_select_field("clinician_affiliation_id", "Referring clinician", _practices.opts, current=d.clinician_affiliation_id if d else None, default_first=true) }}


### PR DESCRIPTION
## Summary

PR 4 of 5 in the Clinician / Organization / Affiliation straightening sequence (#1308, #1311, #1313 prior).

Both the "Referring clinician" picker on the referral form and the "Which practice?" picker on the opening form iterated affiliations and used `aff.org.name` as the option label. That:

- Erased the person entirely when one user owned multiple clinicians ("Acme Counseling" vs. "Acme Counseling" tells you nothing about which person).
- Broke entirely for solo clinicians after #1311, because their affiliation has `org_id` NULL and `aff.org` is `None`.

Both pickers now build labels person-first, org as disambiguator when present:

- `"Jane Smith"` — solo affiliation (`org_id` NULL).
- `"Jane Smith · Acme Counseling"` — affiliated with an org.

One option per (clinician, affiliation) pair stays the rule. The option's *value* is still the affiliation id — the server still derives `referring_clinician_id` / opening `clinician_id` from it via `_resolve_affiliation_context`, so a multi-affiliation clinician still produces multiple distinct options.

## Contract-surface check

- HTML form labels only — no wire schema, URL, or persisted-state change. Compatible.

## Test plan

- [x] `dev test` — 2466 passed
- [x] `dev test contract` — 40 passed
- [x] `dev lint`
- [x] New parametrized tests covering both kinds + both label shapes:
  - `test_create_form_picker_labels_person_first_with_org` (with-org case)
  - `test_create_form_picker_labels_solo_with_name_only` (solo case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)