### PR TITLE
Render org_picker_help on every org dropdown

### DIFF
--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -1349,6 +1349,16 @@ async def test_owner_edit_form_renders_affiliations_section(
     )
     assert delete_button is not None
 
+    # The inline add-practice form's Organization dropdown carries the
+    # shared `org_picker_help()` affordance so the "Don't see your
+    # organization? Create one." escape hatch is one click away —
+    # mirrors the program create/edit forms. The same `<small>` slot
+    # carries the link to the org create form.
+    helper = add_form.css_first('select[name="org_id"] ~ small')
+    assert helper is not None
+    assert "Don't see your organization" in helper.text()
+    assert helper.css_first('a[href="/organizations/form"]') is not None
+
 
 # --- Education / certification happy paths ------------------------------
 

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -1,6 +1,6 @@
 {% extends "views/form_edit.html" %}
 {%- from "_shared/form_fields.html" import form_section, text_field, select_field, checkbox_field, multi_select_field, entity_select_field -%}
-{%- from "_shared/form_copy.html" import npi_help -%}
+{%- from "_shared/form_copy.html" import npi_help, org_picker_help -%}
 {%- from "_shared/forms.html" import inline_add_form -%}
 {%- from "_shared/actions.html" import actions -%}
 {%- from "clinicians/_credential_list.html" import credential_list -%}
@@ -72,7 +72,7 @@
          posts blank → schema coerces to None → solo affiliation row.
          Location / sessions left blank → NULLs on the new row; the
          user fills them in via the row's own PATCH later. #}
-      {{ entity_select_field("org_id", "Organization", orgs, required=false, blank_label="(Solo practice — no organization)") }}
+      {{ entity_select_field("org_id", "Organization", orgs, required=false, blank_label="(Solo practice — no organization)", help=org_picker_help() ) }}
       <div class="grid">
         {{ text_field("location_city", "City", required=false, maxlength=120) }}
         {{ select_field("location_state", "State", US_STATES, required=false, placeholder=true) }}


### PR DESCRIPTION
## Summary

`org_picker_help()` (the "Don't see your organization? Create one." affordance) was wired into the program create + edit forms but the clinician inline "Add another practice" form (added in #1323) didn't carry it. Now it does — so every `org_id` `<select>` in the app surfaces the same one-click escape hatch.

The audit:

```
$ grep -rn 'entity_select_field.*org_id\|name="org_id"' src/domain/templates/
src/domain/templates/programs/_form_new_fragment.html       — has help
src/domain/templates/programs/form_edit.html                — has help
src/domain/templates/clinicians/form_edit.html              — needed it
```

The clinician form's H1 fallback comments + `_shared/form_copy.html` already documented this affordance as a copy-deduplication primitive; the gap was just a missed callsite.

## Contract-surface check

- Template render only. No wire schema, URL, or persisted-state change. Compatible.

## Test plan

- [x] `dev test` — 2473 passed
- [x] `dev test contract` — 40 passed
- [x] `dev lint`
- [x] `test_owner_edit_form_renders_affiliations_section` extended to assert the help text and link are rendered next to the org dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)