### PR TITLE
Phase C: template_component_check lint forbids raw HTML in domain templates

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,7 @@ CLAUDE.md and other docs that want to mention a command link to `dev --help` rat
 
 - `dev_cli.py` — the `dev` CLI entry point (argparse).
 - `dev/` — one file per `dev <command>` implementation, each with a colocated `test_*.py`.
-- `dev/title_case_check.py` / `dev/template_imports_check.py` / `dev/python_cluster_imports_check.py` — lint checks invoked by `dev lint`.
+- `dev/title_case_check.py` / `dev/template_imports_check.py` / `dev/python_cluster_imports_check.py` / `dev/template_component_check.py` — lint checks invoked by `dev lint`.
 - `runtime/` — container-entrypoint scripts: `start.sh` (production CMD: runs migrations, starts uvicorn) and `start-dev.sh` (dev: adds LiveReload + hot reload).
 - `check_doc_test_coupling.py` — Claude Code `Stop` hook; reminds the agent when `src/` code changed without touching colocated README/tests. Wired via [`.claude/settings.json`](../.claude/settings.json).
 - `session_start_branch_check.py` — Claude Code `SessionStart` hook; prints the real branch, dirty state, and stash list at session start, warns loudly when the agent lands on `main`/`master` in the shared working tree, and **auto-pulls** (`git pull --ff-only`) when on a clean main with a remote tracking branch — so agents always start from HEAD without a manual "git pull". Wired via [`.claude/settings.json`](../.claude/settings.json).

