### PR TITLE
Lock /posts/form program-intake tile via a new capability

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -65,6 +65,11 @@ REASON_EMAIL_UNVERIFIED = "email_unverified"
 # (create post CTA) are locked. Fixed by completing any verification
 # path (Claim A or Claim B).
 REASON_NETWORK_UNVERIFIED = "network_unverified"
+# Program-intake gate: the user can't currently publish a program-intake
+# post on /posts/form. Three sub-conditions feed it (email + verified
+# org rep + an owned program); the capability detail page renders the
+# tree so the user can see exactly which step is open.
+REASON_PROGRAM_INTAKE_LOCKED = "program_intake_locked"
 
 
 @dataclass(frozen=True)
@@ -108,6 +113,12 @@ _REASON_META = {
         unlock="Get provider network access to unlock this.",
         fix_label="Get access",
         fix_url="/users/me/access/capabilities/provider-network",
+    ),
+    REASON_PROGRAM_INTAKE_LOCKED: ReasonMeta(
+        title="Program intake",
+        unlock="Verify your organization and add a program to unlock this.",
+        fix_label="Get access",
+        fix_url="/users/me/access/capabilities/program-intake",
     ),
 }
 
@@ -248,6 +259,23 @@ def _org_rep_any_leaf(user: Any) -> Condition:
     )
 
 
