### PR TITLE
Close server-side gap for program_intake (Claim B per-row check)

### DIFF
--- a/src/domain/logic/posts/handlers.py
+++ b/src/domain/logic/posts/handlers.py
@@ -90,10 +90,12 @@ async def _assert_post_payload_authz(
        (:func:`_assert_post_payload_capability`):
 
        - ``referral`` / ``clinician_opening`` → Claim A
-         (`capabilities.clinician_verified(user)`).
+         (`capabilities.clinician_verified(user)`), via the sync
+         :func:`_assert_post_payload_capability`.
        - ``program_intake`` → Claim B for the referenced Program's org
-         (deferred — the org lookup lands when the Profile Hub PR
-         (Phase 5) wires the program-intake create flow end-to-end).
+         (`capabilities.can_post_program_intake(user, org)`), via the
+         async :func:`_assert_program_intake_org_rep` — split out because
+         the check needs the program's org id, which requires a DB read.
 
     Superusers fall through to the self path, where both the ownership
     and capability checks bypass for admins — so an admin still writes
@@ -124,6 +126,12 @@ async def _assert_post_payload_authz(
         program_repo=program_repo,
     )
     _assert_post_payload_capability(payload, requesting_user)
+    await _assert_program_intake_org_rep(
+        payload=payload,
+        requesting_user=requesting_user,
+        program_repo=program_repo,
+        organization_repo=organization_repo,
+    )
 
 
 async def _is_verified_org_rep_for_affiliation(
@@ -189,13 +197,15 @@ async def _resolve_affiliation_context(
 
 
 def _assert_post_payload_capability(payload: BaseModel, requesting_user: User) -> None:
-    """Per-kind capability gate. Skips for superusers (admin write
-    rights override the claim-based gate). For `program_intake`, the
-    Claim-B check requires the referenced Program's org id — which is
-    a DB read we don't want to add to this payload-time hook. The
-    Profile Hub PR (Phase 5) introduces the dedicated program-intake
-    create path that takes the org check; this hook stays focused on
-    Claim A."""
+    """Per-kind Claim-A capability gate. Stays sync because the
+    underlying predicates (`can_post_referral`, `can_post_opening`)
+    only read off the user object and don't touch the database.
+    Superusers bypass — admin writes override the claim-based gate.
+
+    `program_intake`'s Claim-B gate lives in the async
+    :func:`_assert_program_intake_org_rep` helper, called from the
+    orchestrator immediately after this one. Split because the
+    Claim-B check needs the target program's org id — a DB read."""
     if getattr(requesting_user, "is_superuser", False):
         return
     kind = getattr(payload, "kind", None)
@@ -215,8 +225,55 @@ def _assert_post_payload_capability(payload: BaseModel, requesting_user: User) -
                 "profile (Claim A). Visit /users/me to complete verification."
             ),
         )
-    # `program_intake` Claim-B gate is intentionally deferred — see
-    # docstring above.
+
+
+async def _assert_program_intake_org_rep(
+    *,
+    payload: BaseModel,
+    requesting_user: User,
+    program_repo: ProgramRepository,
+    organization_repo: OrganizationRepository,
+) -> None:
+    """Per-row Claim-B check for `program_intake` payloads.
+
+    Loads the referenced `Program`, walks to its `Organization`, and
+    asserts `capabilities.can_post_program_intake(user, org)`. This
+    closes the gap the picker-side `check_program_intake` already
+    expresses on `/posts/form`: without it, a user who owns a Program
+    under an unverified org could direct-POST `kind=program_intake`
+    and bypass the locked tile.
+
+    No-op when:
+    - kind is not `program_intake` (referral/opening go through the
+      sync Claim-A helper above);
+    - the user is a superuser (admin writes bypass);
+    - the payload omits `program_id` (a PATCH that doesn't touch the
+      FK — though create requires it); or
+    - the program/org row isn't loadable (already 404'd by
+      :func:`_assert_post_payload_target_ownership` upstream — re-
+      checking here would only mask the upstream error).
+
+    403s with the `program-intake` capability detail URL so the user
+    lands on the same explainer the picker popover points at."""
+    if getattr(requesting_user, "is_superuser", False):
+        return
+    if getattr(payload, "kind", None) != "program_intake":
+        return
+    program_id = getattr(payload, "program_id", None)
+    if program_id is None:
+        return
+    program = await program_repo.get_by_model_id(Program, program_id)
+    if program is None:
+        return
+    org = await organization_repo.get_by_model_id(Organization, program.org_id)
+    if org is None or not capabilities.can_post_program_intake(requesting_user, org):
+        raise ForbiddenError(
+            detail=(
+                "Posting a program intake requires a verified organization "
+                "claim (Claim B) for the program's owning organization. "
+                "Visit /users/me/access/capabilities/program-intake."
+            ),
+        )
 
 
 async def _assert_post_payload_target_ownership(

--- a/src/domain/logic/posts/test_capability_gate.py
+++ b/src/domain/logic/posts/test_capability_gate.py
@@ -1,4 +1,4 @@
-"""Phase-7 tests: the per-kind Claim-A capability gate on post create.
+"""Per-kind capability gates on post create.
 
 `_assert_post_payload_authz` runs FK-ownership AND the matching
 capability check from the two-claim verification model. Per handoff
@@ -6,9 +6,17 @@ capability check from the two-claim verification model. Per handoff
 who owns the referenced Clinician but isn't `clinician_verified`
 should be refused at the payload-authz boundary.
 
+Two helpers handle this in `handlers.py`:
+
+- The sync :func:`_assert_post_payload_capability` covers Claim A
+  for `referral` / `clinician_opening` — pure predicates on the user
+  object, no DB.
+- The async :func:`_assert_program_intake_org_rep` covers Claim B
+  for `program_intake` — requires loading the target Program's org.
+
 The existing `_assert_post_payload_target_ownership` invariant (own
 the FK target row) is exercised in higher-level integration tests;
-these tests focus narrowly on the new capability layer.
+these tests focus narrowly on the capability layer.
 """
 
 from __future__ import annotations
@@ -18,7 +26,11 @@ from uuid import uuid4
 
 import pytest
 
-from src.domain.logic.posts.handlers import _assert_post_payload_capability
+from src.domain.logic.posts.handlers import (
+    _assert_post_payload_capability,
+    _assert_program_intake_org_rep,
+)
+from src.domain.models import Organization, Program
 from src.framework.http.exceptions import ForbiddenError
 
 
@@ -70,13 +82,11 @@ def test_clinician_opening_allowed_for_verified_clinician():
     )
 
 
-def test_program_intake_capability_deferred_to_phase_5():
-    """`program_intake` is intentionally not gated here — the Claim-B
-    check requires the program's org id which is a DB read we'd rather
-    not add to the payload-authz hook. The Profile Hub PR (Phase 5)
-    introduces a dedicated program-intake create path that takes the
-    org check; until then this hook lets program_intake through (the
-    FK-ownership check still runs upstream)."""
+def test_program_intake_skipped_by_sync_claim_a_helper():
+    """The sync `_assert_post_payload_capability` is the Claim-A gate
+    only. `program_intake` payloads pass through it untouched — their
+    Claim-B gate lives in the async `_assert_program_intake_org_rep`
+    helper, called from the orchestrator immediately after."""
     _assert_post_payload_capability(_payload("program_intake"), _user())
 
 
@@ -94,3 +104,233 @@ def test_email_unverified_blocks_referral():
     user = _user(is_verified=False, clinician_verified=True)
     with pytest.raises(ForbiddenError, match="Claim A"):
         _assert_post_payload_capability(_payload("referral"), user)
+
+
+# ---------- _assert_program_intake_org_rep (async, Claim-B gate) ---------
+#
+# Stubbed-repo tests for the per-row Claim-B check. The orchestrator
+# is exercised end-to-end in `test_org_rep_authority.py`; these tests
+# pin the new helper's matrix narrowly.
+
+
+class _Repo:
+    """`get_by_model_id` stub that dispatches on the model class to a
+    per-type lookup dict — same shape as the orchestrator-test repo
+    in `test_org_rep_authority.py`."""
+
+    def __init__(self, by_model: dict | None = None):
+        self._by_model = by_model or {}
+        self.calls: list = []
+
+    async def get_by_model_id(self, model, model_id):
+        self.calls.append((model.__name__, model_id))
+        return self._by_model.get(model.__name__, {}).get(model_id)
+
+
+def _intake_user(
+    *,
+    verified_rep_org_id=None,
+    is_superuser: bool = False,
+    is_verified: bool = True,
+) -> SimpleNamespace:
+    reps = (
+        [
+            SimpleNamespace(
+                org_id=verified_rep_org_id,
+                authority_status="verified",
+                archived_at=None,
+            )
+        ]
+        if verified_rep_org_id is not None
+        else []
+    )
+    return SimpleNamespace(
+        id=uuid4(),
+        is_superuser=is_superuser,
+        is_verified=is_verified,
+        org_representations=reps,
+        clinicians=[],
+    )
+
+
+def _intake_payload(*, program_id) -> SimpleNamespace:
+    return SimpleNamespace(kind="program_intake", program_id=program_id)
+
+
+def _program_under(*, program_id, org_id) -> SimpleNamespace:
+    return SimpleNamespace(id=program_id, org_id=org_id)
+
+
+def _verified_org(*, org_id) -> SimpleNamespace:
+    return SimpleNamespace(id=org_id, org_verified=True)
+
+
+async def test_program_intake_org_rep_blocks_unverified_rep():
+    """The user owns the referenced Program but isn't a verified rep
+    of its org — the new helper 403s. This is the gap PR #1341 left
+    open (picker-locked, server-open)."""
+    program_id, org_id = uuid4(), uuid4()
+    program_repo = _Repo(
+        {
+            Program.__name__: {
+                program_id: _program_under(
+                    program_id=program_id,
+                    org_id=org_id,
+                )
+            }
+        }
+    )
+    organization_repo = _Repo(
+        {Organization.__name__: {org_id: _verified_org(org_id=org_id)}}
+    )
+    user = _intake_user(verified_rep_org_id=None)  # no Claim B
+
+    with pytest.raises(ForbiddenError, match="Claim B"):
+        await _assert_program_intake_org_rep(
+            payload=_intake_payload(program_id=program_id),
+            requesting_user=user,
+            program_repo=program_repo,
+            organization_repo=organization_repo,
+        )
+
+
+async def test_program_intake_org_rep_allows_verified_rep():
+    """The user holds Claim B for the program's org — the helper
+    returns cleanly (no exception). Paired with the previous test
+    this pins the gate's positive truth value."""
+    program_id, org_id = uuid4(), uuid4()
+    program_repo = _Repo(
+        {
+            Program.__name__: {
+                program_id: _program_under(
+                    program_id=program_id,
+                    org_id=org_id,
+                )
+            }
+        }
+    )
+    organization_repo = _Repo(
+        {Organization.__name__: {org_id: _verified_org(org_id=org_id)}}
+    )
+    user = _intake_user(verified_rep_org_id=org_id)
+
+    await _assert_program_intake_org_rep(
+        payload=_intake_payload(program_id=program_id),
+        requesting_user=user,
+        program_repo=program_repo,
+        organization_repo=organization_repo,
+    )
+
+
+async def test_program_intake_org_rep_blocks_rep_for_wrong_org():
+    """The user is a verified rep — but of a *different* org than the
+    program's owning org. The per-row check uses the *program's* org,
+    not the user's set of verified orgs, so this is rejected."""
+    program_id, target_org_id, other_org_id = uuid4(), uuid4(), uuid4()
+    program_repo = _Repo(
+        {
+            Program.__name__: {
+                program_id: _program_under(
+                    program_id=program_id,
+                    org_id=target_org_id,
+                )
+            }
+        }
+    )
+    organization_repo = _Repo(
+        {Organization.__name__: {target_org_id: _verified_org(org_id=target_org_id)}}
+    )
+    # Rep for a different org — won't match the program's owning org.
+    user = _intake_user(verified_rep_org_id=other_org_id)
+
+    with pytest.raises(ForbiddenError, match="Claim B"):
+        await _assert_program_intake_org_rep(
+            payload=_intake_payload(program_id=program_id),
+            requesting_user=user,
+            program_repo=program_repo,
+            organization_repo=organization_repo,
+        )
+
+
+async def test_program_intake_org_rep_skips_non_program_intake_payloads():
+    """Referral/opening payloads hit the orchestrator with the same
+    repos plumbed — the helper must no-op so it doesn't accidentally
+    block other kinds."""
+    referral_payload = SimpleNamespace(kind="referral", program_id=None)
+    await _assert_program_intake_org_rep(
+        payload=referral_payload,
+        requesting_user=_intake_user(),
+        program_repo=_Repo(),
+        organization_repo=_Repo(),
+    )
+
+
+async def test_program_intake_org_rep_skips_when_program_id_missing():
+    """PATCH-style payloads that don't touch the FK pass through — same
+    discipline as the existing FK-ownership helper."""
+    await _assert_program_intake_org_rep(
+        payload=_intake_payload(program_id=None),
+        requesting_user=_intake_user(),
+        program_repo=_Repo(),
+        organization_repo=_Repo(),
+    )
+
+
+async def test_program_intake_org_rep_skips_when_program_not_found():
+    """If the Program doesn't load, the upstream ownership helper has
+    already 404'd — re-checking here would only mask that error."""
+    missing_id = uuid4()
+    await _assert_program_intake_org_rep(
+        payload=_intake_payload(program_id=missing_id),
+        requesting_user=_intake_user(),
+        program_repo=_Repo({Program.__name__: {}}),
+        organization_repo=_Repo(),
+    )
+
+
+async def test_program_intake_org_rep_bypasses_for_superuser():
+    """Admins write any row — same discipline as every other gate in
+    this hook."""
+    program_id, org_id = uuid4(), uuid4()
+    # Repos return None for everything — would otherwise 403, but admin
+    # bypass short-circuits before any load runs.
+    program_repo = _Repo()
+    organization_repo = _Repo()
+    user = _intake_user(is_superuser=True)
+
+    await _assert_program_intake_org_rep(
+        payload=_intake_payload(program_id=program_id),
+        requesting_user=user,
+        program_repo=program_repo,
+        organization_repo=organization_repo,
+    )
+    # Bypass means no DB load was issued.
+    assert program_repo.calls == []
+    assert organization_repo.calls == []
+
+
+async def test_program_intake_org_rep_blocks_when_org_missing():
+    """Program loads but its org doesn't — defensive 403 (shouldn't
+    happen in practice given the FK constraint, but better than a
+    silent allow if the row ever desyncs)."""
+    program_id, org_id = uuid4(), uuid4()
+    program_repo = _Repo(
+        {
+            Program.__name__: {
+                program_id: _program_under(
+                    program_id=program_id,
+                    org_id=org_id,
+                )
+            }
+        }
+    )
+    organization_repo = _Repo({Organization.__name__: {}})
+    user = _intake_user(verified_rep_org_id=org_id)
+
+    with pytest.raises(ForbiddenError, match="Claim B"):
+        await _assert_program_intake_org_rep(
+            payload=_intake_payload(program_id=program_id),
+            requesting_user=user,
+            program_repo=program_repo,
+            organization_repo=organization_repo,
+        )


### PR DESCRIPTION
Closes #1345.

## Summary

PR #1341 locked the `/posts/form` "Program intake" tile for users who don't pass the three-leaf check, but `_assert_post_payload_capability` left the per-row Claim-B check (does the user hold verified rep for *this program's* org?) intentionally deferred. A user who owned a Program under an unverified org could direct-POST `/posts` with `kind=program_intake` and bypass the locked tile.

This closes that gap.

- New async helper `_assert_program_intake_org_rep` in `handlers.py` — runs only for `program_intake` payloads, loads the referenced Program → walks to its Organization → asserts `capabilities.can_post_program_intake(user, org)`. 403s with the same `/users/me/access/capabilities/program-intake` URL the picker popover points at.
- `_assert_post_payload_authz` calls the new helper immediately after the existing sync `_assert_post_payload_capability`. The sync helper stays sync (its Claim-A predicates don't touch the DB); the Claim-B gate splits out because it needs the program's org id — a DB read.
- Removes the "deferred — Phase 5" comment; updates the orchestrator docstring to point at the new helper.

## Test plan

- [x] `dev test` passes (2521 passed, 101 skipped)
- [x] `dev lint` passes
- [x] 8 new tests in `test_capability_gate.py` cover every branch:
  - 403 when no Claim B for the program's org
  - Allowed with Claim B for the program's org
  - 403 with Claim B for a *different* org (per-row variant catches what picker `any_org_rep` can't)
  - No-op for non-program_intake kinds (doesn't accidentally block referrals/openings)
  - No-op when `program_id` is None (PATCH-style)
  - No-op when Program doesn't load (upstream ownership helper already 404'd)
  - Superuser bypass with assertion that no DB load was issued
  - 403 when Program loads but org doesn't (defensive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)