### PR TITLE
Lock /posts/form referral + opening tiles on can_act_as_provider

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -295,7 +295,21 @@ OWNS_PROGRAM_LEAF = LEAVES.register(
 
 
 def check_provider_identity(user: Any) -> CapabilityCheck:
-    """Structured capability check for full-feed read access.
+    """Structured capability check for "the user has a verified provider
+    identity" — a clinician (Claim A) or an org rep (Claim B), plus a
+    verified email.
+
+    Two surfaces share this gate:
+
+    - **Read** — full-feed access (un-redacted provider details on the
+      directory and feed). `can_act_as_provider` is the boolean form.
+    - **Authored posts** — the `referral` and `clinician_opening`
+      picker tiles on `/posts/form` (see `domain/templates/posts/
+      form_new.html`). The picker is "coarse" — a Claim-B user
+      without an affiliation passes the tile but still bounces at
+      payload-authz time. Per-row payload authz lives in
+      `_assert_post_payload_authz`; this check is for surfacing
+      identity verification as the gating step in the picker UI.
 
     Tree: email_verified AND (clinician_verified OR org_rep_verified).
     `ever_verified_at` retention is intentionally excluded — access

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -124,21 +124,27 @@ async def test_form_new_picker_responds_200(
     `POST_KINDS[k].noun` (the SOT after #1330); descriptions come from
     `POST_KINDS[k].picker_description`. Tiles for kinds whose
     capability the viewer doesn't hold render as a locked-CTA instead
-    of a navigable `?kind=` link — `program_intake` is gated on
-    `capabilities.check_program_intake` and is locked for the default
-    test user (no verified org rep, no owned program)."""
+    of a navigable `?kind=` link. For the default test user (no
+    verified email, no claims, no programs):
+
+    - `program_intake` is locked on `capabilities.check_program_intake`
+      (REASON_PROGRAM_INTAKE_LOCKED — email + verified org rep + owned
+      program).
+    - `referral` and `clinician_opening` are locked on
+      `capabilities.can_act_as_provider`
+      (REASON_NOT_A_VERIFIED_PROVIDER — email + (Claim A OR Claim B)).
+    """
     response = await authenticated_client.get("/posts/form")
     assert response.status_code == 200
     body = response.text
     for heading in ("Referral", "Opening", "Program intake"):
         assert heading in body
-    # Unlocked tiles deep-link via `?kind=<value>`.
-    for kind in ("referral", "clinician_opening"):
-        assert f"?kind={kind}" in body
-    # The program-intake tile is locked for the default test user, so its
-    # heading is a `data-locked-cta` anchor with no navigable href.
-    assert "?kind=program_intake" not in body
+    # All three tiles are locked for the default test user, so none of
+    # them carry a navigable `?kind=` link.
+    for kind in ("referral", "clinician_opening", "program_intake"):
+        assert f"?kind={kind}" not in body
     assert 'data-locked-cta="program_intake_locked"' in body
+    assert 'data-locked-cta="network_unverified"' in body
     # The picker no longer wraps its heading in a `<header>` band
     # (#1330 — the cards render flatter via Pico's default chrome).
     assert "<header>" not in body

--- a/src/domain/templates/posts/form_new.html
+++ b/src/domain/templates/posts/form_new.html
@@ -15,9 +15,11 @@ read from the same field.
 Per-kind locking: a tile renders as a locked-CTA (lock icon + popover)
 when the viewer doesn't yet hold the capability that kind requires.
 `program_intake` is gated on `capabilities.check_program_intake` —
-email + verified org rep + an owned program; the other kinds carry no
-per-tile lock here (their per-row authz lives at create time in
-`_assert_post_payload_capability`).
+email + verified org rep + an owned program. `referral` and
+`clinician_opening` are gated on `capabilities.can_act_as_provider` —
+email + (verified clinician OR verified org rep) — the same gate that
+guards full-feed reads. Per-row authz still fires at create time in
+`_assert_post_payload_capability` / `_assert_post_payload_authz`.
 #}
 {% extends "views/form_new.html" %}
 {%- from "_shared/_picker.html" import picker -%}
@@ -29,6 +31,9 @@ per-tile lock here (their per-row authz lives at create time in
     {%- if kind.name == "program_intake"
       and not capabilities.can_post_program_intake_picker(current_user) -%}
       {%- set _locked_reason = capabilities.REASON_PROGRAM_INTAKE_LOCKED -%}
+    {%- elif kind.name in ("referral", "clinician_opening")
+      and not capabilities.can_act_as_provider(current_user) -%}
+      {%- set _locked_reason = capabilities.REASON_NOT_A_VERIFIED_PROVIDER -%}
     {%- endif -%}
     {%- set _opts.items = _opts.items + [
         {"href": entity_form_url("post") + "?kind=" + kind.name,


### PR DESCRIPTION
Issue 2 from a two-part fix to model capability dependencies more accurately. Follow-up to #1350 (the rename).

## Summary

- The provider-identity gate (email + (Claim A OR Claim B)) is the posting tier for clinician-authored kinds, not just the read tier for the feed. This PR surfaces it as a picker lock so the affordance and the underlying authz agree.
- `form_new.html`: `referral` and `clinician_opening` tiles now render as locked-CTAs (lock icon + popover routing to `/users/me/access/capabilities/provider-network`) for viewers without a verified clinician or org rep — matching how `program_intake` already locks today.
- Picker semantics stay "coarse": a Claim-B user without an affiliation passes the tile but still bounces at payload-authz time (`can_post_org_referral` requires the affiliation). Same shape as the program-intake tile, where per-row Claim B is re-checked at create time. Adding affiliation-aware picker logic is deferred — write it up as a follow-up if feedback shows the bounce confuses users.
- `check_provider_identity` docstring now spells out the dual use (read gate + authored-post gate).

## Test plan

- [x] `test_form_new_picker_responds_200` updated — pins that all three tiles render as locked-CTAs with the correct `data-locked-cta` value for an unverified default test user
- [x] Full `dev test` — 2528 passed, 101 skipped
- [x] `dev test contract` — 40 passed
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)