+def _owns_program_leaf(user: Any) -> Condition:
+    """Does the user own at least one `Program`? The `User.programs`
+    relationship (selectin) is the source of truth; the create flow at
+    `/programs/form` is what changes it. Note this leaf doesn't filter
+    by the program's org being verified — the per-row write gate in
+    `_assert_post_payload_capability` re-checks `org_rep_verified` for
+    the specific program's org at create time, so the picker only needs
+    the "has any program" shape here."""
+    programs = getattr(user, "programs", None) or ()
+    return Condition(
+        label_active="Add a program",
+        label_done="Program added",
+        met=bool(programs),
+        fix_url="/programs/form",
+    )
+
+
 def check_network(user: Any) -> CapabilityCheck:
     """Structured capability check for full-feed read access.
 
@@ -274,6 +302,51 @@ def check_network(user: Any) -> CapabilityCheck:
             ),
         ),
     )
+
+
+def check_program_intake(user: Any) -> CapabilityCheck:
+    """Structured capability check for publishing a program-intake post.
+
+    Tree: email_verified AND any_org_rep_verified AND owns_a_program.
+    Each conjunct corresponds to one Condition leaf with its own
+    `fix_url`, so the user can see exactly which step is open and click
+    straight into it.
+
+    Per-row Claim B for the specific program's org is *not* enforced
+    here — `_assert_post_payload_capability` (Phase 5) does that at
+    create time against the chosen program. This check is the per-user
+    "should the picker tile be lit" gate; the post payload hook is the
+    per-row write gate.
+    """
+    return CapabilityCheck(
+        name="program-intake",
+        description="Publish a program intake on /posts/form.",
+        tree=Bundle(
+            label_active="Program intake",
+            label_done="Program intake",
+            children=(
+                _email_leaf(user),
+                _org_rep_any_leaf(user),
+                _owns_program_leaf(user),
+            ),
+        ),
+    )
+
+
+def can_post_program_intake_picker(user: Any) -> bool:
+    """Picker-tile gate: superuser bypass, otherwise the structured
+    check.
+
+    Symmetric with `can_access_network` — both are the boolean form of
+    the matching `check_*` for surfaces that only need granted/not
+    (the picker tile, the locked-CTA branch). Per-row authorization on
+    the post create payload stays with
+    `can_post_program_intake(user, org)` and its caller in
+    `_assert_post_payload_capability`.
+    """
+    if getattr(user, "is_superuser", False):
+        return True
+    return check_program_intake(user).granted
 
 
 def can_access_network(user: Any) -> bool:

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -20,16 +20,19 @@ from src.domain.logic import capabilities
 def _user(
     *,
     is_verified: bool = False,
+    is_superuser: bool = False,
     clinicians: list | None = None,
     org_representations: list | None = None,
+    programs: list | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         id=uuid4(),
-        is_superuser=False,
+        is_superuser=is_superuser,
         username="test",
         is_verified=is_verified,
         clinicians=clinicians or [],
         org_representations=org_representations or [],
+        programs=programs or [],
     )
 
 
@@ -594,6 +597,19 @@ def test_org_rep_any_leaf_met_with_verified_rep():
     assert capabilities._org_rep_any_leaf(user).met is True
 
 
+def test_owns_program_leaf_canonical_shape():
+    leaf = capabilities._owns_program_leaf(_user(is_verified=True))
+    assert leaf.label_active == "Add a program"
+    assert leaf.label_done == "Program added"
+    assert leaf.fix_url == "/programs/form"
+    assert leaf.met is False
+
+
+def test_owns_program_leaf_met_with_any_program():
+    user = _user(is_verified=True, programs=[SimpleNamespace(id=uuid4())])
+    assert capabilities._owns_program_leaf(user).met is True
+
+
 # ---------- check_network -------------------------------------------
 
 
@@ -685,6 +701,90 @@ def test_check_network_label_and_description():
     check = capabilities.check_network(_user())
     assert check.tree.label_active == "Provider network"
     assert check.description == "See full provider details and reach out directly."
+
+
+# ---------- check_program_intake ------------------------------------------
+
+
+def _intake_ready_user():
+    """A user who passes every leaf of `check_program_intake`."""
+    org = _org(org_verified=True)
+    return _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+        programs=[SimpleNamespace(id=uuid4(), org_id=org.id)],
+    )
+
+
+def test_check_program_intake_anon_denied():
+    check = capabilities.check_program_intake(None)
+    assert check.granted is False
+    assert check.name == "program-intake"
+
+
+def test_check_program_intake_tree_is_flat_and_three_leaves():
+    """Tree is a Bundle of three Condition leaves (email AND org-rep AND
+    program). No nested Gate — the picker uses the structure to render
+    a one-step-per-row checklist."""
+    check = capabilities.check_program_intake(_user())
+    assert check.tree.__class__.__name__ == "Bundle"
+    assert len(check.tree.children) == 3
+    assert all(c.__class__.__name__ == "Condition" for c in check.tree.children)
+
+
+def test_check_program_intake_email_unverified_blocks():
+    """Email is the floor — even with org rep + program, an unverified
+    email keeps the tile locked. The first leaf is the email Condition."""
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=False,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+        programs=[SimpleNamespace(id=uuid4())],
+    )
+    check = capabilities.check_program_intake(user)
+    assert check.granted is False
+    assert check.tree.children[0].label_done == "Email verified"
+    assert check.tree.children[0].met is False
+
+
+def test_check_program_intake_missing_org_rep_blocks():
+    """Email + program but no verified org rep → middle leaf unmet."""
+    user = _user(is_verified=True, programs=[SimpleNamespace(id=uuid4())])
+    check = capabilities.check_program_intake(user)
+    assert check.granted is False
+    assert check.tree.children[1].met is False
+
+
+def test_check_program_intake_missing_program_blocks():
+    """Email + verified org rep but no program → trailing leaf unmet,
+    and its fix URL points at the create-program form."""
+    org = _org(org_verified=True)
+    user = _user(
+        is_verified=True,
+        org_representations=[_rep(org_id=org.id, authority_status="verified")],
+    )
+    check = capabilities.check_program_intake(user)
+    assert check.granted is False
+    program_leaf = check.tree.children[2]
+    assert program_leaf.met is False
+    assert program_leaf.fix_url == "/programs/form"
+
+
+def test_check_program_intake_all_three_leaves_grants():
+    check = capabilities.check_program_intake(_intake_ready_user())
+    assert check.granted is True
+
+
+def test_can_post_program_intake_picker_superuser_bypass():
+    """Symmetric with `can_access_network` — admins post any kind even
+    without the underlying leaves."""
+    admin = _user(is_verified=False, is_superuser=True)
+    assert capabilities.can_post_program_intake_picker(admin) is True
+
+
+def test_can_post_program_intake_picker_tracks_check():
+    assert capabilities.can_post_program_intake_picker(None) is False
+    assert capabilities.can_post_program_intake_picker(_intake_ready_user()) is True
 
 
 # ---------- UUID type sanity for claim_state.b ----------------------------

--- a/src/domain/routes/access.py
+++ b/src/domain/routes/access.py
@@ -17,6 +17,7 @@ access_router = APIRouter(prefix="/users/me/access", tags=["access"])
 
 _CHECKS = {
     "provider-network": capabilities.check_network,
+    "program-intake": capabilities.check_program_intake,
 }
 
 mount_capability_routes(access_router, _CHECKS)

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -120,16 +120,25 @@ async def test_form_new_picker_responds_200(
 ):
     """`/posts/form` (no `?kind=`) renders the kind-picker page so the
     user can pick which kind to create. Rendered via the shared
