### PR TITLE
Encode "Save changes" as the actions() form-layout default

### DIFF
--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -73,7 +73,7 @@ Fieldset-level "everything below is optional" lines (the previous `<small>Both l
 ### Buttons
 
 - **Verb-noun, sentence case.** `Create program`, `Post referral`, `Save changes`, `Send reset link`.
-- **Create / edit submit pattern.** Create forms use `entity_create_label(spec.name, kind=...)` so the submit button text matches the H1 (`Create Opening` everywhere). Edit forms use `Save changes` — every edit form, no exceptions. The structural pin lives in `entity_create_label` (see [`../../framework/templates/README.md` § "Create / filter labels"](../../framework/templates/README.md)).
+- **Create / edit submit pattern.** Create forms use `entity_create_label(spec.name, kind=...)` so the submit button text matches the H1 (`Create Opening` everywhere). Edit forms use `Save changes` — every edit form, no exceptions; this is the `actions(...)` macro's `wrapper="form"` default, so edit pages just omit `submit_label` and inherit it (pinned by `test_form_layout_submit_label_defaults_to_save_changes` in `../../framework/templates/_shared/test_actions.py`). The matching create-form structural pin lives in `entity_create_label` (see [`../../framework/templates/README.md` § "Create / filter labels"](../../framework/templates/README.md)).
 
 ### Vocabulary
 

--- a/src/domain/templates/certifications/_form_certification.html
+++ b/src/domain/templates/certifications/_form_certification.html
@@ -6,7 +6,7 @@
    edit forms structurally identical and prevents drift.
 
    Args:
-     action_url, method, submit_label, cancel_url, delete_url,
+     action_url, method, heading, cancel_url, delete_url,
      delete_confirm, current — same contract as
      `licensures/_form_licensure.html::licensure_form`. See that
      macro's docstring for the full surface.
@@ -14,10 +14,10 @@
 {%- from "_shared/form_fields.html" import text_field, select_field, form_section with context -%}
 {%- from "_shared/forms.html" import entity_form -%}
 {%- from "_shared/actions.html" import actions -%}
-{% macro certification_form(action_url, method, submit_label, cancel_url, delete_url=None, delete_confirm=None, current=None) -%}
+{% macro certification_form(action_url, method, heading, cancel_url, delete_url=None, delete_confirm=None, current=None) -%}
   <div class="entity-form-page">
     {% call entity_form(action_url, method=method) %}
-      {% call form_section(submit_label) %}
+      {% call form_section(heading) %}
         {{ select_field("certification_type", "Certification type", CERTIFICATION_TYPES,
                 labels=CERTIFICATION_TYPES_LABELS,
                 current=(current.certification_type if current else None) ,
@@ -29,7 +29,7 @@
                 current=(current.expiration_date if current else None) ,
         required=false, type="date") }}
       {% endcall %}
-      {{ actions(submit_label,
+      {{ actions(heading if method == "post" else none,
             cancel_url=cancel_url,
             delete_url=delete_url,
             delete_confirm=delete_confirm) }}

--- a/src/domain/templates/certifications/form_edit.html
+++ b/src/domain/templates/certifications/form_edit.html
@@ -8,7 +8,7 @@
 {% block form_content %}
   {{ certification_form(resource_detail_url,
     "patch",
-    "Save certification",
+    edit_heading,
     cancel_url=resource_url,
     delete_url=resource_detail_url,
     delete_confirm="Remove this certification?",

--- a/src/domain/templates/certifications/form_new.html
+++ b/src/domain/templates/certifications/form_new.html
@@ -5,6 +5,6 @@
 {% block form_content %}
   {{ certification_form(resource_url,
     "post",
-    entity_create_label('clinician_certification') ,
-  cancel_url=resource_url) }}
+    create_heading,
+    cancel_url=resource_url) }}
 {% endblock %}

--- a/src/domain/templates/clinician_affiliations/_form_affiliation.html
+++ b/src/domain/templates/clinician_affiliations/_form_affiliation.html
@@ -6,9 +6,12 @@
    in via a subsequent edit.
 
    Args:
-     action_url, method, submit_label, cancel_url, delete_url,
+     action_url, method, heading, cancel_url, delete_url,
      delete_confirm, current — same contract as
-     `licensures/_form_licensure.html::licensure_form`.
+     `licensures/_form_licensure.html::licensure_form`. The
+     affiliation form's per-section legends are static ("Practice",
+     "Services offered", etc.); `heading` here only feeds the create
+     submit button — edit inherits the framework default.
      orgs — list of organizations for the picker. Required (the
      handler injects it via context).
 #}
@@ -27,7 +30,7 @@
    cache toggled by the OpeningDetail lifecycle (see the schema docstring
    and `src/domain/models/clinician_affiliations/README.md#steady-state-profile-1358-pr-f`).
    `languages` is also NOT here — it's person-level on `Clinician`. #}
-{% macro affiliation_form(action_url, method, submit_label, cancel_url, orgs, delete_url=None, delete_confirm=None, current=None) -%}
+{% macro affiliation_form(action_url, method, heading, cancel_url, orgs, delete_url=None, delete_confirm=None, current=None) -%}
   <div class="entity-form-page">
     {% call entity_form(action_url, method=method) %}
       {% call form_section("Practice") %}
@@ -98,7 +101,7 @@
                 required=false,
                 current=(current.referral_instructions if current else None) ) }}
       {% endcall %}
