### PR TITLE
Null-safe Practice fact in shared clinician card + H1 fallbacks

### DIFF
--- a/src/domain/templates/clinicians/detail.html
+++ b/src/domain/templates/clinicians/detail.html
@@ -13,14 +13,18 @@
 {% block resource_label %}Clinicians{% endblock %}
 {# H1 — clinician's name when set; falls back to the primary affiliation's
    organization name for legacy rows without name data. Redacted viewers
-   see a locked-name placeholder rather than the underlying identity. #}
+   see a locked-name placeholder rather than the underlying identity. The
+   `org` fallback branch must guard on `clinician.org` because a solo
+   primary affiliation has no Organization (#1311). #}
 {% block current_label %}
   {% if _redacted %}
     {{ locked_name("Dr. J. Doe") }}
   {% elif clinician.first_name and clinician.last_name %}
     {{ clinician.first_name }} {{ clinician.last_name }}
-  {% else %}
+  {% elif clinician.org %}
     {{ clinician.org.name }}
+  {% else %}
+    Clinician
   {% endif %}
 {% endblock %}
 {% block subtitle %}

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -6,13 +6,19 @@
 {%- from "clinicians/_credential_list.html" import credential_list -%}
 {%- from "clinicians/_credential_row.html" import credential_row -%}
 {% block resource_label %}Clinicians{% endblock %}
-{# Same H1-fallback shape as the detail page — name when set, primary
-   affiliation's org name otherwise. #}
+{# H1-fallback: name when set, else primary affiliation's org name when
+   present, else "Clinician". ClinicianCreate requires first_name +
+   last_name (#1207), so the fallback branches should be unreachable in
+   practice — but `clinician.org` is None for solo affiliations (#1311),
+   so the fallback is explicit about it instead of crashing. Detail page
+   shares the same shape. #}
 {% block current_label %}
   {% if clinician.first_name and clinician.last_name %}
     {{ clinician.first_name }} {{ clinician.last_name }}
-  {% else %}
+  {% elif clinician.org %}
     {{ clinician.org.name }}
+  {% else %}
+    Clinician
   {% endif %}
 {% endblock %}
 {% block form_content %}

--- a/src/framework/templates/_shared/_clinician_card.html
+++ b/src/framework/templates/_shared/_clinician_card.html
@@ -73,8 +73,17 @@
           {%- if _redacted -%}
             {{ locked_field(capabilities.REASON_NETWORK_UNVERIFIED) }}
           {%- elif affiliations -%}
+            {# Solo affiliations (`ClinicianAffiliation` with `org_id`
+               NULL — the row carries practice posture without an
+               organizational entity to point at) render as a plain
+               "Solo practice" chip; org-affiliated rows link to the
+               org page. A clinician with one of each shows both. #}
             {%- for aff in affiliations -%}
-              {{ entity_link('organization', aff.org.name, id=aff.org_id) }}
+              {%- if aff.org -%}
+                {{ entity_link('organization', aff.org.name, id=aff.org_id) }}
+              {%- else -%}
+                <span>Solo practice</span>
+              {%- endif -%}
             {%- endfor -%}
           {%- else -%}
             &mdash;

--- a/src/framework/templates/_shared/test_clinician_card_redaction.py
+++ b/src/framework/templates/_shared/test_clinician_card_redaction.py
@@ -113,6 +113,43 @@ def test_un_redacted_when_viewer_owns_the_row() -> None:
     assert "Jane Doe" in html
 
 
+def test_solo_affiliation_renders_as_plain_practice_chip() -> None:
+    """Solo clinician path: an affiliation with `org_id` NULL / `org`
+    None (the shape #1311 introduced) renders the Practice fact as a
+    plain "Solo practice" chip without trying to deref `aff.org.name`.
+    Pre-fix this branch was an `AttributeError: 'NoneType' object has
+    no attribute 'name'` waiting to fire the first time a solo clinician
+    surfaced in `/clinicians` / favorites / a user's clinician list."""
+    env = _make_env()
+    viewer_id = uuid.uuid4()
+    solo_aff = SimpleNamespace(
+        org=None,
+        org_id=None,
+        location_city="Brooklyn",
+        location_state="NY",
+    )
+    solo = SimpleNamespace(
+        id=uuid.uuid4(),
+        owner_id=viewer_id,
+        clinician_affiliations=[solo_aff],
+        licensures=[],
+        first_name="Janet",
+        last_name="Solo",
+    )
+    html = _render_card(
+        env,
+        clinician=solo,
+        can_access_network=True,
+        current_user_id=viewer_id,
+    )
+    tree = HTMLParser(html)
+    practice = tree.css_first('div[data-fact="practice"] dd')
+    assert practice is not None
+    assert "Solo practice" in practice.text()
+    # No org link rendered — `entity_link` is bypassed entirely.
+    assert practice.css_first("a") is None
+
+
 def test_redacted_when_viewer_not_owner_and_not_network() -> None:
     """The redaction branch: a non-network viewer looking at another
     user's row sees the headline name replaced by `locked_name`'s


### PR DESCRIPTION
## Summary

Follow-up to the Clinician / Org / Affiliation straightening sequence (#1308 → #1317), per the audit recommendation that came out of PR #1311 and PR #1317 retros: after `ClinicianAffiliation.org_id` became nullable to model solo practitioners, the `aff.org.name` read sites in templates needed null-safety.

PR #1317 closed one site (`clinicians/form_edit.html` row label). This PR closes the rest:

- **`_shared/_clinician_card.html` Practice fact** — iterated affiliations and called `entity_link('organization', aff.org.name, id=aff.org_id)` per row, which raises `AttributeError: 'NoneType' object has no attribute 'name'` for any solo affiliation. This card is rendered by `/clinicians`, `/users/me/favorites`, `/users/{id}/clinicians`, and the embedded preview on `/users/{id}` — highest blast radius. Now renders solo rows as a plain `"Solo practice"` chip and keeps the org link for affiliated rows. A clinician with one of each shows both.
- **`clinicians/detail.html` and `clinicians/form_edit.html` H1 fallbacks** — dereferenced `clinician.org.name` when first/last name were both unset. `ClinicianCreate` requires first_name + last_name (#1207) so the branch is unreachable in practice, but the fallback is split defensively into "org present → org name" vs "neither → 'Clinician'" so a future legacy/admin/seed path can't silently re-discover the crash.

## Contract-surface check

- Template-render only. No wire schema, URL, or persisted-state change. Compatible.

## Test plan

- [x] `dev test` — 2468 passed
- [x] `dev test contract` — 40 passed
- [x] `dev lint`
- [x] New `test_solo_affiliation_renders_as_plain_practice_chip` in `_shared/test_clinician_card_redaction.py` pins the Practice fact rendering for a solo affiliation: "Solo practice" present, no `<a>` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)