### PR TITLE
Surface referral matching-dimension fields in form + detail (#1358 PR-a/b/c UI)

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -180,6 +180,13 @@ def _make_cr_post(**detail_overrides):
         accepts_out_of_network_superbill=False,
         accepts_private_pay=False,
         insurance_carriers=["anthem_bcbs"],
+        # CR-only matching-dimension lists (#1358 PR-a/b/c). Default
+        # empty so tests that don't care about matching-dimension
+        # surfacing don't have to override; tests that do pin
+        # their own values.
+        affirming_identities=[],
+        acceptable_license_types=[],
+        clinical_niches=[],
     )
     defaults.update(detail_overrides)
     return SimpleNamespace(
@@ -394,6 +401,45 @@ def test_view_cr_subject_none_when_absent():
     """No subject on the detail row → `subject` key is None in view."""
     v = post_card_view(_make_cr_post(subject=None))
     assert v["subject"] is None
+
+
+def test_view_cr_matching_dimensions_default_empty():
+    """CR matching-dimension lists (#1358 PR-a/b/c) propagate as empty
+    lists when the detail row has none set, matching the schema's
+    column-default of `[]`. Templates iterate them via `{% if view.x %}`
+    so an empty list cleanly suppresses the row."""
+    v = post_card_view(_make_cr_post())
+    assert v["affirming_identities"] == []
+    assert v["acceptable_license_types"] == []
+    assert v["clinical_niches"] == []
+
+
+def test_view_cr_matching_dimensions_round_trip():
+    """When the CR detail row carries matching-dimension tokens, the
+    view-model surfaces them as plain Python lists so the facts block
+    can label-lookup (`AFFIRMING_IDENTITY_LABELS`, `LICENSE_TYPES_LABELS`)
+    and join. `clinical_niches` is free-form so values pass through
+    unchanged."""
+    v = post_card_view(
+        _make_cr_post(
+            affirming_identities=["lgbtq", "trans"],
+            acceptable_license_types=["md", "pmhnp"],
+            clinical_niches=["DGBI", "ADHD in women"],
+        )
+    )
+    assert v["affirming_identities"] == ["lgbtq", "trans"]
+    assert v["acceptable_license_types"] == ["md", "pmhnp"]
+    assert v["clinical_niches"] == ["DGBI", "ADHD in women"]
+
+
+def test_view_pa_matching_dimensions_empty_for_other_kinds():
+    """Matching-dimension keys are CR-only; PA/program populate the
+    view-model with empty lists so templates iterate uniformly without
+    branching on `view.kind`."""
+    v = post_card_view(_make_pa_post())
+    assert v["affirming_identities"] == []
+    assert v["acceptable_license_types"] == []
+    assert v["clinical_niches"] == []
 
 
 # --- post_card_view: opening ------------------------------

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -299,6 +299,11 @@ def post_card_view(post) -> dict[str, Any]:
             detail row; ``None`` for other kinds.
         insurance_carriers: CR-only list of carrier tokens; empty list
             for CR with no carriers specified, ``[]`` for other kinds.
+        affirming_identities / acceptable_license_types /
+        clinical_niches: CR-only matching-dimension lists (#1358 PR-a/b/c).
+            Raw token lists (free-form `str` for `clinical_niches`);
+            empty list both for CR with none specified and for other
+            kinds, so templates iterate uniformly via ``{% if view.x %}``.
         in_network_carriers / accepts_out_of_network: PA-only raw
             values from the linked Clinician. ``in_network_carriers``
             comes back as an empty list when unset, matching the
@@ -342,6 +347,12 @@ def post_card_view(post) -> dict[str, Any]:
         "insurance_carriers": [],
         "in_network_carriers": [],
         "accepts_out_of_network": None,
+        # CR-only matching-dimension lists (#1358 PR-a/b/c). Default
+        # empty so the detail-page facts block can iterate them
+        # uniformly across kinds via `{% if view.x %}`.
+        "affirming_identities": [],
+        "acceptable_license_types": [],
+        "clinical_niches": [],
         "referral": None,
     }
 
@@ -379,6 +390,14 @@ def post_card_view(post) -> dict[str, Any]:
             ),
             accepts_private_pay=getattr(d, "accepts_private_pay", None),
             insurance_carriers=list(getattr(d, "insurance_carriers", None) or []),
