### PR TITLE
Collapse singleton_alias plumbing into one synthesis helper

### DIFF
--- a/src/framework/dispatch/mounts/README.md
+++ b/src/framework/dispatch/mounts/README.md
@@ -42,11 +42,15 @@ Shared infrastructure:
 
 - `_spec.py` — `QueryParam` and `ResourceSpec` dataclasses + the
   module-private `_UNSET` sentinel used by `QueryParam.required()`.
-- `_synth.py` — `synthesize_route_fn`, `SynthOptions`, `MountError`,
-  and the type-inspection helpers. Every per-verb mount calls
+- `_synth.py` — `synthesize_route_fn`, `synthesize_alias_route_fn`,
+  `SynthOptions`, `MountError`, and the type-inspection helpers. Every
+  per-verb mount calls
   `synthesize_route_fn(handler=…, spec=…, options=…, response_builder=…)`
   to turn the handler's typed signature into a FastAPI-visible route
-  function.
+  function. `synthesize_alias_route_fn` is the single producer of the
+  `singleton_alias` route shape (literal `/<alias>` segment that
+  derives the resource id from a session dep instead of the URL) used
+  by `mount_detail` and `mount_related_list`.
 - `_common.py` — small helpers shared across the per-verb modules:
   `path_segments_under_router`, `parent_path_param_pairs`,
   `walk_parent_chain`, `normalize_filters`, `resolve_dotted_path`,

