### PR TITLE
Hand off Gmail "Open inbox" CTA to the iOS Gmail app

### DIFF
--- a/src/domain/logic/auth/email_providers.py
+++ b/src/domain/logic/auth/email_providers.py
@@ -3,14 +3,24 @@
 Stripe-style: when we recognize the email's domain as a webmail provider
 that supports a URL-driven inbox search, return an "Open Gmail" / "Open
 Yahoo Mail" deep link pre-filtered to messages from our verify sender.
-When we don't, return ``(None, None)`` — the page falls back to a plain
-"check your inbox" sentence with no link.
+When we don't, return ``(None, None, None)`` — the page falls back to a
+plain "check your inbox" sentence with no link.
 
 The table is deliberately conservative: only providers whose URL search
 syntax is publicly documented and stable land here. Providers without
 URL-driven search (Outlook, iCloud, AOL, Proton) fall back to the plain
 sentence rather than ship a misleading "Open X" button that lands on
 the inbox root.
+
+``ios_app_url`` is the iOS URL scheme that opens the provider's native
+app — only set when the provider publishes one. On iOS, mobile Safari
+opens ``https://mail.google.com/...`` in mobile web rather than handing
+off to the Gmail app (universal links don't fire reliably for
+``target="_blank"`` navigations), so the template overrides the click
+on iPhone/iPad to use the ``googlegmail://`` scheme instead. The scheme
+opens Gmail at its default inbox view — the inbox search filter is
+lost, but the verification email is the most recent so it sits at the
+top anyway.
 """
 
 from __future__ import annotations
@@ -33,33 +43,40 @@ def _yahoo_search_url(from_address: str) -> str:
     return f"https://mail.yahoo.com/d/search/keyword={query}"
 
 
-_PROVIDERS: dict[str, tuple[str, Callable[[str], str]]] = {
-    "gmail.com": ("Gmail", _gmail_search_url),
-    "googlemail.com": ("Gmail", _gmail_search_url),
-    "yahoo.com": ("Yahoo Mail", _yahoo_search_url),
-    "yahoo.co.uk": ("Yahoo Mail", _yahoo_search_url),
+# `(label, web_url_builder, ios_app_url)`. ``ios_app_url`` is the URL
+# scheme that opens the provider's native iOS app — None when the
+# provider doesn't publish one we trust.
+_PROVIDERS: dict[str, tuple[str, Callable[[str], str], str | None]] = {
+    "gmail.com": ("Gmail", _gmail_search_url, "googlegmail://"),
+    "googlemail.com": ("Gmail", _gmail_search_url, "googlegmail://"),
+    "yahoo.com": ("Yahoo Mail", _yahoo_search_url, None),
+    "yahoo.co.uk": ("Yahoo Mail", _yahoo_search_url, None),
 }
 
 
 def email_provider_search_url(
     email: str, from_address: str
-) -> tuple[str | None, str | None]:
-    """Return ``(provider_label, search_url)`` for a recognized webmail
-    provider, or ``(None, None)`` when the domain isn't in the table.
+) -> tuple[str | None, str | None, str | None]:
+    """Return ``(provider_label, web_search_url, ios_app_url)`` for a
+    recognized webmail provider, or ``(None, None, None)`` when the
+    domain isn't in the table.
 
     ``provider_label`` is the human-readable name used in CTA copy
-    ("Open Gmail"). ``search_url`` opens that provider's inbox
-    pre-filtered to messages from ``from_address``.
+    ("Open Gmail"). ``web_search_url`` opens that provider's inbox
+    pre-filtered to messages from ``from_address``. ``ios_app_url`` is
+    the URL scheme the template uses on iOS to hand off to the
+    provider's native app instead of loading mobile web; ``None`` when
+    the provider doesn't publish one.
     """
     if "@" not in email:
-        return None, None
+        return None, None, None
     local, _, domain = email.rpartition("@")
     local = local.strip()
     domain = domain.strip().lower()
     if not local or not domain:
-        return None, None
+        return None, None, None
     entry = _PROVIDERS.get(domain)
     if entry is None:
-        return None, None
-    label, builder = entry
-    return label, builder(from_address)
+        return None, None, None
+    label, builder, ios_url = entry
+    return label, builder(from_address), ios_url

--- a/src/domain/logic/auth/test_email_providers.py
+++ b/src/domain/logic/auth/test_email_providers.py
@@ -16,41 +16,50 @@ ENCODED_QUERY = "from%3Ano-reply%40bedlamconnect.com"
 
 
 @pytest.mark.parametrize(
-    "email,expected_label,expected_url",
+    "email,expected_label,expected_url,expected_ios_url",
     [
         (
             "alice@gmail.com",
             "Gmail",
             f"https://mail.google.com/mail/u/0/#search/{ENCODED_QUERY}",
+            "googlegmail://",
         ),
         (
             "ALICE@GMAIL.COM",
             "Gmail",
             f"https://mail.google.com/mail/u/0/#search/{ENCODED_QUERY}",
+            "googlegmail://",
         ),
         (
             "bob@googlemail.com",
             "Gmail",
             f"https://mail.google.com/mail/u/0/#search/{ENCODED_QUERY}",
+            "googlegmail://",
         ),
         (
             "carol@yahoo.com",
             "Yahoo Mail",
             f"https://mail.yahoo.com/d/search/keyword={ENCODED_QUERY}",
+            None,
         ),
         (
             "dave@yahoo.co.uk",
             "Yahoo Mail",
             f"https://mail.yahoo.com/d/search/keyword={ENCODED_QUERY}",
+            None,
         ),
     ],
 )
 def test_known_provider_returns_label_and_search_url(
-    email: str, expected_label: str, expected_url: str
+    email: str,
+    expected_label: str,
+    expected_url: str,
+    expected_ios_url: str | None,
 ):
