### PR TITLE
Declare OWNS_PROGRAM_LEAF.requires = (ORG_REP_ANY_LEAF,)

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -290,6 +290,12 @@ OWNS_PROGRAM_LEAF = LEAVES.register(
         label_done="Program added",
         fix_url="/programs/form",
         predicate=owns_program,
+        # A user can't own a program until they're a verified rep for
+        # that program's org (Program.create requires Claim B). Declaring
+        # the dependency on the leaf means every capability that pulls
+        # `owns_program` in via `evaluate_chain` gets `org_rep_any`
+        # surfaced as a sibling step without each consumer re-listing it.
+        requires=(ORG_REP_ANY_LEAF,),
     )
 )
 
@@ -342,7 +348,9 @@ def check_program_intake(user: Any) -> CapabilityCheck:
     Tree: email_verified AND any_org_rep_verified AND owns_a_program.
     Each conjunct corresponds to one Condition leaf with its own
     `fix_url`, so the user can see exactly which step is open and click
-    straight into it.
+    straight into it. `ORG_REP_ANY_LEAF` is pulled in via
+    `OWNS_PROGRAM_LEAF.requires` rather than listed inline — the
+    dependency is declared once on the leaf.
 
     Per-row Claim B for the specific program's org is *not* enforced
     here — `_assert_post_payload_capability` (Phase 5) does that at
@@ -358,8 +366,7 @@ def check_program_intake(user: Any) -> CapabilityCheck:
             label_done="Program intake",
             children=(
                 EMAIL_LEAF.evaluate(user),
-                ORG_REP_ANY_LEAF.evaluate(user),
-                OWNS_PROGRAM_LEAF.evaluate(user),
+                *OWNS_PROGRAM_LEAF.evaluate_chain(user),
             ),
         ),
     )

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -641,6 +641,15 @@ def test_owns_program_predicate_handles_anon():
     assert capabilities.owns_program(None) is False
 
 
+def test_owns_program_leaf_requires_org_rep_any():
+    """Owning a program presupposes a verified org rep on the program's
+    org — Program.create gates on Claim B. Declaring the dependency on
+    the leaf means every consumer that pulls `owns_program` in via
+    `evaluate_chain` gets `org_rep_any` surfaced as a sibling step
+    without re-listing it."""
+    assert capabilities.OWNS_PROGRAM_LEAF.requires == (capabilities.ORG_REP_ANY_LEAF,)
+
+
 # ---------- check_provider_identity -------------------------------------------
 
 


### PR DESCRIPTION
Issue 1 from a two-part fix to model capability dependencies more accurately. Follow-up to #1348 (Leaf.requires primitive).

## Summary

- A user can't own a program until their org is verified (Program.create gates on Claim B). The dependency was previously enforced only implicitly — every `check_*` that pulled in `owns_program` had to remember to list `org_rep_any` as a sibling.
- Declares `OWNS_PROGRAM_LEAF.requires = (ORG_REP_ANY_LEAF,)`. Any future consumer that pulls `OWNS_PROGRAM_LEAF.evaluate_chain(user)` gets `org_rep_any` surfaced as a sibling step without re-listing it.
- `check_program_intake` simplified: explicit `ORG_REP_ANY_LEAF.evaluate(user)` replaced with `*OWNS_PROGRAM_LEAF.evaluate_chain(user)`. The rendered tree is identical (three flat Conditions in order: email, org-rep, owns-program), so the picker template and detail page render unchanged.

## Test plan

- [x] Existing `test_check_program_intake_tree_is_flat_and_three_leaves` still passes (pins shape unchanged)
- [x] Existing `test_check_program_intake_missing_org_rep_blocks` / `missing_program_blocks` still pass (per-leaf met state still correct via chain order)
- [x] New `test_owns_program_leaf_requires_org_rep_any` pins the declaration
- [x] Full `dev test` — 2529 passed, 101 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)