### PR TITLE
Extend parent wire schemas with steady-state fields (#1358)

### DIFF
--- a/src/domain/logic/clinician_affiliations/schema.py
+++ b/src/domain/logic/clinician_affiliations/schema.py
@@ -29,9 +29,15 @@ from src.domain.logic.value_objects.location import (
     LocationPartial,
 )
 from src.domain.models.enums import (
+    CLIENT_AGE_GROUPS,
+    GENDERS,
     INSURANCE_CARRIERS,
     LOCATION_AVAILABILITY_OPTIONS,
+    REFERRAL_SERVICES,
+    TREATMENT_MODALITIES,
+    TREATMENT_SETTINGS,
 )
+from src.framework.rendering.form_fields import HtmlTextarea, HtmlUrl
 from src.framework.schema_validators import (
     PartialUpdate,
     ReadProjection,
@@ -43,6 +49,29 @@ from src.framework.schema_validators import (
 InNetworkCarriersField = Annotated[
     list[Literal[*INSURANCE_CARRIERS]], BeforeValidator(scalar_to_list)
 ]
+
+# Steady-state-profile multi-select aliases (#1358 PR-f). Same shape as
+# the aliases in `programs/schema.py`: a `Literal[*TUPLE]` layered over
+# the shared `scalar_to_list` coercion so a 1-checkbox-checked form post
+# still validates. `languages` is deliberately NOT here — it's
+# person-level on `Clinician`, not per-affiliation (see the model
+# docstring on `ClinicianAffiliation`).
+_ServicesField = Annotated[
+    list[Literal[*REFERRAL_SERVICES]], BeforeValidator(scalar_to_list)
+]
+_SettingsField = Annotated[
+    list[Literal[*TREATMENT_SETTINGS]], BeforeValidator(scalar_to_list)
+]
+_ModalitiesField = Annotated[
+    list[Literal[*TREATMENT_MODALITIES]], BeforeValidator(scalar_to_list)
+]
+_AgeGroupsField = Annotated[
+    list[Literal[*CLIENT_AGE_GROUPS]], BeforeValidator(scalar_to_list)
+]
+_GendersField = Annotated[list[Literal[*GENDERS]], BeforeValidator(scalar_to_list)]
+# Free-text fields, same idiom as `programs/schema.py`.
+_WebsiteField = Annotated[StrippedOptionalText, HtmlUrl()]
+_ReferralInstructionsField = Annotated[StrippedOptionalText, HtmlTextarea()]
 
 
 class ClinicianAffiliationRead(FlatLocationSchema, ReadProjection):
@@ -76,6 +105,20 @@ class ClinicianAffiliationRead(FlatLocationSchema, ReadProjection):
     in_network_carriers: list[str] = []
     sliding_scale: bool
     cost: str | None = None
+    # Steady-state practice profile (#1358 PR-f). Empty list = "no
+    # value provided"; mirrors how the program schemas default these.
+    services: _ServicesField = []
+    settings: _SettingsField = []
+    modalities: _ModalitiesField = []
+    age_groups: _AgeGroupsField = []
+    genders: _GendersField = []
+    website: str | None = None
+    referral_instructions: str | None = None
+    # Denormalized "accepting new patients" cache (#1358 PR-f). The
+    # OpeningDetail lifecycle handlers toggle this; the wire surface
+    # exposes it as a Read field so directory list/filter UI can show
+    # one column without joining.
+    currently_accepting_new_patients: bool = False
 
 
 class ClinicianAffiliationCreate(FlatLocationSchema, WirePayload):
@@ -100,6 +143,17 @@ class ClinicianAffiliationCreate(FlatLocationSchema, WirePayload):
     in_network_carriers: InNetworkCarriersField = []
     sliding_scale: bool = False
     cost: StrippedOptionalText = None
+    # Steady-state practice profile (#1358 PR-f). Empty list = "no
+    # value provided"; mirrors `ProgramCreate`. `currently_accepting_new_patients`
+    # is server-managed (toggled by OpeningDetail lifecycle handlers)
+    # and intentionally not on Create.
+    services: _ServicesField = []
+    settings: _SettingsField = []
+    modalities: _ModalitiesField = []
+    age_groups: _AgeGroupsField = []
+    genders: _GendersField = []
+    website: _WebsiteField = None
+    referral_instructions: _ReferralInstructionsField = None
 
 
 class ClinicianAffiliationUpdate(FlatLocationSchema, PartialUpdate):
@@ -113,3 +167,15 @@ class ClinicianAffiliationUpdate(FlatLocationSchema, PartialUpdate):
     in_network_carriers: InNetworkCarriersField | None = None
     sliding_scale: bool | None = None
     cost: StrippedOptionalText = None
+    # Steady-state practice profile (#1358 PR-f). List-valued PATCH
+    # replaces the whole list; `None` = leave unchanged; `[]` = clear.
+    # `currently_accepting_new_patients` is denormalized cache state,
+    # mutated server-side by OpeningDetail lifecycle handlers — not on
+    # the PATCH surface.
+    services: _ServicesField | None = None
+    settings: _SettingsField | None = None
+    modalities: _ModalitiesField | None = None
+    age_groups: _AgeGroupsField | None = None
+    genders: _GendersField | None = None
+    website: _WebsiteField = None
+    referral_instructions: _ReferralInstructionsField = None

--- a/src/domain/logic/clinician_affiliations/test_schema.py
+++ b/src/domain/logic/clinician_affiliations/test_schema.py
@@ -113,6 +113,169 @@ def test_update_is_partial():
     assert dumped == {"sliding_scale": True}
 
 
+# --- Steady-state profile (#1358 PR-f, parent-schema extension) --------
+
+
+def test_create_defaults_steady_state_profile_to_empty():
+    """Multi-selects default to `[]`; free-text fields to `None`.
+    Mirrors `ProgramCreate`."""
+    payload = ClinicianAffiliationCreate()
+    assert payload.services == []
+    assert payload.settings == []
+    assert payload.modalities == []
+    assert payload.age_groups == []
+    assert payload.genders == []
+    assert payload.website is None
+    assert payload.referral_instructions is None
+
+
+def test_create_accepts_steady_state_profile():
+    payload = ClinicianAffiliationCreate(
+        services=["psychotherapy", "medication_management"],
+        settings=["outpatient"],
+        modalities=["dbt", "emdr"],
+        age_groups=["adults_25_64"],
+        genders=["female"],
+        website="https://example.com",
+        referral_instructions="Email intake@example.com.",
+    )
+    assert payload.services == ["psychotherapy", "medication_management"]
+    assert payload.settings == ["outpatient"]
+    assert payload.modalities == ["dbt", "emdr"]
+    assert payload.age_groups == ["adults_25_64"]
+    assert payload.genders == ["female"]
+    assert payload.website == "https://example.com"
+    assert payload.referral_instructions == "Email intake@example.com."
+
+
+def test_create_normalizes_scalar_service_to_list():
+    payload = ClinicianAffiliationCreate(services="psychotherapy")
+    assert payload.services == ["psychotherapy"]
+
+
+def test_create_rejects_unknown_service():
+    with pytest.raises(ValidationError):
+        ClinicianAffiliationCreate(services=["not_a_service"])
+
+
+def test_create_strips_blank_website_to_none():
+    payload = ClinicianAffiliationCreate(website="   ")
+    assert payload.website is None
+
+
+def test_create_rejects_currently_accepting_new_patients_on_create():
+    """`currently_accepting_new_patients` is a server-managed cache
+    (toggled by OpeningDetail lifecycle handlers) and intentionally not
+    on the Create surface."""
+    with pytest.raises(ValidationError, match="extra"):
+        ClinicianAffiliationCreate(currently_accepting_new_patients=True)
+
+
+def test_create_rejects_languages():
+    """`languages` is person-level (lives on `Clinician`), not
+    per-affiliation — model contract; the wire must reject it here."""
+    with pytest.raises(ValidationError, match="extra"):
+        ClinicianAffiliationCreate(languages=["en"])
+
+
+def test_update_accepts_steady_state_field():
+    payload = ClinicianAffiliationUpdate(services=["psychotherapy"])
+    assert payload.services == ["psychotherapy"]
+
+
+def test_update_accepts_empty_list_to_clear():
+    """List-valued PATCH replaces the whole list; `[]` clears."""
+    payload = ClinicianAffiliationUpdate(services=[])
+    assert payload.services == []
+
+
+def test_update_rejects_unknown_modality():
+    with pytest.raises(ValidationError):
+        ClinicianAffiliationUpdate(modalities=["not_a_modality"])
+
+
+def test_update_rejects_currently_accepting_new_patients():
+    """Same server-managed-cache rationale as Create."""
+    with pytest.raises(ValidationError, match="extra"):
+        ClinicianAffiliationUpdate(currently_accepting_new_patients=True)
+
+
+def test_read_defaults_steady_state_profile_to_empty():
+    """A row with no explicit steady-state values reads as `[]`/`None`,
+    matching the columns' server-side defaults. The `bool` field
+    `currently_accepting_new_patients` defaults to `False`."""
+
+    class _Fake:
+        id = uuid.uuid4()
+        clinician_id = uuid.uuid4()
+        org_id = None
+        created_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        updated_at = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        location_city = None
+        location_state = None
+        location_zip = None
+        in_person_sessions = None
+        virtual_sessions = None
+        accepts_out_of_network = True
+        in_network_carriers = []
+        sliding_scale = False
+        cost = None
+        services = []
+        settings = []
+        modalities = []
+        age_groups = []
+        genders = []
+        website = None
+        referral_instructions = None
+        currently_accepting_new_patients = False
+
+    read = ClinicianAffiliationRead.model_validate(_Fake(), from_attributes=True)
+    assert read.services == []
+    assert read.settings == []
+    assert read.modalities == []
+    assert read.age_groups == []
+    assert read.genders == []
+    assert read.website is None
+    assert read.referral_instructions is None
+    assert read.currently_accepting_new_patients is False
+
+
+def test_read_round_trips_steady_state_profile():
+    class _Fake:
+        id = uuid.uuid4()
+        clinician_id = uuid.uuid4()
+        org_id = uuid.uuid4()
+        created_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        updated_at = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        location_city = None
+        location_state = None
+        location_zip = None
+        in_person_sessions = None
+        virtual_sessions = None
+        accepts_out_of_network = True
+        in_network_carriers = []
+        sliding_scale = False
+        cost = None
+        services = ["psychotherapy"]
+        settings = ["outpatient"]
+        modalities = ["dbt"]
+        age_groups = ["adults_25_64"]
+        genders = ["female"]
+        website = "https://example.com"
+        referral_instructions = "Email intake@example.com."
+        currently_accepting_new_patients = True
+
+    read = ClinicianAffiliationRead.model_validate(_Fake(), from_attributes=True)
+    assert read.services == ["psychotherapy"]
+    assert read.settings == ["outpatient"]
+    assert read.modalities == ["dbt"]
+    assert read.age_groups == ["adults_25_64"]
+    assert read.genders == ["female"]
+    assert read.website == "https://example.com"
+    assert read.referral_instructions == "Email intake@example.com."
+    assert read.currently_accepting_new_patients is True
+
+
 def test_read_roundtrips_from_attribute_object():
     """`ClinicianAffiliationRead` reads through Pydantic's `from_attributes`
     path — it has to handle a flat ORM-style object (city/state/zip

--- a/src/domain/logic/clinicians/schema.py
+++ b/src/domain/logic/clinicians/schema.py
@@ -51,6 +51,7 @@ from src.domain.models.enums import (
     AFFIRMING_IDENTITIES,
     CERTIFICATION_TYPES,
     EDUCATION_TYPES,
+    LANGUAGES,
     LICENSE_TYPES,
     US_STATES,
 )
@@ -80,6 +81,15 @@ AffirmingIdentitiesField = Annotated[
 # used tags later. `clean_free_form_tags` strips, drops empties, and
 # deduplicates.
 ClinicalNichesField = Annotated[list[str], BeforeValidator(clean_free_form_tags)]
+
+# Languages spoken — person-level (#1358 PR-f). Multi-checkbox shape
+# matches `affirming_identities` above: scalar-to-list coercion lets a
+# 1-checkbox form post validate, and the per-member `Literal[*LANGUAGES]`
+# check stays in lockstep with the `LANGUAGES` tuple. Defined here (not
+# in `posts/schema.py`) because that module's alias is internal to the
+# post wire surface; clinicians own this typed alias for their own
+# person-level use.
+LanguagesField = Annotated[list[Literal[*LANGUAGES]], BeforeValidator(scalar_to_list)]
 
 _NPI_RE = re.compile(r"^[0-9]{10}$")
 
@@ -258,6 +268,10 @@ class ClinicianRead(FlatLocationSchema, ReadProjection):
     # niches stated. See `ClinicalNichesField` for the simplicity
     # rationale (tagged free-text now; promote to enum later).
     clinical_niches: ClinicalNichesField = []
+    # Languages spoken (#1358 PR-f). Person-level: invariant across
+    # affiliations. Defaults to `["en"]` matching the column's
+    # server-side default and the prior `OpeningDetail` default.
+    languages: LanguagesField = ["en"]
     licensures: list[ClinicianLicensureRead] = []
     educations: list[ClinicianEducationRead] = []
     certifications: list[ClinicianCertificationRead] = []
@@ -306,6 +320,11 @@ class ClinicianUpdate(PartialUpdate):
     # Same partial-update semantics as `affirming_identities` above:
     # `None` = leave unchanged, `[]` = clear all tags, list = replace.
     clinical_niches: ClinicalNichesField | None = None
+    # Same partial-update semantics: `None` = leave unchanged,
+    # `[]` = clear (no languages stated), list = replace. List-valued
+    # PATCH replaces the whole list — partial add/remove is out of
+    # scope. (#1358 PR-f)
+    languages: LanguagesField | None = None
 
 
 # --- Admin verification-state axis ---------------------------------------

--- a/src/domain/logic/clinicians/test_schema.py
+++ b/src/domain/logic/clinicians/test_schema.py
@@ -472,6 +472,81 @@ def test_clinician_read_round_trips_clinical_niches():
     assert p.clinical_niches == ["DGBI", "ADHD in women"]
 
 
+# --- Languages (person-level, #1358 PR-f) -------------------------------
+
+
+def test_clinician_update_accepts_languages_patch():
+    """`languages` is a multi-checkbox `Literal[*LANGUAGES]` field on the
+    person-level Update — clinicians declare which languages they can
+    deliver care in. Empty list and a populated list both validate;
+    `None` (omitted) means "leave unchanged" per `PartialUpdate`
+    semantics."""
+    upd = ClinicianUpdate(languages=["en", "es"])
+    assert upd.languages == ["en", "es"]
+
+
+def test_clinician_update_accepts_empty_languages():
+    """Explicit empty list = clear the language list. Distinct from
+    `None` (omitted = leave unchanged)."""
+    upd = ClinicianUpdate(languages=[])
+    assert upd.languages == []
+
+
+def test_clinician_update_coerces_scalar_language_to_list():
+    """HTML form checkboxes with a single checked value submit as a
+    scalar string — `scalar_to_list` normalizes to `["value"]` before
+    `Literal[*LANGUAGES]` validation."""
+    upd = ClinicianUpdate(languages="en")
+    assert upd.languages == ["en"]
+
+
+def test_clinician_update_rejects_unknown_language():
+    with pytest.raises(ValidationError):
+        ClinicianUpdate(languages=["not_a_real_language"])
+
+
+def test_clinician_create_rejects_languages_on_create():
+    """Create stays minimal — languages, like affirming_identities, is
+    claim-management set later via PATCH."""
+    with pytest.raises(ValidationError, match="extra"):
+        ClinicianCreate(**_VALID_CREATE, languages=["en"])
+
+
+def test_clinician_read_defaults_languages_to_english():
+    """A row with no explicit languages reads as `["en"]`, matching the
+    column's server-side default."""
+    now = _now()
+    p = ClinicianRead.model_validate(
+        {
+            "id": uuid.uuid4(),
+            "owner_id": uuid.uuid4(),
+            "created_at": now,
+            "updated_at": now,
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "npi": "1234567890",
+        }
+    )
+    assert p.languages == ["en"]
+
+
+def test_clinician_read_round_trips_languages():
+    now = _now()
+    p = ClinicianRead.model_validate(
+        {
+            "id": uuid.uuid4(),
+            "owner_id": uuid.uuid4(),
+            "created_at": now,
+            "updated_at": now,
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "npi": "1234567890",
+            "languages": ["en", "es"],
+        }
+    )
+    assert p.languages == ["en", "es"]
+
+
 # --- Insurance carrier label guardrail ----------------------------------
 
 

--- a/src/domain/logic/programs/schema.py
+++ b/src/domain/logic/programs/schema.py
@@ -35,6 +35,7 @@ from pydantic import BeforeValidator
 from src.domain.models.enums import (
     CLIENT_AGE_GROUPS,
     GENDERS,
+    LANGUAGES,
     REFERRAL_SERVICES,
     TREATMENT_MODALITIES,
     TREATMENT_SETTINGS,
@@ -67,6 +68,7 @@ _AgeGroupsField = Annotated[
     list[Literal[*CLIENT_AGE_GROUPS]], BeforeValidator(scalar_to_list)
 ]
 _GendersField = Annotated[list[Literal[*GENDERS]], BeforeValidator(scalar_to_list)]
+_LanguagesField = Annotated[list[Literal[*LANGUAGES]], BeforeValidator(scalar_to_list)]
 # Free-text fields. `website` is rendered as `<input type=url>` (the
 # `HtmlUrl` marker drives `field_for`). `referral_instructions` renders
 # as `<textarea>`. Both stripped-to-None on blank input.
@@ -97,6 +99,11 @@ class ProgramRead(ReadProjection):
     modalities: _ModalitiesField = []
     age_groups: _AgeGroupsField = []
     genders: _GendersField = []
+    # Defaults to `["en"]` matching the column's server-side default
+    # and the prior `OpeningDetail` default. `languages` lives on
+    # Program (and on Clinician) because a program may operate in a
+    # different language set than any individual clinician staffing it.
+    languages: _LanguagesField = ["en"]
     website: str | None = None
     referral_instructions: str | None = None
 
@@ -126,6 +133,10 @@ class ProgramCreate(WirePayload):
     modalities: _ModalitiesField = []
     age_groups: _AgeGroupsField = []
     genders: _GendersField = []
+    # Defaults to `["en"]` matching the column's server-side default.
+    # Create accepts an explicit list so a brand-new program records
+    # its language set on day one.
+    languages: _LanguagesField = ["en"]
     website: _WebsiteField = None
     referral_instructions: _ReferralInstructionsField = None
 
@@ -151,5 +162,8 @@ class ProgramUpdate(PartialUpdate):
     modalities: _ModalitiesField | None = None
     age_groups: _AgeGroupsField | None = None
     genders: _GendersField | None = None
+    # List-valued PATCH replaces the whole list. `None` = leave
+    # unchanged. `[]` = clear (no languages stated).
+    languages: _LanguagesField | None = None
     website: _WebsiteField = None
     referral_instructions: _ReferralInstructionsField = None

--- a/src/domain/logic/programs/test_schema.py
+++ b/src/domain/logic/programs/test_schema.py
@@ -169,3 +169,66 @@ def test_update_accepts_empty_list_to_clear():
 def test_update_rejects_unknown_modality():
     with pytest.raises(ValidationError):
         ProgramUpdate(modalities=["not_a_modality"])
+
+
+# --- Languages (#1358 PR-f, parent-schema extension) --------------------
+
+
+def test_create_defaults_languages_to_english():
+    """`languages` defaults to `["en"]`, matching the column's
+    server-side default and the prior `OpeningDetail` default."""
+    payload = ProgramCreate(**_create_kwargs())
+    assert payload.languages == ["en"]
+
+
+def test_create_accepts_explicit_languages():
+    payload = ProgramCreate(**_create_kwargs(languages=["en", "es"]))
+    assert payload.languages == ["en", "es"]
+
+
+def test_create_normalizes_scalar_language_to_list():
+    payload = ProgramCreate(**_create_kwargs(languages="es"))
+    assert payload.languages == ["es"]
+
+
+def test_create_rejects_unknown_language():
+    with pytest.raises(ValidationError):
+        ProgramCreate(**_create_kwargs(languages=["not_a_real_language"]))
+
+
+def test_update_accepts_languages_patch():
+    payload = ProgramUpdate(languages=["en", "es"])
+    assert payload.languages == ["en", "es"]
+
+
+def test_update_accepts_empty_languages_to_clear():
+    """`[]` clears the language list; `None` (omitted) leaves unchanged."""
+    payload = ProgramUpdate(languages=[])
+    assert payload.languages == []
+
+
+def test_update_rejects_unknown_language():
+    with pytest.raises(ValidationError):
+        ProgramUpdate(languages=["not_a_real_language"])
+
+
+def test_read_defaults_languages_to_english():
+    """A Program row with no explicit `languages` reads as `["en"]`."""
+    from datetime import datetime, timezone
+
+    from src.domain.logic.programs.schema import ProgramRead
+
+    now = datetime.now(timezone.utc)
+    p = ProgramRead.model_validate(
+        {
+            "id": uuid.uuid4(),
+            "owner_id": uuid.uuid4(),
+            "org_id": uuid.uuid4(),
+            "org_name": "Sunrise",
+            "name": "RISE IOP",
+            "accepting_referrals": True,
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
+    assert p.languages == ["en"]

--- a/src/domain/models/clinician_affiliations/README.md
+++ b/src/domain/models/clinician_affiliations/README.md
@@ -29,11 +29,11 @@ The PR-f refactor shipped in three sub-PRs:
 
 `languages` is *not* in this set on the affiliation — it moves to `Clinician` (a person attribute, invariant across affiliations). See [`../clinicians/README.md`](../clinicians/README.md).
 
-`currently_accepting_new_patients` is a denormalized cache toggled by the `OpeningDetail` lifecycle. Distinct from the analogous flag on `Program.accepting_referrals` which is an operator-set standing posture.
+`currently_accepting_new_patients` is a denormalized cache toggled by the `OpeningDetail` lifecycle. Distinct from the analogous flag on `Program.accepting_referrals` which is an operator-set standing posture. The wire surface (`src/domain/logic/clinician_affiliations/schema.py`) exposes the steady-state profile fields on `ClinicianAffiliationCreate` / `ClinicianAffiliationUpdate` / `ClinicianAffiliationRead`; `currently_accepting_new_patients` is `Read`-only — server-managed, never accepted on the wire.
 
 ## Write path: how a clinician edit lands on ClinicianAffiliation
 
-After #1308, practice posture is patched **directly on the affiliation**, not through the clinician's PATCH form: `ClinicianUpdate` accepts only `first_name` / `last_name` / `npi`, and the affiliation owns everything else. The clinician edit page surfaces affiliations as inline rows for create / delete; an inline-edit affordance is the next step.
+After #1308, practice posture is patched **directly on the affiliation**, not through the clinician's PATCH form: `ClinicianUpdate` is **person-level only** (identity + person-level claims like `affirming_identities`, `clinical_niches`, `languages`), and the affiliation owns the per-(clinician × org) practice posture. The clinician edit page surfaces affiliations as inline rows for create / delete; an inline-edit affordance is the next step.
 
 - **Create clinician**: the framework's generic create handler calls `Clinician(**payload.model_dump())`. If per-role kwargs are supplied (older code paths / tests), they are forwarded into a new `ClinicianAffiliation` appended onto `clinician.clinician_affiliations`; otherwise the verification handler creates a stub with all per-role columns NULL/default. `cascade="all, delete-orphan"` flushes both rows together.
 - **Patch a ClinicianAffiliation's posture**: `PATCH /clinicians/{id}/clinician_affiliations/{aff_id}` with the per-role fields. Mounted via the framework's generic sub-resource update handler against `ClinicianAffiliationUpdate`. This is the canonical write path for posture after #1308.


### PR DESCRIPTION
## Summary

Closes the gap PR-f sub-1 (#1380) left: model columns were added on `Clinician`, `Program`, and `ClinicianAffiliation`, but the Pydantic `Create`/`Update`/`Read` schemas never grew matching fields. Prior UI PRs (#1405, #1407) had to ship partial because the wire wouldn't accept the new fields.

- `ClinicianRead` / `ClinicianUpdate` gain `languages` (new `LanguagesField` alias alongside the existing person-level typed aliases).
- `ProgramCreate` / `ProgramUpdate` / `ProgramRead` gain `languages`.
- `ClinicianAffiliationCreate` / `ClinicianAffiliationUpdate` / `ClinicianAffiliationRead` gain the steady-state profile (`services` / `settings` / `modalities` / `age_groups` / `genders` / `website` / `referral_instructions`); Read additionally surfaces the server-managed cache `currently_accepting_new_patients`. `languages` is intentionally NOT on the affiliation — it's person-level on `Clinician` per the model contract.

Purely additive; no migration needed because columns already exist (#1380).

## Test plan

- [x] Added colocated round-trip + Literal-vocabulary tests for each new field.
- [x] `dev test` — 2675 passed.
- [x] `dev test contract` — 39 passed.
- [x] `dev lint` — passed.
- [x] Affiliation model README updated: `ClinicianUpdate` is "person-level only (identity + person-level claims)", not strictly `first_name`/`last_name`/`npi`.