-      {{ actions(submit_label,
+      {{ actions(heading if method == "post" else none,
             cancel_url=cancel_url,
             delete_url=delete_url,
             delete_confirm=delete_confirm) }}

--- a/src/domain/templates/clinician_affiliations/form_edit.html
+++ b/src/domain/templates/clinician_affiliations/form_edit.html
@@ -8,7 +8,7 @@
 {% block form_content %}
   {{ affiliation_form(resource_detail_url,
     "patch",
-    "Save practice",
+    edit_heading,
     cancel_url=resource_url,
     orgs=orgs,
     delete_url=resource_detail_url,

--- a/src/domain/templates/clinician_affiliations/form_new.html
+++ b/src/domain/templates/clinician_affiliations/form_new.html
@@ -5,7 +5,7 @@
 {% block form_content %}
   {{ affiliation_form(resource_url,
     "post",
-    entity_create_label('clinician_affiliation') ,
-  cancel_url=resource_url,
-  orgs=orgs) }}
+    create_heading,
+    cancel_url=resource_url,
+    orgs=orgs) }}
 {% endblock %}

--- a/src/domain/templates/clinicians/form_edit.html
+++ b/src/domain/templates/clinicians/form_edit.html
@@ -58,7 +58,7 @@
       {{ text_field("_clinical_niches_input", "Clinical niches", current=((clinician.clinical_niches | join(", ") ) if clinician.clinical_niches else None), required=false, help="Comma-separated free-form tags (e.g. \"DGBI, ADHD in women, complex trauma\").") }}
       <div id="clinical-niches-hidden" hidden></div>
     {% endcall %}
-    {{ actions("Save changes", cancel_url=entity_url('clinician', id=clinician.id) ) }}
+    {{ actions(cancel_url=entity_url('clinician', id=clinician.id) ) }}
   {% endcall %}
   <script>
   /* Clinical-niche tag splitter (#1358 PR-c). The visible input is a

--- a/src/domain/templates/educations/_form_education.html
+++ b/src/domain/templates/educations/_form_education.html
@@ -5,10 +5,10 @@
 {%- from "_shared/form_fields.html" import text_field, select_field, form_section with context -%}
 {%- from "_shared/forms.html" import entity_form -%}
 {%- from "_shared/actions.html" import actions -%}
-{% macro education_form(action_url, method, submit_label, cancel_url, delete_url=None, delete_confirm=None, current=None) -%}
+{% macro education_form(action_url, method, heading, cancel_url, delete_url=None, delete_confirm=None, current=None) -%}
   <div class="entity-form-page">
     {% call entity_form(action_url, method=method) %}
-      {% call form_section(submit_label) %}
+      {% call form_section(heading) %}
         {{ select_field("education_type", "Education type", EDUCATION_TYPES,
                 labels=EDUCATION_TYPES_LABELS,
                 current=(current.education_type if current else None) ,
@@ -20,7 +20,7 @@
                 current=(current.month_completed if current else None) ,
         required=false, type="month") }}
       {% endcall %}
-      {{ actions(submit_label,
+      {{ actions(heading if method == "post" else none,
             cancel_url=cancel_url,
             delete_url=delete_url,
             delete_confirm=delete_confirm) }}

--- a/src/domain/templates/educations/form_edit.html
+++ b/src/domain/templates/educations/form_edit.html
@@ -6,7 +6,7 @@
 {% block form_content %}
   {{ education_form(resource_detail_url,
     "patch",
-    "Save education",
+    edit_heading,
     cancel_url=resource_url,
     delete_url=resource_detail_url,
     delete_confirm="Remove this education?",

--- a/src/domain/templates/educations/form_new.html
+++ b/src/domain/templates/educations/form_new.html
@@ -5,6 +5,6 @@
 {% block form_content %}
   {{ education_form(resource_url,
     "post",
-    entity_create_label('clinician_education') ,
-  cancel_url=resource_url) }}
+    create_heading,
+    cancel_url=resource_url) }}
 {% endblock %}

--- a/src/domain/templates/licensures/_form_licensure.html
+++ b/src/domain/templates/licensures/_form_licensure.html
@@ -10,8 +10,11 @@
      action_url — the POST or PATCH target. Create posts to
        `/clinicians/{id}/licensures`; edit patches to
        `/clinicians/{id}/licensures/{lic_id}`.
-     method — "post" (create) or "patch" (edit).
-     submit_label — the action cluster's primary button label.
+     method — "post" (create) or "patch" (edit). Drives the submit
+       button label: create reuses `heading`; edit inherits the
+       framework-default `"Save changes"` from `actions(...)`.
+     heading — the form-section `<legend>` text (mirrors the page
+       H1: `create_heading` on create, `edit_heading` on edit).
      cancel_url — the action cluster's Cancel link target (back to
        the list page).
      delete_url — optional; when set on the edit page, renders Delete
@@ -29,10 +32,10 @@
 {%- from "_shared/form_fields.html" import text_field, select_field, form_section with context -%}
 {%- from "_shared/forms.html" import entity_form -%}
 {%- from "_shared/actions.html" import actions, confirm_action_button -%}
-{% macro licensure_form(action_url, method, submit_label, cancel_url, delete_url=None, delete_confirm=None, attest_url=None, current=None) -%}
+{% macro licensure_form(action_url, method, heading, cancel_url, delete_url=None, delete_confirm=None, attest_url=None, current=None) -%}
   <div class="entity-form-page">
     {% call entity_form(action_url, method=method) %}
-      {% call form_section(submit_label) %}
+      {% call form_section(heading) %}
         {{ select_field("license_type", "License type", LICENSE_TYPES,
                 labels=LICENSE_TYPES_LABELS,
                 current=(current.license_type if current else None) ,
@@ -47,7 +50,10 @@
                 current=(current.expiration_date if current else None) ,
         required=false, type="date") }}
       {% endcall %}
-      {{ actions(submit_label,
+      {# Create reuses `heading` as the submit label ("Create licensure");
+         edit passes nothing and inherits the framework default
+         ("Save changes") from `actions(...)`. #}
+      {{ actions(heading if method == "post" else none,
             cancel_url=cancel_url,
             delete_url=delete_url,
             delete_confirm=delete_confirm) }}

--- a/src/domain/templates/licensures/form_edit.html
+++ b/src/domain/templates/licensures/form_edit.html
@@ -14,9 +14,12 @@
 {% block form_content %}
   {%- set list_url = resource_url -%}
   {%- set attest_url = (resource_detail_url ~ "/attestation") if not clinician_licensure.attested_active else None -%}
+  {# Submit button inherits "Save changes" from `actions()`'s component-
+     library default; `edit_heading` ("Edit licensure") feeds the
+     form-section legend only. #}
   {{ licensure_form(resource_detail_url,
     "patch",
-    "Save licensure",
+    edit_heading,
     cancel_url=list_url,
     delete_url=resource_detail_url,
     delete_confirm="Remove this licensure?",

--- a/src/domain/templates/licensures/form_new.html
+++ b/src/domain/templates/licensures/form_new.html
@@ -10,6 +10,6 @@
 {% block form_content %}
   {{ licensure_form(resource_url,
     "post",
-    entity_create_label('clinician_licensure') ,
-  cancel_url=resource_url) }}
+    create_heading,
+    cancel_url=resource_url) }}
 {% endblock %}

--- a/src/domain/templates/organizations/form_edit.html
+++ b/src/domain/templates/organizations/form_edit.html
@@ -11,8 +11,7 @@
       {{ text_field("name", "Name", current=organization.name, maxlength=200) }}
       {{ text_field("npi", "NPI", current=organization.npi, required=false, pattern="\\d{10}", maxlength=10, help=npi_help() ) }}
     {% endcall %}
-    {{ actions("Save changes",
-        cancel_url=entity_url('organization', id=organization.id) ,
+    {{ actions(cancel_url=entity_url('organization', id=organization.id) ,
     delete_url=entity_url('organization', id=organization.id),
     delete_confirm="Delete this organization?",
     ) }}

--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -5,7 +5,10 @@ Used by both `posts/new_clinician_opening.html` (create) and
 
   - `hx_method`: "post" or "patch"
   - `action`: the form submit URL
-  - `submit_label`: the visible submit-button text
+  - `submit_label`: the visible submit-button text. Create callers
+    pass `entity_create_label('post', kind='clinician_opening')`;
+    edit callers omit it so `actions(...)` defaults to "Save changes"
+    (the canonical edit-button text — see `_shared/actions.html`).
   - `post`: the persisted Post (for edit) or `None` (for create)
   - `current_user`: the requesting User; the dropdown iterates
     `current_user.clinicians` and then each clinician's `.clinician_affiliations`
@@ -40,7 +43,7 @@ Field order:
 {%- from "_shared/forms.html" import entity_form -%}
 {%- from "_shared/form_copy.html" import schedule_notes_help -%}
 {%- from "_shared/actions.html" import actions -%}
-{%- macro opening_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
+{%- macro opening_form(hx_method, action, submit_label=none, post=None, schema=None, current_user=None, cancel_url=None) -%}
   {%- set d = post.opening_detail if post else None -%}
   {# `error_swap=True` lights up the response-targets attrs that swap a
      422 validation re-render in place; `mount_create` and `mount_update`

--- a/src/domain/templates/posts/_form_program_intake.html
+++ b/src/domain/templates/posts/_form_program_intake.html
@@ -5,7 +5,10 @@ Used by both `posts/new_program_intake.html` (create) and
 
   - `hx_method`: "post" or "patch"
   - `action`: the form submit URL
-  - `submit_label`: the visible submit-button text
+  - `submit_label`: the visible submit-button text. Create callers
+    pass `entity_create_label('post', kind='program_intake')`; edit
+    callers omit it so `actions(...)` defaults to "Save changes" (the
+    canonical edit-button text — see `_shared/actions.html`).
   - `post`: the persisted Post (for edit) or `None` (for create)
   - `current_user`: the requesting User; `current_user.programs` is
     the dropdown's option source (mirrors PA's `current_user.clinicians`
@@ -40,7 +43,7 @@ Field order:
 {%- from "_shared/forms.html" import entity_form -%}
 {%- from "_shared/form_copy.html" import schedule_notes_help -%}
 {%- from "_shared/actions.html" import actions -%}
-{%- macro intake_form(hx_method, action, submit_label, post=None, schema=None, current_user=None, cancel_url=None) -%}
+{%- macro intake_form(hx_method, action, submit_label=none, post=None, schema=None, current_user=None, cancel_url=None) -%}
   {%- set d = post.intake_detail if post else None -%}
   {# `error_swap=True` lights up the response-targets attrs that swap a
      422 validation re-render in place; success path is unaffected

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -5,7 +5,10 @@ Used by both `posts/new_referral.html` (create, no prefill) and
 
   - `hx_method`: "post" or "patch"
   - `action`: the form submit URL
-  - `submit_label`: the visible submit-button text
+  - `submit_label`: the visible submit-button text. Create callers
+    pass `entity_create_label('post', kind='referral')`; edit callers
+    omit it so `actions(...)` defaults to "Save changes" (the
+    canonical edit-button text — see `_shared/actions.html`).
   - `post`: the persisted Post (for edit) or `None` (for create)
 
 Field order:
@@ -35,7 +38,7 @@ which FastAPI/Pydantic parses as a list.
 {%- from "_shared/forms.html" import entity_form -%}
 {%- from "_shared/form_copy.html" import modality_help, select_all_help -%}
 {%- from "_shared/actions.html" import actions -%}
-{%- macro referral_form(hx_method, action, submit_label, post=None, schema=None, cancel_url=None) -%}
+{%- macro referral_form(hx_method, action, submit_label=none, post=None, schema=None, cancel_url=None) -%}
   {%- set d = post.referral_detail if post else None -%}
   {# `error_swap=True` lights up the response-targets attrs that swap a
      422 validation re-render in place; success path is unaffected

--- a/src/domain/templates/posts/edit_clinician_opening.html
+++ b/src/domain/templates/posts/edit_clinician_opening.html
@@ -12,5 +12,5 @@
   {% if view.header_state %}, {{ view.header_state }}{% endif %}
 {% endblock %}
 {% block form_content %}
-  {{ opening_form("patch", entity_url('post', id=post.id) , "Save changes", post=post, schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('post', id=post.id)) }}
+  {{ opening_form("patch", entity_url('post', id=post.id) , post=post, schema=opening_create_schema, current_user=current_user, cancel_url=entity_url('post', id=post.id)) }}
 {% endblock %}

--- a/src/domain/templates/posts/edit_program_intake.html
+++ b/src/domain/templates/posts/edit_program_intake.html
@@ -10,5 +10,5 @@
   {% if view.header_state %}, {{ view.header_state }}{% endif %}
 {% endblock %}
 {% block form_content %}
-  {{ intake_form("patch", entity_url('post', id=post.id) , "Save changes", post=post, schema=intake_create_schema, current_user=current_user, cancel_url=entity_url('post', id=post.id)) }}
+  {{ intake_form("patch", entity_url('post', id=post.id) , post=post, schema=intake_create_schema, current_user=current_user, cancel_url=entity_url('post', id=post.id)) }}
 {% endblock %}

--- a/src/domain/templates/posts/edit_referral.html
+++ b/src/domain/templates/posts/edit_referral.html
@@ -10,5 +10,5 @@
 {% block resource_label %}Posts{% endblock %}
 {% block current_label %}{{ view.headline or 'Referral' }}{% endblock %}
 {% block form_content %}
-  {{ referral_form("patch", entity_url('post', id=post.id) , "Save changes", post=post, schema=referral_create_schema, cancel_url=entity_url('post', id=post.id)) }}
+  {{ referral_form("patch", entity_url('post', id=post.id) , post=post, schema=referral_create_schema, cancel_url=entity_url('post', id=post.id)) }}
 {% endblock %}

--- a/src/domain/templates/programs/form_edit.html
+++ b/src/domain/templates/programs/form_edit.html
@@ -46,8 +46,7 @@
       {{ url_field("website", "Website", current=program.website, required=false) }}
       {{ textarea_field("referral_instructions", "Referral instructions", current=program.referral_instructions, required=false) }}
     {% endcall %}
-    {{ actions("Save changes",
-        cancel_url=entity_url('program', id=program.id) ,
+    {{ actions(cancel_url=entity_url('program', id=program.id) ,
     delete_url=entity_url('program', id=program.id),
     delete_confirm="Delete this program?",
     ) }}

--- a/src/framework/templates/_shared/actions.html
+++ b/src/framework/templates/_shared/actions.html
@@ -52,7 +52,11 @@ Cancel = neutral, Edit = secondary, Delete = destructive); change the
 class on one line here and every callsite updates.
 
 Slot semantics:
-  - `submit_label` — Save button text. Form layout only.
+  - `submit_label` — Save button text. Form layout only. Defaults to
+    `"Save changes"` (the canonical edit-button label per the domain
+    templates README) when omitted; create forms pass an explicit
+    `"Create <noun>"` from `entity_create_label(...)`. Toolbar layout
+    suppresses the button when `submit_label` is omitted.
   - `cancel_url` — neutral outline Cancel link. Form layout only.
   - `edit_url` + `edit_label` — secondary outline Edit link. Mainly
     toolbar, but valid in form layout too.
@@ -89,12 +93,19 @@ Examples:
   wrapper="form"
   ) -%}
   {%- set is_toolbar = wrapper == "toolbar" -%}
+  {# Component-library default: every form-layout submit button reads
+     "Save changes" unless the caller passes an explicit label (Create
+     forms pass `entity_create_label(...)`). The toolbar wrapper is used
+     for detail-page action menus that never carry a Save, so the
+     default is form-only — toolbar callers still get no button when
+     they omit `submit_label`. #}
+  {%- set _resolved_submit_label = submit_label if submit_label else (none if is_toolbar else "Save changes") -%}
   {%- if not is_toolbar %}<div class="form-actions">{% endif %}
-    {%- if submit_label %}
+    {%- if _resolved_submit_label %}
       {%- if is_toolbar %}
         <li>
         {% endif -%}
-        <button type="submit">{{ submit_label }}</button>
+        <button type="submit">{{ _resolved_submit_label }}</button>
         {%- if is_toolbar %}</li>{% endif %}
     {%- endif %}
     {%- if edit_url %}

--- a/src/framework/templates/_shared/test_actions.py
+++ b/src/framework/templates/_shared/test_actions.py
@@ -91,3 +91,35 @@ def test_dirty_form_script_not_emitted_in_toolbar_layout() -> None:
     appears in a ``<menu>`` toolbar, not adjacent to a ``<form>``."""
     html = _render_actions(_make_env(), cancel_url="/things/1", wrapper="toolbar")
     assert HTMLParser(html).css_first("script") is None
+
+
+# ---------------------------------------------------------------------------
+# submit_label default — the "Save changes" canonical rule
+# ---------------------------------------------------------------------------
+
+
+def test_form_layout_submit_label_defaults_to_save_changes() -> None:
+    """Per the domain templates README "every edit form uses Save changes,
+    no exceptions" — the rule is encoded as the form-layout default here.
+    Edit pages omit ``submit_label`` and inherit the canonical text;
+    Create pages pass an explicit ``entity_create_label(...)``."""
+    html = _render_actions(_make_env(), cancel_url="/things/1")
+    button = HTMLParser(html).css_first("button[type='submit']")
+    assert button is not None
+    assert button.text().strip() == "Save changes"
+
+
+def test_form_layout_explicit_submit_label_wins_over_default() -> None:
+    """Create forms still pass an explicit label and must keep it —
+    the default only fires when no label is supplied."""
+    html = _render_actions(_make_env(), submit_label="Create organization")
+    button = HTMLParser(html).css_first("button[type='submit']")
+    assert button is not None
+    assert button.text().strip() == "Create organization"
+
+
+def test_toolbar_layout_submit_label_not_defaulted() -> None:
+    """Detail-page toolbars never carry a Save button — omitting
+    ``submit_label`` must NOT inject "Save changes" in toolbar layout."""
+    html = _render_actions(_make_env(), wrapper="toolbar", edit_url="/things/1/form")
+    assert HTMLParser(html).css_first("button[type='submit']") is None

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -456,32 +456,39 @@ def test_actions_buttons_fill_row_width_on_desktop() -> None:
     )
 
 
-def test_actions_macro_supports_cancel_only_for_page_level_clusters() -> None:
-    """The `actions` macro accepts `submit_label=None` so multi-section
-    pages (e.g. `clinicians/form_edit.html`) can render a page-level
-    Cancel-only cluster without a redundant Save button. Pinned because
-    the bare `<div class="form-actions">` that used to live in that
-    template diverged from the macro's styling on the desktop width fix
-    — every cluster must route through the macro."""
+def test_actions_macro_routes_page_level_clusters_through_form_wrapper() -> None:
+    """Every form-layout cluster routes through the `actions` macro so the
+    `.form-actions` styling is consistent. Pinned because the bare
+    `<div class="form-actions">` that used to live in `clinicians/form_edit.html`
+    diverged from the macro's styling on the desktop width fix.
+
+    With the component-library default in place (`wrapper="form"` +
+    omitted `submit_label` → "Save changes"), the canonical edit cluster
+    is `actions(cancel_url=...)` — both buttons render and styling stays
+    uniform. The Cancel-only carve-out the macro used to support was
+    dropped when the README's "every edit form uses Save changes"
+    rule moved into the macro itself (see
+    `test_form_layout_submit_label_defaults_to_save_changes` in
+    `_shared/test_actions.py`)."""
     env = _make_env()
     _add_child(
         env,
         "stub.html",
         """
         {% from "_shared/actions.html" import actions %}
-        <div id="cancel-only">
+        <div id="cluster">
           {{ actions(cancel_url="/widgets/1") }}
         </div>
         """,
     )
     html = env.get_template("stub.html").render()
     tree = HTMLParser(html)
-    cluster = tree.css_first("#cancel-only .form-actions")
-    assert cluster is not None, "macro must still render `.form-actions` wrapper"
-    # No submit button when `submit_label` is omitted.
-    assert (
-        cluster.css_first("button[type='submit']") is None
-    ), "Cancel-only cluster must not render a stray Save button"
+    cluster = tree.css_first("#cluster .form-actions")
+    assert cluster is not None, "macro must render `.form-actions` wrapper"
+    # The default "Save changes" submit button renders.
+    submit = cluster.css_first("button[type='submit']")
+    assert submit is not None
+    assert submit.text().strip() == "Save changes"
     # Cancel link is present and points at the supplied URL.
     cancel = cluster.css_first("a[role='button']")
     assert cancel is not None


### PR DESCRIPTION
## Summary

- The domain templates README pinned "Edit forms use Save changes — every edit form, no exceptions." But every edit form passed the string literally, and the four credential edit pages had silently drifted to "Save licensure" / "Save certification" / "Save education" / "Save practice". A convention not enforced by the component library is a convention waiting to drift.
- Default `submit_label` to `"Save changes"` in `_shared/actions.html` when `wrapper="form"` and no value is passed. Edit pages omit the arg and inherit; Create pages keep passing `entity_create_label(...)` so the H1 ↔ button equivalence pin still holds. Toolbar layout is unchanged.
- The four credential shared form macros decouple the form-section legend (now `heading`, sourced from `create_heading` / `edit_heading` so it matches the page H1) from the submit button: on create they pass `heading` through to `actions()`, on edit they pass `None` and the default kicks in.
- The three post form macros default `submit_label=none` the same way; `edit_*.html` callers drop the literal `"Save changes"` arg.
- README pointer updated to name the new structural pin.

## Pin tests

- `test_form_layout_submit_label_defaults_to_save_changes` — `actions(cancel_url=...)` renders the "Save changes" button.
- `test_form_layout_explicit_submit_label_wins_over_default` — create forms keep their explicit "Create X" label.
- `test_toolbar_layout_submit_label_not_defaulted` — detail toolbars omitting `submit_label` get no Save button.
- The pre-existing `test_actions_macro_supports_cancel_only_for_page_level_clusters` was rewritten — its protected behavior (Cancel-only with no Save) is superseded by the new canonical shape (every form-layout cluster renders both buttons).

## Test plan

- [x] `dev lint` clean
- [x] `dev test` — 2694 passed, 99 skipped
- [ ] Spot-check the four credential edit pages + org/program/clinician/post edit pages in the running app (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)