### PR TITLE
Remove dead .form-field-control CSS class

### DIFF
--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -232,8 +232,7 @@ dd { margin: 0; }
 }
 .entity-form-page form .form-field > input,
 .entity-form-page form .form-field > select,
-.entity-form-page form .form-field > textarea,
-.entity-form-page form .form-field > .form-field-control { margin: 0; min-width: 0; }
+.entity-form-page form .form-field > textarea { margin: 0; min-width: 0; }
 /* Multi-selection rendered as a scrollable checkbox list (replaces the
    old `<select multiple>` listbox — see `multi_select_field` in
    `_shared/form_fields.html`). The max-height cap is the whole point:
@@ -313,18 +312,6 @@ dd { margin: 0; }
   grid-column: auto;
 }
 .entity-form-page form .grid > .form-field > small { grid-column: 2; }
-/* Radio cluster: yes/no labels inline inside the right column. */
-.form-field-control {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-}
-.form-field-control > .form-field-inline {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-}
 @media (max-width: 640px) {
   .entity-form-page form {
     grid-template-columns: 1fr;

--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -243,7 +243,7 @@ emitted attribute string. #}
        {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
        {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>
     <span class="form-field-label" id="{{ name }}-label">{{ _field_label(label, required) }}</span>
-    <div class="checkbox-list form-field-control">
+    <div class="checkbox-list">
       {%- for v in options %}
         <label class="checkbox-list-option">
           <input type="checkbox"


### PR DESCRIPTION
## Summary

- Removed the `.form-field-control` class — its only HTML site was the `multi_select_field` checkbox-list, where its `gap: 0.75rem` was overriding `.checkbox-list`'s intended `gap: 0.125rem` on the same element.
- The orphaned `.form-field-control > .form-field-inline` rule goes with it; `.form-field-inline` had no other consumers.

## Test plan

- [x] `dev lint` passes
- [x] `dev test` passes (2467 passed, existing `test_form_fields.py` still pins `.checkbox-list`)
- [ ] Visually confirm the multi-select checkbox list still renders correctly (tighter gap now restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)