+            # CR-only matching-dimension lists (#1358 PR-a/b/c). The
+            # detail-page facts block surfaces these on the expanded
+            # view; empty list = "no preference / no constraint".
+            affirming_identities=list(getattr(d, "affirming_identities", None) or []),
+            acceptable_license_types=list(
+                getattr(d, "acceptable_license_types", None) or []
+            ),
+            clinical_niches=list(getattr(d, "clinical_niches", None) or []),
         )
         return base
 

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -637,6 +637,186 @@ async def test_create_form_picker_labels_solo_with_name_only(
     assert option.text(strip=True) == "Janet Solo"
 
 
+# --- Referral form: matching-dimension fields (#1358 PR-a/b/c) -------------
+
+
+async def test_referral_create_form_renders_matching_dimension_fields(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """GET /posts/form?kind=referral renders the three matching-dimension
+    fields the schema-reconciliation work added (#1358 PR-a/b/c):
+
+    * `affirming_identities` — multi-checkbox sourced from
+      `AFFIRMING_IDENTITIES` (request-side mirror of the clinician claim).
+    * `acceptable_license_types` — multi-checkbox sourced from
+      `LICENSE_TYPES` (the "psychiatrist OR PMHNP" disjunction).
+    * `clinical_niches` — free-form comma-separated tag input.
+
+    Pins each field's `name` (and the surrounding wrapper for the multi-
+    checkbox groups) so a future refactor of the form template can't
+    silently drop them.
+    """
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/posts/form?kind=referral")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    # affirming_identities — multi_select_field renders a
+    # `<div role="group" id="affirming_identities">` wrapper around per-
+    # value checkboxes.
+    ai_group = tree.css_first('div[role="group"]#affirming_identities')
+    assert ai_group is not None, "no affirming_identities checkbox group"
+    assert (
+        tree.css_first(
+            'input[type="checkbox"][name="affirming_identities"][value="lgbtq"]'
+        )
+        is not None
+    ), "affirming_identities is missing the `lgbtq` option"
+
+    # acceptable_license_types — same multi_select_field shape.
+    lic_group = tree.css_first('div[role="group"]#acceptable_license_types')
+    assert lic_group is not None, "no acceptable_license_types checkbox group"
+    assert (
+        tree.css_first(
+            'input[type="checkbox"][name="acceptable_license_types"][value="md"]'
+        )
+        is not None
+    ), "acceptable_license_types is missing the `md` option"
+
+    # clinical_niches — text input under the staging name
+    # `_clinical_niches_input`; the inline splitter script rewrites it to
+    # repeated hidden `clinical_niches` inputs on submit.
+    niches_input = tree.css_first('input[name="_clinical_niches_input"]')
+    assert (
+        niches_input is not None
+    ), "no _clinical_niches_input text field (clinical_niches tag input)"
+    assert (
+        tree.css_first("#clinical-niches-hidden") is not None
+    ), "no #clinical-niches-hidden container for the niche splitter"
+
+
+async def test_referral_edit_form_prefills_matching_dimension_fields(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The edit form (`GET /posts/{id}/form`) pre-checks any stored
+    affirming-identity / license-class tokens and pre-populates the
+    clinical-niches text input with a comma-joined view of the persisted
+    tags. Asserts the round-trip-display path matches what the create
+    form would have accepted on submit."""
+    post = _referral_post(
+        owner_id=logged_in_user.id,
+        affirming_identities=["lgbtq", "trans"],
+        acceptable_license_types=["md", "pmhnp"],
+        clinical_niches=["DGBI", "ADHD in women"],
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    # Both selected affirming-identity checkboxes are pre-checked.
+    for tok in ("lgbtq", "trans"):
+        box = tree.css_first(
+            f'input[type="checkbox"][name="affirming_identities"][value="{tok}"]'
+        )
+        assert box is not None, f"affirming_identities option {tok!r} missing"
+        assert (
+            "checked" in box.attributes
+        ), f"affirming_identities[{tok}] should be pre-checked on edit"
+
+    # Both selected license classes are pre-checked.
+    for tok in ("md", "pmhnp"):
+        box = tree.css_first(
+            f'input[type="checkbox"][name="acceptable_license_types"][value="{tok}"]'
+        )
+        assert box is not None, f"acceptable_license_types option {tok!r} missing"
+        assert (
+            "checked" in box.attributes
+        ), f"acceptable_license_types[{tok}] should be pre-checked on edit"
+
+    # The clinical_niches text input is pre-populated with a comma-joined
+    # view of the persisted tags. Order matches storage order.
+    niches_input = tree.css_first('input[name="_clinical_niches_input"]')
+    assert niches_input is not None
+    assert (
+        niches_input.attributes.get("value") == "DGBI, ADHD in women"
+    ), niches_input.attributes.get("value")
+
+
+async def test_referral_detail_renders_matching_dimension_rows(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The referral detail page (`/posts/{id}`) surfaces each matching-
+    dimension row when the persisted referral has values for it. The
+    facts block uses `AFFIRMING_IDENTITY_LABELS` / `LICENSE_TYPES_LABELS`
+    for display labels (the raw enum tokens shouldn't appear) and renders
+    the free-form `clinical_niches` values verbatim."""
+    post = _referral_post(
+        owner_id=logged_in_user.id,
+        affirming_identities=["lgbtq"],
+        acceptable_license_types=["md"],
+        clinical_niches=["DGBI", "ADHD in women"],
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    body = response.text
+
+    # Label dicts: AFFIRMING_IDENTITY_LABELS["lgbtq"] is "LGBTQ+";
+    # LICENSE_TYPES_LABELS["md"] is the MD label. Assert the label
+    # appears (not the raw token), so a future label rename will
+    # surface here as a single diff. We assert the row's section label
+    # is present rather than pin the entire `<dt>` markup.
+    assert "Affirming identities" in body
+    assert "Acceptable license classes" in body
+    assert "Clinical niches" in body
+    # Free-form niches render verbatim (they pass through label lookup).
+    assert "DGBI" in body
+    assert "ADHD in women" in body
+
+
+async def test_referral_detail_hides_matching_dimension_rows_when_empty(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """An older / minimal referral with no matching-dimension data set
+    omits all three rows — `{% if view.x %}` guards each row, so an
+    empty list does not render a labeled-but-empty row."""
+    post = _referral_post(
+        owner_id=logged_in_user.id,
+        affirming_identities=[],
+        acceptable_license_types=[],
+        clinical_niches=[],
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(post)
+
+    response = await authenticated_client.get(f"/posts/{post.id}")
+    assert response.status_code == 200
+    body = response.text
+    assert "Affirming identities" not in body
+    assert "Acceptable license classes" not in body
+    assert "Clinical niches" not in body
+
+
 # --- Anonymization gate (can_act_as_provider) ---------------------------------
 
 

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -73,6 +73,12 @@ register_template_globals(
     GENDER_LABELS=enums.GENDER_LABELS,
     INSURANCE_POSTURES=enums.INSURANCE_POSTURES,
     INSURANCE_POSTURE_LABELS=enums.INSURANCE_POSTURE_LABELS,
+    # Affirming-identity vocabulary (#1358 PR-a). Referral request side
+    # and Clinician person-level side both pull from this tuple; the
+    # referral create/edit form's multi-checkbox renders directly from
+    # the global.
+    AFFIRMING_IDENTITIES=enums.AFFIRMING_IDENTITIES,
+    AFFIRMING_IDENTITY_LABELS=enums.AFFIRMING_IDENTITY_LABELS,
     # LICENSE_TYPES and EDUCATION/CERTIFICATION equivalents are exposed here
     # as globals so bespoke templates (like the profile hub's license step)
     # can reference them without relying on CLINICIAN_ENTITY.static_context,
@@ -157,6 +163,7 @@ register_choice_labels(enums.REFERRAL_SERVICES, enums.REFERRAL_SERVICE_LABELS)
 register_choice_labels(enums.TREATMENT_SETTINGS, enums.TREATMENT_SETTINGS_LABELS)
 register_choice_labels(enums.TREATMENT_MODALITIES, enums.TREATMENT_MODALITY_LABELS)
 register_choice_labels(enums.GENDERS, enums.GENDER_LABELS)
+register_choice_labels(enums.AFFIRMING_IDENTITIES, enums.AFFIRMING_IDENTITY_LABELS)
 register_choice_labels(enums.LICENSE_TYPES, enums.LICENSE_TYPES_LABELS)
 register_choice_labels(enums.EDUCATION_TYPES, enums.EDUCATION_TYPES_LABELS)
 register_choice_labels(enums.CERTIFICATION_TYPES, enums.CERTIFICATION_TYPES_LABELS)

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -63,10 +63,27 @@ which FastAPI/Pydantic parses as a list.
     {%- endfor -%}
     {{ composite_select_field("clinician_affiliation_id", "Referring clinician", _practices.opts, current=d.clinician_affiliation_id if d else None, default_first=true) }}
     {{ textarea_field("description", "About the client", current=d.description if d else None, help="Anything else a clinician needs to know. Please don't include identifying details.") }}
+    {# Clinical-niche tags (#1358 PR-c). Free-form `list[str]` on the
+       wire — the niche vocabulary is too open-ended to commit to a
+       closed enum on day one. UI is a single comma-separated text input
+       that a tiny inline script (below) splits into multiple hidden
+       `clinical_niches` inputs on submit, so the server still receives
+       the wire shape Pydantic expects (repeated `clinical_niches=tag`
+       pairs the `scalar_to_list`/`clean_free_form_tags` validator
+       accepts). The raw input is disabled at submit time so it doesn't
+       also POST a stale comma-joined value. #}
+    {{ text_field("_clinical_niches_input", "Clinical niches", current=((d.clinical_niches | join(", ") ) if d and d.clinical_niches else None), required=false, help="Comma-separated free-form tags (e.g. \"DGBI, ADHD in women, complex trauma\"). Match what the clinician self-claims.") }}
+    <div id="clinical-niches-hidden" hidden></div>
     {% call form_section("Client demographics") %}
       {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help() ) }}
       {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
       {{ select_field("gender", "Gender", GENDERS, labels=GENDER_LABELS, current=d.gender if d else None) }}
+      {# Affirming-identity request constraints (#1358 PR-a). Symmetric
+         to `Clinician.affirming_identities` — the referrer states the
+         affordances the client needs, the clinician claims the ones
+         they offer. Empty selection = "no preference stated", which is
+         the schema default. #}
+      {{ multi_select_field("affirming_identities", "Affirming identities", AFFIRMING_IDENTITIES, labels=AFFIRMING_IDENTITY_LABELS, current=d.affirming_identities if d else None, required=false, help=select_all_help() ) }}
     {% endcall %}
     {% call form_section("Client location") %}
       {{ text_field("location_city", "City", current=d.location_city if d else None) }}
@@ -81,6 +98,12 @@ which FastAPI/Pydantic parses as a list.
     {% call form_section("Services needed") %}
       {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
       {{ multi_select_field("modalities", "Treatment modalities", TREATMENT_MODALITIES, labels=TREATMENT_MODALITY_LABELS, current=d.modalities if d else None, required=false) }}
+      {# License-class disjunction on the referred provider (#1358 PR-b).
+         Captures "psychiatrist OR PMHNP" patterns that `services` can't
+         express (medication_management could be delivered by a PCP, PA,
+         or non-psychiatric NP). Empty selection = "no constraint" — any
+         license class accepted; the schema default. #}
+      {{ multi_select_field("acceptable_license_types", "Acceptable license classes", LICENSE_TYPES, labels=LICENSE_TYPES_LABELS, current=d.acceptable_license_types if d else None, required=false, help="Leave empty for no constraint. Select multiple to express disjunction (e.g. psychiatrist OR PMHNP).") }}
     {% endcall %}
     {# Insurance / payment paths (#1358 PR-e). Three independent checkbox
      booleans the corpus consistently distinguishes — "Anthem PPO;
@@ -116,6 +139,39 @@ which FastAPI/Pydantic parses as a list.
     }
     inNet.addEventListener('change', sync);
     sync();
+  })();
+  </script>
+  <script>
+  /* Clinical-niche tag splitter (#1358 PR-c). The visible input is a
+     single comma-separated text field; on form submit (capture phase so
+     htmx's submit handler sees the synthesized hidden inputs) we split
+     on comma, strip, drop empties, dedupe, and inject one hidden input
+     per tag with name="clinical_niches" — the wire shape the
+     `clean_free_form_tags` validator expects. The raw input is then
+     disabled so it doesn't also POST a stale comma-joined value under
+     its `_clinical_niches_input` name. Empty input is fine — zero
+     hidden inputs, which the schema reads as the default empty list. */
+  (function () {
+    var raw = document.querySelector('input[name="_clinical_niches_input"]');
+    var hidden = document.getElementById('clinical-niches-hidden');
+    if (!raw || !hidden) return;
+    var form = raw.closest('form');
+    if (!form) return;
+    form.addEventListener('submit', function () {
+      hidden.innerHTML = '';
+      var seen = {};
+      (raw.value || '').split(',').forEach(function (part) {
+        var tag = part.trim();
+        if (!tag || seen[tag]) return;
+        seen[tag] = true;
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'clinical_niches';
+        input.value = tag;
+        hidden.appendChild(input);
+      });
+      raw.disabled = true;
+    }, true);
   })();
   </script>
 {%- endmacro -%}

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -34,7 +34,9 @@ Two modes:
     (program), organization link (PA + program — clickable jump to
     `/organizations/{id}`), full address line, desired times,
     schedule notes (PA/program), payment paths + insurance carriers
-    (CR), sliding scale + cost (PA). Languages always render in
+    (CR), sliding scale + cost (PA), matching-dimension rows
+    (CR: affirming identities, acceptable license classes, clinical
+    niches per #1358 PR-a/b/c). Languages always render in
     expanded mode (the English-only suppression is a list-density
     concern; on detail the row is welcome). Gender for CR is also
     shown in expanded mode — the headline still carries it but the
@@ -196,6 +198,22 @@ Reads from `view` (the `post_card_view` dict). Display-label dicts
                           {%- if view.accepts_private_pay %}{{ fact('accepts_private_pay', 'Private pay', 'Yes', icon='shield') }}{%- endif %}
                             {%- if view.sliding_scale %}{{ fact('sliding_scale', 'Sliding scale', 'Yes') }}{%- endif %}
                               {%- if view.cost %}{{ fact('cost', 'Cost', view.cost) }}{%- endif %}
-                              {%- endif %}
-                            {%- endcall %}
-                          {%- endmacro %}
+                                {#- Matching-dimension rows (#1358 PR-a/b/c). CR-only;
+                                  other kinds populate the view-model keys as empty
+                                  lists, so the `{% if view.x %}` guards skip them. #}
+                                {%- if view.affirming_identities %}
+                                  {%- set _ai_labels = [] -%}
+                                  {%- for a in view.affirming_identities -%}{%- set _ = _ai_labels.append(AFFIRMING_IDENTITY_LABELS[a]) -%}{%- endfor -%}
+                                    {{ fact('affirming_identities', 'Affirming identities', _ai_labels | join(", ") , icon='heart') }}
+                                  {%- endif %}
+                                  {%- if view.acceptable_license_types %}
+                                    {%- set _lic_labels = [] -%}
+                                    {%- for l in view.acceptable_license_types -%}{%- set _ = _lic_labels.append(LICENSE_TYPES_LABELS[l]) -%}{%- endfor -%}
+                                      {{ fact('acceptable_license_types', 'Acceptable license classes', _lic_labels | join(", ") , icon='award') }}
+                                    {%- endif %}
+                                    {%- if view.clinical_niches %}
+                                      {{ fact('clinical_niches', 'Clinical niches', view.clinical_niches | join(", ") , icon='tag') }}
+                                    {%- endif %}
+                                  {%- endif %}
+                                {%- endcall %}
+                              {%- endmacro %}


### PR DESCRIPTION
## Summary

The schema-reconciliation sub-PRs landed the columns + Pydantic fields for `affirming_identities` (#1365 PR-a), `acceptable_license_types` (#1369 PR-b), and `clinical_niches` (#1372 PR-c) but the referral form never grew inputs for them and the detail page never grew rows. Users could not populate the new fields and the values stayed invisible.

This PR surfaces all three in the user-facing UI.

### Form (`_form_referral.html`)
- `affirming_identities` — multi-checkbox in the **Client demographics** cluster (near `gender`), mirroring `age_groups`. Vocabulary pulled from new `AFFIRMING_IDENTITIES` / `AFFIRMING_IDENTITY_LABELS` Jinja globals.
- `acceptable_license_types` — multi-checkbox in the **Services needed** cluster (near `services`), reusing the existing `LICENSE_TYPES` / `LICENSE_TYPES_LABELS` vocabulary that `ClinicianLicensure` already writes from.
- `clinical_niches` — single comma-separated text input near `description`. A small inline `submit`-time script splits commas, trims, dedupes, and emits one hidden `clinical_niches` input per tag so the persisted shape stays a `list[str]` rather than a single comma-joined string. Mirrors the existing inline-script pattern the in-network carrier toggle uses.

### Detail (`_facts_block.html` + `post_card_view`)
- Three new view-model keys default to empty lists across kinds and populate from the referral detail row in the CR branch.
- The expanded section renders one row per non-empty list, label-looked-up via `AFFIRMING_IDENTITY_LABELS` / `LICENSE_TYPES_LABELS`; the free-form `clinical_niches` joins verbatim. Empty lists suppress the row entirely.

## Test plan
- [x] View-model: round-trip + empty-default coverage in `test_view.py` (CR + PA branches).
- [x] Routes: form-render asserts each new field's `name` is present on `GET /posts/form?kind=referral`.
- [x] Edit-form: pre-checks stored affirming/license tokens and pre-populates the comma-joined niche input.
- [x] Detail page: rows render when set, omit when empty.
- [x] Full `dev test` + `dev test contract` passes (2,631 + 40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)