### PR TITLE
Surface affiliation rows as "Practices" + fix solo aff.org.name crash

### DIFF
--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -15,6 +15,7 @@ from src.framework.audit.repository import AuditRepository
 from tests.helpers import (
     clinician_payload,
     create_test_user,
+    make_clinician,
     make_clinician_licensure,
     make_clinician_with_org,
     make_organization_row,
@@ -1254,11 +1255,11 @@ async def test_owner_edit_form_renders_affiliations_section(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """The clinician edit page surfaces every ClinicianAffiliation row in a
-    dedicated "Affiliations" section with inline add and per-row
-    delete — #642 PR 1's UI. The Clinician's initial ClinicianAffiliation
-    (built by `Clinician.__init__` from the create payload) appears
-    prefilled."""
+    """The clinician edit page surfaces every `ClinicianAffiliation` row
+    in a dedicated section. The DB model calls them affiliations
+    (clinician × org); the UI surfaces them as "Practices" because
+    that's what they are to the user — including the solo case where
+    `org_id` is NULL. Inline add + per-row delete are present."""
     clinician_id = await _seed_clinician_for(
         db_test_session_manager, user_id=logged_in_user.id
     )
@@ -1268,7 +1269,7 @@ async def test_owner_edit_form_renders_affiliations_section(
     tree = HTMLParser(response.text)
 
     headings = [h.text(strip=True) for h in tree.css("h2")]
-    assert "Affiliations" in headings
+    assert "Practices" in headings
 
     # The inline add form posts to /clinicians/{id}/clinician_affiliations.
     add_form = tree.css_first(
@@ -1450,6 +1451,55 @@ async def test_owner_edit_form_renders_credentials_as_rows(
     assert meta is not None
     assert "L-12345" in meta.text()
     assert "CA" in meta.text()
+
+
+async def test_owner_edit_form_renders_solo_affiliation_without_crashing(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Solo clinician path: a `ClinicianAffiliation` with `org_id` NULL
+    (the shape #1311 introduced for solo practitioners) renders without
+    dereferencing `aff.org.name`. The row label falls back to
+    "Solo practice" and the section heading reads "Practices" — the UI
+    drops the "affiliation" word in the solo case, matching how the
+    user thinks about it."""
+    from src.domain.models import Clinician, ClinicianAffiliation
+
+    clinician = make_clinician(
+        owner_id=logged_in_user.id,
+        first_name="Janet",
+        last_name="Solo",
+    )
+    clinician.clinician_affiliations = [ClinicianAffiliation(clinician=clinician)]
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+        await session.refresh(clinician)
+    clinician_id = clinician.id
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    # Section heading is "Practices", not "Affiliations".
+    headings = [h.text(strip=True) for h in tree.css("h2")]
+    assert "Practices" in headings
+    assert "Affiliations" not in headings
+    # The solo affiliation row's label falls back to "Solo practice".
+    async with db_test_session_manager() as session:
+        loaded = await session.get(Clinician, clinician_id)
+        aff_id = loaded.clinician_affiliations[0].id
+    delete = tree.css_first(
+        f'button[hx-delete="/clinicians/{clinician_id}/clinician_affiliations/{aff_id}"]'
+    )
+    assert delete is not None
+    row = delete.parent
+    while row is not None and "credential-row" not in (
+        row.attributes.get("class") or ""
+    ):
+        row = row.parent
+    assert row is not None
+    assert row.css_first("strong").text(strip=True) == "Solo practice"
 
 
 async def test_admin_can_open_edit_form_for_any_clinician(

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -20,7 +20,7 @@
    insurance, cost, org) lives on `ClinicianAffiliation` because the
    same person can have different posture at different practice contexts
    (telehealth solo + in-person group, etc.) — those edits happen on the
-   Affiliations list below, not on this form. See the affiliations cluster
+   Practices list below, not on this form. See the affiliations cluster
    README for the "affiliation is the practice-posture container" model. #}
   <form hx-patch="{{ entity_url('clinician', id=clinician.id) }}">
     {% call form_section("Clinician") %}
@@ -35,9 +35,15 @@
    own self-contained mini-form; the section headings group them
    visually but they're not part of the clinician's edit grid. #}
   <section>
-    {# Affiliations — clinician's practice-role rows. #}
-    <h2>Affiliations</h2>
-    {% call(aff) credential_list(clinician.clinician_affiliations, "No affiliations yet.") %}
+    {# Practices — clinician's `ClinicianAffiliation` rows. The DB model
+       calls them affiliations because that's what the (clinician × org)
+       join is; in the UI we just call them practices because that's
+       what they are to the user. A row with `org_id` NULL is a solo
+       practice — the affiliation owns the posture, with no
+       organizational entity to point at. See the affiliations cluster
+       README. #}
+    <h2>Practices</h2>
+    {% call(aff) credential_list(clinician.clinician_affiliations, "No practices yet.") %}
       {%- set meta_parts = [
             aff.location_city,
             aff.location_state,
@@ -49,13 +55,13 @@
             "Sliding scale" if aff.sliding_scale else None,
             aff.cost,
             ] -%}
-      {{ credential_row(aff.org.name,
-            meta_parts,
-            delete_url=entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations/" ~ aff.id|string,
-      delete_confirm="Remove this affiliation?",
+      {{ credential_row((aff.org.name if aff.org else "Solo practice") ,
+      meta_parts,
+      delete_url=entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations/" ~ aff.id|string,
+      delete_confirm="Remove this practice?",
       ) }}
     {% endcall %}
-    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations", "Add affiliation", "Add affiliation") %}
+    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations", "Add another practice", "Add another practice") %}
       <label for="aff_org_id">
         Organization
         <select id="aff_org_id" name="org_id" required>


### PR DESCRIPTION
## Summary

PR 5 of 5 — the closing PR in the Clinician / Organization / Affiliation straightening sequence (#1308, #1311, #1313, #1315 prior).

This PR fixes a latent crash and aligns the UI vocabulary with the user's mental model:

- **Latent crash fix**: after #1311 made `ClinicianAffiliation.org_id` nullable, the clinician edit page rendered each affiliation row's label as `aff.org.name` — which raises `AttributeError: 'NoneType' object has no attribute 'name'` for any solo affiliation (`org_id IS NULL`). Now falls back to `"Solo practice"` when `aff.org is None`.
- **UI relabel**: "Affiliations" → "Practices" on the clinician edit page. The DB model still calls them affiliations because that's what the (clinician × org) join is, but in the UI we call them practices because that's what they are to the user — solo and org-affiliated cases share the same noun.
  - Section heading: "Affiliations" → "Practices"
  - Empty state: "No affiliations yet." → "No practices yet."
  - Delete confirm: "Remove this affiliation?" → "Remove this practice?"
  - Add button: "Add affiliation" → "Add another practice"

## Contract-surface check

- HTML labels + a null-safe template expression only. No wire schema, URL, or persisted-state change. Compatible.

## Follow-up

The inline add-practice form below still requires `org_id` because `ClinicianAffiliationCreate.org_id` is required (along with `Location` and the session columns). Users can add a *second* solo practice today only by going through the create-clinician + verify pipeline that auto-creates the stub. A follow-up PR would relax `ClinicianAffiliationCreate` and add a "Solo practice (no organization)" option to the inline form's dropdown.

The H1 fallback `clinician.org.name` (`form_edit.html:15`, `detail.html:23`) is also unsafe in principle, but `ClinicianCreate` requires `first_name`/`last_name` (#1207), so the fallback should be unreachable in practice. Left for a separate audit.

## Test plan

- [x] `dev test` — 2467 passed
- [x] `dev test contract` — 40 passed
- [x] `dev lint`
- [x] New test `test_owner_edit_form_renders_solo_affiliation_without_crashing` — explicit no-crash + "Practices" heading + "Solo practice" row label
- [x] Updated `test_owner_edit_form_renders_affiliations_section` to assert the new heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)