### PR TITLE
Zero margins on article headings and nested sections

### DIFF
--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -65,6 +65,19 @@ ul.entity-list > li { list-style: none; padding: 0; }
    which Pico does not card-style. The `entity-card` /
    `entity-header` / `entity-facts` / etc. class names persist as
    DOM hooks (tests query them) but contribute no styling. */
+/* Article inner-spacing reset — applied to every `<article>` so
+   the card chrome (background, border, padding band) owns the
+   visual rhythm, not the default heading / section margins inside.
+   Two rules:
+     1) `article > header` headings (h1-h6) drop bottom margin so the
+        subtitle / body sits flush against the headline inside the
+        tinted header band — otherwise Pico's h-margin stacks an
+        extra gap below the title and the band reads oversized.
+     2) `article section` zeros out section margin so nested
+        `<section class="entity-facts">` etc. don't push their own
+        gap on top of the article's padding. */
+article > header :is(h1, h2, h3, h4, h5, h6) { margin-bottom: 0; }
+article section { margin: 0; }
 /* Lucide icons — single source of truth for sizing AND
    spacing. `color: inherit` lets each icon pick up the
    surrounding text color (so an icon inside a `<small>` or a


### PR DESCRIPTION
## Summary
- Added two framework-level CSS rules so `<article>` chrome owns the visual rhythm:
  - `article > header h1-h6` → `margin-bottom: 0` (title sits flush against subtitle / body in the tinted header band).
  - `article section` → `margin: 0` (nested `<section class="entity-facts">` etc. don't double-pad against the article's padding).
- Verified via `/dev/components` snapshot — every `article > header h*` reads `margin-bottom: 0px`; every `article section` reads `margin: 0px`. No template changes.

## Test plan
- [x] `dev lint` passes
- [x] `dev test` passes (2581 passed, 101 skipped)
- [x] Visual check on `/dev/components` — card header band sits flush, facts section sits flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)