### PR TITLE
Carry proper UI nouns for clinician sub-resources on EntitySpec

### DIFF
--- a/src/domain/specs/_credential.py
+++ b/src/domain/specs/_credential.py
@@ -44,6 +44,7 @@ CANONICAL_CREDENTIAL_ROUTES: RouteSet = RouteSet(
 def make_clinician_credential_entity(
     *,
     name: str,
+    singular_label: str,
     url_collection: str,
     id_param: str,
     model: type,
@@ -91,6 +92,12 @@ def make_clinician_credential_entity(
 
     return EntitySpec(
         name=name,
+        # The user-visible noun for chrome labels (form-page H1, list
+        # toolbar CTA, etc.). The spec `name` is the URL-identifier
+        # ("clinician_licensure") and would surface in the UI as the
+        # bare snake-case literal without this override. See
+        # `src/framework/rendering/labels.py`.
+        singular_label=singular_label,
         url_collection=url_collection,
         id_param=id_param,
         model=model,

--- a/src/domain/specs/clinician_affiliation.py
+++ b/src/domain/specs/clinician_affiliation.py
@@ -44,6 +44,12 @@ from src.framework.dispatch.entity_spec import (
 
 CLINICIAN_AFFILIATION_ENTITY: Final[EntitySpec] = EntitySpec(
     name="clinician_affiliation",
+    # The DB model + URL slug call them affiliations because that's
+    # what the (clinician × org) join is; the UI calls them "practices"
+    # because that's what they are to the user. The `singular_label`
+    # carries the UI noun so chrome labels read "Create practice" /
+    # "Edit practice" instead of "Edit clinician_affiliation".
+    singular_label="practice",
     url_collection="clinician_affiliations",
     id_param="clinician_affiliation_id",
     model=ClinicianAffiliation,

--- a/src/domain/specs/clinician_certification.py
+++ b/src/domain/specs/clinician_certification.py
@@ -26,6 +26,7 @@ from src.framework.dispatch.entity_spec import EntitySpec
 
 CERTIFICATION_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
     name="clinician_certification",
+    singular_label="certification",
     url_collection="certifications",
     id_param="certification_id",
     model=ClinicianCertification,

--- a/src/domain/specs/clinician_education.py
+++ b/src/domain/specs/clinician_education.py
@@ -24,6 +24,7 @@ from src.framework.dispatch.entity_spec import EntitySpec
 
 EDUCATION_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
     name="clinician_education",
+    singular_label="education",
     url_collection="educations",
     id_param="education_id",
     model=ClinicianEducation,

--- a/src/domain/specs/clinician_licensure.py
+++ b/src/domain/specs/clinician_licensure.py
@@ -57,6 +57,7 @@ def _attestation_response_to_dict(licensure: ClinicianLicensure) -> dict:
 
 LICENSURE_ENTITY: Final[EntitySpec] = make_clinician_credential_entity(
     name="clinician_licensure",
+    singular_label="licensure",
     url_collection="licensures",
     id_param="licensure_id",
     model=ClinicianLicensure,

--- a/src/domain/templates/certifications/form_new.html
+++ b/src/domain/templates/certifications/form_new.html
@@ -5,6 +5,6 @@
 {% block form_content %}
   {{ certification_form(resource_url,
     "post",
-    "Create certification",
-    cancel_url=resource_url) }}
+    entity_create_label('clinician_certification') ,
+  cancel_url=resource_url) }}
 {% endblock %}

--- a/src/domain/templates/certifications/list.html
+++ b/src/domain/templates/certifications/list.html
@@ -10,7 +10,7 @@
 {% block actions %}
   <li>
     <a href="{{ entity_url('clinician', id=clinician.id) }}/certifications/form"
-       role="button">Create certification</a>
+       role="button">{{ entity_create_label("clinician_certification") }}</a>
   </li>
 {% endblock %}
 {%- macro certification_card(cert) %}

--- a/src/domain/templates/clinician_affiliations/form_new.html
+++ b/src/domain/templates/clinician_affiliations/form_new.html
@@ -5,7 +5,7 @@
 {% block form_content %}
   {{ affiliation_form(resource_url,
     "post",
-    "Create practice",
-    cancel_url=resource_url,
-    orgs=orgs) }}
+    entity_create_label('clinician_affiliation') ,
+  cancel_url=resource_url,
+  orgs=orgs) }}
 {% endblock %}

--- a/src/domain/templates/clinician_affiliations/list.html
+++ b/src/domain/templates/clinician_affiliations/list.html
@@ -24,7 +24,7 @@
 {% block actions %}
   <li>
     <a href="{{ entity_url('clinician', id=clinician.id) }}/clinician_affiliations/form"
-       role="button">Create practice</a>
+       role="button">{{ entity_create_label("clinician_affiliation") }}</a>
   </li>
 {% endblock %}
 {%- macro affiliation_card(aff) %}

--- a/src/domain/templates/educations/form_new.html
+++ b/src/domain/templates/educations/form_new.html
@@ -5,6 +5,6 @@
 {% block form_content %}
   {{ education_form(resource_url,
     "post",
-    "Create education",
-    cancel_url=resource_url) }}
+    entity_create_label('clinician_education') ,
+  cancel_url=resource_url) }}
 {% endblock %}

--- a/src/domain/templates/educations/list.html
+++ b/src/domain/templates/educations/list.html
@@ -10,7 +10,7 @@
 {% block actions %}
   <li>
     <a href="{{ entity_url('clinician', id=clinician.id) }}/educations/form"
