### PR TITLE
Inline checkbox-list border as default, drop the modifier

### DIFF
--- a/src/domain/templates/dev/components.html
+++ b/src/domain/templates/dev/components.html
@@ -419,7 +419,7 @@ it's dev-only chrome that should never ship to production. #}
           Checkbox list (<code>.checkbox-list</code>)
         </h2>
         <p>
-          <small>Shared scrollable list-of-checkboxes primitive. Base class caps height + scrolls; modifiers layer on chrome (<code>.checkbox-list-bordered</code>) or layout (<code>.checkbox-list-grid</code>). Used by search/list filter sidebars (<code>_shared/_filter_field.html</code>) and by <code>multi_select_field</code> in entity forms.</small>
+          <small>Shared scrollable list-of-checkboxes primitive. Bordered + scrollable by default; adds <code>.checkbox-list-grid</code> to swap the vertical column for a responsive grid (long filter lists). Used by search/list filter sidebars (<code>_shared/_filter_field.html</code>) and by <code>multi_select_field</code> in entity forms.</small>
         </p>
         <h3>Single-column (default — filter sidebar)</h3>
         <fieldset class="search-checkbox-fieldset">
@@ -441,17 +441,6 @@ it's dev-only chrome that should never ship to production. #}
             {% endfor %}
           </div>
         </fieldset>
-        <h3>
-          Bordered (<code>.checkbox-list-bordered</code>) — form input
-        </h3>
-        <p>
-          <small>Used by <code>multi_select_field</code>. Adds input-control chrome (border / radius / bg) so the list visually pairs with sibling text inputs and selects.</small>
-        </p>
-        <div class="checkbox-list checkbox-list-bordered">
-          {{ filter_checkbox("services", "opt1", "Option 1", checked=True) }}
-          {{ filter_checkbox("services", "opt2", "Option 2", checked=False) }}
-          {{ filter_checkbox("services", "opt3", "Option 3", checked=True) }}
-        </div>
       </section>
       <section class="gallery-section" id="forms">
         <h2>Form fields</h2>

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -240,14 +240,14 @@ dd { margin: 0; }
    this caps the visual envelope at ~14rem and scrolls the overflow.
    Short vocabularies render shorter than the cap and don't scroll.
 
-   Used by two surfaces:
-     * `multi_select_field` (form_fields.html) — replaces the old
-       `<select multiple>` listbox. Adds `.checkbox-list-bordered` for
-       the input-control chrome and inherits aria-invalid styling.
-     * `_filter_field.html` (search/list filter sidebars) — sits
-       inside a `<fieldset>` so the legend stays pinned outside the
-       scroll viewport. Adds `.checkbox-list-grid` when the choice
-       set is large enough to read better as multi-column.
+   The container reads as a single visual control — bordered like an
+   input, padded inside so the option-label text doesn't kiss the
+   scrollbar gutter. Used by `multi_select_field` (form_fields.html,
+   replacing the old `<select multiple>` listbox) and by
+   `_filter_field.html` (search/list filter sidebars, inside a
+   `<fieldset>` so the legend stays pinned outside the scroll
+   viewport). Long filter choice sets add `.checkbox-list-grid` to
+   swap the flex-column layout for a responsive grid.
 
    Each option is a flex row so the checkbox and the text baseline-
    align even when the label wraps. Spacing is via container `gap`
@@ -256,6 +256,10 @@ dd { margin: 0; }
 .checkbox-list {
   max-height: 14rem;
   overflow-y: auto;
+  border: 1px solid var(--pico-form-element-border-color);
+  border-radius: var(--pico-border-radius);
+  background: var(--pico-form-element-background-color);
+  padding: 0.375rem 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
@@ -271,18 +275,8 @@ dd { margin: 0; }
   margin: 0;
   flex: 0 0 auto;
 }
-/* Bordered modifier — used by form inputs (`multi_select_field`) so
-   the list reads as a single visual control alongside text inputs and
-   selects. Padding stops the option-label text from kissing the
-   scrollbar gutter. */
-.checkbox-list-bordered {
-  border: 1px solid var(--pico-form-element-border-color);
-  border-radius: var(--pico-border-radius);
-  background: var(--pico-form-element-background-color);
-  padding: 0.375rem 0.5rem;
-}
-.checkbox-list-bordered[aria-invalid="true"],
-.form-field[aria-invalid="true"] > .checkbox-list-bordered {
+.checkbox-list[aria-invalid="true"],
+.form-field[aria-invalid="true"] > .checkbox-list {
   border-color: var(--pico-form-element-invalid-border-color);
 }
 .entity-form-page form .form-field > small {

--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -243,7 +243,7 @@ emitted attribute string. #}
        {% if help or error %}aria-describedby="{{ name }}-helper"{% endif %}
        {% if aria_invalid is not none %}aria-invalid="{{ 'true' if aria_invalid else 'false' }}"{% endif %}>
     <span class="form-field-label" id="{{ name }}-label">{{ _field_label(label, required) }}</span>
-    <div class="checkbox-list checkbox-list-bordered">
+    <div class="checkbox-list">
       {%- for v in options %}
         <label>
           <input type="checkbox"


### PR DESCRIPTION
## Summary

The bordered look is the more common case (form `multi_select_field`), and the filter-sidebar case reads fine bordered too. Folds border / padding / bg / aria-invalid styling into the `.checkbox-list` base and drops the `.checkbox-list-bordered` modifier.

**Visible change:** search/list filter sidebar option lists now show the input-control border + bg they previously lacked — they visually pair with the rest of the form controls instead of floating loose inside their fieldset.

## Test plan

- [x] `dev lint` passes
- [x] `dev test` passes (2473 passed)
- [ ] Visit `/dev/components#checkboxes` and confirm both variants render bordered
- [ ] Visit a search page (e.g. `/clinicians/search`) and confirm the filter checkbox lists render bordered

🤖 Generated with [Claude Code](https://claude.com/claude-code)