### PR TITLE
Add Leaf.requires for declarative upstream-leaf dependencies

### DIFF
--- a/src/framework/access/capabilities/capabilities.py
+++ b/src/framework/access/capabilities/capabilities.py
@@ -115,9 +115,19 @@ class Leaf:
     capabilities reference the same fact without re-declaring its
     label/fix-URL.
 
-    Use `leaf.evaluate(actor)` to produce a `Condition` for a tree. The
-    predicate is invoked once per evaluation — leaves are not cached,
-    because capability checks are read-light and per-request.
+    `requires` declares this leaf's upstream dependencies in the DAG —
+    other leaves that must hold for this one to be meaningful (e.g.
+    `OWNS_PROGRAM_LEAF.requires = (ORG_REP_ANY_LEAF,)`: you can't own
+    a program without a verified org rep on its org). Composers
+    `evaluate_chain(actor)` to splat the dependency closure into a
+    parent Bundle's children, instead of every consumer remembering to
+    list the prereqs as siblings. The bare `evaluate(actor)` is
+    unchanged: it returns just this leaf's own `Condition` — use it
+    when you don't want the chain (e.g. one fact's bool for a
+    standalone gate).
+
+    The predicate is invoked once per evaluation — leaves are not
+    cached, because capability checks are read-light and per-request.
     """
 
     name: str
@@ -125,6 +135,7 @@ class Leaf:
     label_done: str  # passive-past: "Email verified"
     fix_url: str  # deep-link to the resource that flips this bit
     predicate: Callable[[Any], bool]
+    requires: tuple["Leaf", ...] = ()
 
     def evaluate(self, actor: Any) -> Condition:
         return Condition(
@@ -133,6 +144,29 @@ class Leaf:
             met=bool(self.predicate(actor)),
             fix_url=self.fix_url,
         )
+
+    def evaluate_chain(self, actor: Any) -> tuple[Condition, ...]:
+        """Yield this leaf's `Condition` preceded by every transitive
+        prerequisite, in dependency-first order, dedup'd by leaf name.
+
+        Splat the result into a parent `Bundle`'s `children` so the
+        prereqs appear as siblings of the leaf — same flat structure
+        the existing renderer expects, but declared once on the leaf
+        instead of duplicated at every consumer site.
+        """
+        seen: set[str] = set()
+        chain: list[Condition] = []
+
+        def visit(leaf: "Leaf") -> None:
+            if leaf.name in seen:
+                return
+            seen.add(leaf.name)
+            for req in leaf.requires:
+                visit(req)
+            chain.append(leaf.evaluate(actor))
+
+        visit(self)
+        return tuple(chain)
 
 
 class LeafRegistry:

--- a/src/framework/access/capabilities/test_capabilities.py
+++ b/src/framework/access/capabilities/test_capabilities.py
@@ -161,13 +161,18 @@ def test_nested_gate_inside_bundle():
 # ---------- Leaf -----------------------------------------------------------
 
 
-def _leaf(name: str = "x", predicate=lambda a: True) -> Leaf:
+def _leaf(
+    name: str = "x",
+    predicate=lambda a: True,
+    requires: tuple[Leaf, ...] = (),
+) -> Leaf:
     return Leaf(
         name=name,
         label_active=f"Do {name}",
         label_done=f"{name} done",
         fix_url=f"/fix/{name}",
         predicate=predicate,
+        requires=requires,
     )
 
 
@@ -206,6 +211,91 @@ def test_leaf_evaluate_coerces_falsy_predicate_to_bool():
     cond = _leaf(predicate=lambda a: []).evaluate(actor=None)
     assert cond.met is False
     assert isinstance(cond.met, bool)
+
+
+# ---------- Leaf.requires / evaluate_chain --------------------------------
+
+
+def test_leaf_requires_defaults_to_empty_tuple():
+    """Leaves with no upstream dependencies don't have to declare
+    `requires` — the default matches the existing single-leaf shape."""
+    assert _leaf().requires == ()
+
+
+def test_leaf_evaluate_chain_no_requires_returns_self_only():
+    """A leaf with no `requires` returns just its own `Condition` — same
+    boolean as `evaluate()`, just wrapped in a one-tuple so callers can
+    splat uniformly."""
+    leaf = _leaf(name="x", predicate=lambda a: True)
+    chain = leaf.evaluate_chain(actor=None)
+    assert len(chain) == 1
+    assert chain[0].label_active == "Do x"
+    assert chain[0].met is True
+
+
+def test_leaf_evaluate_chain_one_requires_emits_dep_first():
+    """`A.requires = (B,)` → `A.evaluate_chain()` yields `(B_cond,
+    A_cond)`. Dep-first order matches reading the UI top-to-bottom:
+    prerequisites appear above the dependent step."""
+    b = _leaf(name="b", predicate=lambda a: True)
+    a = _leaf(name="a", predicate=lambda a: False, requires=(b,))
+    chain = a.evaluate_chain(actor=None)
+    assert [c.label_active for c in chain] == ["Do b", "Do a"]
+    assert [c.met for c in chain] == [True, False]
+
+
+def test_leaf_evaluate_chain_transitive_requires():
+    """A→B→C: `A.evaluate_chain()` yields `(C, B, A)`. The chain is the
+    full transitive closure so a consumer only ever names the top of
+    the chain to pull in everything below it."""
+    c = _leaf(name="c")
+    b = _leaf(name="b", requires=(c,))
+    a = _leaf(name="a", requires=(b,))
+    chain = a.evaluate_chain(actor=None)
+    assert [cnd.label_active for cnd in chain] == ["Do c", "Do b", "Do a"]
+
+
+def test_leaf_evaluate_chain_dedupes_shared_dep():
+    """A.requires=(C,), B.requires=(C,), and a Bundle wants both: each
+    leaf's own chain still includes C. The chain dedupes within a
+    single `evaluate_chain` call by leaf name — and tree-level dedup
+    across siblings is the composer's responsibility (Bundle's
+    children are listed once)."""
+    c = _leaf(name="c")
+    a = _leaf(name="a", requires=(c, c))  # accidental double-require
+    chain = a.evaluate_chain(actor=None)
+    assert [cnd.label_active for cnd in chain] == ["Do c", "Do a"]
+
+
+def test_leaf_evaluate_chain_diamond_dedupes_by_name():
+    """A.requires=(B, C); B.requires=(D,); C.requires=(D,): D is shared
+    so it appears once. Order: D before B and C; A last."""
+    d = _leaf(name="d")
+    b = _leaf(name="b", requires=(d,))
+    c = _leaf(name="c", requires=(d,))
+    a = _leaf(name="a", requires=(b, c))
+    chain = a.evaluate_chain(actor=None)
+    labels = [cnd.label_active for cnd in chain]
+    assert labels == ["Do d", "Do b", "Do c", "Do a"]
+
+
+def test_leaf_evaluate_chain_passes_actor_to_every_predicate():
+    """Every leaf in the chain — including transitive prereqs — sees
+    the same actor passed to `evaluate_chain`."""
+    seen: list = []
+
+    def record(name):
+        def pred(actor):
+            seen.append((name, actor))
+            return True
+
+        return pred
+
+    c = _leaf(name="c", predicate=record("c"))
+    b = _leaf(name="b", predicate=record("b"), requires=(c,))
+    a = _leaf(name="a", predicate=record("a"), requires=(b,))
+    a.evaluate_chain(actor="sentinel")
+    assert seen == [("c", "sentinel"), ("b", "sentinel"), ("a", "sentinel")]
 
 
 # ---------- LeafRegistry --------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `requires: tuple[Leaf, ...] = ()` to `Leaf` so a leaf can declare which other leaves must hold for it to be meaningful (e.g. owning a program presupposes a verified org rep on its org).
- Adds `Leaf.evaluate_chain(actor) -> tuple[Condition, ...]` that walks the dependency closure depth-first, dedup'd by leaf name, with prereqs ordered before the leaf they support. A consumer splats the result into a parent `Bundle`'s children — the rendered tree shape stays flat, but the dependency is declared once on the leaf instead of duplicated at every consumer site.
- Framework-only: no domain leaf declares `requires` yet. Follow-up PRs will wire `OWNS_PROGRAM_LEAF.requires = (ORG_REP_ANY_LEAF,)` and friends.

## Test plan

- [x] `dev test src/framework/access/capabilities/` passes (35/35, 7 new tests covering no-requires, one-requires dep-first ordering, transitive chains, accidental double-require dedup, diamond shape, and actor pass-through)
- [x] `dev lint` clean
- [x] `dev test src/domain/logic/test_capabilities.py` still passes — no behavior change for any consumer that doesn't set `requires`

🤖 Generated with [Claude Code](https://claude.com/claude-code)