### PR TITLE
Cap entity form label column at 40% width

### DIFF
--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -152,7 +152,7 @@ dd { margin: 0; }
 }
 /* Form-field layout — the form-side mirror of the `<dl>` grid
    above. The key trick is **subgrid**: the parent `<form>` declares
-   a 2-column grid track once (`max-content 1fr`), and every
+   a 2-column grid track once (`fit-content(40%) 1fr`), and every
    `.form-field` row uses `grid-template-columns: subgrid` to inherit
    those tracks. That makes the label column the SAME width across
    every row in the form — including across fieldset boundaries —
@@ -190,7 +190,11 @@ dd { margin: 0; }
    keep their existing flow. */
 .entity-form-page form {
   display: grid;
-  grid-template-columns: max-content 1fr;
+  /* Label column sizes to its content but is capped at 40% of the
+     form width (a 4:6 max ratio against the control column). Past
+     the cap, long labels wrap instead of squeezing the controls;
+     short labels still hug their text. */
+  grid-template-columns: fit-content(40%) 1fr;
   column-gap: 0.75rem;
   row-gap: var(--pico-spacing);
   align-items: baseline;


### PR DESCRIPTION
## Summary
- `.entity-form-page form` was `grid-template-columns: max-content 1fr` — long labels stole the whole row and squeezed controls into a tiny strip.
- Swap to `fit-content(40%) 1fr`: label column still hugs max-content for short labels, but caps at 40% of form width (the 4:6 ratio). Past the cap, labels wrap; controls keep their space.
- Comment on the subgrid-track reference updated to match.

## Test plan
- [ ] Visit any entity create/edit form (clinician, program, etc.); confirm short-label rows still hug the label width.
- [ ] Confirm a form with a deliberately long label wraps the label instead of crushing the control column.
- [ ] Mobile (<640px): single-column collapse still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)