### PR TITLE
Lift form_extras / payload_authz / detail_extras patterns into the framework

### DIFF
--- a/src/domain/logic/clinicians/handlers.py
+++ b/src/domain/logic/clinicians/handlers.py
@@ -20,7 +20,10 @@ from src.domain.models import (
     Organization,
     User,
 )
-from src.framework.access.authz.authz import assert_fk_ownership, list_visible_to
+from src.framework.access.authz.authz import (
+    list_visible_to,
+    make_fk_ownership_payload_authz,
+)
 from src.framework.audit.repository import AuditRepository
 from src.framework.dispatch.pagination import (
     DEFAULT_PAGE_SIZE,
@@ -145,28 +148,18 @@ async def after_update_clinician_verification(
     await clinician_repo.session.refresh(row)
 
 
-async def _assert_clinician_payload_org_ownership(
-    *,
-    payload: BaseModel,
-    requesting_user: User,
-    organization_repo: OrganizationRepository,
-) -> None:
-    """Payload authz for clinician create/update.
-
-    Delegates to the framework's FK-ownership guard. Create payloads
-    never carry ``org_id`` (org assignment happens later via the
-    affiliation sub-resource); update payloads may, and `assert_fk_ownership`
-    treats a missing/None FK as a no-op.
-    """
-    await assert_fk_ownership(
-        payload=payload,
-        attr="org_id",
-        requesting_user=requesting_user,
-        parent_repo=organization_repo,
-        parent_model=Organization,
-        parent_noun="Organization",
-        child_noun="Clinician",
-    )
+# `CLINICIAN_ENTITY.payload_authz_path` target — the per-entity wrapper
+# is now a one-line factory call. Create payloads never carry `org_id`
+# (org assignment happens via the affiliation sub-resource); update
+# payloads may, and `assert_fk_ownership` (called by the factory) treats
+# a missing/None FK as a no-op.
+_assert_clinician_payload_org_ownership = make_fk_ownership_payload_authz(
+    attr="org_id",
+    parent_model=Organization,
+    parent_noun="Organization",
+    child_noun="Clinician",
+    parent_repo_kwarg="organization_repo",
+)
 
 
 async def clinician_form_extras(

--- a/src/domain/logic/programs/handlers.py
+++ b/src/domain/logic/programs/handlers.py
@@ -5,24 +5,25 @@ Two callables, mirroring :mod:`src.domain.logic.clinicians.handlers`:
 * :func:`program_form_extras` — driven by
   ``PROGRAM_ENTITY.form_extras_path``. Loads the requesting user's
   visible Organizations into the form context so the create / edit
-  form can render an Org-picker scoped to Orgs the user owns.
+  form can render an Org-picker scoped to Orgs the user owns. On
+  edit, re-includes the row's currently-attached Org when it would
+  otherwise be missing from the visible set.
 * :func:`_assert_program_payload_org_ownership` — driven by
   ``PROGRAM_ENTITY.payload_authz_path``. Wire-side authorization on
   the cross-entity FK: the user may only attach a Program to an Org
   they own (superusers bypass; nonexistent Org → 404 with no info
-  leak about other users' Org ids).
+  leak about other users' Org ids). Built from
+  :func:`~src.framework.access.authz.authz.make_fk_ownership_payload_authz`
+  — the per-entity wrapper is now a one-line factory call.
 
 No bespoke CRUD handlers — the framework's factory-built
 ``handle_create`` / ``handle_update`` / etc. consume both hooks via
 the spec's dotted-path declarations, so the route file is a single
-:func:`mount_entity` call (the conformance check for the framework
-generalizations from PRs #534 + #535).
+:func:`mount_entity` call.
 """
 
 import logging
 from typing import Any
-
-from pydantic import BaseModel
 
 from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.models import (
@@ -30,31 +31,24 @@ from src.domain.models import (
     Program,
     User,
 )
-from src.framework.access.authz.authz import assert_fk_ownership, list_visible_to
-from src.framework.http.exceptions import ForbiddenError, NotFoundError  # noqa: F401
+from src.framework.access.authz.authz import (
+    list_picker_options_for,
+    make_fk_ownership_payload_authz,
+)
 
 logger = logging.getLogger(__name__)
 
 
-async def _assert_program_payload_org_ownership(
-    *,
-    payload: BaseModel,
-    requesting_user: User,
-    organization_repo: OrganizationRepository,
-) -> None:
-    """`PROGRAM_ENTITY.payload_authz_path` target — thin wrapper around
-    the framework's generic FK-ownership assertion. Keeps the dotted-
-    path on the spec stable while the rule lives in one framework spot.
-    """
-    await assert_fk_ownership(
-        payload=payload,
-        attr="org_id",
-        requesting_user=requesting_user,
-        parent_repo=organization_repo,
-        parent_model=Organization,
-        parent_noun="Organization",
-        child_noun="Program",
-    )
+# `PROGRAM_ENTITY.payload_authz_path` target — see the factory's docstring
+# for the contract. Module-level binding so the spec's dotted import
+# resolves.
+_assert_program_payload_org_ownership = make_fk_ownership_payload_authz(
+    attr="org_id",
+    parent_model=Organization,
+    parent_noun="Organization",
+    child_noun="Program",
+    parent_repo_kwarg="organization_repo",
+)
 
 
 async def program_form_extras(
@@ -79,15 +73,15 @@ async def program_form_extras(
     attached Org is still included in the dropdown so the form
     doesn't silently drop the FK on submit. The user can still
     re-point at any other Org they own; they just can't pretend the
-    current attachment doesn't exist.
+    current attachment doesn't exist. The framework helper
+    `list_picker_options_for` owns this re-include rule for every
+    parent-Org picker.
     """
-    orgs = await list_visible_to(organization_repo, requesting_user, Organization)
-    if target is not None:
-        org_ids = {o.id for o in orgs}
-        if target.org_id not in org_ids:
-            attached = await organization_repo.get_by_model_id(
-                Organization, target.org_id
-            )
-            if attached is not None:
-                orgs = [*orgs, attached]
-    return {"organizations": orgs}
+    return {
+        "organizations": await list_picker_options_for(
+            organization_repo,
+            requesting_user,
+            Organization,
+            attached_id=target.org_id if target is not None else None,
+        )
+    }

--- a/src/domain/logic/users/handlers.py
+++ b/src/domain/logic/users/handlers.py
@@ -1,35 +1,35 @@
 import logging
-from typing import Any
 from uuid import UUID
 
-from src.domain.logic.clinicians.repository import ClinicianRepository
 from src.domain.logic.users.repository import UserRepository
 from src.domain.logic.users.schema import UserActivationUpdate
 from src.domain.models import User
 from src.domain.specs.user import USER_ENTITY
 from src.framework.audit.core import record_audit
 from src.framework.audit.repository import AuditRepository
+from src.framework.dispatch.extras_factories import make_detail_extras_handler
 from src.framework.http.exceptions import NotFoundError
 
 logger = logging.getLogger(__name__)
 
 
-async def user_detail_extras(
-    *,
-    target: User,
-    clinician_repo: ClinicianRepository,
-    **_: Any,
-) -> dict[str, Any]:
-    """Per-viewer detail extras for `make_detail_handler(USER_ENTITY)`.
-
-    Fetches the clinicians the target owns. Viewer-derived flags
-    (`is_self`, `can_admin_actions`, `can_view_private`) and the
-    `target_user` projection are framework-injected by `handle_detail`
-    from `USER_ENTITY.public_fields` / `private_fields` /
-    `private_field_predicate` — defense-in-depth (a forgotten template
-    guard can re-leak; a missing dict key can't) is preserved.
-    """
-    return {"clinicians": await clinician_repo.list_for_user(target.id)}
+# `USER_ENTITY.detail_extras_path` target — fetches the clinicians the
+# target user owns and injects them under `clinicians` for the detail
+# template. Viewer-derived flags (`is_self`, `can_admin_actions`,
+# `can_view_private`) and the `target_user` projection are framework-
+# injected by `handle_detail` from `USER_ENTITY.public_fields` /
+# `private_fields` / `private_field_predicate` — defense-in-depth (a
+# forgotten template guard can re-leak; a missing dict key can't) is
+# preserved.
+user_detail_extras = make_detail_extras_handler(
+    (
+        (
+            "clinicians",
+            "clinician_repo",
+            lambda repo, target, _user: repo.list_for_user(target.id),
+        ),
+    )
+)
 
 
 async def handle_set_user_activation(

--- a/src/framework/access/authz/authz.py
+++ b/src/framework/access/authz/authz.py
@@ -4,11 +4,13 @@ asserting forms wrap them so `write_authz` (raising) and `can_write`
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from src.framework.http.exceptions import ForbiddenError
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+
     from src.framework.access.actor.actor import Actor
 
 
@@ -124,6 +126,40 @@ async def list_visible_to(repo, user: "Actor", model, *, owner_attr: str = "owne
     return list(await repo.list_for_user(user.id))
 
 
+async def list_picker_options_for(
+    repo,
+    requesting_user: "Actor",
+    model,
+    *,
+    attached_id=None,
+    owner_attr: str = "owner_id",
+):
+    """Return picker options for a form field, with the attached row
+    re-included when it would otherwise be missing.
+
+    Generalization of `list_visible_to` for edit forms whose row is
+    attached to a parent the requesting user no longer owns (ownership
+    transferred, viewer is a superuser editing someone else's row,
+    etc.). Without re-inclusion, a `<select>` rendered from the visible
+    set would silently drop the FK on submit; the framework's
+    `payload_authz` still gates whether the user may *change* the FK,
+    but the picker shouldn't pretend the current attachment doesn't
+    exist.
+
+    `attached_id=None` → equivalent to `list_visible_to` (create-form,
+    or an edit-form whose attachment is already in the visible set).
+    """
+    visible = await list_visible_to(repo, requesting_user, model, owner_attr=owner_attr)
+    if attached_id is None:
+        return visible
+    if any(getattr(row, "id", None) == attached_id for row in visible):
+        return visible
+    attached = await repo.get_by_model_id(model, attached_id)
+    if attached is None:
+        return visible
+    return [*visible, attached]
+
+
 async def assert_fk_ownership(
     *,
     payload,
@@ -163,3 +199,46 @@ async def assert_fk_ownership(
         raise ForbiddenError(
             detail=f"You may only attach a {child_noun} to a {parent_noun} you own"
         )
+
+
+def make_fk_ownership_payload_authz(
+    *,
+    attr: str,
+    parent_model,
+    parent_noun: str,
+    child_noun: str,
+    parent_repo_kwarg: str,
+) -> Callable[..., Awaitable[None]]:
+    """Build the `payload_authz` callable an `EntitySpec` references via
+    `payload_authz_path`.
+
+    Closes over the four nouns/columns that distinguish the per-entity
+    FK-ownership rule and returns an async hook with the framework-
+    expected signature (``async def hook(*, payload, requesting_user,
+    **typed_repos) -> None``). `parent_repo_kwarg` names the kwarg the
+    framework injects from `payload_authz_repos` (e.g.
+    ``"organization_repo"``).
+
+    Replaces the per-entity ``_assert_<x>_payload_org_ownership``
+    wrappers that used to exist solely to give the spec's
+    ``payload_authz_path`` a dotted target. The result is module-level
+    bound (so the dotted path resolves) but declarative.
+    """
+
+    async def _payload_authz(
+        *,
+        payload: "BaseModel",
+        requesting_user: "Actor",
+        **typed_repos: Any,
+    ) -> None:
+        await assert_fk_ownership(
+            payload=payload,
+            attr=attr,
+            requesting_user=requesting_user,
+            parent_repo=typed_repos[parent_repo_kwarg],
+            parent_model=parent_model,
+            parent_noun=parent_noun,
+            child_noun=child_noun,
+        )
+
+    return _payload_authz

--- a/src/framework/access/authz/test_authz.py
+++ b/src/framework/access/authz/test_authz.py
@@ -12,8 +12,10 @@ from src.framework.access.authz.authz import (
     is_owner,
     is_owner_or_admin,
     is_self_or_admin,
+    list_picker_options_for,
+    make_fk_ownership_payload_authz,
 )
-from src.framework.http.exceptions import ForbiddenError
+from src.framework.http.exceptions import ForbiddenError, NotFoundError
 
 
 def _user(*, is_superuser: bool = False, id_=None):
@@ -186,4 +188,229 @@ def test_assert_stranger_raises():
         assert_self_or_admin(target, actor, action="view this profile")
     assert "Only the user themselves or an admin can view this profile" in str(
         excinfo.value.detail
+    )
+
+
+# --- list_picker_options_for ----------------------------------------------
+#
+# Composes `list_visible_to` (already pinned through per-entity integration
+# tests) with the re-include-attached rule. The unit tests below only need
+# to lock the re-include branching since the visible-set call is straight
+# delegation.
+
+
+class _StubRepo:
+    """In-memory stand-in for a repository — minimum surface needed by
+    `list_picker_options_for`: `list_for_user`, `list_default`, and
+    `get_by_model_id`."""
+
+    def __init__(self, *, owned, all_, by_id=None):
+        self._owned = list(owned)
+        self._all = list(all_)
+        self._by_id = by_id or {}
+
+    async def list_for_user(self, _user_id):
+        return list(self._owned)
+
+    async def list_default(self, _model, order_by=None):
+        return list(self._all)
+
+    async def get_by_model_id(self, _model, id_):
+        return self._by_id.get(id_)
+
+
+class _StubModel:
+    """Stand-in for a SQLAlchemy model class — `list_visible_to` reads
+    `model.created_at.desc()` for the superuser path."""
+
+    created_at = SimpleNamespace(desc=lambda: None)
+
+
+def _row(*, id_):
+    return SimpleNamespace(id=id_)
+
+
+@pytest.mark.asyncio
+async def test_list_picker_options_for_no_attached_returns_visible_set():
+    """When `attached_id=None` (create form, or edit form whose row's
+    FK *is* in the visible set), the helper is a straight pass-through
+    over `list_visible_to`."""
+    user = _user()
+    a, b = _row(id_=uuid.uuid4()), _row(id_=uuid.uuid4())
+    repo = _StubRepo(owned=[a, b], all_=[a, b])
+    out = await list_picker_options_for(repo, user, _StubModel)
+    assert out == [a, b]
+
+
+@pytest.mark.asyncio
+async def test_list_picker_options_for_appends_attached_when_unowned():
+    """Edit-form's attached row that the requesting user no longer owns
+    still appears in the picker — otherwise the rendered `<select>`
+    would silently drop the FK on submit. Re-fetched from the repo and
+    appended; `assert_fk_ownership` still gates whether the user may
+    *change* the FK."""
+    user = _user()
+    visible = _row(id_=uuid.uuid4())
+    orphan_id = uuid.uuid4()
+    orphan = _row(id_=orphan_id)
+    repo = _StubRepo(owned=[visible], all_=[], by_id={orphan_id: orphan})
+    out = await list_picker_options_for(repo, user, _StubModel, attached_id=orphan_id)
+    assert out == [visible, orphan]
+
+
+@pytest.mark.asyncio
+async def test_list_picker_options_for_no_duplicate_when_attached_is_owned():
+    """When the attached row is already in the visible set, the helper
+    returns the visible list unchanged — no duplicate entry."""
+    user = _user()
+    owned_id = uuid.uuid4()
+    owned = _row(id_=owned_id)
+    repo = _StubRepo(owned=[owned], all_=[])
+    out = await list_picker_options_for(repo, user, _StubModel, attached_id=owned_id)
+    assert out == [owned]
+
+
+@pytest.mark.asyncio
+async def test_list_picker_options_for_attached_missing_returns_visible_set():
+    """When the attached row id no longer resolves (deleted parent),
+    don't surface a None — return the visible set as-is. The downstream
+    form will render without the now-deleted FK, which is the right UX
+    for an orphaned attachment."""
+    user = _user()
+    visible = _row(id_=uuid.uuid4())
+    repo = _StubRepo(owned=[visible], all_=[], by_id={})
+    out = await list_picker_options_for(
+        repo, user, _StubModel, attached_id=uuid.uuid4()
+    )
+    assert out == [visible]
+
+
+@pytest.mark.asyncio
+async def test_list_picker_options_for_superuser_sees_all():
+    """Superusers get the full set (the visible-set branch reads
+    `list_default`, not `list_for_user`)."""
+    admin = _user(is_superuser=True)
+    a, b = _row(id_=uuid.uuid4()), _row(id_=uuid.uuid4())
+    repo = _StubRepo(owned=[], all_=[a, b])
+    out = await list_picker_options_for(repo, admin, _StubModel)
+    assert out == [a, b]
+
+
+# --- make_fk_ownership_payload_authz --------------------------------------
+#
+# The factory closes over (attr, parent_model, parent_noun, child_noun,
+# parent_repo_kwarg) and produces a callable that matches the framework's
+# `payload_authz` contract. Each per-entity wrapper that used to be a
+# hand-written `async def` becomes a one-line factory call.
+
+
+class _StubParentModel:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_make_fk_ownership_payload_authz_owner_passes():
+    """Happy path: payload's FK points at a parent the requesting user
+    owns. No exception."""
+    user = _user()
+    parent_id = uuid.uuid4()
+    parent = SimpleNamespace(id=parent_id, owner_id=user.id)
+    repo = _StubRepo(owned=[], all_=[], by_id={parent_id: parent})
+    hook = make_fk_ownership_payload_authz(
+        attr="parent_id",
+        parent_model=_StubParentModel,
+        parent_noun="Parent",
+        child_noun="Child",
+        parent_repo_kwarg="parent_repo",
+    )
+    await hook(
+        payload=SimpleNamespace(parent_id=parent_id),
+        requesting_user=user,
+        parent_repo=repo,
+    )
+
+
+@pytest.mark.asyncio
+async def test_make_fk_ownership_payload_authz_unowned_403():
+    """403 when the parent exists but belongs to someone else."""
+    user = _user()
+    parent_id = uuid.uuid4()
+    parent = SimpleNamespace(id=parent_id, owner_id=uuid.uuid4())
+    repo = _StubRepo(owned=[], all_=[], by_id={parent_id: parent})
+    hook = make_fk_ownership_payload_authz(
+        attr="parent_id",
+        parent_model=_StubParentModel,
+        parent_noun="Parent",
+        child_noun="Child",
+        parent_repo_kwarg="parent_repo",
+    )
+    with pytest.raises(ForbiddenError):
+        await hook(
+            payload=SimpleNamespace(parent_id=parent_id),
+            requesting_user=user,
+            parent_repo=repo,
+        )
+
+
+@pytest.mark.asyncio
+async def test_make_fk_ownership_payload_authz_missing_404():
+    """404 when the parent doesn't exist — same shape as
+    `assert_fk_ownership` (no info leak about other users' parent ids)."""
+    user = _user()
+    parent_id = uuid.uuid4()
+    repo = _StubRepo(owned=[], all_=[], by_id={})
+    hook = make_fk_ownership_payload_authz(
+        attr="parent_id",
+        parent_model=_StubParentModel,
+        parent_noun="Parent",
+        child_noun="Child",
+        parent_repo_kwarg="parent_repo",
+    )
+    with pytest.raises(NotFoundError):
+        await hook(
+            payload=SimpleNamespace(parent_id=parent_id),
+            requesting_user=user,
+            parent_repo=repo,
+        )
+
+
+@pytest.mark.asyncio
+async def test_make_fk_ownership_payload_authz_none_fk_noop():
+    """PATCH payloads where the FK is absent / None are a no-op —
+    same delegation contract as `assert_fk_ownership`."""
+    user = _user()
+    repo = _StubRepo(owned=[], all_=[], by_id={})
+    hook = make_fk_ownership_payload_authz(
+        attr="parent_id",
+        parent_model=_StubParentModel,
+        parent_noun="Parent",
+        child_noun="Child",
+        parent_repo_kwarg="parent_repo",
+    )
+    await hook(
+        payload=SimpleNamespace(parent_id=None),
+        requesting_user=user,
+        parent_repo=repo,
+    )
+
+
+@pytest.mark.asyncio
+async def test_make_fk_ownership_payload_authz_superuser_bypass():
+    """Superusers bypass the owner check (the rule the underlying
+    `assert_fk_ownership` enforces)."""
+    admin = _user(is_superuser=True)
+    parent_id = uuid.uuid4()
+    parent = SimpleNamespace(id=parent_id, owner_id=uuid.uuid4())
+    repo = _StubRepo(owned=[], all_=[], by_id={parent_id: parent})
+    hook = make_fk_ownership_payload_authz(
+        attr="parent_id",
+        parent_model=_StubParentModel,
+        parent_noun="Parent",
+        child_noun="Child",
+        parent_repo_kwarg="parent_repo",
+    )
+    await hook(
+        payload=SimpleNamespace(parent_id=parent_id),
+        requesting_user=admin,
+        parent_repo=repo,
     )

--- a/src/framework/dispatch/README.md
+++ b/src/framework/dispatch/README.md
@@ -27,6 +27,7 @@ mount's query_params= tuple).
 - `redirects.py` — `Redirects` utility class with canned redirect-callable factories (`to_edit_form`, `to_detail`) for the `*_redirect` spec fields. Extracted from `entity_spec.py` to keep that file focused on the spec dataclass.
 - `mounts/` — the `mount_entity` dispatcher and the per-verb `mount_*` family, one file per verb. See [`mounts/README.md`](mounts/README.md) for the file-by-file layout. The `ResourceSpec` dataclass `mount_entity` constructs internally from the upstream `EntitySpec` lives at `mounts/_spec.py`. Per-mount docstrings document required spec fields and handler signatures. Handler synthesis infrastructure (`_FactoryShape`, shape constants, `_make_factory_handler`) lives in `mounts/_factory.py`.
 - `resource_routes.py` — re-export shim that lifts the public surface (`mount_entity`, the `mount_*` family, `ResourceSpec`, `QueryParam`, `MountError`) out of `mounts/` so external imports of `src.framework.dispatch.resource_routes` keep working.
+- `extras_factories.py` — `make_detail_extras_handler` (and future `make_*_extras_handler` siblings) that build the dotted-path target of `EntitySpec.detail_extras_path` / `form_extras_path` from a declarative tuple of `(context_key, repo_kwarg, fetch_fn)` rows. Hand-written hooks remain the right tool when the callable branches; the factory is for the pure "fetch → dict" shape.
 - `filters.py` — declarative filter types (`Filter` base, `TextFilter`, `ChoiceFilter`, `FlagFilter`) that an entity declares on `EntitySpec.filters`. Each carries both the URL contract (`name`, `annotation`, `default` — bridged to `QueryParam` via `to_query_param()` so FastAPI sees a normal `Query(...)` param) and UI metadata (`kind`, `label`, `placeholder`, `choices`, `multi`). Every declared `Filter` renders as a form control on the dedicated `/<collection>/search` page (`views/search.html`); the list-page toolbar carries only the "Filter · N" link (left) and the page-action menu (right). Active values appear as removable tags in the active-filter strip below the toolbar. Raw `QueryParam` entries on `EntitySpec.filters` still work (URL-only, no UI); `Filter` is layered on top, not a replacement.
 - `pagination.py` — `Page` snapshot dataclass + `parse_page` / `offset_for` / `paginate` / `base_query` helpers consumed by `handle_list` and the bespoke list handlers (`handle_list_my_favorites`, `handle_list_user_clinicians`). Reads `?page=N` from the request, asks the logic layer for `per_page + 1` rows, slices the probe off to compute `has_next` without a `COUNT(*)`. `DEFAULT_PAGE_SIZE = 25`; per-entity override via `EntitySpec.page_size`. The view-type template `views/list.html` renders the `_shared/pagination.html` footer automatically from the `page_meta` context var; pages where the result fits on a single page emit nothing.
 - `base_router.py` — thin `APIRouter` wrapper that applies the framework's common decorators (`handle_route_errors`, logging) and the per-entity router factory `make_entity_router(spec)`.
@@ -63,6 +64,38 @@ to any Org, but a different rule might not).
 Declaring `payload_authz_path` alongside an explicit `handlers["create"]`
 or `handlers["update"]` is rejected at mount time — the explicit
 handler would silently bypass the spec hook. Use one or the other.
+
+The common shape — "the user must own the parent row the payload's
+FK points at" — is captured by
+[`make_fk_ownership_payload_authz`](../access/authz/authz.py).
+Per-entity hooks that used to be hand-written `async def` wrappers
+around `assert_fk_ownership` are now one-line factory calls bound at
+module top level so the spec's dotted `payload_authz_path` resolves.
+Hooks that combine FK-ownership with other rules (e.g. AO name
+matching, rep-approval) stay hand-written.
+
+## Declarative extras hooks
+
+`detail_extras_path` (and the form / list variants) point at a
+callable whose body is often pure DI orchestration: call a small set
+of repo methods, return a dict for the template. That shape is
+captured by [`make_detail_extras_handler`](extras_factories.py) —
+the dotted path's target becomes a one-line factory call instead of
+an `async def`. Hand-written hooks remain appropriate when the
+callable branches on the requesting user (anonymous-viewer fallback,
+role-derived field set) or assembles return keys from non-1:1
+sources.
+
+## Picker options on form_extras hooks
+
+Form-extras hooks that populate a parent picker share a contract:
+owners see their own rows, superusers see all, and the edit path
+re-includes the currently-attached row when it would otherwise be
+missing (so a `<select>` doesn't silently drop the FK on submit when
+the attachment leaves the user's owned set). The
+[`list_picker_options_for`](../access/authz/authz.py) helper owns
+that rule; entity hooks delegate to it with `attached_id=target.<fk>
+if target else None`.
 
 ## Handler stitching
 

--- a/src/framework/dispatch/extras_factories.py
+++ b/src/framework/dispatch/extras_factories.py
@@ -1,0 +1,71 @@
+"""Factories that build per-spec extras callables (`detail_extras_path`,
+`form_extras_path` targets) from a declarative tuple of fetches.
+
+The hand-written extras callables are pure DI orchestration: call a
+small set of repo methods, assemble a dict for the template. This
+module captures that shape so a spec's hook target can be a one-line
+``make_*_extras_handler(...)`` call instead of a hand-written async
+def.
+
+The hand-written form is still appropriate when the hook branches on
+the requesting user (e.g. anonymous-viewer fallback, role-derived
+field set) or shapes the return dict from multiple sources whose
+relationship isn't 1:1 key/value. Use the factory only when each
+returned key maps to one repo call.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Sequence
+
+DetailFetch = tuple[
+    str,
+    str,
+    Callable[[Any, Any, Any], Awaitable[Any]],
+]
+"""One row in the `fetches` tuple passed to `make_detail_extras_handler`.
+
+Tuple of:
+
+- ``context_key`` — the dict key the result lands under in the
+  template context.
+- ``repo_kwarg`` — the name of the typed-repo kwarg the framework
+  injects (must match an entry in the spec's ``detail_extras_repos``).
+- ``fetch`` — an async callable ``fetch(repo, target, requesting_user)
+  -> value`` that returns the per-context-key value.
+
+The viewer arg is always passed (even when unused) so a fetch can
+react to viewer identity without changing the factory signature.
+"""
+
+
+def make_detail_extras_handler(
+    fetches: Sequence[DetailFetch],
+) -> Callable[..., Awaitable[dict[str, Any]]]:
+    """Build a ``detail_extras_path`` target from a tuple of
+    ``(context_key, repo_kwarg, fetch_fn)`` fetches.
+
+    The returned async callable matches the framework's extras contract
+    (``async def hook(*, target, requesting_user, request=None,
+    **typed_repos) -> dict[str, Any]``) and, for each fetch, calls
+    ``fetch_fn(repos[repo_kwarg], target, requesting_user)``. Results
+    assemble into a dict keyed by ``context_key`` and merge into the
+    template context downstream.
+
+    Bind the result at module top level so the spec's
+    ``detail_extras_path`` can resolve it via dotted-string import.
+    """
+    fetches_tuple = tuple(fetches)
+
+    async def _detail_extras(
+        *,
+        target: Any,
+        requesting_user: Any,
+        **typed_repos: Any,
+    ) -> dict[str, Any]:
+        return {
+            key: await fetch(typed_repos[repo_kwarg], target, requesting_user)
+            for key, repo_kwarg, fetch in fetches_tuple
+        }
+
+    return _detail_extras

--- a/src/framework/dispatch/test_extras_factories.py
+++ b/src/framework/dispatch/test_extras_factories.py
@@ -1,0 +1,76 @@
+"""Tests for `src/framework/dispatch/extras_factories.py`."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.framework.dispatch.extras_factories import make_detail_extras_handler
+
+
+@pytest.mark.asyncio
+async def test_make_detail_extras_handler_single_fetch():
+    """One fetch → one key in the result dict, populated by the
+    fetch's awaited return value."""
+
+    async def _fetch(repo, target, requesting_user):
+        return repo.suffix + str(target.id)
+
+    hook = make_detail_extras_handler(
+        (("label", "main_repo", _fetch),),
+    )
+    repo = SimpleNamespace(suffix="row-")
+    target = SimpleNamespace(id=7)
+    result = await hook(target=target, requesting_user=None, main_repo=repo)
+    assert result == {"label": "row-7"}
+
+
+@pytest.mark.asyncio
+async def test_make_detail_extras_handler_multiple_fetches_resolve_independently():
+    """Multiple fetches assemble into a single dict, each pulling from
+    its own declared repo kwarg."""
+
+    async def _fetch_a(repo, _target, _user):
+        return repo.value
+
+    async def _fetch_b(repo, _target, _user):
+        return repo.value
+
+    hook = make_detail_extras_handler(
+        (
+            ("a", "repo_a", _fetch_a),
+            ("b", "repo_b", _fetch_b),
+        ),
+    )
+    result = await hook(
+        target=SimpleNamespace(id=1),
+        requesting_user=None,
+        repo_a=SimpleNamespace(value="alpha"),
+        repo_b=SimpleNamespace(value="beta"),
+    )
+    assert result == {"a": "alpha", "b": "beta"}
+
+
+@pytest.mark.asyncio
+async def test_make_detail_extras_handler_passes_requesting_user_to_fetch():
+    """The viewer is threaded through every fetch — supports per-viewer
+    derivations like `is_favorited` without changing the factory shape."""
+    seen = {}
+
+    async def _fetch(_repo, _target, requesting_user):
+        seen["user"] = requesting_user
+        return None
+
+    hook = make_detail_extras_handler((("v", "r", _fetch),))
+    user = SimpleNamespace(id="u-1")
+    await hook(target=SimpleNamespace(id=1), requesting_user=user, r=None)
+    assert seen["user"] is user
+
+
+@pytest.mark.asyncio
+async def test_make_detail_extras_handler_empty_fetches_returns_empty_dict():
+    """Zero fetches is a degenerate but valid spec — the hook returns
+    `{}` so a future entity can declare the hook target before wiring
+    up its first fetch."""
+    hook = make_detail_extras_handler(())
+    result = await hook(target=SimpleNamespace(id=1), requesting_user=None)
+    assert result == {}


### PR DESCRIPTION
## Summary

Three hook callables in `src/domain/logic/*/handlers.py` were thin wrappers around framework primitives — `list_visible_to`, `assert_fk_ownership`, and a generic "fetch a few repos, return a dict" shape. Each is now a framework helper / factory, and the domain wrappers shrink to a single declarative call.

- `list_picker_options_for` (`framework/access/authz/authz.py`) — visible-to-viewer + re-include-attached rule. `program_form_extras` delegates instead of hand-rolling the re-include branch. Future parent-picker form_extras hooks (clinician affiliations, organization parent-org picker once it leaves stub status) can adopt without rewriting the logic.
- `make_fk_ownership_payload_authz` (`framework/access/authz/authz.py`) — factory for the `EntitySpec.payload_authz_path` "user must own the FK-referenced parent" rule. Replaces the clinician + program `_assert_*_payload_org_ownership` async-def wrappers with one-line module-level bindings.
- `make_detail_extras_handler` (`framework/dispatch/extras_factories.py`) — factory for the `EntitySpec.detail_extras_path` "fetch → dict" shape. `user_detail_extras` becomes declarative. `clinician_detail_extras` stays hand-written because it branches on anonymous viewer; the README spells out when the factory is the wrong tool.

The dispatch README documents both factories + the picker helper so future entity authors find them on the way to declaring a hook.

No behavior change. Per-entity integration tests still pass; the contract surfaces (HTTP, persisted JSON, URL shape, DB constraints) are untouched.

## Test plan

- [x] `dev test` (2724 passed, 99 skipped)
- [x] `dev lint`
- [x] New `framework/access/authz/test_authz.py` cases pin `list_picker_options_for` (5 branches) and `make_fk_ownership_payload_authz` (5 branches: owner / unowned-403 / missing-404 / none-fk-noop / superuser-bypass)
- [x] New `framework/dispatch/test_extras_factories.py` pins `make_detail_extras_handler` over the dict-assembly + viewer-threading + empty-fetches branches
- [x] Existing program / clinician / users handler tests pass unchanged — confirms behavior preservation through the factory rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)