-       role="button">Create education</a>
+       role="button">{{ entity_create_label("clinician_education") }}</a>
   </li>
 {% endblock %}
 {%- macro education_card(edu) %}

--- a/src/domain/templates/licensures/form_new.html
+++ b/src/domain/templates/licensures/form_new.html
@@ -10,6 +10,6 @@
 {% block form_content %}
   {{ licensure_form(resource_url,
     "post",
-    "Create licensure",
-    cancel_url=resource_url) }}
+    entity_create_label('clinician_licensure') ,
+  cancel_url=resource_url) }}
 {% endblock %}

--- a/src/domain/templates/licensures/list.html
+++ b/src/domain/templates/licensures/list.html
@@ -20,7 +20,7 @@
 {% block actions %}
   <li>
     <a href="{{ entity_url('clinician', id=clinician.id) }}/licensures/form"
-       role="button">Create licensure</a>
+       role="button">{{ entity_create_label("clinician_licensure") }}</a>
   </li>
 {% endblock %}
 {%- macro licensure_card(lic) %}

--- a/src/framework/rendering/labels.py
+++ b/src/framework/rendering/labels.py
@@ -26,13 +26,27 @@ if TYPE_CHECKING:
 
 
 def _spec_by_name(name: str) -> "EntitySpec":
-    """Resolve an entity name to its registered spec. Duplicates the
-    helper in `route_urls.py` because importing across rendering helpers
-    would close a cycle; the helper is one-liner."""
+    """Resolve an entity name to its registered spec (or owned subentity
+    of a registered spec). Duplicates the helper in `route_urls.py`
+    because importing across rendering helpers would close a cycle; the
+    helper is one-liner.
+
+    Top-level entities live in `entity_registry` directly. Owned
+    subentities (e.g. `clinician_licensure`) self-register on their
+    parent's `_children` instead — those still need to resolve via this
+    helper so their list-page CTA / form-page H1 can read
+    `entity_create_label('clinician_licensure')` and produce
+    "Create licensure" via the subentity's own `singular_label`.
+    """
     for spec in entity_registry.specs():
         if spec.name == name:
             return spec
-    known = sorted(s.name for s in entity_registry.specs())
+        for child in spec.children:
+            if child.name == name:
+                return child
+    known = sorted(
+        s.name for spec in entity_registry.specs() for s in (spec, *spec.children)
+    )
     raise ValueError(
         f"Unknown entity name {name!r}. Known entities: {known}. "
         "Entity names are singular (e.g. 'organization', not 'organizations')."

--- a/src/framework/rendering/test_labels.py
+++ b/src/framework/rendering/test_labels.py
@@ -79,6 +79,24 @@ def test_filter_label_uses_url_collection():
     assert filter_label_for(CLINICIAN_ENTITY) == "Filter clinicians"
 
 
+def test_subentity_labels_use_singular_label_not_spec_name():
+    """Clinician sub-resource specs carry URL-identifier names
+    (`clinician_licensure`, `clinician_affiliation`) but the user-facing
+    noun is the bare word — pinned via `singular_label`. Without it,
+    every "Create X" / "Edit X" string in the four sub-resource pages
+    surfaces the snake-case identifier."""
+    assert entity_create_label("clinician_licensure") == "Create licensure"
+    assert entity_edit_label("clinician_licensure") == "Edit licensure"
+    assert entity_create_label("clinician_certification") == "Create certification"
+    assert entity_edit_label("clinician_certification") == "Edit certification"
+    assert entity_create_label("clinician_education") == "Create education"
+    assert entity_edit_label("clinician_education") == "Edit education"
+    # Affiliation diverges intentionally — DB model name is
+    # `clinician_affiliation` but the UI noun is "practice".
+    assert entity_create_label("clinician_affiliation") == "Create practice"
+    assert entity_edit_label("clinician_affiliation") == "Edit practice"
+
+
 # --- Registry-driven structural pins -----------------------------------
 
 


### PR DESCRIPTION
## Summary

- Edit-page H1s for the four clinician sub-resources read their text from `edit_label_for(spec)` → `"Edit " + spec.singular_label`. None of the four specs set `singular_label`, so the H1s rendered the URL identifier verbatim — "Edit clinician_licensure", "Edit clinician_education", "Edit clinician_certification", "Edit clinician_affiliation".
- Set `singular_label` on each spec:
  - `clinician_licensure` → `"licensure"`
  - `clinician_certification` → `"certification"`
  - `clinician_education` → `"education"`
  - `clinician_affiliation` → `"practice"` (DB model name diverges from the UI noun — the join row is an affiliation; the user sees a practice)
- Threaded `make_clinician_credential_entity` through the new parameter.
- Toolbar Create CTAs and form_new submit buttons now read through `entity_create_label('clinician_X')` so the H1 ↔ button equivalence holds the same way it does for every top-level resource — no more hardcoded "Create licensure".
- Taught `_spec_by_name` in `framework/rendering/labels.py` to walk `spec.children` so owned subentities resolve through the registry (top-level entities live directly; owned subentities self-register on their parent's `_children`).
- Pinned the four new noun assertions in `test_labels.py` so a regression surfaces as a unit-test failure.

## Test plan

- [x] `dev lint` clean
- [x] `dev test` — 2691 passed
- [x] New `test_subentity_labels_use_singular_label_not_spec_name` pins the noun mapping
- [x] `test_every_registry_spec_resolves_via_entity_edit_label` (existing structural pin) still passes — covers any future spec that lands without `singular_label`
- [ ] Spot-check the four `/clinicians/{id}/{collection}/{row_id}/form` pages in the running app (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)