### PR TITLE
Auto-inject parent breadcrumb on every parent-owned mount

### DIFF
--- a/src/framework/dispatch/mounts/README.md
+++ b/src/framework/dispatch/mounts/README.md
@@ -52,12 +52,15 @@ Shared infrastructure:
   `walk_parent_chain`, `normalize_filters`, `resolve_dotted_path`,
   `resolve_handler`, `resolve_spec_bound_handler`,
   `call_handler_with`, `owned_factory_makers`, the
-  `TOP_LEVEL_AUTO_BIND_VERBS` constant, and
-  `subresource_breadcrumb_items` — the single producer of the 3-step
-  `_breadcrumb_items` injected by `mount_related_list` and
-  `mount_edge_routes` (collection → parent row → child label, with
-  the collection segment's lock reason sourced from
-  `entity_lock_reason(parent_spec.name, viewer)`).
+  `TOP_LEVEL_AUTO_BIND_VERBS` constant, `subresource_breadcrumb_items`
+  (the single producer of the 3-step `_breadcrumb_items` —
+  collection → parent row → child label, with the collection segment's
+  lock reason sourced from `entity_lock_reason(parent_spec.name,
+  viewer)`), and `ParentBreadcrumbPlumbing` (the single handshake
+  that wires `_breadcrumb_items` into each parent-owned mount —
+  `mount_list`, `mount_form`, `mount_related_list`). `mount_edge_routes`
+  emits the same shape via a different code path because its parent
+  row is the requesting user with no PK lookup.
 
 ## Dependency direction
 

--- a/src/framework/dispatch/mounts/_common.py
+++ b/src/framework/dispatch/mounts/_common.py
@@ -313,3 +313,108 @@ def subresource_breadcrumb_items(
         (parent_label_fn(parent_row), parent_path, None),
         (child_label, None, None),
     ]
+
+
+class ParentBreadcrumbPlumbing:
+    """Mount-time resolver + request-time injector for the parent-owned
+    `_breadcrumb_items` handshake.
+
+    Every per-verb mount that renders an HTML page for a parent-owned
+    spec needs the same two pieces:
+
+      1. At mount time, declare a static dep that resolves the parent's
+         repo (so the synthesis layer can inject it as a route param).
+      2. At request time, fetch the parent row by id and call
+         `subresource_breadcrumb_items` to build the chain, then stuff
+         the result under `_breadcrumb_items` so the view-type chrome
+         templates (`list.html`, `form_edit.html`, `form_new.html`)
+         pick it up via their `{% if _breadcrumb_items is defined %}`
+         branch.
+
+    Both pieces gate on the parent declaring `display_label_fn` — that
+    field is the opt-in. A parent without it falls back to the
+    single-segment chrome breadcrumb every top-level page renders.
+
+    Two constructors cover the two call shapes in the codebase:
+
+      - `for_child_spec(child)` reads `child.parent` — used by
+        `mount_form` and `mount_list` (the parent ResourceSpec is on
+        the child spec).
+      - `for_parent_spec(parent)` takes the parent directly — used by
+        `mount_related_list` (the parent comes in as a separate kwarg
+        because the same child entity can be related-listed under
+        different parents).
+
+    `mount_edge_routes` uses a different shape (the "parent" is the
+    relation's `from_entity`, and the parent row is the requesting user
+    itself with no PK lookup) and doesn't share this helper.
+    """
+
+    def __init__(self, parent_spec: ResourceSpec | None) -> None:
+        self._parent_spec = parent_spec
+
+    @classmethod
+    def for_child_spec(cls, child_spec: ResourceSpec) -> "ParentBreadcrumbPlumbing":
+        return cls(child_spec.parent)
+
+    @classmethod
+    def for_parent_spec(cls, parent_spec: ResourceSpec) -> "ParentBreadcrumbPlumbing":
+        return cls(parent_spec)
+
+    @property
+    def parent_entity_spec(self) -> "EntitySpec | None":
+        """The parent's `EntitySpec`, or `None` when no parent is set or
+        the parent has no `display_label_fn` (the opt-in gate)."""
+        if self._parent_spec is None:
+            return None
+        es = getattr(self._parent_spec, "entity_spec", None)
+        if es is None or es.display_label_fn is None:
+            return None
+        return es
+
+    @property
+    def active(self) -> bool:
+        return self.parent_entity_spec is not None
+
+    @property
+    def extra_static_deps(self) -> tuple[tuple[str, Any], ...]:
+        """Extra `(kwarg_name, Depends)` pairs for `SynthOptions` so the
+        parent-row fetch has a repo to call. Empty when inactive — no
+        unused deps land on the route signature."""
+        if not self.active:
+            return ()
+        assert self._parent_spec is not None  # active implies parent set
+        return (("__parent_repo__", self._parent_spec.repo_dep),)
+
+    async def inject(
+        self,
+        *,
+        context: dict[str, Any],
+        kwargs: dict[str, Any],
+        child_label: str,
+    ) -> None:
+        """Build `_breadcrumb_items` from the parent row and stuff it
+        into `context`. No-op when inactive (no parent, or parent has
+        no `display_label_fn`) or when the parent row can't be found
+        (the route's handler will have its own 404 path; the breadcrumb
+        chain is best-effort, not load-bearing)."""
+        if not self.active:
+            return
+        parent_entity_spec = self.parent_entity_spec
+        assert parent_entity_spec is not None
+        assert self._parent_spec is not None
+        parent_id = kwargs[self._parent_spec.id_param]
+        parent_repo = kwargs["__parent_repo__"]
+        parent_row = await parent_repo.get_by_model_id(
+            parent_entity_spec.model, parent_id
+        )
+        if parent_row is None:
+            return
+        collection = parent_entity_spec.url_collection
+        context["_breadcrumb_items"] = subresource_breadcrumb_items(
+            parent_spec=parent_entity_spec,
+            parent_row=parent_row,
+            parent_path=f"/{collection}/{parent_id}",
+            child_label=child_label,
+            viewer=kwargs.get("requesting_user"),
+        )

