### PR TITLE
Mount clinician sub-resource list pages

### DIFF
--- a/src/domain/logic/clinicians/handlers.py
+++ b/src/domain/logic/clinicians/handlers.py
@@ -7,6 +7,9 @@ from uuid import UUID
 from fastapi import Request
 from pydantic import BaseModel
 
+from src.domain.logic.clinician_affiliations.repository import (
+    ClinicianAffiliationRepository,
+)
 from src.domain.logic.clinicians.repository import ClinicianRepository
 from src.domain.logic.favorites.repository import UserFavoriteRepository
 from src.domain.logic.organizations.repository import OrganizationRepository
@@ -437,3 +440,107 @@ async def handle_set_clinician_verification_state(
         requesting_user.id,
     )
     return clinician
+
+
+# --- Sub-resource list handlers ------------------------------------------
+#
+# `GET /clinicians/{clinician_id}/<sub>` — one dedicated list page per
+# clinician sub-resource (practices, licensures, educations, certifications).
+# The sub-resources are already eager-loaded on the clinician via
+# `relationship(lazy="selectin")`, so each handler just loads the parent
+# and returns its rows. The framework's `mount_related_list` auto-injects
+# the breadcrumb chain because `CLINICIAN_ENTITY.display_label_fn` is set.
+# The repo arg is the child's repo (per `RelatedListSubresource`
+# convention); the credentials all use `ClinicianRepository`, and
+# affiliations use `ClinicianAffiliationRepository` — neither is queried
+# here since the data is already on the parent, but the synth layer
+# requires the param to satisfy the spec contract.
+
+
+async def _list_clinician_subresource_context(
+    *,
+    request: Request,
+    clinician_id: UUID,
+    clinician_repo: ClinicianRepository,
+    attr: str,
+) -> dict[str, Any]:
+    """Shared list-handler body for clinician sub-resources. Loads the
+    parent clinician (404 on miss) and returns its eager-loaded
+    sub-resource list under ``rows``."""
+    clinician = await clinician_repo.get_by_model_id(Clinician, clinician_id)
+    if clinician is None:
+        raise NotFoundError(detail=f"Clinician {clinician_id} not found")
+    return {
+        "request": request,
+        "clinician": clinician,
+        "rows": getattr(clinician, attr),
+    }
+
+
+async def handle_list_clinician_affiliations(
+    request: Request,
+    clinician_id: UUID,
+    repo: ClinicianAffiliationRepository,
+    clinician_repo: ClinicianRepository,
+    organization_repo: OrganizationRepository,
+    requesting_user: User,
+) -> dict[str, Any]:
+    """List the clinician's `ClinicianAffiliation` rows. The inline
+    add-practice form on this page renders an Org `<select>`, so the
+    handler also pulls the requesting user's visible Orgs into context
+    (same source as the clinician edit page's `form_extras`)."""
+    context = await _list_clinician_subresource_context(
+        request=request,
+        clinician_id=clinician_id,
+        clinician_repo=clinician_repo,
+        attr="clinician_affiliations",
+    )
+    context["orgs"] = await list_visible_to(
+        organization_repo, requesting_user, Organization
+    )
+    return context
+
+
+async def handle_list_clinician_licensures(
+    request: Request,
+    clinician_id: UUID,
+    repo: ClinicianRepository,
+    clinician_repo: ClinicianRepository,
+    requesting_user: User,
+) -> dict[str, Any]:
+    return await _list_clinician_subresource_context(
+        request=request,
+        clinician_id=clinician_id,
+        clinician_repo=clinician_repo,
+        attr="licensures",
+    )
+
+
+async def handle_list_clinician_educations(
+    request: Request,
+    clinician_id: UUID,
+    repo: ClinicianRepository,
+    clinician_repo: ClinicianRepository,
+    requesting_user: User,
+) -> dict[str, Any]:
+    return await _list_clinician_subresource_context(
+        request=request,
+        clinician_id=clinician_id,
+        clinician_repo=clinician_repo,
+        attr="educations",
+    )
+
+
+async def handle_list_clinician_certifications(
+    request: Request,
+    clinician_id: UUID,
+    repo: ClinicianRepository,
+    clinician_repo: ClinicianRepository,
+    requesting_user: User,
+) -> dict[str, Any]:
+    return await _list_clinician_subresource_context(
+        request=request,
+        clinician_id=clinician_id,
+        clinician_repo=clinician_repo,
+        attr="certifications",
+    )