-    `_picker.html` macro — one card per kind, each deep-linking to
-    `?kind=<value>`. Headings come from `POST_KINDS[k].noun` (the SOT
-    after #1330); descriptions come from `POST_KINDS[k].picker_description`."""
+    `_picker.html` macro — one card per kind. Headings come from
+    `POST_KINDS[k].noun` (the SOT after #1330); descriptions come from
+    `POST_KINDS[k].picker_description`. Tiles for kinds whose
+    capability the viewer doesn't hold render as a locked-CTA instead
+    of a navigable `?kind=` link — `program_intake` is gated on
+    `capabilities.check_program_intake` and is locked for the default
+    test user (no verified org rep, no owned program)."""
     response = await authenticated_client.get("/posts/form")
     assert response.status_code == 200
     body = response.text
     for heading in ("Referral", "Opening", "Program intake"):
-        assert f">{heading}</a>" in body
-    for kind in ("referral", "clinician_opening", "program_intake"):
+        assert heading in body
+    # Unlocked tiles deep-link via `?kind=<value>`.
+    for kind in ("referral", "clinician_opening"):
         assert f"?kind={kind}" in body
+    # The program-intake tile is locked for the default test user, so its
+    # heading is a `data-locked-cta` anchor with no navigable href.
+    assert "?kind=program_intake" not in body
+    assert 'data-locked-cta="program_intake_locked"' in body
     # The picker no longer wraps its heading in a `<header>` band
     # (#1330 — the cards render flatter via Pico's default chrome).
     assert "<header>" not in body

--- a/src/domain/templates/posts/form_new.html
+++ b/src/domain/templates/posts/form_new.html
@@ -11,6 +11,13 @@ an existing one is a one-place change in
 `src/domain/models/posts/post_kinds.py`; this picker, the /posts
 sidebar `kind` filter, and every "Create X" / "Edit X" headline all
 read from the same field.
+
+Per-kind locking: a tile renders as a locked-CTA (lock icon + popover)
+when the viewer doesn't yet hold the capability that kind requires.
+`program_intake` is gated on `capabilities.check_program_intake` —
+email + verified org rep + an owned program; the other kinds carry no
+per-tile lock here (their per-row authz lives at create time in
+`_assert_post_payload_capability`).
 #}
 {% extends "views/form_new.html" %}
 {%- from "_shared/_picker.html" import picker -%}
@@ -18,10 +25,16 @@ read from the same field.
 {% block form_content %}
   {%- set _opts = namespace(items=[]) -%}
   {%- for kind in POST_KINDS.values() -%}
+    {%- set _locked_reason = none -%}
+    {%- if kind.name == "program_intake"
+      and not capabilities.can_post_program_intake_picker(current_user) -%}
+      {%- set _locked_reason = capabilities.REASON_PROGRAM_INTAKE_LOCKED -%}
+    {%- endif -%}
     {%- set _opts.items = _opts.items + [
         {"href": entity_form_url("post") + "?kind=" + kind.name,
         "heading": kind.noun,
-        "description": kind.picker_description}
+        "description": kind.picker_description,
+        "locked_reason": _locked_reason}
         ] -%}
   {%- endfor -%}
   {{ picker(_opts.items) }}

--- a/src/framework/templates/_shared/_locked.html
+++ b/src/framework/templates/_shared/_locked.html
@@ -78,6 +78,7 @@ affordances". JS lives inline in `src/framework/templates/base.html`. #}
   {%- set _all = [
     capabilities.REASON_EMAIL_UNVERIFIED,
     capabilities.REASON_NETWORK_UNVERIFIED,
+    capabilities.REASON_PROGRAM_INTAKE_LOCKED,
     ] -%}
   {%- for reason in _all -%}
     {%- set meta = capabilities.reason_meta(reason) -%}

--- a/src/framework/templates/_shared/_picker.html
+++ b/src/framework/templates/_shared/_picker.html
@@ -17,13 +17,21 @@ The heading is a vanilla `<h2><a>` link; the description is a plain `<p>`.
 No custom CSS — markup alone carries the look.
 
 Each option is a dict with keys:
-  href:        URL to navigate to on click (ignored when selected=true)
-  heading:     short label (e.g. "Solo practice")
-  description: one-line tagline
-  selected:    (optional bool) when true, renders the heading without a
-               link and tags the card with `aria-current="page"` so the
-               active path can't be re-selected — marked with a checkmark
-               glyph in front of the heading.
+  href:          URL to navigate to on click (ignored when selected=true
+                 or locked_reason is set)
+  heading:       short label (e.g. "Solo practice")
+  description:   one-line tagline
+  selected:      (optional bool) when true, renders the heading without a
+                 link and tags the card with `aria-current="page"` so the
+                 active path can't be re-selected — marked with a checkmark
+                 glyph in front of the heading.
+  locked_reason: (optional `REASON_*` code) when set, the heading renders
+                 as a `data-locked-cta` anchor with a lock glyph instead
+                 of a real link — clicking opens the popover whose copy
+                 comes from `capabilities.reason_meta(reason)`. Mutually
+                 exclusive with `selected`. Used when a tile points at a
+                 capability the viewer doesn't yet hold (e.g.
+                 program-intake on /posts/form for a non-org-rep user).
 #}
 {%- macro picker(options) -%}
   {%- for opt in options %}
@@ -31,6 +39,18 @@ Each option is a dict with keys:
       <article class="picker-option" aria-current="page">
         <h2>
           <i class="icon-check"></i> {{ opt.heading }}
+        </h2>
+        <p>{{ opt.description }}</p>
+      </article>
+    {%- elif opt.locked_reason %}
+      <article class="picker-option">
+        <h2>
+          <a class="locked-link"
+             aria-disabled="true"
+             tabindex="0"
+             data-locked-cta="{{ opt.locked_reason }}">
+            <i class="icon-lock" aria-hidden="true"></i> {{ opt.heading }}
+          </a>
         </h2>
         <p>{{ opt.description }}</p>
       </article>

--- a/src/framework/templates/_shared/test_picker.py
+++ b/src/framework/templates/_shared/test_picker.py
@@ -124,6 +124,46 @@ def test_picker_selected_option_renders_marked_card_not_a_link() -> None:
     assert links[0].attributes.get("href") == "/x/form?kind=b"
 
 
+def test_picker_locked_option_renders_locked_link_with_reason() -> None:
+    """A ``locked_reason`` option renders the heading as a `data-locked-cta`
+    anchor (no `href`) with the lock glyph, so the locked-affordance JS
+    in base.html can anchor its popover. Other options stay as normal
+    link cards — the locked branch is per-option, not per-picker."""
+    env = _make_env()
+    options = [
+        {
+            "href": "/posts/form?kind=referral",
+            "heading": "Referral",
+            "description": "Place a client.",
+        },
+        {
+            "href": "/posts/form?kind=program_intake",
+            "heading": "Program intake",
+            "description": "Announce open slots.",
+            "locked_reason": "program_intake_locked",
+        },
+    ]
+    tree = HTMLParser(_render_picker(env, options))
+
+    cards = tree.css("article.picker-option")
+    assert len(cards) == 2
+    # First tile is a normal link card.
+    first_link = cards[0].css_first("h2 a")
+    assert first_link.attributes.get("href") == "/posts/form?kind=referral"
+    assert first_link.attributes.get("data-locked-cta") is None
+    # Locked tile renders a locked-link anchor with the reason code and no
+    # navigable href — clicking opens the popover instead of landing on
+    # the form.
+    locked = cards[1].css_first("h2 a")
+    assert locked.attributes.get("data-locked-cta") == "program_intake_locked"
+    assert locked.attributes.get("href") is None
+    assert locked.attributes.get("aria-disabled") == "true"
+    assert "locked-link" in locked.attributes.get("class", "")
+    assert cards[1].css_first("h2 i.icon-lock") is not None
+    # The description still renders so the user sees what the tile is for.
+    assert cards[1].css_first("p").text(strip=True) == "Announce open slots."
+
+
 def test_picker_empty_options_renders_nothing() -> None:
     """An empty option list renders no cards — the macro stacks vanilla
     ``<article>`` blocks, so with zero options it emits nothing for the


### PR DESCRIPTION
## Summary

Posting a program intake requires three things: a verified email, a verified org rep claim, and an owned program. Today `/posts/form` lights the "Program intake" tile for every user; if they don't hold all three, they hit a form that will eventually 403 — and the picker can't tell them what's missing.

This wires `program-intake` as a second named capability, sibling to `provider-network`.

- `check_program_intake(user)` returns a `CapabilityCheck` with a flat three-leaf tree: `email AND any_org_rep AND owns_a_program`. Each conjunct has its own fix URL, so `/users/me/access/capabilities/program-intake` shows the user exactly which step is open.
- Composes the leaf factories landed in #1339 (`_email_leaf`, `_org_rep_any_leaf`) and adds `_owns_program_leaf`. Email + org-rep copy/fix-URL are shared with `provider-network` by reference, not by re-declaration.
- New `REASON_PROGRAM_INTAKE_LOCKED` + `_REASON_META` entry pointing at the capability detail page; registered in the shared `locked_popovers()` tuple.
- `can_post_program_intake_picker(user)` is the boolean form (superuser bypass + `check.granted`) the picker template calls — symmetric with `can_access_network`. The per-row write gate stays `can_post_program_intake(user, org)` at create time.
- The picker macro grows a third species: an option with `locked_reason` renders the heading as `data-locked-cta` instead of a navigable `<a href>`.

`mount_capability_routes` picks up the new entry automatically, so `/users/me/access/capabilities/program-intake` ships with no new template wiring.

## Test plan
- [x] `dev test` passes (2502 passed, 101 skipped)
- [x] `dev lint` passes
- [x] New truth-table tests cover each leaf path and the granted/denied transitions
- [x] Route test asserts the program-intake tile renders with `data-locked-cta="program_intake_locked"` and no `?kind=program_intake` href for the default unverified user

🤖 Generated with [Claude Code](https://claude.com/claude-code)