### PR TITLE
Expand Language vocab beyond en/es (#1358 PR-d)

### DIFF
--- a/src/domain/models/enums.py
+++ b/src/domain/models/enums.py
@@ -138,12 +138,23 @@ CLIENT_AGE_GROUPS: Final[tuple[str, ...]] = ClientAgeGroup.values()
 
 
 # Spoken-language tokens used by the multi-valued `languages` field on
-# both post kinds. Tokens are ISO-639 codes; labels are the English
-# display names. Starts minimal — covers every seed example today — and
-# grows as real posts demand more entries.
+# both post kinds. Tokens are BCP 47 short codes (ISO-639-1 where
+# available); labels are the English display names. Vocabulary widens
+# only — `languages` is a JSON-list column with no SQL CHECK against
+# array members (Pydantic enforces the wire-side `Literal[*LANGUAGES]`
+# in `domain/logic/posts/schema.py`), so adding tokens is non-breaking
+# for persisted rows. Expansion beyond en/es tracks the corpus
+# evidence surfaced in #1355 / #1358 PR-d (Mandarin-speaking referrals
+# plus the next tier of California-relevant languages).
 class Language(LabeledChoice):
     en = "en", "English"
     es = "es", "Spanish"
+    zh = "zh", "Mandarin"
+    yue = "yue", "Cantonese"
+    vi = "vi", "Vietnamese"
+    tl = "tl", "Tagalog"
+    ko = "ko", "Korean"
+    ru = "ru", "Russian"
 
 
 LANGUAGES: Final[tuple[str, ...]] = Language.values()

--- a/src/domain/models/test_enums.py
+++ b/src/domain/models/test_enums.py
@@ -15,7 +15,7 @@ from src.domain.models import enums as e
 # is a schema change — it must come with an Alembic migration.
 MIGRATED_VALUES = {
     e.LocationAvailability: ("yes", "no", "please_contact"),
-    e.Language: ("en", "es"),
+    e.Language: ("en", "es", "zh", "yue", "vi", "tl", "ko", "ru"),
     e.NetworkPreference: (
         "in_network_required",
         "in_network_preferred",


### PR DESCRIPTION
## Summary
- Implements PR-d of #1358: adds `zh`, `yue`, `vi`, `tl`, `ko`, `ru` to the `Language` enum (BCP 47 short codes).
- Vocab widening only — `languages` is a JSON-list column with no SQL CHECK against array members, and wire-side `Literal[*LANGUAGES]` validation updates automatically. No DB migration needed; existing `en`/`es` rows remain valid.
- Test pin in `test_enums.py` updated to the new frozen vocab tuple.

## Test plan
- [x] `dev test` passes
- [x] `dev lint` passes (covered by `dev test` prelude)
- [x] No README enumerates the language vocab — the enum docstring + `test_enums.py` are the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)