--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -1780,6 +1780,114 @@ async def test_get_clinician_openings_404_for_missing_clinician(
     assert response.status_code == 404
 
 
+# --- Sub-resource list pages (#1336) ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "collection",
+    ["clinician_affiliations", "licensures", "educations", "certifications"],
+)
+async def test_get_clinician_subresource_list_responds_200(
+    collection: str,
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Each clinician sub-resource has its own `GET /clinicians/{id}/<sub>`
+    page (`mount_related_list` from #1336). The pages render the existing
+    inline add-form + per-row delete affordances for that sub-resource —
+    same data the PR 2 picker on `/clinicians/{id}` deep-links into."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+    response = await authenticated_client.get(
+        f"/clinicians/{clinician_id}/{collection}"
+    )
+    assert response.status_code == 200, response.text
+
+
+async def test_get_clinician_licensures_renders_existing_rows(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """An existing licensure on the clinician renders as a `.credential-row`
+    on the dedicated list page, with a delete button pointing at the
+    standard `DELETE /clinicians/{id}/licensures/{lic_id}` URL."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+    clinician_id = await _clinician_id_for(db_test_session_manager, clinician_id)
+    licensure = make_clinician_licensure(
+        clinician_id=clinician_id, license_type="lcsw", license_number="L-9999"
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(licensure)
+        await session.refresh(licensure)
+    lic_id = licensure.id
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}/licensures")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    delete = tree.css_first(
+        f'button[hx-delete="/clinicians/{clinician_id}/licensures/{lic_id}"]'
+    )
+    assert delete is not None
+    # Inline add-form posts to the same collection URL.
+    add_form = tree.css_first(f'form[hx-post="/clinicians/{clinician_id}/licensures"]')
+    assert add_form is not None
+    assert add_form.css_first('select[name="license_type"]') is not None
+
+
+async def test_get_clinician_affiliations_carries_org_picker(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """The affiliations list's inline add-practice form needs an Org
+    `<select>` populated with the viewer's owned Orgs. The handler pulls
+    `orgs` into context the same way the clinician edit page's
+    `form_extras` does."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+    await _seed_org(
+        db_test_session_manager, owner_id=logged_in_user.id, name="My Practice LLC"
+    )
+    response = await authenticated_client.get(
+        f"/clinicians/{clinician_id}/clinician_affiliations"
+    )
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    add_form = tree.css_first(
+        f'form[hx-post="/clinicians/{clinician_id}/clinician_affiliations"]'
+    )
+    assert add_form is not None
+    org_select = add_form.css_first('select[name="org_id"]')
+    assert org_select is not None
+    option_labels = [o.text(strip=True) for o in org_select.css("option")]
+    assert any("My Practice LLC" in lbl for lbl in option_labels)
+
+
+@pytest.mark.parametrize(
+    "collection",
+    ["clinician_affiliations", "licensures", "educations", "certifications"],
+)
+async def test_get_clinician_subresource_list_404_for_missing_clinician(
+    collection: str,
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    """A nonexistent clinician id 404s for every sub-resource list page,
+    same shape as the existing openings list (mount_related_list runs
+    the parent lookup before the handler)."""
+    response = await authenticated_client.get(
+        f"/clinicians/{uuid.uuid4()}/{collection}"
+    )
+    assert response.status_code == 404
+
+
 async def test_patch_clinician_npi_change_reruns_verification(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/specs/_credential.py
+++ b/src/domain/specs/_credential.py
@@ -11,10 +11,12 @@ shared shape; the three spec modules pass the per-credential pieces
 through it.
 """
 
+from typing import Callable
+
 from pydantic import BaseModel, TypeAdapter
 
 from src.domain.logic.clinicians.repository import get_clinician_repository
-from src.domain.specs.clinician import CLINICIAN_ENTITY, _clinician_form_redirect
+from src.domain.specs.clinician import CLINICIAN_ENTITY
 from src.framework.dispatch.entity_spec import (
     AUTHENTICATED,
     OWNER_OR_ADMIN,
@@ -34,6 +36,7 @@ def make_clinician_credential_entity(
     read_schema: type[BaseModel],
     create_adapter: type[BaseModel] | TypeAdapter,
     update_adapter: type[BaseModel] | TypeAdapter,
+    mutation_redirect: Callable[..., str],
     state_axes: tuple[StateAxis, ...] = (),
 ) -> EntitySpec:
     """Build a credential-subentity `EntitySpec` from its varying pieces.
@@ -47,6 +50,11 @@ def make_clinician_credential_entity(
     constructor synthesizes `read_to_dict` from it and defaults
     `audit_snapshot` to it as well (credential audit snapshots are
     byte-identical to their read projection).
+
+    `mutation_redirect` is the post-create/update/delete redirect
+    callable. After #1336 each credential redirects to its own
+    list page (`/clinicians/{id}/licensures` etc.) rather than the
+    parent's edit form.
 
     `state_axes` is the per-credential state-axis tuple. Only
     `LICENSURE_ENTITY` uses it today (the `attestation` axis); the
@@ -70,13 +78,14 @@ def make_clinician_credential_entity(
         create_adapter=create_adapter,
         update_adapter=update_adapter,
         read_schema=read_schema,
-        # Subrow CRUD only — sub-rows aren't independently listed or
-        # detailed (they only appear in the parent clinician's pages).
+        # Subrow CRUD only. The parent CLINICIAN_ENTITY now owns a
+        # `RelatedListSubresource` per credential type (#1336) — the
+        # list page is mounted there, not here.
         routes=RouteSet(create=True, update=True, delete=True),
-        # Sub-row mutations send HTMX clients back to the parent edit
-        # form so the user can keep editing.
-        create_redirect=_clinician_form_redirect,
-        update_redirect=_clinician_form_redirect,
-        delete_redirect=_clinician_form_redirect,
+        # Sub-row mutations send HTMX clients back to the sub-resource's
+        # own list page so the user keeps managing in place.
+        create_redirect=mutation_redirect,
+        update_redirect=mutation_redirect,
+        delete_redirect=mutation_redirect,
         state_axes=state_axes,
     )

--- a/src/domain/specs/clinician.py
+++ b/src/domain/specs/clinician.py
@@ -16,6 +16,9 @@ Read by:
 
 from typing import Final
 
+from src.domain.logic.clinician_affiliations.repository import (
+    get_clinician_affiliation_repository,
+)
 from src.domain.logic.clinicians.repository import (
     ClinicianRepository,
     get_clinician_repository,
@@ -67,10 +70,54 @@ _clinician_referrals_child = ResourceSpec(
     collection="referrals", id_param="post_id", repo_dep=get_post_repository
 )
 
-# Post-update: stay on the edit form so the user can keep iterating on
-# the parent + its credentials. The same callable is reused by the three
-# credential subentities (their parent is this clinician directory entry).
+# The four canonical clinician sub-resources — `GET /clinicians/{id}/<sub>`
+# pages. Hand-rolled inline child specs (matching the openings/referrals
+# pattern above) avoid the import cycle that would result from pulling
+# in `<SUB>_ENTITY.to_resource_spec()` here (each sub-entity spec
+# imports `CLINICIAN_ENTITY`). The credential trio shares
+# `get_clinician_repository` because credentials are loaded as relations
+# on the parent clinician; affiliations have their own repo.
+_clinician_affiliations_child = ResourceSpec(
+    collection="clinician_affiliations",
+    id_param="clinician_affiliation_id",
+    repo_dep=get_clinician_affiliation_repository,
+)
+_clinician_licensures_child = ResourceSpec(
+    collection="licensures",
+    id_param="licensure_id",
+    repo_dep=get_clinician_repository,
+)
+_clinician_educations_child = ResourceSpec(
+    collection="educations",
+    id_param="education_id",
+    repo_dep=get_clinician_repository,
+)
+_clinician_certifications_child = ResourceSpec(
+    collection="certifications",
+    id_param="certification_id",
+    repo_dep=get_clinician_repository,
+)
+
+# Post-update for the clinician itself: stay on the edit form so the
+# user can keep iterating on the person-level fields.
 _clinician_form_redirect = Redirects.to_edit_form("clinicians", "clinician_id")
+
+# Post-mutation redirects for the four clinician sub-resources — after
+# add/delete on any of them, send HTMX clients back to the sub-resource's
+# own list page (the page the user is already on, post-#1336). Each
+# child spec imports its own redirect from below.
+_clinician_affiliations_list_redirect = Redirects.to_related_list(
+    "clinicians", "clinician_id", "clinician_affiliations"
+)
+_clinician_licensures_list_redirect = Redirects.to_related_list(
+    "clinicians", "clinician_id", "licensures"
+)
+_clinician_educations_list_redirect = Redirects.to_related_list(
+    "clinicians", "clinician_id", "educations"
+)
+_clinician_certifications_list_redirect = Redirects.to_related_list(
+    "clinicians", "clinician_id", "certifications"
+)
 
 
 # Post-create: drop the user on the homepage. NPPES verification now
@@ -243,6 +290,43 @@ CLINICIAN_ENTITY: Final[EntitySpec] = EntitySpec(
             template="clinicians/referrals_list.html",
             handler_path=(
                 "src.domain.logic.posts.handlers.handle_list_clinician_referrals"
+            ),
+        ),
+        # Four sub-resource list pages — the picker landing on
+        # `/clinicians/{id}` (PR-2) deep-links into each of these. Each
+        # page renders the existing inline add-form + per-row delete
+        # affordances for that sub-resource, surfaced from the
+        # clinician edit page (which moves to person-level-only in PR-2).
+        RelatedListSubresource(
+            child_spec=_clinician_affiliations_child,
+            template="clinicians/clinician_affiliations_list.html",
+            handler_path=(
+                "src.domain.logic.clinicians.handlers."
+                "handle_list_clinician_affiliations"
+            ),
+        ),
+        RelatedListSubresource(
+            child_spec=_clinician_licensures_child,
+            template="clinicians/licensures_list.html",
+            handler_path=(
+                "src.domain.logic.clinicians.handlers."
+                "handle_list_clinician_licensures"
+            ),
+        ),
+        RelatedListSubresource(
+            child_spec=_clinician_educations_child,
+            template="clinicians/educations_list.html",
+            handler_path=(
+                "src.domain.logic.clinicians.handlers."
+                "handle_list_clinician_educations"
+            ),
+        ),
+        RelatedListSubresource(
+            child_spec=_clinician_certifications_child,
+            template="clinicians/certifications_list.html",
+            handler_path=(
+                "src.domain.logic.clinicians.handlers."
+                "handle_list_clinician_certifications"
             ),
         ),
     ),

--- a/src/domain/specs/clinician_affiliation.py
+++ b/src/domain/specs/clinician_affiliation.py
@@ -25,7 +25,10 @@ from src.domain.logic.clinician_affiliations.schema import (
     ClinicianAffiliationUpdate,
 )
 from src.domain.models import ClinicianAffiliation
-from src.domain.specs.clinician import CLINICIAN_ENTITY, _clinician_form_redirect
+from src.domain.specs.clinician import (
+    CLINICIAN_ENTITY,
+    _clinician_affiliations_list_redirect,
+)
 from src.framework.dispatch.entity_spec import (
     AUTHENTICATED,
     OWNER_OR_ADMIN,
@@ -49,12 +52,13 @@ CLINICIAN_AFFILIATION_ENTITY: Final[EntitySpec] = EntitySpec(
     create_adapter=ClinicianAffiliationCreate,
     update_adapter=ClinicianAffiliationUpdate,
     read_schema=ClinicianAffiliationRead,
-    # Sub-row CRUD only — affiliations are managed inline on the
-    # parent clinician's edit page; no independent list/detail surface.
+    # Sub-row CRUD only — list/detail/form pages are owned by the
+    # parent's `RelatedListSubresource` (`/clinicians/{id}/clinician_affiliations`,
+    # #1336) which renders the inline add + per-row delete affordances.
     routes=RouteSet(create=True, update=True, delete=True),
-    # Sub-row mutations redirect HTMX clients back to the parent
-    # clinician's edit form so the user keeps editing in place.
-    create_redirect=_clinician_form_redirect,
-    update_redirect=_clinician_form_redirect,
-    delete_redirect=_clinician_form_redirect,
+    # Sub-row mutations redirect HTMX clients back to the sub-resource's
+    # own list page — the page the user is already on after #1336.
+    create_redirect=_clinician_affiliations_list_redirect,
+    update_redirect=_clinician_affiliations_list_redirect,
+    delete_redirect=_clinician_affiliations_list_redirect,
 )

--- a/src/domain/specs/clinician_certification.py
+++ b/src/domain/specs/clinician_certification.py
@@ -13,6 +13,7 @@ from src.domain.logic.clinicians.schema import (
 )
 from src.domain.models import ClinicianCertification
 from src.domain.specs._credential import make_clinician_credential_entity
+from src.domain.specs.clinician import _clinician_certifications_list_redirect
 from src.framework.dispatch.entity_spec import EntitySpec
 
 CERTIFICATION_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
@@ -24,4 +25,5 @@ CERTIFICATION_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
     read_schema=ClinicianCertificationRead,
     create_adapter=ClinicianCertificationCreate,
     update_adapter=ClinicianCertificationUpdate,
+    mutation_redirect=_clinician_certifications_list_redirect,
 )

--- a/src/domain/specs/clinician_education.py
+++ b/src/domain/specs/clinician_education.py
@@ -13,6 +13,7 @@ from src.domain.logic.clinicians.schema import (
 )
 from src.domain.models import ClinicianEducation
 from src.domain.specs._credential import make_clinician_credential_entity
+from src.domain.specs.clinician import _clinician_educations_list_redirect
 from src.framework.dispatch.entity_spec import EntitySpec
 
 EDUCATION_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
@@ -24,4 +25,5 @@ EDUCATION_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
     read_schema=ClinicianEducationRead,
     create_adapter=ClinicianEducationCreate,
     update_adapter=ClinicianEducationUpdate,
+    mutation_redirect=_clinician_educations_list_redirect,
 )

--- a/src/domain/specs/clinician_licensure.py
+++ b/src/domain/specs/clinician_licensure.py
@@ -26,6 +26,7 @@ from src.domain.logic.clinicians.schema import (
 )
 from src.domain.models import ClinicianLicensure
 from src.domain.specs._credential import make_clinician_credential_entity
+from src.domain.specs.clinician import _clinician_licensures_list_redirect
 from src.framework.audit.core import AuditAction
 from src.framework.dispatch.entity_spec import EntitySpec, StateAxis
 
@@ -59,6 +60,7 @@ LICENSURE_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
     read_schema=ClinicianLicensureRead,
     create_adapter=ClinicianLicensureCreate,
     update_adapter=ClinicianLicensureUpdate,
+    mutation_redirect=_clinician_licensures_list_redirect,
     state_axes=(
         StateAxis(
             name="attestation",

--- a/src/domain/specs/test_clinician_credentials.py
+++ b/src/domain/specs/test_clinician_credentials.py
@@ -41,11 +41,13 @@ def test_parent_is_clinician_entity(entity, _stem):
 
 
 @pytest.mark.parametrize("entity,_stem", CREDENTIALS)
-def test_redirects_target_parent_form(entity, _stem):
-    """Sub-row mutations send HTMX clients back to the parent edit form
-    — the user keeps editing the parent clinician entry after each
-    credential write."""
-    target = "/clinicians/abc-123/form"
+def test_redirects_target_sub_resource_list(entity, _stem):
+    """Sub-row mutations send HTMX clients back to the sub-resource's
+    own list page — the page the user is already on after #1336 promoted
+    each credential into its own dedicated /clinicians/{id}/<sub> route.
+    The list page is the canonical "stay where you were" target now that
+    the clinician edit form is person-level only."""
+    target = f"/clinicians/abc-123/{entity.url_collection}"
     assert entity.create_redirect(clinician_id="abc-123") == target
     assert entity.update_redirect(clinician_id="abc-123") == target
     assert entity.delete_redirect(clinician_id="abc-123") == target

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -81,6 +81,10 @@ register_template_globals(
     # which only runs through the framework's generic entity handlers.
     LICENSE_TYPES=enums.LICENSE_TYPES,
     LICENSE_TYPES_LABELS=enums.LICENSE_TYPES_LABELS,
+    EDUCATION_TYPES=enums.EDUCATION_TYPES,
+    EDUCATION_TYPES_LABELS=enums.EDUCATION_TYPES_LABELS,
+    CERTIFICATION_TYPES=enums.CERTIFICATION_TYPES,
+    CERTIFICATION_TYPES_LABELS=enums.CERTIFICATION_TYPES_LABELS,
     # `LICENSE_TYPES`, `EDUCATION_TYPES`, `CERTIFICATION_TYPES` and
     # their `_LABELS` also flow into the context via
     # `CLINICIAN_ENTITY.static_context` (merged by `handle_detail` /

--- a/src/domain/templates/clinicians/certifications_list.html
+++ b/src/domain/templates/clinicians/certifications_list.html
@@ -1,0 +1,30 @@
+{# Sub-resource list page — clinician's ClinicianCertification rows.
+
+Reached via `GET /clinicians/{clinician_id}/certifications`. Breadcrumb is
+auto-injected by `mount_related_list` because
+`CLINICIAN_ENTITY.display_label_fn` is set.
+#}
+{% extends "views/list.html" %}
+{%- from "_shared/form_fields.html" import text_field, select_field -%}
+{%- from "_shared/forms.html" import inline_add_form -%}
+{%- from "clinicians/_credential_list.html" import credential_list -%}
+{%- from "clinicians/_credential_row.html" import credential_row -%}
+{% block resource_label %}Certifications{% endblock %}
+{% block list_body %}
+  <section>
+    {% call(cert) credential_list(rows, "No certifications yet.") %}
+      {{ credential_row(CERTIFICATION_TYPES_LABELS[cert.certification_type],
+            [cert.certifying_body, ("Expires " ~ cert.expiration_date) if cert.expiration_date else None],
+      delete_url=entity_url('clinician', id=clinician.id) ~ "/certifications/" ~ cert.id|string,
+      delete_confirm="Remove this certification?",
+      ) }}
+    {% endcall %}
+  </section>
+  <section>
+    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/certifications", "Add certification", "Add certification") %}
+      {{ select_field("certification_type", "Certification type", CERTIFICATION_TYPES, labels=CERTIFICATION_TYPES_LABELS, placeholder=true) }}
+      {{ text_field("certifying_body", "Certifying body", maxlength=200) }}
+      {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
+    {% endcall %}
+  </section>
+{% endblock %}

--- a/src/domain/templates/clinicians/clinician_affiliations_list.html
+++ b/src/domain/templates/clinicians/clinician_affiliations_list.html
@@ -1,0 +1,64 @@
+{# Sub-resource list page — clinician's ClinicianAffiliation rows.
+
+Reached via `GET /clinicians/{clinician_id}/clinician_affiliations`. The DB
+model calls them affiliations because that's what the (clinician × org)
+join is; the UI calls them "practices" because that's what they are
+to the user. A row with `org_id` NULL is a solo practice — see the
+affiliations cluster README for the model.
+
+Breadcrumb is auto-injected by `mount_related_list` because
+`CLINICIAN_ENTITY.display_label_fn` is set.
+#}
+{% extends "views/list.html" %}
+{%- from "_shared/form_fields.html" import text_field, select_field, checkbox_field, multi_select_field, entity_select_field -%}
+{%- from "_shared/form_copy.html" import org_picker_help -%}
+{%- from "_shared/forms.html" import inline_add_form -%}
+{%- from "clinicians/_credential_list.html" import credential_list -%}
+{%- from "clinicians/_credential_row.html" import credential_row -%}
+{% block resource_label %}Practices{% endblock %}
+{% block list_body %}
+  <section>
+    {% call(aff) credential_list(rows, "No practices yet.") %}
+      {%- set meta_parts = [
+            aff.location_city,
+            aff.location_state,
+            aff.location_zip,
+            ("In-person: " ~ LOCATION_AVAILABILITY_LABELS[aff.in_person_sessions]) if aff.in_person_sessions else None,
+            ("Virtual: " ~ LOCATION_AVAILABILITY_LABELS[aff.virtual_sessions]) if aff.virtual_sessions else None,
+            ("In-network: " ~ (aff.in_network_carriers | map('lower') | map('capitalize') | join(', '))) if aff.in_network_carriers else None,
+            "Out-of-network OK" if aff.accepts_out_of_network else None,
+            "Sliding scale" if aff.sliding_scale else None,
+            aff.cost,
+            ] -%}
+      {{ credential_row((aff.org.name if aff.org else "Solo practice") ,
+      meta_parts,
+      delete_url=entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations/" ~ aff.id|string,
+      delete_confirm="Remove this practice?",
+      ) }}
+    {% endcall %}
+  </section>
+  <section>
+    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations", "Add another practice", "Add another practice") %}
+      {# Every field is optional. Org = "(Solo practice)" → `org_id`
+         posts blank → schema coerces to None → solo affiliation row.
+         Location / sessions left blank → NULLs on the new row; the
+         user fills them in via the row's own PATCH later. #}
+      {{ entity_select_field("org_id", "Organization", orgs, required=false, blank_label="(Solo practice — no organization)", help=org_picker_help() ) }}
+      <div class="grid">
+        {{ text_field("location_city", "City", required=false, maxlength=120) }}
+        {{ select_field("location_state", "State", US_STATES, required=false, placeholder=true) }}
+        {{ text_field("location_zip", "ZIP", required=false, pattern="\\d{5}", maxlength=5) }}
+      </div>
+      <div class="grid">
+        {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, required=false, placeholder=true) }}
+        {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, required=false, placeholder=true) }}
+      </div>
+      {{ multi_select_field("in_network_carriers", "In-network carriers", INSURANCE_CARRIERS, labels=INSURANCE_CARRIER_LABELS) }}
+      <div class="grid">
+        {{ checkbox_field("accepts_out_of_network", "Accepts out-of-network patients", current=true) }}
+        {{ checkbox_field('sliding_scale', 'Offers sliding scale') }}
+      </div>
+      {{ text_field("cost", "Cost", required=false) }}
+    {% endcall %}
+  </section>
+{% endblock %}

--- a/src/domain/templates/clinicians/educations_list.html
+++ b/src/domain/templates/clinicians/educations_list.html
@@ -1,0 +1,30 @@
+{# Sub-resource list page — clinician's ClinicianEducation rows.
+
+Reached via `GET /clinicians/{clinician_id}/educations`. Breadcrumb is
+auto-injected by `mount_related_list` because
+`CLINICIAN_ENTITY.display_label_fn` is set.
+#}
+{% extends "views/list.html" %}
+{%- from "_shared/form_fields.html" import text_field, select_field -%}
+{%- from "_shared/forms.html" import inline_add_form -%}
+{%- from "clinicians/_credential_list.html" import credential_list -%}
+{%- from "clinicians/_credential_row.html" import credential_row -%}
+{% block resource_label %}Education{% endblock %}
+{% block list_body %}
+  <section>
+    {% call(edu) credential_list(rows, "No education entries yet.") %}
+      {{ credential_row(EDUCATION_TYPES_LABELS[edu.education_type],
+            [edu.institution, edu.month_completed],
+            delete_url=entity_url('clinician', id=clinician.id) ~ "/educations/" ~ edu.id|string,
+      delete_confirm="Remove this education entry?",
+      ) }}
+    {% endcall %}
+  </section>
+  <section>
+    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/educations", "Add education", "Add education") %}
+      {{ select_field("education_type", "Education type", EDUCATION_TYPES, labels=EDUCATION_TYPES_LABELS, placeholder=true) }}
+      {{ text_field("institution", "Institution", maxlength=200) }}
+      {{ text_field("month_completed", "Month completed", required=false, type="month") }}
+    {% endcall %}
+  </section>
+{% endblock %}

--- a/src/domain/templates/clinicians/licensures_list.html
+++ b/src/domain/templates/clinicians/licensures_list.html
@@ -1,0 +1,32 @@
+{# Sub-resource list page — clinician's ClinicianLicensure rows.
+
+Reached via `GET /clinicians/{clinician_id}/licensures`. Breadcrumb is
+auto-injected by `mount_related_list` because
+`CLINICIAN_ENTITY.display_label_fn` is set.
+#}
+{% extends "views/list.html" %}
+{%- from "_shared/form_fields.html" import text_field, select_field -%}
+{%- from "_shared/forms.html" import inline_add_form -%}
+{%- from "clinicians/_credential_list.html" import credential_list -%}
+{%- from "clinicians/_credential_row.html" import credential_row -%}
+{% block resource_label %}Licensures{% endblock %}
+{% block list_body %}
+  <section>
+    {% call(lic) credential_list(rows, "No licensures yet.") %}
+      {{ credential_row(LICENSE_TYPES_LABELS[lic.license_type],
+            ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None, lic.status | title],
+      delete_url=entity_url('clinician', id=clinician.id) ~ "/licensures/" ~ lic.id|string,
+      delete_confirm="Remove this licensure?",
+      attest_url=(entity_url('clinician', id=clinician.id) ~ "/licensures/" ~ lic.id|string ~ "/attestation") if not lic.attested_active else None,
+      ) }}
+    {% endcall %}
+  </section>
+  <section>
+    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/licensures", "Add licensure", "Add licensure") %}
+      {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
+      {{ text_field("license_number", "License number", maxlength=120) }}
+      {{ select_field("issuing_state", "Issuing state", US_STATES, placeholder=true) }}
+      {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
+    {% endcall %}
+  </section>
+{% endblock %}

--- a/src/framework/dispatch/redirects.py
+++ b/src/framework/dispatch/redirects.py
@@ -32,3 +32,24 @@ class Redirects:
             return f"/{collection}/{kwargs[id_param]}"
 
         return _redirect
+
+    @staticmethod
+    def to_related_list(
+        parent_collection: str,
+        parent_id_param: str,
+        child_collection: str,
+    ) -> Callable[..., str]:
+        """Build a redirect callable producing
+        ``/<parent_collection>/{parent_id}/<child_collection>``.
+
+        Used by parent-owned subentities whose post-mutation UX is "stay
+        on the related-list page the user came from" rather than the
+        whole-parent edit form. The clinician sub-resources (affiliations,
+        licensures, educations, certifications) all use this after #1336
+        promoted each into its own list page.
+        """
+
+        def _redirect(**kwargs: Any) -> str:
+            return f"/{parent_collection}/{kwargs[parent_id_param]}/{child_collection}"
+
+        return _redirect


### PR DESCRIPTION
## Summary

Promote each clinician sub-resource (practices, licensures, educations, certifications) into its own dedicated list page at `GET /clinicians/{id}/<collection>`. Each page renders the existing inline-add + per-row-delete affordances for that sub-resource — the same UI the clinician edit form has carried inline so far. This is the substrate the PR-2 picker on `/clinicians/{id}` will deep-link into.

- Add four `RelatedListSubresource` entries to `CLINICIAN_ENTITY` pointing at four new list templates and four list handlers.
- Four small list handlers in `src/domain/logic/clinicians/handlers.py` share a tiny `_list_clinician_subresource_context` helper. The affiliations handler additionally pulls `orgs` into context because its inline add-form renders an Org `<select>`.
- Four templates extend `views/list.html` and reuse the existing `credential_list` / `credential_row` / `inline_add_form` macros.
- New `Redirects.to_related_list(parent_collection, parent_id_param, child_collection)` helper. Each sub-entity spec now points its create/update/delete redirects at its own list page rather than the parent's edit form — the user stays on the page they were on.
- `template_globals.py` registers the credential-type enums + labels as Jinja globals so the new templates resolve labels without the parent's `static_context`.

## Contract-surface check

- URL shape: four additive GET routes (`/clinicians/{id}/clinician_affiliations`, `/licensures`, `/educations`, `/certifications`). Compatible.
- Mutation redirects on the four sub-entity specs change from `/clinicians/{id}/form` → the sub-resource's own list page. Internal — only the edit page's inline add forms relied on the old target, and they continue to function (they now land on the dedicated list page after add). PR 2 retires the inline-add UI on the edit page entirely.
- Wire schemas / DB / persisted JSON: unchanged.

## Test plan

- [x] `dev test` — 2487 passed
- [x] `dev test contract` — 40 passed
- [x] `dev lint`
- [x] Parametrized 200 / 404 over all four collections.
- [x] Licensures list renders existing rows + add-form.
- [x] Affiliations list carries the Org dropdown populated from the viewer's owned Orgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)