### PR TITLE
Surface clinician person-level matching-dimension fields in UI (#1358 PR-a/c/f)

### DIFF
--- a/src/domain/logic/clinicians/test_view.py
+++ b/src/domain/logic/clinicians/test_view.py
@@ -247,6 +247,38 @@ def test_view_passes_through_optional_cost_and_npi():
     assert v["npi"] == "1234567890"
 
 
+def test_view_matching_dimensions_default_empty_when_unset():
+    """Person-level matching-dimension lists (#1358 PR-a/c/f) come back
+    as empty lists when the clinician stub doesn't carry them, so the
+    detail-page facts block can iterate them uniformly via
+    ``{% if view.x %}`` without nullability handling. ``languages`` on
+    a real (flushed) clinician defaults to ``["en"]`` at the model
+    layer; the SimpleNamespace stub here doesn't carry the attribute,
+    matching the "older row without the column" path."""
+    v = clinician_card_view(_stub_clinician())
+    assert v["affirming_identities"] == []
+    assert v["clinical_niches"] == []
+    assert v["languages"] == []
+
+
+def test_view_matching_dimensions_round_trip():
+    """When the clinician carries matching-dimension tokens, the view-
+    model surfaces them as plain Python lists so the facts block can
+    label-lookup (``AFFIRMING_IDENTITY_LABELS``, ``LANGUAGE_LABELS``)
+    and join. ``clinical_niches`` is free-form so values pass through
+    unchanged."""
+    v = clinician_card_view(
+        _stub_clinician(
+            affirming_identities=["lgbtq", "trans"],
+            clinical_niches=["DGBI", "ADHD in women"],
+            languages=["en", "zh"],
+        )
+    )
+    assert v["affirming_identities"] == ["lgbtq", "trans"]
+    assert v["clinical_niches"] == ["DGBI", "ADHD in women"]
+    assert v["languages"] == ["en", "zh"]
+
+
 def test_view_returns_empty_list_for_missing_credentials():
     """The template iterates `view.licensures / educations / certifications`
     via `{% for ... %}`; empty lists render nothing without needing a

--- a/src/domain/logic/clinicians/view.py
+++ b/src/domain/logic/clinicians/view.py
@@ -203,6 +203,15 @@ def clinician_card_view(clinician) -> dict[str, Any]:
         sliding_scale_label: ``"Yes"`` or ``"No"``.
         cost: pass-through optional free-text.
         npi: pass-through optional 10-digit NPI.
+        affirming_identities / clinical_niches / languages: person-level
+            matching-dimension lists (#1358 PR-a/c/f). Raw token lists
+            (free-form ``str`` for ``clinical_niches``); empty list both
+            for clinicians with none set and for SimpleNamespace stubs
+            that don't carry the attribute, so the detail-page facts
+            block can iterate them uniformly via ``{% if view.x %}``.
+            ``languages`` defaults to ``["en"]`` at the model layer; an
+            empty list here would only happen on a stub or unflushed
+            row.
         licensures / educations / certifications: pass-through ORM
             collections (the template iterates them via the existing
             ``credential_row`` partial; no shape change).
@@ -236,6 +245,16 @@ def clinician_card_view(clinician) -> dict[str, Any]:
         ),
         "cost": _role_attr(clinician, "cost"),
         "npi": getattr(clinician, "npi", None),
+        # Person-level matching-dimension lists (#1358 PR-a/c/f). The
+        # detail-page facts block surfaces these; empty lists are
+        # rendered as suppressed rows via ``{% if view.x %}``. We
+        # default each to ``[]`` so SimpleNamespace stubs without these
+        # attributes don't blow the template up.
+        "affirming_identities": list(
+            getattr(clinician, "affirming_identities", None) or []
+        ),
+        "clinical_niches": list(getattr(clinician, "clinical_niches", None) or []),
+        "languages": list(getattr(clinician, "languages", None) or []),
         "licensures": list(getattr(clinician, "licensures", None) or []),
         "educations": list(getattr(clinician, "educations", None) or []),
         "certifications": list(getattr(clinician, "certifications", None) or []),

--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -1425,6 +1425,209 @@ async def test_non_owner_cannot_open_edit_form(
     assert response.status_code == 403
 
 
+# --- Person-level matching-dimension fields (#1358 PR-a/c/f) ---------------
+
+
+async def test_clinician_edit_form_renders_matching_dimension_fields(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """`GET /clinicians/{id}/form` renders the person-level matching-
+    dimension fields the schema-reconciliation work added (#1358 PR-a/c):
+
+    * `affirming_identities` — multi-checkbox sourced from
+      `AFFIRMING_IDENTITIES` (clinician's self-claim, symmetric to the
+      Referral form's request-side mirror).
+    * `clinical_niches` — free-form comma-separated tag input,
+      mirroring the splitter pattern PR #1403 introduced on the
+      Referral form.
+
+    `languages` (#1358 PR-f) is intentionally not on the edit form yet
+    — `ClinicianUpdate` doesn't accept it; the column reads through
+    the detail page only until the schema is extended.
+    """
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    # affirming_identities — multi_select_field renders a
+    # `<div role="group" id="affirming_identities">` wrapper around
+    # per-value checkboxes.
+    ai_group = tree.css_first('div[role="group"]#affirming_identities')
+    assert ai_group is not None, "no affirming_identities checkbox group"
+    assert (
+        tree.css_first(
+            'input[type="checkbox"][name="affirming_identities"][value="lgbtq"]'
+        )
+        is not None
+    ), "affirming_identities is missing the `lgbtq` option"
+
+    # clinical_niches — text input under the staging name
+    # `_clinical_niches_input`; the inline splitter script rewrites it
+    # to repeated hidden `clinical_niches` inputs on submit.
+    niches_input = tree.css_first('input[name="_clinical_niches_input"]')
+    assert (
+        niches_input is not None
+    ), "no _clinical_niches_input text field (clinical_niches tag input)"
+    assert (
+        tree.css_first("#clinical-niches-hidden") is not None
+    ), "no #clinical-niches-hidden container for the niche splitter"
+
+
+async def test_clinician_edit_form_prefills_matching_dimension_fields(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """The edit form pre-checks any stored affirming-identity tokens
+    and pre-populates the clinical-niches text input with a comma-
+    joined view of the persisted tags. Asserts the round-trip-display
+    path matches what the form would have accepted on submit."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager,
+        user_id=logged_in_user.id,
+        affirming_identities=["lgbtq", "trans"],
+        clinical_niches=["DGBI", "ADHD in women"],
+    )
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}/form")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    # Both selected affirming-identity checkboxes are pre-checked.
+    for tok in ("lgbtq", "trans"):
+        box = tree.css_first(
+            f'input[type="checkbox"][name="affirming_identities"][value="{tok}"]'
+        )
+        assert box is not None, f"affirming_identities option {tok!r} missing"
+        assert (
+            "checked" in box.attributes
+        ), f"affirming_identities[{tok}] should be pre-checked on edit"
+
+    # The clinical_niches text input is pre-populated with a comma-
+    # joined view of the persisted tags. Order matches storage order.
+    niches_input = tree.css_first('input[name="_clinical_niches_input"]')
+    assert niches_input is not None
+    assert (
+        niches_input.attributes.get("value") == "DGBI, ADHD in women"
+    ), niches_input.attributes.get("value")
+
+
+async def test_patch_clinician_persists_matching_dimensions_round_trip(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """End-to-end: PATCH `/clinicians/{id}` with affirming_identities
+    + clinical_niches persists the values, and the detail page (`GET
+    /clinicians/{id}`) renders the row labels back. Pins the wire
+    shape the splitter script synthesizes (repeated `clinical_niches`
+    pairs) and the partial-update semantics of `ClinicianUpdate`."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+
+    # Use form-urlencoded content with repeated keys to mirror the
+    # wire shape the splitter script synthesizes on submit. Passing
+    # `data=[(k, v), ...]` to httpx's AsyncClient hits the sync-only
+    # multipart encoder; building the body explicitly avoids that.
+    from urllib.parse import urlencode
+
+    patch = await authenticated_client.patch(
+        f"/clinicians/{clinician_id}",
+        content=urlencode(
+            [
+                ("affirming_identities", "lgbtq"),
+                ("affirming_identities", "neurodiversity"),
+                ("clinical_niches", "DGBI"),
+                ("clinical_niches", "ADHD in women"),
+            ]
+        ),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert patch.status_code in (200, 204), patch.text
+
+    async with db_test_session_manager() as session:
+        row = await session.get(Clinician, clinician_id)
+        assert list(row.affirming_identities) == ["lgbtq", "neurodiversity"]
+        assert list(row.clinical_niches) == ["DGBI", "ADHD in women"]
+
+    detail = await authenticated_client.get(f"/clinicians/{clinician_id}")
+    assert detail.status_code == 200
+    body = detail.text
+    # Section labels (the row's `<dt>` text) — label-lookup wins, raw
+    # tokens shouldn't appear.
+    assert "Affirming identities" in body
+    assert "Clinical niches" in body
+    # Free-form niches render verbatim.
+    assert "DGBI" in body
+    assert "ADHD in women" in body
+
+
+async def test_clinician_detail_renders_matching_dimension_rows(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """The clinician detail page (`/clinicians/{id}`) surfaces each
+    person-level matching-dimension row when the row has values for it.
+    `languages` (#1358 PR-f) renders here as a read-only display row
+    (the column is on the model; the wire schema for editing isn't
+    extended yet). Display labels (`AFFIRMING_IDENTITY_LABELS` /
+    `LANGUAGE_LABELS`) are looked up; free-form `clinical_niches`
+    renders verbatim."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager,
+        user_id=logged_in_user.id,
+        affirming_identities=["lgbtq"],
+        clinical_niches=["DGBI"],
+        languages=["en", "es"],
+    )
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    # Each row is identified by a `data-fact="<key>"` wrapper.
+    assert tree.css_first('[data-fact="affirming_identities"]') is not None
+    assert tree.css_first('[data-fact="languages"]') is not None
+    assert tree.css_first('[data-fact="clinical_niches"]') is not None
+    body = response.text
+    assert "Affirming identities" in body
+    assert "Languages" in body
+    assert "Clinical niches" in body
+    assert "DGBI" in body
+
+
+async def test_clinician_detail_hides_matching_dimension_rows_when_empty(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A clinician with no affirming-identity / niche claims and the
+    default `languages=["en"]` shows only the Languages row (the
+    column has a NOT NULL default of `["en"]` at the model layer).
+    The affirming-identity and clinical-niche rows are guarded by
+    `{% if view.x %}` and suppress cleanly when the list is empty."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    assert tree.css_first('[data-fact="affirming_identities"]') is None
+    assert tree.css_first('[data-fact="clinical_niches"]') is None
+    # `languages` defaults to ["en"] at the model layer, so the row
+    # renders here even without an explicit value.
+    assert tree.css_first('[data-fact="languages"]') is not None
+
+
 # --- Pagination ---------------------------------------------------------
 
 

--- a/src/domain/templates/clinicians/detail.html
+++ b/src/domain/templates/clinicians/detail.html
@@ -3,6 +3,7 @@
 {%- from "_shared/_locked.html" import locked_name -%}
 {%- from "_shared/_picker.html" import picker -%}
 {%- from "_shared/icon_label.html" import icon_label -%}
+{%- from "_shared/sections.html" import fact, facts_block -%}
 {%- set view = clinician_card_view(clinician) -%}
 {# When the viewer lacks provider-network access and isn't the owner,
    redact identifying fields per the `_clinician_card.html` /
@@ -68,18 +69,46 @@
    land on the sub-resource list pages and see those pages' own
    redaction rules. #}
 {% block content %}
-  {{ picker([
-    {"href": entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations",
-  "heading": "Practices",
-  "description": "Where this clinician sees clients — location, availability, in-network insurance, and rates."},
-  {"href": entity_url('clinician', id=clinician.id) ~ "/licensures",
-  "heading": "Licensures",
-  "description": "Professional licenses on file with their issuing states."},
-  {"href": entity_url('clinician', id=clinician.id) ~ "/educations",
-  "heading": "Education",
-  "description": "Degrees, programs, and where they were completed."},
-  {"href": entity_url('clinician', id=clinician.id) ~ "/certifications",
-  "heading": "Certifications",
-  "description": "Specialized credentials and their certifying bodies."},
-  ]) }}
-{% endblock %}
+  {# Person-level identity cluster (#1358 PR-a/c/f). Affirming identities,
+     languages, and clinical niches are *person* attributes — they move
+     with the clinician across affiliations, the same way credentials
+     do. We render the block above the sub-resource picker so the
+     viewer reads "who this clinician is" before "where they practice
+     / what they're licensed in". Each row is guarded by
+     `{% if view.x %}` so an unset list cleanly suppresses the row.
+     Redacted viewers see the same cluster — affirming identities /
+     languages / niches are non-identifying. Display-label dicts
+     (`AFFIRMING_IDENTITY_LABELS`, `LANGUAGE_LABELS`) are Jinja
+     globals; `clinical_niches` is free-form and renders verbatim. #}
+  {%- if view.affirming_identities or view.languages or view.clinical_niches %}
+    {% call facts_block() %}
+      {%- if view.affirming_identities %}
+        {%- set _ai_labels = [] -%}
+        {%- for a in view.affirming_identities -%}{%- set _ = _ai_labels.append(AFFIRMING_IDENTITY_LABELS[a]) -%}{%- endfor -%}
+          {{ fact('affirming_identities', 'Affirming identities', _ai_labels | join(", ") , icon='heart') }}
+        {%- endif %}
+        {%- if view.languages %}
+          {%- set _lang_labels = [] -%}
+          {%- for lg in view.languages -%}{%- set _ = _lang_labels.append(LANGUAGE_LABELS[lg]) -%}{%- endfor -%}
+            {{ fact('languages', 'Languages', _lang_labels | join(", ") , icon='message-circle') }}
+          {%- endif %}
+          {%- if view.clinical_niches %}
+            {{ fact('clinical_niches', 'Clinical niches', view.clinical_niches | join(", ") , icon='tag') }}
+          {%- endif %}
+        {% endcall %}
+      {%- endif %}
+      {{ picker([
+            {"href": entity_url('clinician', id=clinician.id) ~ "/clinician_affiliations",
+      "heading": "Practices",
+      "description": "Where this clinician sees clients — location, availability, in-network insurance, and rates."},
+      {"href": entity_url('clinician', id=clinician.id) ~ "/licensures",
+      "heading": "Licensures",
+      "description": "Professional licenses on file with their issuing states."},
+      {"href": entity_url('clinician', id=clinician.id) ~ "/educations",
+      "heading": "Education",
+      "description": "Degrees, programs, and where they were completed."},
+      {"href": entity_url('clinician', id=clinician.id) ~ "/certifications",
+      "heading": "Certifications",
+      "description": "Specialized credentials and their certifying bodies."},
+      ]) }}
+    {% endblock %}

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -1,7 +1,7 @@
 {% extends "views/form_edit.html" %}
-{%- from "_shared/form_fields.html" import form_section, text_field -%}
+{%- from "_shared/form_fields.html" import form_section, multi_select_field, text_field -%}
 {%- from "_shared/forms.html" import entity_form -%}
-{%- from "_shared/form_copy.html" import npi_help -%}
+{%- from "_shared/form_copy.html" import npi_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
 {% block resource_label %}Clinicians{% endblock %}
 {# H1-fallback: name when set, else primary affiliation's org name when
@@ -35,6 +35,63 @@
       {{ text_field("last_name", "Last name", current=clinician.last_name, maxlength=120) }}
       {{ text_field("npi", "NPI", current=clinician.npi, pattern="\\d{10}", maxlength=10, help=npi_help() ) }}
     {% endcall %}
+    {# Person-level matching-dimension fields (#1358 PR-a/c). Symmetric
+       to the referral request side (`ReferralDetail.affirming_identities`
+       / `clinical_niches` — see `posts/_form_referral.html`). Both
+       move with the person across affiliations, the same way
+       credentials do. `languages` (#1358 PR-f) is on the model and
+       displayed on the detail page, but is intentionally NOT in this
+       form yet — `ClinicianUpdate` does not currently accept
+       `languages`; adding it requires a schema patch tracked outside
+       this PR. #}
+    {% call form_section("Affirming identities & niches") %}
+      {{ multi_select_field("affirming_identities", "Affirming identities", AFFIRMING_IDENTITIES, labels=AFFIRMING_IDENTITY_LABELS, current=clinician.affirming_identities, required=false, help=select_all_help() ) }}
+      {# Clinical-niche tags (#1358 PR-c). Free-form `list[str]` on the
+         wire — the niche vocabulary is too open-ended to commit to a
+         closed enum on day one. UI is a single comma-separated text
+         input that a tiny inline script (below) splits into multiple
+         hidden `clinical_niches` inputs on submit, so the server still
+         receives the wire shape Pydantic expects (repeated
+         `clinical_niches=tag` pairs the `clean_free_form_tags`
+         validator accepts). Mirrors the pattern PR #1403 introduced on
+         the Referral form. #}
+      {{ text_field("_clinical_niches_input", "Clinical niches", current=((clinician.clinical_niches | join(", ") ) if clinician.clinical_niches else None), required=false, help="Comma-separated free-form tags (e.g. \"DGBI, ADHD in women, complex trauma\").") }}
+      <div id="clinical-niches-hidden" hidden></div>
+    {% endcall %}
     {{ actions("Save changes", cancel_url=entity_url('clinician', id=clinician.id) ) }}
   {% endcall %}
+  <script>
+  /* Clinical-niche tag splitter (#1358 PR-c). The visible input is a
+     single comma-separated text field; on form submit (capture phase
+     so htmx's submit handler sees the synthesized hidden inputs) we
+     split on comma, strip, drop empties, dedupe, and inject one
+     hidden input per tag with name="clinical_niches" — the wire
+     shape the `clean_free_form_tags` validator expects. The raw
+     input is then disabled so it doesn't also POST a stale comma-
+     joined value under its `_clinical_niches_input` name. Empty
+     input is fine — zero hidden inputs, which the schema reads as
+     "leave unchanged" via the `None` default on `ClinicianUpdate`. */
+  (function () {
+    var raw = document.querySelector('input[name="_clinical_niches_input"]');
+    var hidden = document.getElementById('clinical-niches-hidden');
+    if (!raw || !hidden) return;
+    var form = raw.closest('form');
+    if (!form) return;
+    form.addEventListener('submit', function () {
+      hidden.innerHTML = '';
+      var seen = {};
+      (raw.value || '').split(',').forEach(function (part) {
+        var tag = part.trim();
+        if (!tag || seen[tag]) return;
+        seen[tag] = true;
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'clinical_niches';
+        input.value = tag;
+        hidden.appendChild(input);
+      });
+      raw.disabled = true;
+    }, true);
+  })();
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Mirrors PR #1403's referral-side pattern on the Clinician profile, surfacing the person-level matching-dimension fields the schema-reconciliation work added in #1358.

- `form_edit.html` gains `affirming_identities` (multi-checkbox) and `clinical_niches` (free-form comma-separated tag input with the same splitter script as the referral form).
- `detail.html` renders an identity-cluster facts block (affirming identities, languages, clinical niches) above the sub-resource picker. Each row is `{% if view.x %}`-guarded.
- `clinician_card_view` surfaces all three lists for the template to iterate uniformly.
- `languages` is read-only on the detail page — the column exists on `Clinician` (default `["en"]`) but `ClinicianUpdate` does not currently expose it, so the edit form intentionally omits the field. Schema extension tracked separately.

## Test plan

- [x] `dev test --skip-lint` (2613 pass, 101 skipped)
- [x] New unit tests in `test_view.py` cover empty-default + round-trip surfacing on `clinician_card_view`
- [x] New route tests in `test_clinicians.py` cover edit-form render, prefill, PATCH round-trip with repeated-key wire shape, and detail-page row suppression
- [x] black / isort / djlint pass on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)