### PR TITLE
Move user admin actions to detail-only (no list-page menu)

### DIFF
--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -156,12 +156,12 @@ async def test_list_users_multiple_users(
 # --- Admin actions partial visibility ------------------------------------
 
 
-async def test_list_hides_admin_actions_for_non_admin(
+async def test_list_omits_admin_actions_for_non_admin(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """Non-admin viewers must not see deactivate/delete buttons."""
+    """Non-admin viewers must not see deactivate/delete buttons on the list."""
     other = create_test_user(username=f"target-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
         async with session.begin():
@@ -172,14 +172,24 @@ async def test_list_hides_admin_actions_for_non_admin(
     assert (
         tree.css_first("button[hx-put*='/activation']") is None
     ), "Non-admin should not see admin action buttons"
+    assert (
+        tree.css_first("button[hx-delete*='/users/']") is None
+    ), "Non-admin should not see admin delete buttons"
 
 
-async def test_list_shows_admin_actions_for_admin(
+async def test_list_omits_admin_actions_for_admin(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
-    """Admin viewers see deactivate + delete buttons on each non-self row."""
+    """Admin viewers do NOT see admin actions on the user list either.
+
+    Per-row admin actions on a card list invite mis-clicks (especially
+    the irreversible Delete); admins click through to a user's detail
+    page to act. The detail-page toolbar is the canonical home —
+    covered by ``test_detail_shows_admin_actions_for_admin`` and
+    ``test_detail_admin_actions_render_inside_toolbar`` below.
+    """
     await promote_to_admin(db_test_session_manager, logged_in_user.email)
     other = create_test_user(username=f"target-{uuid.uuid4()}")
     async with db_test_session_manager() as session:
@@ -188,31 +198,12 @@ async def test_list_shows_admin_actions_for_admin(
 
     response = await authenticated_client.get("/users")
     tree = HTMLParser(response.text)
-    activation_buttons = tree.css(f"button[hx-put='/users/{other.id}/activation']")
     assert (
-        len(activation_buttons) == 1
-    ), "Expected one activation button (one non-self row)"
-    assert activation_buttons[0].text().strip() == "Deactivate"
-    assert tree.css_first(f"button[hx-delete='/users/{other.id}']") is not None
-
-
-async def test_list_shows_reactivate_for_deactivated_user(
-    authenticated_client: AsyncClient,
-    db_test_session_manager: async_sessionmaker[AsyncSession],
-    logged_in_user: User,
-):
-    """A deactivated user shows 'Reactivate' rather than 'Deactivate'."""
-    await promote_to_admin(db_test_session_manager, logged_in_user.email)
-    other = create_test_user(username=f"target-{uuid.uuid4()}", is_active=False)
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            session.add(other)
-
-    response = await authenticated_client.get("/users")
-    tree = HTMLParser(response.text)
-    activation_button = tree.css_first(f"button[hx-put='/users/{other.id}/activation']")
-    assert activation_button is not None
-    assert activation_button.text().strip() == "Reactivate"
+        tree.css_first(f"button[hx-put='/users/{other.id}/activation']") is None
+    ), "Admin should not see per-row activation buttons on the list"
+    assert (
+        tree.css_first(f"button[hx-delete='/users/{other.id}']") is None
+    ), "Admin should not see per-row delete buttons on the list"
 
 
 # --- Detail page ---------------------------------------------------------

--- a/src/domain/templates/users/_admin_actions.html
+++ b/src/domain/templates/users/_admin_actions.html
@@ -8,15 +8,16 @@
                           not introspect `current_user`.
 
    Renders nothing unless `can_admin_actions` is truthy. Each action
-   is a `<li>` because this partial renders inside a `<menu>` —
-   either the page toolbar on `/users/{id}` or the card footer on
-   the `/users` index card (`users/list.html` wraps the include in a
-   `<menu>` inside the card's `<footer>`). The buttons themselves
-   carry the user's identity in their `hx-*` URLs
-   (`/users/{id}/activation`, `/users/{id}`); tests find them by
+   is a `<li>` because this partial renders inside the page toolbar's
+   `<menu class="toolbar-right">` on `/users/{id}` — the canonical
+   home for per-target admin actions. The `/users` index card used to
+   wrap this include in a card-footer `<menu>` too, but per-row
+   commands on a list invited mis-clicks (especially for the
+   irreversible Delete); admins click through to detail to act.
+   The buttons themselves carry the user's identity in their `hx-*`
+   URLs (`/users/{id}/activation`, `/users/{id}`); tests find them by
    attribute rather than a wrapper class. To add a new admin action,
-   append a `<li><button>…</button></li>` below; every view that
-   includes this partial picks it up automatically.
+   append a `<li><button>…</button></li>` below.
 
    Backend self-guards live in src/logic/users/user_processing.py — this
    `{% if %}` is presentation only.

--- a/src/domain/templates/users/list.html
+++ b/src/domain/templates/users/list.html
@@ -2,6 +2,11 @@
 {%- from "_shared/_card.html" import card -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {%- from "_shared/_locked.html" import locked_name -%}
+{# Admin actions (Deactivate / Reactivate / Delete) live ONLY on the
+   user-detail page (`users/detail.html`'s toolbar), not on this list.
+   Per-row commands on a card list invite mis-clicks on the wrong row,
+   and the bulk-admin efficiency wasn't worth the irreversible-delete
+   risk. Admins click through to a user's detail page to act on them. #}
 {%- macro user_card(user) %}
   {# Redact the username (the only identifying field surfaced in the
      card chrome) when the viewer lacks network access and isn't this
@@ -21,18 +26,6 @@
     headline_url=None if _redacted else entity_url('user', id=user.id),
     headline=locked_name("J. Doe") if _redacted else user.username,
     subtitle=status_subtitle) -%}
-    {# Admin actions live in the card footer. viewer_is_admin() reads the
-       request-scoped viewer set by handle_list, so user_card stays a
-       single-arg callable compatible with item_list. #}
-    {%- if viewer_is_admin() %}
-      <footer>
-        <menu>
-          {%- with target_user = user, can_admin_actions = true -%}
-            {%- include "users/_admin_actions.html" -%}
-          {%- endwith -%}
-        </menu>
-      </footer>
-    {%- endif %}
   {%- endcall %}
 {%- endmacro %}
 {% block list_body %}


### PR DESCRIPTION
## Summary

- Remove the per-row Deactivate / Reactivate / Delete `<menu>` from `users/list.html`; admin actions now render only on the user-detail toolbar.
- Update `users/_admin_actions.html` docstring to reflect the single mount point.
- Update `test_users.py`: replace the two "shows on list" tests with a single `test_list_omits_admin_actions_for_admin` (and tighten the non-admin counterpart) — admin viewers now also see no admin buttons on the list.

## Why

Per-row admin actions on a card list invite mis-clicks on the wrong row, especially for the irreversible Delete. The `hx-confirm` dialog names the username, but confirm dialogs are routinely dismissed without reading. The bulk-admin efficiency of acting from the list isn't worth the irreversible-delete risk; admins now click through to `/users/{id}` where the target is unambiguous from the toolbar H1.

Surfaced in #1193 Phase A.5 triage as an "open product question — possibly Trash"; resolved Trash.

## Test plan

- [x] `dev test src/domain/routes/test_users.py` — 45 passed, including new `test_list_omits_admin_actions_for_admin` and updated `test_list_omits_admin_actions_for_non_admin`.
- [x] `dev lint` — passes.
- [ ] Manual: GET `/users` as a superuser → no per-row admin buttons. GET `/users/{id}` as a superuser → toolbar still carries Deactivate + Delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)