--- a/src/framework/dispatch/mounts/_synth.py
+++ b/src/framework/dispatch/mounts/_synth.py
@@ -299,3 +299,61 @@ def synthesize_route_fn(
 
     _route.__signature__ = inspect.Signature(parameters=synth_params)  # type: ignore[attr-defined]
     return _route
+
+
+def synthesize_alias_route_fn(
+    *,
+    handler: Callable[..., Any],
+    spec: ResourceSpec,
+    response_builder: Callable[..., Awaitable[Any]],
+    singleton_alias: tuple[str, Callable[..., Any]],
+    id_param: str,
+    extra_static_deps: tuple[tuple[str, Callable[..., Any]], ...] = (),
+) -> Callable[..., Any]:
+    """Build a route fn for a literal-segment alias (e.g. `/users/me`)
+    that derives the resource id from the session-resolved user.
+
+    Wraps the primary route's ``response_builder`` so the session user's
+    id lands under ``id_param`` and the user itself under
+    ``requesting_user`` before delegation. Both `mount_detail` and
+    `mount_related_list` accept ``singleton_alias=("me",
+    current_active_user)``; this helper is the single producer of the
+    alias-mount shape so the kwarg-swap closure and the
+    ``__session_user__`` Depends wiring live in one place.
+
+    The caller registers the returned route_fn under whatever path it
+    wants (`/{alias_segment}` for `mount_detail`,
+    `/{alias_segment}/{child.collection}` for `mount_related_list`).
+
+    ``id_param`` is the kwarg name the response_builder reads the id
+    under — `spec.id_param` for `mount_detail`, the parent's
+    `id_param` for `mount_related_list` (the URL would have carried it
+    as a path segment in the non-alias form).
+
+    ``extra_static_deps`` composes with the `__session_user__` Depends
+    that this helper always injects — e.g. `mount_related_list` adds
+    the parent-repo dep its breadcrumb plumbing needs.
+    """
+    _alias_segment, session_dep = singleton_alias
+
+    async def alias_response_builder(*, handler, handler_kwarg_names, kwargs):
+        session_user = kwargs["__session_user__"]
+        kwargs = {
+            **kwargs,
+            id_param: session_user.id,
+            "requesting_user": session_user,
+        }
+        return await response_builder(
+            handler=handler, handler_kwarg_names=handler_kwarg_names, kwargs=kwargs
+        )
+
+    return synthesize_route_fn(
+        handler=handler,
+        spec=spec,
+        options=SynthOptions(
+            user_dep=None,  # session_dep supplies the user; don't double-inject
+            handler_supplied_names=(id_param, "requesting_user"),
+            extra_static_deps=(("__session_user__", session_dep),) + extra_static_deps,
+        ),
+        response_builder=alias_response_builder,
+    )

--- a/src/framework/dispatch/mounts/detail.py
+++ b/src/framework/dispatch/mounts/detail.py
@@ -18,7 +18,11 @@ from src.framework.dispatch.mounts._common import (
     call_handler_with,
 )
 from src.framework.dispatch.mounts._spec import ResourceSpec
-from src.framework.dispatch.mounts._synth import SynthOptions, synthesize_route_fn
+from src.framework.dispatch.mounts._synth import (
+    SynthOptions,
+    synthesize_alias_route_fn,
+    synthesize_route_fn,
+)
 from src.framework.http.exceptions import NotFoundError
 from src.framework.http.responses import APIResponse
 from src.framework.persistence.base_repository import BaseRepository
@@ -90,33 +94,14 @@ def mount_detail(
         # Register the literal alias path BEFORE the parametric `/{id}` route
         # so FastAPI matches `/users/me` against the alias instead of trying
         # to parse `me` as a UUID against `/users/{user_id}`.
-        alias_segment, session_dep = singleton_alias
-
-        async def alias_response_builder(*, handler, handler_kwarg_names, kwargs):
-            # Source the resource id from the session-resolved user.
-            session_user = kwargs["__session_user__"]
-            kwargs = {
-                **kwargs,
-                id_param: session_user.id,
-                "requesting_user": session_user,
-            }
-            return await response_builder(
-                handler=handler, handler_kwarg_names=handler_kwarg_names, kwargs=kwargs
-            )
-
-        alias_route_fn = synthesize_route_fn(
+        alias_route_fn = synthesize_alias_route_fn(
             handler=handler,
             spec=spec,
-            options=SynthOptions(
-                user_dep=None,  # session_dep supplies the user; don't double-inject
-                # Tell synthesis that `id_param` and `requesting_user` come
-                # from the wrapper, not from the URL or auth dep.
-                handler_supplied_names=(id_param, "requesting_user"),
-                extra_static_deps=(("__session_user__", session_dep),),
-            ),
-            response_builder=alias_response_builder,
+            response_builder=response_builder,
+            singleton_alias=singleton_alias,
+            id_param=id_param,
         )
-        router.get(f"/{alias_segment}")(alias_route_fn)
+        router.get(f"/{singleton_alias[0]}")(alias_route_fn)
 
     router.get(f"/{{{id_param}}}")(route_fn)
 

--- a/src/framework/dispatch/mounts/related_list.py
+++ b/src/framework/dispatch/mounts/related_list.py
@@ -9,7 +9,11 @@ from src.framework.dispatch.mounts._common import (
     call_handler_with,
 )
 from src.framework.dispatch.mounts._spec import ResourceSpec
-from src.framework.dispatch.mounts._synth import SynthOptions, synthesize_route_fn
+from src.framework.dispatch.mounts._synth import (
+    SynthOptions,
+    synthesize_alias_route_fn,
+    synthesize_route_fn,
+)
 from src.framework.http.responses import APIResponse
 
 
@@ -103,31 +107,14 @@ def mount_related_list(
     )
 
     if singleton_alias is not None:
-        alias_segment, session_dep = singleton_alias
-        alias_path = f"/{alias_segment}/{child_spec.collection}"
-
-        async def alias_response_builder(*, handler, handler_kwarg_names, kwargs):
-            session_user = kwargs["__session_user__"]
-            kwargs = {
-                **kwargs,
-                parent_id_param: session_user.id,
-                "requesting_user": session_user,
-            }
-            return await response_builder(
-                handler=handler, handler_kwarg_names=handler_kwarg_names, kwargs=kwargs
-            )
-
-        alias_route_fn = synthesize_route_fn(
+        alias_route_fn = synthesize_alias_route_fn(
             handler=handler,
             spec=child_spec,
-            options=SynthOptions(
-                user_dep=None,
-                handler_supplied_names=(parent_id_param, "requesting_user"),
-                extra_static_deps=(("__session_user__", session_dep),)
-                + _breadcrumb_dep,
-            ),
-            response_builder=alias_response_builder,
+            response_builder=response_builder,
+            singleton_alias=singleton_alias,
+            id_param=parent_id_param,
+            extra_static_deps=_breadcrumb_dep,
         )
-        router.get(alias_path)(alias_route_fn)
+        router.get(f"/{singleton_alias[0]}/{child_spec.collection}")(alias_route_fn)
 
     router.get(path)(route_fn)


### PR DESCRIPTION
## Summary

- `mount_detail` and `mount_related_list` both carried a byte-for-byte copy of the same singleton-alias handshake (kwarg-swap closure + `__session_user__` Depends + `handler_supplied_names` wiring). Extract `synthesize_alias_route_fn` in `_synth.py` as the single producer; both call sites collapse to a 6-line call that names the differences explicitly (spec, `id_param`, any composed extra deps).
- Follow-up to #1427's `ParentBreadcrumbPlumbing` extraction — same lens, different repeated pattern. The retrospective on that PR called out the audit; this is its concrete output.

## Test plan

- [x] `dev test` (2710 passed)
- [x] `dev test contract` (39 passed)
- [x] `dev lint`
- [x] Existing `test_mount_detail_singleton_alias_sources_id_from_session` and `test_mount_related_list_singleton_alias_sources_id_from_session` integration tests both still pin the alias behavior end-to-end — pure refactor, no behavioral delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)