### PR TITLE
Restyle /clinicians/{id} as a dispatching picker

### DIFF
--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -221,8 +221,11 @@ async def test_get_clinician_renders_detail_page(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """`GET /clinicians/{id}` renders the read-only HTML detail page
-    with practice fields and an Edit link for the owner."""
+    """`GET /clinicians/{id}` is a dispatching picker (#1336): person-
+    level identity in the H1 + subtitle band, plus four cards deep-
+    linking to the sub-resource list pages. The owner toolbar carries
+    Edit / Delete; no inline sub-resource data appears on this page
+    (it lives on `/clinicians/{id}/<sub>` after the restyle)."""
     clinician_id = await _seed_clinician_for(
         db_test_session_manager, user_id=logged_in_user.id, practice_name="Mine"
     )
@@ -239,18 +242,27 @@ async def test_get_clinician_renders_detail_page(
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     tree = HTMLParser(response.text)
-    # Licensure section renders the seeded row.
-    assert "L-99999" in response.text
-    # Owner sees an Edit link, no edit forms (read-only) in the page body.
-    # (The header dropdown link is not a form — scoping to main is still
-    #  the right approach for future-proofing, but the original reason no
-    #  longer applies.)
+    # Inline sub-resource data is NOT on the detail page anymore — it
+    # lives on each sub-resource's own list page.
+    assert "L-99999" not in response.text
+    # Toolbar carries the owner's Edit link.
     assert tree.css_first(f'a[href="/clinicians/{clinician_id}/form"]') is not None
     assert tree.css_first("main form") is None
-    # Regression for #594 — the practice name lives in the header
-    # `<strong>` only. The facts list relabels its row "Organization"
-    # so the same string is not repeated under a "Practice name" `<dt>`.
-    assert "<dt>Practice name</dt>" not in response.text
+    # Four picker cards, deep-linking to the four sub-resource list
+    # pages mounted in #1335. The picker macro renders one
+    # `article.picker-option` per option (no `<header>` band after
+    # #1330) with the link inside `<h2><a>`.
+    cards = tree.css("main article.picker-option")
+    assert len(cards) == 4
+    hrefs = {card.css_first("h2 a").attributes.get("href") for card in cards}
+    assert hrefs == {
+        f"/clinicians/{clinician_id}/clinician_affiliations",
+        f"/clinicians/{clinician_id}/licensures",
+        f"/clinicians/{clinician_id}/educations",
+        f"/clinicians/{clinician_id}/certifications",
+    }
+    headings = {card.css_first("h2 a").text(strip=True) for card in cards}
+    assert headings == {"Practices", "Licensures", "Education", "Certifications"}
 
 
 async def test_get_clinician_detail_shows_verification_badge(
@@ -286,75 +298,6 @@ async def test_get_clinician_detail_shows_no_badge_without_verification(
     assert response.status_code == 200
     assert "icon-shield-check" not in response.text
     assert "icon-shield-x" not in response.text
-
-
-async def test_get_clinician_detail_renders_stacked_affiliation_cards(
-    authenticated_client: AsyncClient,
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-    logged_in_user: User,
-):
-    """`GET /clinicians/{id}` renders one stacked card per ClinicianAffiliation
-    after #642 PR 2. Seed a Clinician with two affiliations (the one
-    `Clinician.__init__` builds from the create payload + a second one
-    appended) and assert both org names render and both
-    `[data-testid="affiliation-card"]` blocks appear, in the order
-    `clinician.clinician_affiliations` returns (oldest first by `created_at`).
-    """
-    from src.domain.models import ClinicianAffiliation
-
-    clinician_id = await _seed_clinician_for(
-        db_test_session_manager,
-        user_id=logged_in_user.id,
-        practice_name="Bedlam Health",
-        location_city="Brooklyn",
-        location_state="NY",
-        location_zip="11201",
-    )
-    # Append a second ClinicianAffiliation at a different Org.
-    second_org_id = await _seed_org(
-        db_test_session_manager,
-        owner_id=logged_in_user.id,
-        name="Wellspring",
-    )
-    clinician_id = await _clinician_id_for(db_test_session_manager, clinician_id)
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(
-                ClinicianAffiliation(
-                    clinician_id=clinician_id,
-                    org_id=second_org_id,
-                    location_city="Queens",
-                    location_state="NY",
-                    location_zip="11101",
-                    in_person_sessions="yes",
-                    virtual_sessions="please_contact",
-                    accepts_out_of_network=True,
-                    in_network_carriers=[],
-                    sliding_scale=True,
-                    cost="$220/session",
-                )
-            )
-
-    response = await authenticated_client.get(f"/clinicians/{clinician_id}")
-
-    assert response.status_code == 200
-    tree = HTMLParser(response.text)
-    cards = tree.css('article[data-testid="affiliation-card"]')
-    assert len(cards) == 2, f"expected one card per affiliation, got {len(cards)}"
-    # Both org names render — one card per practice.
-    assert "Bedlam Health" in response.text
-    assert "Wellspring" in response.text
-    # Per-affiliation address rendered inside each card (not just at
-    # the clinician header) — the location belongs to the affiliation.
-    assert "Brooklyn" in response.text
-    assert "Queens" in response.text
-    # Each card links its heading to the owning Organization.
-    org_links_in_cards = []
-    for card in cards:
-        anchor = card.css_first("header.entity-header a[href^='/organizations/']")
-        assert anchor is not None
-        org_links_in_cards.append(anchor.attributes.get("href"))
-    assert f"/organizations/{second_org_id}" in org_links_in_cards
 
 
 async def test_get_clinician_hides_edit_link_for_non_owner(
@@ -1303,16 +1246,16 @@ async def test_delete_affiliation_returns_404_for_mismatched_clinician(
     assert response.status_code == 404
 
 
-async def test_owner_edit_form_renders_affiliations_section(
+async def test_clinician_edit_form_has_no_inline_subresource_ui(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """The clinician edit page surfaces every `ClinicianAffiliation` row
-    in a dedicated section. The DB model calls them affiliations
-    (clinician × org); the UI surfaces them as "Practices" because
-    that's what they are to the user — including the solo case where
-    `org_id` is NULL. Inline add + per-row delete are present."""
+    """After #1336 the clinician edit form is **person-level only** —
+    the inline lists for affiliations / licensures / educations /
+    certifications moved onto each sub-resource's own list page
+    (`/clinicians/{id}/<sub>`). The picker on the detail page is what
+    deep-links into them."""
     clinician_id = await _seed_clinician_for(
         db_test_session_manager, user_id=logged_in_user.id
     )
@@ -1321,43 +1264,27 @@ async def test_owner_edit_form_renders_affiliations_section(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    headings = [h.text(strip=True) for h in tree.css("h2")]
-    assert "Practices" in headings
-
-    # The inline add form posts to /clinicians/{id}/clinician_affiliations.
-    add_form = tree.css_first(
-        f'form[hx-post="/clinicians/{clinician_id}/clinician_affiliations"]'
-    )
-    assert add_form is not None
-    assert add_form.css_first('select[name="org_id"]') is not None
-    assert add_form.css_first('input[name="location_city"]') is not None
-
-    # The existing primary affiliation renders as a row with a
-    # delete button pointing at its own URL.
-    from src.domain.models import ClinicianAffiliation
-
-    async with db_test_session_manager() as session:
-        aff_id = (
-            await session.execute(
-                select(ClinicianAffiliation.id).where(
-                    ClinicianAffiliation.clinician_id == clinician_id
-                )
+    # No `<h2>` headings on the edit form — only the toolbar `<h1>`
+    # ("Edit clinician") and the one `<form>` for person-level fields.
+    assert tree.css("main h2") == []
+    # The sub-resource POST/DELETE forms that used to live inline are gone.
+    for collection in (
+        "clinician_affiliations",
+        "licensures",
+        "educations",
+        "certifications",
+    ):
+        assert (
+            tree.css_first(f'form[hx-post="/clinicians/{clinician_id}/{collection}"]')
+            is None
+        )
+        # No delete buttons for sub-resource rows on this page either.
+        assert (
+            tree.css_first(
+                f'button[hx-delete^="/clinicians/{clinician_id}/{collection}/"]'
             )
-        ).scalar_one()
-    delete_button = tree.css_first(
-        f'button[hx-delete="/clinicians/{clinician_id}/clinician_affiliations/{aff_id}"]'
-    )
-    assert delete_button is not None
-
-    # The inline add-practice form's Organization dropdown carries the
-    # shared `org_picker_help()` affordance so the "Don't see your
-    # organization? Create one." escape hatch is one click away —
-    # mirrors the program create/edit forms. The same `<small>` slot
-    # carries the link to the org create form.
-    helper = add_form.css_first('select[name="org_id"] ~ small')
-    assert helper is not None
-    assert "Don't see your organization" in helper.text()
-    assert helper.css_first('a[href="/organizations/form"]') is not None
+            is None
+        )
 
 
 # --- Education / certification happy paths ------------------------------
@@ -1415,22 +1342,14 @@ async def test_owner_can_open_edit_form(
     logged_in_user: User,
 ):
     """Owner sees the edit form pre-filled with the person-level
-    Clinician fields (first/last/npi) plus the credential and
-    affiliation sub-rows. Practice posture moved off this form in
-    #1308 — `org_id` / location / sessions / insurance now live on
-    each affiliation's own row."""
+    Clinician fields (first/last/npi) only. Practice posture, licensures,
+    educations, and certifications each live on their own list page
+    after #1336."""
     clinician_id = await _seed_clinician_for(
         db_test_session_manager,
         user_id=logged_in_user.id,
         practice_name="Acme Counseling",
     )
-    clinician_id = await _clinician_id_for(db_test_session_manager, clinician_id)
-    licensure = make_clinician_licensure(
-        clinician_id=clinician_id, license_type="lcsw", license_number="L-12345"
-    )
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(licensure)
 
     response = await authenticated_client.get(f"/clinicians/{clinician_id}/form")
     assert response.status_code == 200
@@ -1441,93 +1360,25 @@ async def test_owner_can_open_edit_form(
     assert practice_form.css_first('input[name="first_name"]') is not None
     assert practice_form.css_first('input[name="last_name"]') is not None
     assert practice_form.css_first('input[name="npi"]') is not None
-    # Per-affiliation posture inputs (`org_id`, `location_city`,
-    # `in_person_sessions`, etc.) are NOT on the clinician form — they
-    # belong to each affiliation's own row below.
+    # Per-affiliation posture inputs are not on the clinician form.
     assert practice_form.css_first('select[name="org_id"]') is None
     assert practice_form.css_first('input[name="location_city"]') is None
     assert practice_form.css_first('select[name="in_person_sessions"]') is None
-    # The seeded licensure should be rendered in the licensures list.
-    assert "L-12345" in response.text
-    # Sub-section add forms target the right URLs.
-    assert (
-        tree.css_first(f'form[hx-post="/clinicians/{clinician_id}/licensures"]')
-        is not None
-    )
-    assert (
-        tree.css_first(f'form[hx-post="/clinicians/{clinician_id}/educations"]')
-        is not None
-    )
-    assert (
-        tree.css_first(f'form[hx-post="/clinicians/{clinician_id}/certifications"]')
-        is not None
-    )
 
 
-async def test_owner_edit_form_renders_credentials_as_rows(
-    authenticated_client: AsyncClient,
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-    logged_in_user: User,
-):
-    """Credential lists render as `.credential-row` blocks (not raw
-    `<li>`s) — bold type label, muted meta line, owner-side Delete
-    button. The owning `<section>` already provides the framing; rows
-    stay flat to avoid the card-on-card look."""
-    clinician_id = await _seed_clinician_for(
-        db_test_session_manager,
-        user_id=logged_in_user.id,
-        practice_name="Acme Counseling",
-    )
-    clinician_id = await _clinician_id_for(db_test_session_manager, clinician_id)
-    licensure = make_clinician_licensure(
-        clinician_id=clinician_id,
-        license_type="lcsw",
-        license_number="L-12345",
-        issuing_state="CA",
-    )
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(licensure)
-
-    response = await authenticated_client.get(f"/clinicians/{clinician_id}/form")
-    tree = HTMLParser(response.text)
-    # After #642 PR 1 the affiliations section also renders rows via
-    # `.credential-list .credential-row` (it reuses the same partial);
-    # locate the licensure row by its hx-delete URL, not by section
-    # ordering.
-    delete = tree.css_first(
-        f'button[hx-delete="/clinicians/{clinician_id}/licensures/{licensure.id}"]'
-    )
-    assert delete is not None
-    assert delete.text(strip=True) == "Delete"
-    row = delete.parent  # `.credential-row`
-    while row is not None and "credential-row" not in (
-        row.attributes.get("class") or ""
-    ):
-        row = row.parent
-    assert row is not None
-    assert (
-        row.css_first("strong").text(strip=True)
-        == "Licensed Clinical Social Worker (LCSW)"
-    )
-    meta = row.css_first(".credential-row-text small")
-    assert meta is not None
-    assert "L-12345" in meta.text()
-    assert "CA" in meta.text()
-
-
-async def test_owner_edit_form_renders_solo_affiliation_without_crashing(
+# Placeholder docstring kept to anchor the section comment that
+# follows. The actual solo-affiliation rendering is now pinned at the
+# affiliations list page level (`test_get_clinician_affiliations_*`).
+async def test_clinician_edit_form_renders_for_solo_clinician(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
     """Solo clinician path: a `ClinicianAffiliation` with `org_id` NULL
-    (the shape #1311 introduced for solo practitioners) renders without
-    dereferencing `aff.org.name`. The row label falls back to
-    "Solo practice" and the section heading reads "Practices" — the UI
-    drops the "affiliation" word in the solo case, matching how the
-    user thinks about it."""
-    from src.domain.models import Clinician, ClinicianAffiliation
+    (the shape #1311 introduced for solo practitioners) doesn't break
+    the edit form, because the form is now person-level only and never
+    derefs affiliation fields."""
+    from src.domain.models import ClinicianAffiliation
 
     clinician = make_clinician(
         owner_id=logged_in_user.id,
@@ -1544,25 +1395,9 @@ async def test_owner_edit_form_renders_solo_affiliation_without_crashing(
     response = await authenticated_client.get(f"/clinicians/{clinician_id}/form")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
-    # Section heading is "Practices", not "Affiliations".
-    headings = [h.text(strip=True) for h in tree.css("h2")]
-    assert "Practices" in headings
-    assert "Affiliations" not in headings
-    # The solo affiliation row's label falls back to "Solo practice".
-    async with db_test_session_manager() as session:
-        loaded = await session.get(Clinician, clinician_id)
-        aff_id = loaded.clinician_affiliations[0].id
-    delete = tree.css_first(
-        f'button[hx-delete="/clinicians/{clinician_id}/clinician_affiliations/{aff_id}"]'
-    )
-    assert delete is not None
-    row = delete.parent
-    while row is not None and "credential-row" not in (
-        row.attributes.get("class") or ""
-    ):
-        row = row.parent
-    assert row is not None
-    assert row.css_first("strong").text(strip=True) == "Solo practice"
+    # Person-level form is present; no `<h2>` sub-sections.
+    assert tree.css_first(f'form[hx-patch="/clinicians/{clinician_id}"]') is not None
+    assert tree.css("main h2") == []
 
 
 async def test_admin_can_open_edit_form_for_any_clinician(

--- a/src/domain/templates/clinicians/detail.html
+++ b/src/domain/templates/clinicians/detail.html
@@ -1,9 +1,7 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions -%}
-{%- from "_shared/sections.html" import fact -%}
-{%- from "_shared/_locked.html" import locked_name, locked_field -%}
-{%- from "clinicians/_credential_list.html" import credential_list -%}
-{%- from "clinicians/_credential_row.html" import credential_row -%}
+{%- from "_shared/_locked.html" import locked_name -%}
+{%- from "_shared/_picker.html" import picker -%}
 {%- set view = clinician_card_view(clinician) -%}
 {# When the viewer lacks provider-network access and isn't the owner,
    redact identifying fields per the `_clinician_card.html` /
@@ -74,85 +72,28 @@
     ) }}
   {% endif %}
 {% endblock %}
-{# Detail page uses stacked sections:
-   1. ClinicianAffiliation cards — one per row in `view.clinician_affiliations`.
-   2. Credentials (licensures, educations, certifications) — person-level,
-      shared across every affiliation, rendered once.
-   `clinician_card_view` / `affiliation_card_view` collapse field references
-   so templates don't carry display logic. #}
-{% block content %}
-  {# Identity card collapsed: the toolbar H1 carries `view.practice_name`
-   and the `subtitle` block above carries NPI. The page starts straight
-   into the affiliation cards.
+{# The detail page is a *dispatching picker* (#704 / #1330 pattern):
+   each card deep-links into a dedicated sub-resource list page (#1335)
+   where the user can manage that surface in isolation. Person-level
+   identity reads from the H1 + subtitle band above; this body carries
+   navigation only.
 
-   Stacked affiliation cards — one per row in `clinician.clinician_affiliations`.
-   Reads as "At <Org A>: ... · At <Org B>: ...". Each card links its
-   heading to the owning Organization so the cross-resource navigation
-   the old (single-card) layout exposed via the "Organization" facts
-   row still works. The directory listing (`list.html`) is unchanged
-   — it continues to read `view.practice_name` / the flat per-role
-   keys off the primary affiliation; #642 PR 3 rolls it up. #}
-  {% for aff in view.clinician_affiliations %}
-    <article class="entity-card"
-             data-testid="affiliation-card"
-             data-affiliation-org-id="{{ aff.org_id }}">
-      <header class="entity-header">
-        {% if _redacted %}
-          <strong>At {{ locked_name("Doe Health Group") }}</strong>{# title-case-ignore: placeholder org name #}
-        {% else %}
-          <strong>At <a href="{{ aff.org_url }}">{{ aff.org_name }}</a></strong>
-          {%- if aff.full_address %}<small>{{ aff.full_address }}</small>{%- endif %}
-        {% endif %}
-      </header>
-      <section class="entity-facts">
-        <dl>
-          {%- if aff.full_address %}
-            {% if _redacted %}
-              {%- call fact('address', 'Address') %}{{ locked_field(capabilities.REASON_NETWORK_UNVERIFIED) }}{%- endcall %}
-              {% else %}
-                {{ fact('address', 'Address', aff.full_address) }}
-              {% endif %}
-            {%- endif %}
-            {{ fact('in_person_sessions', 'In-person sessions', aff.in_person_label) }}
-            {{ fact('virtual_sessions', 'Virtual sessions', aff.virtual_label) }}
-            {{ fact('insurance', 'Insurance', aff.insurance_summary) }}
-            {{ fact('sliding_scale', 'Sliding scale', aff.sliding_scale_label) }}
-            {%- if aff.cost %}{{ fact('cost', 'Cost', aff.cost) }}{%- endif %}
-            </dl>
-          </section>
-        </article>
-      {% endfor %}
-      {# Credentials are clinician-level (FK to `clinicians.id` after #635
-   PR A) — they belong to the person, not to any single affiliation,
-   so they render once below the stacked affiliation cards. The
-   list-per-section grammar is the same the old single-card layout
-   used; only the parent card changed. Credentials stay visible under
-   redaction — they describe the role (degree type, license type,
-   certification) rather than the identity (name, address), matching
-   the post-card's "redact identity, keep substantive content" line. #}
-      <section class="entity-card">
-        <section>
-          <h4>Licensures</h4>
-          {% call(lic) credential_list(view.licensures, "No licensures listed.") %}
-            {{ credential_row(LICENSE_TYPES_LABELS[lic.license_type],
-                        ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None],
-            ) }}
-          {% endcall %}
-        </section>
-        <section>
-          <h4>Education</h4>
-          {% call(edu) credential_list(view.educations, "No education entries listed.") %}
-            {{ credential_row(EDUCATION_TYPES_LABELS[edu.education_type],
-                        [edu.institution, edu.month_completed],) }}
-          {% endcall %}
-        </section>
-        <section>
-          <h4>Certifications</h4>
-          {% call(cert) credential_list(view.certifications, "No certifications listed.") %}
-            {{ credential_row(CERTIFICATION_TYPES_LABELS[cert.certification_type],
-                        [cert.certifying_body, ("Expires " ~ cert.expiration_date) if cert.expiration_date else None],
-            ) }}
-          {% endcall %}
-        </section>
-      </section>
-    {% endblock %}
+   Picker cards are rendered for every viewer — non-network viewers
+   land on the sub-resource list pages and see those pages' own
+   redaction rules. #}
+{% block content %}
+  {{ picker([
+    {"href": entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations",
+  "heading": "Practices",
+  "description": "Where this clinician sees clients — location, availability, in-network insurance, and rates."},
+  {"href": entity_url('clinician', id=clinician.id) ~ "/licensures",
+  "heading": "Licensures",
+  "description": "Professional licenses on file with their issuing states."},
+  {"href": entity_url('clinician', id=clinician.id) ~ "/educations",
+  "heading": "Education",
+  "description": "Degrees, programs, and where they were completed."},
+  {"href": entity_url('clinician', id=clinician.id) ~ "/certifications",
+  "heading": "Certifications",
+  "description": "Specialized credentials and their certifying bodies."},
+  ]) }}
+{% endblock %}

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -1,10 +1,7 @@
 {% extends "views/form_edit.html" %}
-{%- from "_shared/form_fields.html" import form_section, text_field, select_field, checkbox_field, multi_select_field, entity_select_field -%}
-{%- from "_shared/form_copy.html" import npi_help, org_picker_help -%}
-{%- from "_shared/forms.html" import inline_add_form -%}
+{%- from "_shared/form_fields.html" import form_section, text_field -%}
+{%- from "_shared/form_copy.html" import npi_help -%}
 {%- from "_shared/actions.html" import actions -%}
-{%- from "clinicians/_credential_list.html" import credential_list -%}
-{%- from "clinicians/_credential_row.html" import credential_row -%}
 {% block resource_label %}Clinicians{% endblock %}
 {# H1-fallback: name when set, else primary affiliation's org name when
    present, else "Clinician". ClinicianCreate requires first_name +
@@ -25,9 +22,12 @@
   {# Person-level fields only. Practice posture (location, availability,
    insurance, cost, org) lives on `ClinicianAffiliation` because the
    same person can have different posture at different practice contexts
-   (telehealth solo + in-person group, etc.) — those edits happen on the
-   Practices list below, not on this form. See the affiliations cluster
-   README for the "affiliation is the practice-posture container" model. #}
+   (telehealth solo + in-person group, etc.). Each of the four
+   clinician sub-resources (practices, licensures, educations,
+   certifications) has its own dedicated list page under
+   `/clinicians/{id}/<sub>` (#1335); the detail page at
+   `/clinicians/{id}` is a picker that links into them. This edit form
+   is the one place name + NPI get patched. #}
   <form hx-patch="{{ entity_url('clinician', id=clinician.id) }}">
     {% call form_section("Clinician") %}
       {{ text_field("first_name", "First name", current=clinician.first_name, maxlength=120) }}
@@ -36,106 +36,4 @@
     {% endcall %}
     {{ actions("Save changes", cancel_url=entity_url('clinician', id=clinician.id) ) }}
   </form>
-  {# Sub-resource lists below the main entity form. These render outside
-   `.entity-form-page form`'s grid because each `inline_add_form` is its
-   own self-contained mini-form; the section headings group them
-   visually but they're not part of the clinician's edit grid. #}
-  <section>
-    {# Practices — clinician's `ClinicianAffiliation` rows. The DB model
-       calls them affiliations because that's what the (clinician × org)
-       join is; in the UI we just call them practices because that's
-       what they are to the user. A row with `org_id` NULL is a solo
-       practice — the affiliation owns the posture, with no
-       organizational entity to point at. See the affiliations cluster
-       README. #}
-    <h2>Practices</h2>
-    {% call(aff) credential_list(clinician.clinician_affiliations, "No practices yet.") %}
-      {%- set meta_parts = [
-            aff.location_city,
-            aff.location_state,
-            aff.location_zip,
-            ("In-person: " ~ LOCATION_AVAILABILITY_LABELS[aff.in_person_sessions]) if aff.in_person_sessions else None,
-            ("Virtual: " ~ LOCATION_AVAILABILITY_LABELS[aff.virtual_sessions]) if aff.virtual_sessions else None,
-            ("In-network: " ~ (aff.in_network_carriers | map('lower') | map('capitalize') | join(', '))) if aff.in_network_carriers else None,
-            "Out-of-network OK" if aff.accepts_out_of_network else None,
-            "Sliding scale" if aff.sliding_scale else None,
-            aff.cost,
-            ] -%}
-      {{ credential_row((aff.org.name if aff.org else "Solo practice") ,
-      meta_parts,
-      delete_url=entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations/" ~ aff.id|string,
-      delete_confirm="Remove this practice?",
-      ) }}
-    {% endcall %}
-    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations", "Add another practice", "Add another practice") %}
-      {# Every field is optional. Org = "(Solo practice)" → `org_id`
-         posts blank → schema coerces to None → solo affiliation row.
-         Location / sessions left blank → NULLs on the new row; the
-         user fills them in via the row's own PATCH later. #}
-      {{ entity_select_field("org_id", "Organization", orgs, required=false, blank_label="(Solo practice — no organization)", help=org_picker_help() ) }}
-      <div class="grid">
-        {{ text_field("location_city", "City", required=false, maxlength=120) }}
-        {{ select_field("location_state", "State", US_STATES, required=false, placeholder=true) }}
-        {{ text_field("location_zip", "ZIP", required=false, pattern="\\d{5}", maxlength=5) }}
-      </div>
-      <div class="grid">
-        {{ select_field("in_person_sessions", "In-person sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, required=false, placeholder=true) }}
-        {{ select_field("virtual_sessions", "Virtual sessions", LOCATION_AVAILABILITY_OPTIONS, labels=LOCATION_AVAILABILITY_LABELS, required=false, placeholder=true) }}
-      </div>
-      {{ multi_select_field("in_network_carriers", "In-network carriers", INSURANCE_CARRIERS, labels=INSURANCE_CARRIER_LABELS) }}
-      <div class="grid">
-        {{ checkbox_field("accepts_out_of_network", "Accepts out-of-network patients", current=true) }}
-        {{ checkbox_field('sliding_scale', 'Offers sliding scale') }}
-      </div>
-      {{ text_field("cost", "Cost", required=false) }}
-    {% endcall %}
-  </section>
-  <section>
-    <h2>Licensures</h2>
-    {% call(lic) credential_list(clinician.licensures, "No licensures yet.") %}
-      {{ credential_row(LICENSE_TYPES_LABELS[lic.license_type],
-            ["#" ~ lic.license_number, lic.issuing_state, ("Expires " ~ lic.expiration_date) if lic.expiration_date else None, lic.status | title],
-      delete_url=entity_url('clinician', id=clinician.id) ~ "/licensures/" ~ lic.id|string,
-      delete_confirm="Remove this licensure?",
-      attest_url=(entity_url('clinician', id=clinician.id) ~ "/licensures/" ~ lic.id|string ~ "/attestation") if not lic.attested_active else None,
-      ) }}
-    {% endcall %}
-    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/licensures", "Add licensure", "Add licensure") %}
-      {{ select_field("license_type", "License type", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, placeholder=true) }}
-      {{ text_field("license_number", "License number", maxlength=120) }}
-      {{ select_field("issuing_state", "Issuing state", US_STATES, placeholder=true) }}
-      {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
-    {% endcall %}
-  </section>
-  <section>
-    <h2>Education</h2>
-    {% call(edu) credential_list(clinician.educations, "No education entries yet.") %}
-      {{ credential_row(EDUCATION_TYPES_LABELS[edu.education_type],
-            [edu.institution, edu.month_completed],
-            delete_url=entity_url('clinician', id=clinician.id) ~ "/educations/" ~ edu.id|string,
-      delete_confirm="Remove this education entry?",
-      ) }}
-    {% endcall %}
-    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/educations", "Add education", "Add education") %}
-      {{ select_field("education_type", "Education type", EDUCATION_TYPES, labels=EDUCATION_TYPES_LABELS, placeholder=true) }}
-      {{ text_field("institution", "Institution", maxlength=200) }}
-      {{ text_field("month_completed", "Month completed", required=false, type="month") }}
-    {% endcall %}
-  </section>
-  <section>
-    <h2>Certifications</h2>
-    {% call(cert) credential_list(clinician.certifications, "No certifications yet.") %}
-      {{ credential_row(CERTIFICATION_TYPES_LABELS[cert.certification_type],
-            [cert.certifying_body, ("Expires " ~ cert.expiration_date) if cert.expiration_date else None],
-      delete_url=entity_url('clinician', id=clinician.id) ~ "/certifications/" ~ cert.id|string,
-      delete_confirm="Remove this certification?",
-      ) }}
-    {% endcall %}
-    {% call inline_add_form(entity_url('clinician', id=clinician.id) ~ "/certifications", "Add certification", "Add certification") %}
-      {{ select_field("certification_type", "Certification type", CERTIFICATION_TYPES, labels=CERTIFICATION_TYPES_LABELS, placeholder=true) }}
-      {{ text_field("certifying_body", "Certifying body", maxlength=200) }}
-      {{ text_field("expiration_date", "Expiration date", required=false, type="date") }}
-    {% endcall %}
-  </section>
-  {{ actions(cancel_url=entity_url('clinician', id=clinician.id) ) }}
 {% endblock %}


### PR DESCRIPTION
## Summary

Builds on #1335. The clinician detail page becomes a *dispatching picker* (#704 / #1330 pattern):

- Person-level identity reads from the H1 + subtitle band (name, NPI, verification badge).
- Page body is four picker cards deep-linking to the sub-resource list pages from #1335:
  - **Practices** → `/clinicians/{id}/clinician_affiliations`
  - **Licensures** → `/clinicians/{id}/licensures`
  - **Education** → `/clinicians/{id}/educations`
  - **Certifications** → `/clinicians/{id}/certifications`
- Toolbar still carries Favorite / Edit clinician / Delete for person-level resource actions — same shape as every other detail page.

The clinician edit form collapses to **person-level only** — first/last/npi + Save. The four inline sub-resource sections that used to live below the form (each with its own `credential_list` + `inline_add_form`) are gone; their UI lives on the dedicated list pages. The edit form is now the one place name + NPI get patched and nothing else.

## Contract-surface check

- HTML response shape for `/clinicians/{id}` and `/clinicians/{id}/form` changes. **Compatible** — no programmatic consumer parses these.
- Wire schemas / DB / URL shape / persisted JSON: unchanged.

## Test plan

- [x] `dev test` — 2471 passed
- [x] `dev test contract` — 40 passed
- [x] `dev lint`
- [x] `test_get_clinician_renders_detail_page`: rewritten to assert the picker structure — 4 cards, right hrefs + headings, no inline sub-resource data on the page.
- [x] `test_clinician_edit_form_has_no_inline_subresource_ui`: new pin that the edit form carries no `<h2>` sub-sections and no sub-resource forms / delete buttons.
- [x] `test_owner_can_open_edit_form`: trimmed to assert person-level inputs only.
- [x] `test_clinician_edit_form_renders_for_solo_clinician`: replaces the old "solo affiliation renders without crashing" pin (the form no longer derefs affiliation fields at all).
- [x] Obsolete tests removed (their concerns are pinned at the sub-resource list-page level in #1335).

🤖 Generated with [Claude Code](https://claude.com/claude-code)