--- a/src/framework/dispatch/mounts/form.py
+++ b/src/framework/dispatch/mounts/form.py
@@ -15,11 +15,11 @@ from pydantic import BaseModel  # noqa: F401 — re-exported for test compat
 
 from src.framework.access.actor.actor import Actor
 from src.framework.dispatch.mounts._common import (
+    ParentBreadcrumbPlumbing,
     assert_kind_lock,
     call_handler_with,
     parent_path_param_pairs,
     path_segments_under_router,
-    subresource_breadcrumb_items,
 )
 from src.framework.dispatch.mounts._spec import QueryParam, ResourceSpec
 from src.framework.dispatch.mounts._synth import SynthOptions, synthesize_route_fn
@@ -72,53 +72,22 @@ def mount_form(
     parent_id_names = tuple(p[0] for p in parent_path_param_pairs(spec))
     path_param_names = parent_id_names + ((id_param,) if on_existing else ())
 
-    # Parent-owned breadcrumb plumbing (mirrors mount_related_list). The
-    # form chrome's default breadcrumb assumes the entity is registered
-    # under its own URL (`breadcrumb_entity_item(entity_name)` → `/<col>`),
-    # which is wrong for a parent-owned spec (its URL is rooted at the
-    # parent). When the parent declares `display_label_fn`, fetch the
-    # parent row at request time and inject `_breadcrumb_items` so the
-    # chrome uses the multi-segment chain instead.
-    _parent_entity_spec = (
-        getattr(spec.parent, "entity_spec", None) if spec.parent else None
-    )
-    _parent_label_fn = (
-        _parent_entity_spec.display_label_fn
-        if _parent_entity_spec is not None
-        else None
-    )
-    _need_parent_repo = _parent_label_fn is not None
-    _parent_repo_dep = spec.parent.repo_dep if _need_parent_repo else None
-    _extra_static_deps: tuple[tuple[str, Any], ...] = (
-        (("__parent_repo__", _parent_repo_dep),) if _need_parent_repo else ()
-    )
+    # Parent-owned breadcrumb plumbing — see `ParentBreadcrumbPlumbing`
+    # in `_common.py`. No-op for top-level specs.
+    _breadcrumb = ParentBreadcrumbPlumbing.for_child_spec(spec)
 
     async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
         context = await call_handler_with(handler, handler_kwarg_names, kwargs)
-        if _parent_label_fn is not None and spec.parent is not None:
-            parent_id_value = kwargs[spec.parent.id_param]
-            parent_repo = kwargs["__parent_repo__"]
-            parent_row = await parent_repo.get_by_model_id(
-                _parent_entity_spec.model, parent_id_value
-            )
-            if parent_row is not None:
-                parent_collection = _parent_entity_spec.url_collection
-                # The "current page" segment is the form heading
-                # (`create_heading` / `edit_heading`). Fall back to the
-                # spec's collection label if the handler didn't set one.
-                heading = (
-                    context.get("create_heading")
-                    or context.get("edit_heading")
-                    or spec.collection.capitalize()
-                )
-                context["_breadcrumb_items"] = subresource_breadcrumb_items(
-                    parent_spec=_parent_entity_spec,
-                    parent_row=parent_row,
-                    parent_path=f"/{parent_collection}/{parent_id_value}",
-                    child_label=heading,
-                    viewer=kwargs.get("requesting_user"),
-                )
+        # The "current page" segment is the form heading
+        # (`create_heading` / `edit_heading`). Fall back to the spec's
+        # collection label if the handler didn't set one.
+        heading = (
+            context.get("create_heading")
+            or context.get("edit_heading")
+            or spec.collection.capitalize()
+        )
+        await _breadcrumb.inject(context=context, kwargs=kwargs, child_label=heading)
         # Resolve template: handler context > per-mount kwarg > spec field.
         # `pop` so the template name doesn't leak into the rendered context.
         resolved_template = (
@@ -145,7 +114,7 @@ def mount_form(
             user_dep=spec.read_user_dep,
             query_params=query_params,
             path_param_names=path_param_names,
-            extra_static_deps=_extra_static_deps,
+            extra_static_deps=_breadcrumb.extra_static_deps,
         ),
         response_builder=response_builder,
     )

--- a/src/framework/dispatch/mounts/list_.py
+++ b/src/framework/dispatch/mounts/list_.py
@@ -15,6 +15,7 @@ from fastapi import Request
 from src.framework.access.actor.actor import Actor
 from src.framework.access.authz.authz import is_admin
 from src.framework.dispatch.mounts._common import (
+    ParentBreadcrumbPlumbing,
     call_handler_with,
     parent_path_param_pairs,
     path_segments_under_router,
@@ -71,6 +72,13 @@ def mount_list(
     authenticated (e.g. clinicians). The handler should declare
     ``requesting_user: User | None`` so the synthesis can pass ``None``
     for anonymous viewers.
+
+    When the spec is parent-owned and the parent declares
+    ``display_label_fn``, the mount fetches the parent row (one PK
+    lookup) and injects ``_breadcrumb_items`` into the template context
+    so ``views/list.html`` auto-renders the ancestry chain. Same
+    handshake `mount_form` and `mount_related_list` use — see
+    `ParentBreadcrumbPlumbing` in ``_common.py``.
     """
     if spec.list_template is None:
         raise ValueError(
@@ -84,9 +92,20 @@ def mount_list(
     path = path_segments_under_router(spec, with_id=False)
     parent_id_names = tuple(p[0] for p in parent_path_param_pairs(spec))
 
+    # Parent-owned breadcrumb plumbing — see `ParentBreadcrumbPlumbing`
+    # in `_common.py`. No-op for top-level specs (top-level list pages
+    # render no breadcrumb; the global-nav tab already communicates the
+    # collection).
+    _breadcrumb = ParentBreadcrumbPlumbing.for_child_spec(spec)
+
     async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
         context = await call_handler_with(handler, handler_kwarg_names, kwargs)
+        await _breadcrumb.inject(
+            context=context,
+            kwargs=kwargs,
+            child_label=spec.collection.capitalize(),
+        )
         resolved_template = context.pop("template_name", None) or list_template
         return APIResponse.html_response(
             template_name=resolved_template,
@@ -103,6 +122,7 @@ def mount_list(
             user_dep=user_dep,
             query_params=query_params,
             path_param_names=parent_id_names,
+            extra_static_deps=_breadcrumb.extra_static_deps,
         ),
         response_builder=response_builder,
     )

--- a/src/framework/dispatch/mounts/related_list.py
+++ b/src/framework/dispatch/mounts/related_list.py
@@ -5,8 +5,8 @@ from typing import Any, Awaitable, Callable
 from fastapi import Request
 
 from src.framework.dispatch.mounts._common import (
+    ParentBreadcrumbPlumbing,
     call_handler_with,
-    subresource_breadcrumb_items,
 )
 from src.framework.dispatch.mounts._spec import ResourceSpec
 from src.framework.dispatch.mounts._synth import SynthOptions, synthesize_route_fn
@@ -65,36 +65,20 @@ def mount_related_list(
     parent_id_param = parent_spec.id_param
     path = f"/{{{parent_id_param}}}/{child_spec.collection}"
 
-    # Resolve the parent entity spec once at mount time so the response
-    # builder closure doesn't re-check on every request.
-    _parent_entity_spec = getattr(parent_spec, "entity_spec", None)
-    _parent_label_fn = (
-        _parent_entity_spec.display_label_fn
-        if _parent_entity_spec is not None
-        else None
-    )
-    # Whether to inject an extra parent-repo dep for the breadcrumb fetch.
-    _need_parent_repo = _parent_label_fn is not None
-    _parent_repo_dep = parent_spec.repo_dep if _need_parent_repo else None
+    # Parent-owned breadcrumb plumbing — see `ParentBreadcrumbPlumbing`
+    # in `_common.py`. The parent is passed in directly here (not via
+    # `child_spec.parent`) because the same child entity can be
+    # related-listed under different parents.
+    _breadcrumb = ParentBreadcrumbPlumbing.for_parent_spec(parent_spec)
 
     async def response_builder(*, handler, handler_kwarg_names, kwargs):
         request: Request = kwargs["request"]
         context = await call_handler_with(handler, handler_kwarg_names, kwargs)
-        if _parent_label_fn is not None:
-            parent_id = kwargs[parent_id_param]
-            parent_repo = kwargs["__parent_repo__"]
-            parent_entity = await parent_repo.get_by_model_id(
-                _parent_entity_spec.model, parent_id
-            )
-            if parent_entity is not None:
-                collection = _parent_entity_spec.url_collection
-                context["_breadcrumb_items"] = subresource_breadcrumb_items(
-                    parent_spec=_parent_entity_spec,
-                    parent_row=parent_entity,
-                    parent_path=f"/{collection}/{parent_id}",
-                    child_label=child_spec.collection.capitalize(),
-                    viewer=kwargs.get("requesting_user"),
-                )
+        await _breadcrumb.inject(
+            context=context,
+            kwargs=kwargs,
+            child_label=child_spec.collection.capitalize(),
+        )
         return APIResponse.html_response(
             template_name=template,
             context=context,
@@ -102,9 +86,7 @@ def mount_related_list(
             current_user=kwargs.get("requesting_user"),
         )
 
-    _breadcrumb_dep: tuple[tuple[str, Any], ...] = (
-        (("__parent_repo__", _parent_repo_dep),) if _need_parent_repo else ()
-    )
+    _breadcrumb_dep = _breadcrumb.extra_static_deps
 
     # The route renders children, so the synthesis hands the handler the
     # *child's* repo under `repo`. The parent-id path param is bound by

--- a/src/framework/dispatch/mounts/test_common.py
+++ b/src/framework/dispatch/mounts/test_common.py
@@ -3,15 +3,25 @@
 `subresource_breadcrumb_items` is the single producer of the 3-step
 `_breadcrumb_items` injected by both `mount_related_list` and
 `mount_edge_routes` — same tuple shape, same lock-reason wiring, one
-test target.
+test target. `ParentBreadcrumbPlumbing` is the single handshake that
+wires that producer into each per-verb mount (`mount_list`,
+`mount_form`, `mount_related_list`) — so the mount-time + request-time
+glue lives in one place too.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
 
 from src.domain.logic import capabilities
-from src.framework.dispatch.mounts._common import subresource_breadcrumb_items
+from src.framework.dispatch.mounts._common import (
+    ParentBreadcrumbPlumbing,
+    subresource_breadcrumb_items,
+)
 
 
 class _Spec:
@@ -116,6 +126,170 @@ def test_asserts_when_parent_spec_lacks_display_label_fn():
             child_label="Child",
             viewer=None,
         )
+
+
+# --- ParentBreadcrumbPlumbing -------------------------------------------
+
+
+class _ParentEntitySpec:
+    """Stand-in EntitySpec — `ParentBreadcrumbPlumbing` reads `name`,
+    `url_collection`, `model`, and `display_label_fn`. The real
+    EntitySpec has dozens of fields we don't need."""
+
+    def __init__(self, *, label_fn, model=object):
+        self.name = "clinician"
+        self.url_collection = "clinicians"
+        self.display_label_fn = label_fn
+        self.model = model
+
+
+class _ParentResourceSpec:
+    """Stand-in ResourceSpec. Holds the `entity_spec` back-reference
+    that `to_resource_spec()` sets on the real ResourceSpec, plus the
+    `id_param` and `repo_dep` the plumbing reads."""
+
+    def __init__(self, *, entity_spec, repo_dep=lambda: None):
+        self.entity_spec = entity_spec
+        self.id_param = "clinician_id"
+        self.repo_dep = repo_dep
+
+
+class _ChildResourceSpec:
+    def __init__(self, *, parent):
+        self.parent = parent
+
+
+def _parent_es(*, label_fn=lambda c: c.name, model=object) -> _ParentEntitySpec:
+    return _ParentEntitySpec(label_fn=label_fn, model=model)
+
+
+def test_plumbing_inactive_for_top_level_spec():
+    """Top-level (parent=None) specs skip the breadcrumb path —
+    `extra_static_deps` is empty and `inject` is a no-op."""
+    plumbing = ParentBreadcrumbPlumbing.for_child_spec(_ChildResourceSpec(parent=None))
+    assert plumbing.active is False
+    assert plumbing.extra_static_deps == ()
+
+
+def test_plumbing_inactive_when_parent_lacks_display_label_fn():
+    """The opt-in gate is `parent.entity_spec.display_label_fn`. Without
+    it, the mount can't produce a parent-row label, so the plumbing
+    falls back to the single-segment chrome breadcrumb instead of
+    injecting a half-built chain."""
+    parent_rs = _ParentResourceSpec(entity_spec=_parent_es(label_fn=None))
+    plumbing = ParentBreadcrumbPlumbing.for_child_spec(
+        _ChildResourceSpec(parent=parent_rs)
+    )
+    assert plumbing.active is False
+    assert plumbing.extra_static_deps == ()
+
+
+def test_plumbing_active_when_parent_has_display_label_fn():
+    """When the parent declares `display_label_fn`, the plumbing exposes
+    a `__parent_repo__` Depends pair so the synthesis layer wires the
+    parent's repo into the route's kwargs."""
+    repo_dep = lambda: "<repo-dep-sentinel>"  # noqa: E731
+    parent_rs = _ParentResourceSpec(
+        entity_spec=_parent_es(label_fn=lambda c: c.name),
+        repo_dep=repo_dep,
+    )
+    plumbing = ParentBreadcrumbPlumbing.for_child_spec(
+        _ChildResourceSpec(parent=parent_rs)
+    )
+    assert plumbing.active is True
+    assert plumbing.extra_static_deps == (("__parent_repo__", repo_dep),)
+
+
+def test_plumbing_for_parent_spec_uses_passed_parent_directly():
+    """`mount_related_list` takes the parent spec as a function arg
+    (not via `child_spec.parent`) because the same child entity can be
+    related-listed under different parents — verify both constructors
+    end up with the same plumbing state for the same parent."""
+    parent_rs = _ParentResourceSpec(entity_spec=_parent_es())
+    via_parent = ParentBreadcrumbPlumbing.for_parent_spec(parent_rs)
+    via_child = ParentBreadcrumbPlumbing.for_child_spec(
+        _ChildResourceSpec(parent=parent_rs)
+    )
+    assert via_parent.active == via_child.active
+    assert via_parent.extra_static_deps == via_child.extra_static_deps
+
+
+class _FakeParentRepo:
+    def __init__(self, row):
+        self._row = row
+        self.calls: list[tuple] = []
+
+    async def get_by_model_id(self, model, obj_id):
+        self.calls.append((model, obj_id))
+        return self._row
+
+
+@pytest.mark.asyncio
+async def test_inject_writes_breadcrumb_items_into_context():
+    """Active plumbing fetches the parent row, builds the chain via
+    `subresource_breadcrumb_items`, and assigns it to
+    `context['_breadcrumb_items']`."""
+    parent_id = uuid4()
+    parent_row = SimpleNamespace(id=parent_id, name="Dr Doe")
+    repo = _FakeParentRepo(parent_row)
+    parent_rs = _ParentResourceSpec(
+        entity_spec=_parent_es(label_fn=lambda c: c.name, model=SimpleNamespace),
+    )
+    plumbing = ParentBreadcrumbPlumbing.for_child_spec(
+        _ChildResourceSpec(parent=parent_rs)
+    )
+    context: dict = {}
+    with patch(
+        "src.framework.rendering.route_urls.entity_lock_reason", return_value=None
+    ):
+        await plumbing.inject(
+            context=context,
+            kwargs={
+                "clinician_id": parent_id,
+                "__parent_repo__": repo,
+                "requesting_user": None,
+            },
+            child_label="Practices",
+        )
+    assert repo.calls == [(SimpleNamespace, parent_id)]
+    assert context["_breadcrumb_items"] == [
+        ("Clinicians", "/clinicians", None),
+        ("Dr Doe", f"/clinicians/{parent_id}", None),
+        ("Practices", None, None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_inject_no_op_when_inactive():
+    """Top-level / opt-out specs leave the context untouched — no
+    `_breadcrumb_items` key, so the chrome falls through to its
+    single-segment default."""
+    plumbing = ParentBreadcrumbPlumbing.for_child_spec(_ChildResourceSpec(parent=None))
+    context: dict = {}
+    await plumbing.inject(context=context, kwargs={}, child_label="anything")
+    assert context == {}
+
+
+@pytest.mark.asyncio
+async def test_inject_no_op_when_parent_row_missing():
+    """A 404 on the parent fetch is best-effort — the route's own
+    handler owns the user-facing 404; the breadcrumb just stays absent
+    rather than crashing the page render."""
+    parent_rs = _ParentResourceSpec(entity_spec=_parent_es())
+    plumbing = ParentBreadcrumbPlumbing.for_child_spec(
+        _ChildResourceSpec(parent=parent_rs)
+    )
+    context: dict = {}
+    await plumbing.inject(
+        context=context,
+        kwargs={
+            "clinician_id": uuid4(),
+            "__parent_repo__": _FakeParentRepo(None),
+            "requesting_user": None,
+        },
+        child_label="Practices",
+    )
+    assert "_breadcrumb_items" not in context
 
 
 def test_parent_path_is_used_verbatim_for_singleton_alias_paths():

--- a/src/framework/templates/views/list.html
+++ b/src/framework/templates/views/list.html
@@ -6,11 +6,13 @@ list pages carry no breadcrumb — a single-segment "Posts" trail duplicates
 what the active global-nav tab already communicates.
 
 Subresource list pages (`/users/me/favorites`, `/users/{id}/clinicians`,
-`/clinicians/{id}/openings`) get a breadcrumb automatically when the
-mount injects `_breadcrumb_items` into the context (set by
-`mount_related_list` / `mount_edge_routes` when the parent entity's spec
-declares `display_label_fn`). The breadcrumb block below renders it when
-present; templates that need a custom chain override the block as before.
+`/clinicians/{id}/openings`, `/clinicians/{id}/clinician_affiliations`)
+get a breadcrumb automatically when the mount injects
+`_breadcrumb_items` into the context (set by `mount_list`,
+`mount_related_list`, and `mount_edge_routes` when the parent entity's
+spec declares `display_label_fn`). The breadcrumb block below renders
+it when present; templates that need a custom chain override the block
+as before.
 
 Toolbar row contents (left-to-right):
   - `<h1>` heading (resource_label)
@@ -78,9 +80,10 @@ Child contract:
   Context the framework's mount helpers inject for subresource pages:
     _breadcrumb_items — list of (label, href|None) tuples; the last
                         entry's href is None (current page). Injected
-                        by `mount_related_list` and `mount_edge_routes`
-                        when the parent entity spec declares
-                        `display_label_fn`. Absent on top-level lists.
+                        by `mount_list`, `mount_related_list`, and
+                        `mount_edge_routes` when the parent entity spec
+                        declares `display_label_fn`. Absent on top-level
+                        lists.
 #}
 {% extends "base.html" %}
 {%- from "_shared/_toolbar.html" import page_toolbar -%}


### PR DESCRIPTION
## Summary

- Sub-entity list pages (e.g. `/clinicians/{id}/clinician_affiliations`) now auto-render the `[Clinicians → Dr Doe → Practices]` breadcrumb instead of falling back to the single-segment chrome default — they were the one parent-owned surface `mount_list` wasn't injecting `_breadcrumb_items` for.
- Extract `ParentBreadcrumbPlumbing` in `_common.py` as the single producer of the mount-time + request-time handshake (resolve parent EntitySpec → gate on `display_label_fn` → inject `__parent_repo__` Depends → fetch parent row → build chain). `mount_form`, `mount_list`, and `mount_related_list` all go through it; the per-site duplication collapses to one path so the next parent-owned entity gets a breadcrumb chain with zero per-entity wiring.
- `mount_edge_routes` keeps its own copy because its parent row IS the requesting user (no PK lookup) — the shape doesn't compose cleanly with the same helper.

## Out of scope

- `mount_detail` still raises `NotImplementedError` for parent-owned specs (slice 8 / #253). Once that lands, wiring it to the same helper is a 2-line change plus an `{% if _breadcrumb_items is defined %}` branch in `views/detail.html` (the form-edit chrome already has the same branch — easy to copy).
- `mount_update` is POST-only; nothing to breadcrumb there.

## Test plan

- [x] `dev test` (2710 passed, 99 skipped)
- [x] `dev test contract` (39 passed)
- [x] `dev lint`
- [ ] Visit `/clinicians/{id}/clinician_affiliations` (and `/clinician_licensures`, `/clinician_educations`, `/clinician_certifications`) as a clinician and confirm the breadcrumb reads `Clinicians › <clinician name> › <Sub-entity>` instead of just `Clinician affiliations`.
- [ ] Visit `/clinicians/{id}/clinician_affiliations/{aff_id}/form` and confirm the form-edit breadcrumb still reads `Clinicians › <name> › Edit practice` (regression check — this surface was already wired).
- [ ] Visit a top-level list (`/clinicians`, `/posts`) and confirm no breadcrumb renders (no `_breadcrumb_items` is injected when `spec.parent is None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)