-    label, url = email_provider_search_url(email, FROM)
+    label, url, ios_url = email_provider_search_url(email, FROM)
     assert label == expected_label
     assert url == expected_url
+    assert ios_url == expected_ios_url
 
 
 @pytest.mark.parametrize(
@@ -69,22 +78,24 @@ def test_known_provider_returns_label_and_search_url(
     ],
 )
 def test_unknown_provider_returns_none(email: str):
-    label, url = email_provider_search_url(email, FROM)
+    label, url, ios_url = email_provider_search_url(email, FROM)
     assert label is None
     assert url is None
+    assert ios_url is None
 
 
 @pytest.mark.parametrize("malformed", ["", "noatsign", "alice@", "@gmail.com"])
 def test_malformed_email_returns_none(malformed: str):
-    label, url = email_provider_search_url(malformed, FROM)
+    label, url, ios_url = email_provider_search_url(malformed, FROM)
     assert label is None
     assert url is None
+    assert ios_url is None
 
 
 def test_from_address_is_url_encoded():
     """A from address with characters that need encoding (`+`, spaces)
     must still produce a valid URL fragment."""
-    label, url = email_provider_search_url(
+    label, url, ios_url = email_provider_search_url(
         "alice@gmail.com", "no-reply+verify@bedlamconnect.com"
     )
     assert label == "Gmail"
@@ -92,3 +103,6 @@ def test_from_address_is_url_encoded():
     # operator-ish in some clients; safer to encode).
     assert "%2B" in url
     assert "no-reply%2Bverify%40bedlamconnect.com" in url
+    # iOS URL scheme is independent of the from address (the scheme
+    # opens Gmail's default inbox view, not a search).
+    assert ios_url == "googlegmail://"

--- a/src/domain/routes/user_email.py
+++ b/src/domain/routes/user_email.py
@@ -33,7 +33,9 @@ async def get_email_form(
     request: Request,
     current_user: User = Depends(current_active_user),
 ):
-    label, url = email_provider_search_url(current_user.email, settings.EMAIL_FROM)
+    label, url, ios_url = email_provider_search_url(
+        current_user.email, settings.EMAIL_FROM
+    )
     return APIResponse.html_response(
         template_name="users/email_form.html",
         context={
@@ -49,6 +51,7 @@ async def get_email_form(
             # viewer is unverified; harmless to compute either way.
             "provider_label": label,
             "provider_url": url,
+            "provider_ios_url": ios_url,
             "from_address": settings.EMAIL_FROM,
             "just_sent": request.query_params.get("sent") == "1",
         },

--- a/src/domain/templates/users/email_form.html
+++ b/src/domain/templates/users/email_form.html
@@ -38,10 +38,23 @@
       </header>
       {% if provider_url %}
         <p>
+          {# `target="_blank"` opens a new tab so the user doesn't lose
+             this page (and the Resend fallback below) when they pop
+             out to their inbox. On iOS, mobile Safari won't reliably
+             hand off `https://mail.google.com/...` to the Gmail app
+             when target="_blank" triggers window.open() — so when the
+             provider publishes a native URL scheme (`provider_ios_url`,
+             set by `email_provider_search_url`), an inline `onclick`
+             swaps the href to that scheme on iPhone/iPad UAs. Loses
+             the inbox search filter, but the verification email is
+             the most recent so it sits at the top anyway. #}
           <a href="{{ provider_url }}"
              target="_blank"
              rel="noopener"
-             role="button">Open {{ provider_label }}</a>
+             role="button"
+             {%- if provider_ios_url %}
+             onclick="if(/iPhone|iPad|iPod/i.test(navigator.userAgent)){this.href='{{ provider_ios_url }}';}"
+             {%- endif %}>Open {{ provider_label }}</a>
         </p>
         <p>
           <small>We'll search your inbox for messages from <strong>{{ from_address }}</strong>.</small>


### PR DESCRIPTION
## Summary

On iPhone/iPad, tapping the existing "Open Gmail" CTA from `/users/me/email/form` opens mobile-web Gmail in a new Safari tab rather than handing off to the Gmail app (universal links don't fire reliably for `target="_blank"` navigations).

Extends `_PROVIDERS` in `email_providers.py` with an optional iOS URL scheme — Gmail gets `googlegmail://`, Yahoo stays `None`. The template adds an inline `onclick` that swaps the href on iPhone/iPad UAs when an iOS scheme is set. Desktop and Android are unchanged (Android's App Links already hand the https URL off to the Gmail app).

The iOS scheme opens Gmail at the default inbox view — the search filter is lost, but the verification email is the most recent so it sits at the top.

## Test plan

- [x] `dev lint` passes
- [x] `dev test` passes (2473 passed)
- [ ] Visit `/users/me/email/form` on desktop as an unverified user, tap "Open Gmail" → opens mail.google.com in a new tab with search filter (unchanged)
- [ ] Same on iPhone Safari → prompts to open in the Gmail app, opens to default inbox view
- [ ] Same on Android Chrome → Gmail App Links handoff still works (unchanged URL)
- [ ] Visit as an unverified user with `@yahoo.com` email → "Open Yahoo Mail" still uses the https URL on all platforms (no iOS scheme set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)