--- a/scripts/dev/template_component_check.py
+++ b/scripts/dev/template_component_check.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Forbid raw HTML primitives in domain templates.
+
+The component-library rule (#1193): every list-card body, detail-page
+card, form, action button, and similar affordance must compose macros
+from ``src/framework/templates/_shared/`` instead of hand-rolling the
+underlying HTML element. Hand-rolling means the visual / behavioral
+vocabulary drifts and the next reader has to grep for which page
+spells ``Cancel`` which way.
+
+This check enforces the rule by scanning every ``.html`` file under
+``src/domain/templates/`` and rejecting any of the forbidden raw tags
+listed below. Comments (``{# ... #}`` Jinja and ``<!-- ... -->`` HTML)
+are stripped before scanning so a docstring that mentions
+"``<article>``" doesn't trigger.
+
+When a real call site genuinely doesn't fit any existing macro and
+isn't worth promoting (e.g. a one-off onboarding surface that exists
+in exactly one place and has no second consumer), add the file path
+to ``ALLOWLIST`` below. The allowlist is the explicit, visible
+exception register — adding to it is a deliberate "no useful macro
+abstraction here" decision, not a default escape valve.
+
+Layered against the existing ``template_imports_check.py`` (which
+forbids cross-resource imports) — that one keeps the partials
+graph honest; this one keeps the HTML vocabulary honest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+# Files (relative to ``src/domain/templates/``) whose raw HTML is a
+# documented carve-out, not a violation. Each entry should be a path
+# the next reader can `grep` against without ambiguity. Use the
+# trailing slash form for whole directories.
+ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Component-library showcase: by definition contains every
+        # primitive directly.
+        "dev/components.html",
+        # The auth flow opts out of the resource grammar entirely —
+        # documented in `src/framework/templates/README.md`.
+        "auth/",
+        # Sign-out button uses a unique `hx-on::after-request` redirect
+        # shim because fastapi-users' logout returns 204 with no
+        # HX-Redirect; the wrapping admin `<article>` is a single-fact
+        # panel without a `card`-macro shape.
+        "users/detail.html",
+        # The unverified-email inbox CTA is a bespoke onboarding
+        # surface: provider deep-link + Resend in a load-bearing alert
+        # panel. Single instance, no second consumer.
+        "users/email_form.html",
+        # Message-the-poster micro-form swaps itself in place on send;
+        # the swap-self contract doesn't match `inline_add_form`.
+        "posts/_shared/_message_form.html",
+        # Capability-tree cards have a status badge inside the heading
+        # band that the `picker` macro doesn't model.
+        "users/access/capabilities/index.html",
+    }
+)
+
+# Tags forbidden in domain templates. Each tag maps to the macro the
+# template should use instead — emitted in the error message so the
+# fix is obvious from the lint output.
+FORBIDDEN: dict[str, str] = {
+    "button": (
+        "use `actions(...)` / `confirm_delete_button(...)` / "
+        "`confirm_action_button(...)` / `favorite_toggle(...)` from "
+        "`_shared/actions.html`"
+    ),
+    "form": (
+        "use `entity_form(...)` / `form_with_errors(...)` / "
+        "`inline_add_form(...)` from `_shared/forms.html` / "
+        "`_shared/form_meta.html`"
+    ),
+    "input": (
+        "use `text_field` / `select_field` / `checkbox_field` / etc. "
+        "from `_shared/form_fields.html` "
+        '(hidden inputs `<input type="hidden">` are allowed and '
+        "skipped by this check)"
+    ),
+    "select": "use `select_field(...)` / `entity_select_field(...)` from `_shared/form_fields.html`",
+    "fieldset": "use `form_section(...)` from `_shared/form_fields.html`",
+    "article": (
+        "use `card(...)` / `picker(...)` / "
+        "`post_feed_row(...)` / `clinician_card(...)` from `_shared/`"
+    ),
+    "menu": (
+        "use `page_toolbar(...)` from `_shared/_toolbar.html` "
+        "(it emits the toolbar `<menu>`)"
+    ),
+    "dl": "use `facts_block()` from `_shared/sections.html`",
+    "dt": "use `fact(...)` from `_shared/sections.html`",
+    "dd": "use `fact(...)` from `_shared/sections.html`",
+}
+
+# Match Jinja `{# ... #}` and HTML `<!-- ... -->` comments. Used to
+# strip docstring mentions of forbidden tags before the per-tag scan.
+# `re.DOTALL` so multi-line docstring comments are removed in full.
+_JINJA_COMMENT_RE = re.compile(r"\{#.*?#\}", re.DOTALL)
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# Match `<input ... type="hidden" ...>` — the one input shape that's
+# always allowed (it's structural form plumbing, not a user-visible
+# control). The negative-lookahead in the input-tag pattern below
+# could express the carve-out, but a post-match check on the captured
+# tag-text is clearer to read and easier to extend.
+_HIDDEN_INPUT_RE = re.compile(r'type\s*=\s*"hidden"', re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Violation:
+    file: Path
+    line: int
+    tag: str
+    suggestion: str
+    snippet: str
+
+    def message(self) -> str:
+        return (
+            f"{self.file}:{self.line}: raw `<{self.tag}>` in domain template — "
+            f"{self.suggestion}\n    {self.snippet.strip()}"
+        )
+
+
+def _strip_comments(text: str) -> str:
+    """Strip both Jinja and HTML comments. Returns text with comment
+    spans replaced character-by-character: non-newline characters
+    become spaces, newlines are preserved. That keeps line numbers
+    (and the count of total lines) aligned with the original file
+    so a multi-line docstring above a real violation doesn't shift
+    the reported line number."""
+
+    def _blank(m: re.Match[str]) -> str:
+        return re.sub(r"[^\n]", " ", m.group(0))
+
+    text = _JINJA_COMMENT_RE.sub(_blank, text)
+    text = _HTML_COMMENT_RE.sub(_blank, text)
+    return text
+
+
+def _is_allowed(rel_path: str) -> bool:
+    """True iff this path is in ``ALLOWLIST`` (either exact match or
+    under a listed directory prefix)."""
+    if rel_path in ALLOWLIST:
+        return True
+    return any(
+        entry.endswith("/") and rel_path.startswith(entry) for entry in ALLOWLIST
+    )
+
+
+def _find_tag_violations(stripped: str, original: str, file: Path) -> list[Violation]:
+    """Scan ``stripped`` for forbidden opening tags. Use ``original``
+    to extract the matched line's full text for the error snippet."""
+    violations: list[Violation] = []
+    original_lines = original.splitlines()
+    for tag, suggestion in FORBIDDEN.items():
+        # `(?<![\w-])<tag\b` requires a word boundary before the `<` so
+        # `<articles>` doesn't trip the `article` check (none exist, but
+        # the safety belt is cheap). `\b` after the tag name is the
+        # right-side anchor.
+        pattern = re.compile(rf"(?<![\w-])<{tag}\b", re.IGNORECASE)
+        for m in pattern.finditer(stripped):
+            line_no = stripped.count("\n", 0, m.start()) + 1
+            snippet = (
+                original_lines[line_no - 1]
+                if 0 < line_no <= len(original_lines)
+                else "(snippet unavailable)"
+            )
+            # Skip the hidden-input carve-out: walk forward in the
+            # original up to the next `>` and check for type="hidden".
+            if tag == "input":
+                tag_end = original.find(">", m.start())
+                if tag_end != -1 and _HIDDEN_INPUT_RE.search(
+                    original[m.start() : tag_end + 1]
+                ):
+                    continue
+            violations.append(
+                Violation(
+                    file=file,
+                    line=line_no,
+                    tag=tag,
+                    suggestion=suggestion,
+                    snippet=snippet,
+                )
+            )
+    return violations
+
+
+def find_violations(files: Iterable[Path], templates_root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for file in files:
+        try:
+            rel = file.resolve().relative_to(templates_root.resolve()).as_posix()
+        except ValueError:
+            continue
+        if _is_allowed(rel):
+            continue
+        text = file.read_text(encoding="utf-8")
+        stripped = _strip_comments(text)
+        violations.extend(_find_tag_violations(stripped, text, file))
+    return violations
+
+
+def _project_root() -> Path:
+    here = Path(__file__).resolve().parent
+    while here != here.parent:
+        if (here / "pyproject.toml").exists():
+            return here
+        here = here.parent
+    raise RuntimeError("Could not locate project root (no pyproject.toml found).")
+
+
+def _domain_templates_root() -> Path:
+    return _project_root() / "src" / "domain" / "templates"
+
+
+def _collect_files(paths: list[str], default_root: Path) -> list[Path]:
+    if not paths:
+        return sorted(default_root.rglob("*.html")) if default_root.exists() else []
+    files: list[Path] = []
+    for raw in paths:
+        p = Path(raw).resolve()
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.html")))
+        elif p.suffix == ".html":
+            files.append(p)
+    return files
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=("Files or directories to check. Defaults to " "src/domain/templates/."),
+    )
+    args = parser.parse_args(argv)
+
+    root = _domain_templates_root()
+    files = _collect_files(args.paths, root)
+    violations = find_violations(files, root)
+
+    if violations:
+        print("❌ Raw HTML primitives in domain templates:", file=sys.stderr)
+        for v in violations:
+            print(f"  {v.message()}", file=sys.stderr)
+        print(
+            "\nDomain templates must compose macros from "
+            "`src/framework/templates/_shared/` instead of hand-rolling "
+            "primitives. See `src/framework/templates/README.md` § "
+            "'Shared macros'. To exempt a genuine one-off, add the file "
+            "to `ALLOWLIST` in this script with a one-line justification.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"✅ No raw HTML primitives in domain templates ({len(files)} files checked)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/test_template_component_check.py
+++ b/scripts/dev/test_template_component_check.py
@@ -1,0 +1,229 @@
+"""Tests for ``template_component_check``.
+
+The check ships with an empty-violation invariant against the live
+codebase (pinned by ``test_live_codebase_is_clean`` below). The rest
+of the suite pins the rules in isolation: each forbidden tag fires,
+allowlisted files are skipped, the hidden-input carve-out is honored,
+and tags mentioned inside comments don't trigger.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.dev.template_component_check import (
+    ALLOWLIST,
+    FORBIDDEN,
+    find_violations,
+)
+
+
+@pytest.fixture
+def templates_root(tmp_path: Path) -> Path:
+    root = tmp_path / "src" / "domain" / "templates"
+    root.mkdir(parents=True)
+    return root
+
+
+def _write(root: Path, rel_path: str, body: str) -> Path:
+    file = root / rel_path
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return file
+
+
+# --- Forbidden-tag detection ------------------------------------------
+
+
+def test_raw_button_is_a_violation(templates_root: Path) -> None:
+    file = _write(
+        templates_root,
+        "clinicians/detail.html",
+        '<button type="button">Click</button>',
+    )
+    violations = find_violations([file], templates_root)
+    assert len(violations) == 1
+    assert violations[0].tag == "button"
+
+
+def test_raw_form_is_a_violation(templates_root: Path) -> None:
+    file = _write(
+        templates_root,
+        "organizations/form_edit.html",
+        '<form hx-patch="/x">save</form>',
+    )
+    violations = find_violations([file], templates_root)
+    assert any(v.tag == "form" for v in violations)
+
+
+def test_raw_dl_is_a_violation(templates_root: Path) -> None:
+    file = _write(
+        templates_root,
+        "programs/detail.html",
+        "<dl><dt>k</dt><dd>v</dd></dl>",
+    )
+    violations = find_violations([file], templates_root)
+    tags = {v.tag for v in violations}
+    assert {"dl", "dt", "dd"}.issubset(tags)
+
+
+def test_every_forbidden_tag_has_a_macro_suggestion() -> None:
+    """The error message names the macro to use instead. Without the
+    suggestion the lint reads as a NACK with no guidance — every entry
+    in ``FORBIDDEN`` must be load-bearing prose."""
+    for tag, suggestion in FORBIDDEN.items():
+        assert (
+            len(suggestion) > 20
+        ), f"`{tag}` suggestion is too terse to guide a fix: {suggestion!r}"
+
+
+# --- Allowlist ---------------------------------------------------------
+
+
+def test_allowlisted_file_is_skipped(templates_root: Path) -> None:
+    """A file in ``ALLOWLIST`` may emit any of the forbidden tags
+    without triggering. (Use sparingly — the allowlist is the
+    explicit-exception register, not the default escape valve.)"""
+    file = _write(
+        templates_root,
+        "dev/components.html",
+        "<button>showcase</button><form><input><select><dl><article><menu>",
+    )
+    assert find_violations([file], templates_root) == []
+
+
+def test_allowlisted_directory_skips_nested_files(templates_root: Path) -> None:
+    """``auth/`` is allowlisted with a trailing slash — every file
+    under it (including nested subdirs) skips the check."""
+    file = _write(
+        templates_root,
+        "auth/login.html",
+        '<form><input type="email"><button>Log in</button></form>',
+    )
+    assert find_violations([file], templates_root) == []
+
+
+def test_non_allowlisted_files_trigger(templates_root: Path) -> None:
+    """Sanity check: a fresh file path that isn't in the allowlist
+    DOES trigger when it emits a forbidden tag."""
+    file = _write(
+        templates_root,
+        "new_cluster/list.html",
+        "<article>hi</article>",
+    )
+    assert len(find_violations([file], templates_root)) == 1
+
+
+# --- Hidden-input carve-out -------------------------------------------
+
+
+def test_hidden_input_does_not_violate(templates_root: Path) -> None:
+    """`<input type="hidden">` is structural form plumbing (kind
+    discriminators, CSRF, etc.), not a user-visible control. The
+    check skips it explicitly."""
+    file = _write(
+        templates_root,
+        "posts/_form_referral.html",
+        '<input type="hidden" name="kind" value="referral" />',
+    )
+    assert find_violations([file], templates_root) == []
+
+
+def test_visible_input_does_violate(templates_root: Path) -> None:
+    """A non-hidden input still violates — those go through the
+    `text_field` / `select_field` / etc. macros."""
+    file = _write(
+        templates_root,
+        "posts/some_form.html",
+        '<input type="text" name="title" />',
+    )
+    assert len(find_violations([file], templates_root)) == 1
+
+
+# --- Comment stripping ------------------------------------------------
+
+
+def test_jinja_comment_mention_does_not_trigger(templates_root: Path) -> None:
+    """A `{# docstring mentioning <article> #}` is documentation, not
+    an emission. Multi-line Jinja comments are stripped before scan."""
+    file = _write(
+        templates_root,
+        "organizations/list.html",
+        """
+        {# This template wraps items in `<article>` via the `card`
+           macro — the raw element never appears here. #}
+        """,
+    )
+    assert find_violations([file], templates_root) == []
+
+
+def test_html_comment_mention_does_not_trigger(templates_root: Path) -> None:
+    """Same rule for HTML comments — `<!-- <form> goes here -->` is
+    docs, not an emission."""
+    file = _write(
+        templates_root,
+        "programs/detail.html",
+        "<!-- a <form> would live here but doesn't -->",
+    )
+    assert find_violations([file], templates_root) == []
+
+
+def test_violation_line_number_is_preserved_after_comment_stripping(
+    templates_root: Path,
+) -> None:
+    """Comments are stripped by space-replacement (not deletion) so the
+    line numbers in the violation report still match the original file.
+    A multi-line Jinja docstring above a real violation shouldn't
+    knock the reported line number out of sync."""
+    file = _write(
+        templates_root,
+        "users/widget.html",
+        """\
+        {# multi-line
+           docstring
+           mentioning <button> #}
+        <button>real</button>
+        """,
+    )
+    violations = find_violations([file], templates_root)
+    assert len(violations) == 1
+    assert violations[0].line == 4
+
+
+# --- Live-codebase invariant ------------------------------------------
+
+
+def test_live_codebase_is_clean() -> None:
+    """The live codebase under ``src/domain/templates/`` must be free of
+    raw HTML primitives (modulo the documented allowlist). This is the
+    real protection — every other test pins the lint's behavior; this
+    one pins the goal state.
+
+    A regression here means a domain template hand-rolled an element
+    that should have been a macro. Either migrate to the macro or
+    (if it's a genuine one-off) add the file to ``ALLOWLIST`` with a
+    one-line justification."""
+    project_root = Path(__file__).resolve().parents[2]
+    root = project_root / "src" / "domain" / "templates"
+    files = sorted(root.rglob("*.html"))
+    violations = find_violations(files, root)
+    assert not violations, "\n".join(v.message() for v in violations)
+
+
+def test_allowlist_only_contains_known_carveouts() -> None:
+    """Pin the allowlist entries against the documented set — adding to
+    it should be a deliberate decision, not silent drift. A new entry
+    here means the corresponding ``ALLOWLIST`` literal in the script
+    also gets updated."""
+    expected = {
+        "dev/components.html",
+        "auth/",
+        "users/detail.html",
+        "users/email_form.html",
+        "posts/_shared/_message_form.html",
+        "users/access/capabilities/index.html",
+    }
+    assert ALLOWLIST == expected

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -424,6 +424,10 @@ class QualityCommands:
                 [sys.executable, "scripts/dev/template_route_check.py"],
             ),
             (
+                "🧱 Checking domain templates for raw HTML primitives...",
+                [sys.executable, "scripts/dev/template_component_check.py"],
+            ),
+            (
                 "🤝 Checking contract-form coverage...",
                 [sys.executable, "scripts/dev/contract_form_coverage_check.py"],
             ),

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -28,6 +28,8 @@ Names resolve by walking the list, so a domain page can `{% extends "views/list.
 
 A template under `<resource>/` in either root may only `{% extends %}` / `{% include %}` / `{% from %}` / `{% import %}` from: a root-level file (`base.html`), its own directory, `_shared/`, or `views/`. Cross-cluster references (e.g. `posts/...` from `clinicians/...`) mean the partial is *de facto* shared and belongs in `_shared/`. Enforced by [`../../../scripts/dev/template_imports_check.py`](../../../scripts/dev/template_imports_check.py) (runs in `dev lint` and pre-commit).
 
+**Domain templates compose macros; raw HTML primitives are forbidden.** Every list-card body, detail-page card, form, action button, etc. under `src/domain/templates/` must use a macro from `_shared/` (or a per-cluster `_shared/`) rather than hand-rolling the underlying tag. Enforced by [`../../../scripts/dev/template_component_check.py`](../../../scripts/dev/template_component_check.py) — the forbidden tag set is `<button>`, `<form>`, `<input>` (except `type="hidden"`), `<select>`, `<fieldset>`, `<article>`, `<menu>`, `<dl>`, `<dt>`, `<dd>`. The error message names the macro to use instead. Files that genuinely don't fit any existing macro and aren't worth promoting (the `dev/components.html` showcase, the `auth/*` opt-out, one-off onboarding surfaces) live in the script's `ALLOWLIST` constant.
+
 ## Generic view-type templates (`views/`)
 
 Each view-type template fills the same unified page-header band (nav + breadcrumb + toolbar + boundary rule, see "Page chrome contract" below) from `base.html` with the breadcrumb and toolbar shape that matches the verb. A child template extending one of these declares only what's unique: a label, a URL, the body markup, and an optional action cluster.


### PR DESCRIPTION
## Summary

- Add `scripts/dev/template_component_check.py`: walks `src/domain/templates/**/*.html`, rejects raw `<button>`, `<form>`, `<input>` (except `type="hidden"`), `<select>`, `<fieldset>`, `<article>`, `<menu>`, `<dl>`, `<dt>`, `<dd>`.
- Strip Jinja `{# ... #}` and HTML `<!-- ... -->` comments before scanning (preserving newlines so reported line numbers match the original file).
- 6-entry `ALLOWLIST` for documented carve-outs: `dev/components.html` showcase, `auth/` opt-out, `users/detail.html` (Sign-out + admin article), `users/email_form.html` (inbox-CTA panel), `posts/_shared/_message_form.html`, `users/access/capabilities/index.html`.
- Wire into `dev lint` (alongside `template_imports_check.py`) and document the rule in `src/framework/templates/README.md` § Layering rule.
- Colocated `test_template_component_check.py` with 14 tests, including a `test_live_codebase_is_clean` invariant that pins the goal state and `test_allowlist_only_contains_known_carveouts` that pins the carve-out set.

## Why

Phase C of #1193 — the enforcement loop. After the 4 Phase B macro+migration PRs (`facts_block`, `entity_form`, `favorite_toggle`, `confirm_action_button`), every domain template either composes a `_shared/` macro or sits in the carve-out list. This lint catches the next regression instead of waiting for it to surface during a code review.

The check is layered against the existing `template_imports_check.py` — that one keeps the partials graph honest; this one keeps the HTML vocabulary honest.

## Test plan

- [x] `dev test scripts/dev/test_template_component_check.py` — 14 passed.
- [x] `python3 scripts/dev/template_component_check.py` — clean on live codebase.
- [x] Wired check fires correctly via `PYTHONPATH=. python3.11 -m scripts.dev.dev_cli lint` (the local `dev` shim resolves to the static install, but CI / post-merge `dev lint` will pick up the wiring from the merged main branch).
- [ ] Sanity-check on CI: lint passes after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)