### PR TITLE
Read opening practice facts from the opening's affiliation

### DIFF
--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -33,15 +33,15 @@ def _cr_post(
     )
 
 
-def _pa_post(**clinician_attrs):
-    clinician_attrs.setdefault("in_network_carriers", [])
-    clinician_attrs.setdefault("accepts_out_of_network", False)
-    clinician_attrs.setdefault("sliding_scale", False)
-    clinician_attrs.setdefault("cost", None)
+def _pa_post(**affiliation_attrs):
+    affiliation_attrs.setdefault("in_network_carriers", [])
+    affiliation_attrs.setdefault("accepts_out_of_network", False)
+    affiliation_attrs.setdefault("sliding_scale", False)
+    affiliation_attrs.setdefault("cost", None)
     return SimpleNamespace(
         kind="clinician_opening",
         opening_detail=SimpleNamespace(
-            clinician=SimpleNamespace(**clinician_attrs),
+            clinician_affiliation=SimpleNamespace(**affiliation_attrs),
         ),
     )
 
@@ -154,8 +154,8 @@ def test_referral_headline_falls_back_when_age_groups_empty():
 #
 # The view-model collapses three kind-specific detail shapes (CR has its
 # own location + a scalar gender; PA reads location + insurance off the
-# linked Clinician; program reads identity off the linked Program) into
-# one flat dict that templates iterate over. Tests below build a stub
+# linked ClinicianAffiliation; program reads identity off the linked
+# Program) into one flat dict that templates iterate over. Tests below build a stub
 # post per kind and pin the dict's shape end-to-end. Templates are
 # tested separately at the route level.
 
@@ -209,6 +209,19 @@ _PA_AFFILIATION_PROFILE_DEFAULTS = dict(
     modalities=[],
     website="https://example.com",
     referral_instructions="Email intake@example.com",
+    # Practice-role facts — org, location, sessions, payment — live on
+    # the affiliation the opening announces, never on the clinician
+    # (whose same-named attributes are primary-affiliation proxies).
+    org=SimpleNamespace(id="org-1", name="Acme Counseling"),
+    location_city="Brooklyn",
+    location_state="NY",
+    location_zip="11201",
+    in_person_sessions="yes",
+    virtual_sessions="please_contact",
+    in_network_carriers=["aetna"],
+    accepts_out_of_network=False,
+    sliding_scale=True,
+    cost="$150/session",
 )
 _PA_CLINICIAN_PERSON_DEFAULTS = dict(
     languages=["en"],
@@ -233,16 +246,6 @@ def _make_pa_post(*, clinician_attrs=None, **overrides):
         id="prov-1",
         first_name="Jane",
         last_name="Smith",
-        org=SimpleNamespace(id="org-1", name="Acme Counseling"),
-        location_city="Brooklyn",
-        location_state="NY",
-        location_zip="11201",
-        in_person_sessions="yes",
-        virtual_sessions="please_contact",
-        in_network_carriers=["aetna"],
-        accepts_out_of_network=False,
-        sliding_scale=True,
-        cost="$150/session",
         **_PA_CLINICIAN_PERSON_DEFAULTS,
     )
     aff = dict(**_PA_AFFILIATION_PROFILE_DEFAULTS)
@@ -463,16 +466,12 @@ def test_view_pa_headline_is_org_name_state_from_clinician():
     assert v["location_chunk"] == {"city": "Brooklyn", "state": "NY", "zip": "11201"}
 
 
-def test_view_pa_in_person_virtual_come_from_clinician():
-    """PA's session availability lives on the linked Clinician, not on
-    the post's detail row. The view-model normalizes both kinds onto
-    the same `in_person`/`virtual` keys so the card's modality chips
-    read from one source."""
-    v = post_card_view(
-        _make_pa_post(
-            clinician_attrs={"in_person_sessions": "no", "virtual_sessions": "yes"}
-        )
-    )
+def test_view_pa_in_person_virtual_come_from_affiliation():
+    """PA's session availability lives on the linked
+    ClinicianAffiliation, not on the post's detail row. The view-model
+    normalizes both kinds onto the same `in_person`/`virtual` keys so
+    the card's modality chips read from one source."""
+    v = post_card_view(_make_pa_post(in_person_sessions="no", virtual_sessions="yes"))
     assert v["in_person"] == "no"
     assert v["virtual"] == "yes"
 
@@ -483,18 +482,19 @@ def test_view_pa_practice_link_carries_id_and_org_name():
 
 
 def test_view_pa_organization_link_carries_org_id_and_name():
-    """Opening's org link reads through `clinician.org` so the detail
-    page's `Organization` row is a one-click jump to the owning org."""
+    """Opening's org link reads through `clinician_affiliation.org` so
+    the detail page's `Organization` row is a one-click jump to the
+    owning org."""
     v = post_card_view(_make_pa_post())
     assert v["organization_link"] == {"id": "org-1", "name": "Acme Counseling"}
 
 
-def test_view_pa_full_address_from_clinician():
+def test_view_pa_full_address_from_affiliation():
     v = post_card_view(_make_pa_post())
     assert v["full_address"] == "Brooklyn, NY 11201"
 
 
-def test_view_pa_insurance_fields_from_clinician():
+def test_view_pa_insurance_fields_from_affiliation():
     v = post_card_view(_make_pa_post())
     assert v["in_network_carriers"] == ["aetna"]
     assert v["accepts_out_of_network"] is False
@@ -658,9 +658,9 @@ def test_view_cr_missing_detail_returns_base_skeleton():
 
 def test_view_pa_missing_clinician_returns_partial_view():
     """PA's detail has a `clinician` relationship that could be None
-    in test stubs. View-model populates the announcement core and the
-    affiliation-sourced steady-state profile and leaves clinician-
-    derived fields at None."""
+    in test stubs, and the affiliation stub may be sparse. View-model
+    populates the announcement core and whatever affiliation-sourced
+    profile exists, leaving the rest at None instead of crashing."""
     post = SimpleNamespace(
         kind="clinician_opening",
         opening_detail=SimpleNamespace(
@@ -846,14 +846,17 @@ def test_row_summary_referral_missing_detail():
 
 def test_row_summary_opening_with_description_and_settings():
     """Opening with description + first settings label + sliding scale.
-    Settings come from the linked affiliation (#1358 PR-f sub-3)."""
+    Settings and sliding scale both come from the linked affiliation
+    (#1358 PR-f sub-3)."""
     post = SimpleNamespace(
         kind="clinician_opening",
         opening_detail=SimpleNamespace(
             description="2 slots open",
-            clinician=SimpleNamespace(sliding_scale=True),
             clinician_affiliation=SimpleNamespace(
-                settings=["outpatient"], age_groups=[], services=[]
+                settings=["outpatient"],
+                age_groups=[],
+                services=[],
+                sliding_scale=True,
             ),
         ),
     )
@@ -867,11 +870,11 @@ def test_row_summary_opening_no_description_builds_from_fields():
         kind="clinician_opening",
         opening_detail=SimpleNamespace(
             description=None,
-            clinician=SimpleNamespace(sliding_scale=False),
             clinician_affiliation=SimpleNamespace(
                 settings=[],
                 age_groups=["adults_25_64"],
                 services=["psychotherapy"],
+                sliding_scale=False,
             ),
         ),
     )
@@ -1152,6 +1155,49 @@ def test_opening_reads_services_from_affiliation():
     assert v["services"] == ["medication_management", "group_therapy"]
 
 
+def test_opening_practice_facts_come_from_its_affiliation_not_clinician_proxy():
+    """Regression: a multi-affiliation clinician's `Clinician` model
+    exposes primary-affiliation proxy properties (`location_city`,
+    `in_network_carriers`, `org`, …). An opening posted under a
+    NON-primary affiliation must show that affiliation's facts, so the
+    view must read them from `opening_detail.clinician_affiliation` —
+    never through the clinician proxies. The clinician stub here
+    carries the conflicting primary-practice values; none of them may
+    leak into the view."""
+    post = _make_pa_post()
+    # The clinician's primary affiliation (proxied on the model) is a
+    # DIFFERENT practice than the one this opening announces.
+    post.opening_detail.clinician = SimpleNamespace(
+        id="prov-1",
+        first_name="Jane",
+        last_name="Smith",
+        languages=["en"],
+        org=SimpleNamespace(id="org-OTHER", name="Primary Practice"),
+        location_city="Oakland",
+        location_state="CA",
+        location_zip="94601",
+        in_person_sessions="no",
+        virtual_sessions="no",
+        in_network_carriers=["cigna"],
+        accepts_out_of_network=True,
+        sliding_scale=False,
+        cost="$999/session",
+    )
+    v = post_card_view(post)
+    assert v["headline"] == "Acme Counseling"
+    assert v["practice_link"] == {"id": "prov-1", "name": "Acme Counseling"}
+    assert v["organization_link"] == {"id": "org-1", "name": "Acme Counseling"}
+    assert v["location_chunk"] == {"city": "Brooklyn", "state": "NY", "zip": "11201"}
+    assert v["full_address"] == "Brooklyn, NY 11201"
+    assert v["in_person"] == "yes"
+    assert v["virtual"] == "please_contact"
+    assert v["in_network_carriers"] == ["aetna"]
+    assert v["accepts_out_of_network"] is False
+    assert v["sliding_scale"] is True
+    assert v["cost"] == "$150/session"
+    assert insurance_posture_for_post(post) == "in_network"
+
+
 def test_opening_no_affiliation_yields_empty_lists():
     """No ``clinician_affiliation`` relationship loaded at all → the
     steady-state fields read as empty (no detail-row fallback after
@@ -1240,11 +1286,12 @@ def test_intake_no_program_yields_empty_lists():
 
 
 def test_feed_headline_opening_uses_affiliation_services():
-    """``post_feed_headline`` for openings reads ``services`` from the
-    linked affiliation."""
+    """``post_feed_headline`` for openings reads ``services`` AND the
+    practice name from the linked affiliation."""
     post = _make_pa_post()
     post.opening_detail.subject = None  # force the auto-generated branch
     post.opening_detail.clinician_affiliation = SimpleNamespace(
+        org=SimpleNamespace(id="org-1", name="Acme Counseling"),
         services=["medication_management"],
         settings=[],
         modalities=[],

--- a/src/domain/logic/posts/view.py
+++ b/src/domain/logic/posts/view.py
@@ -10,7 +10,7 @@ kinds model the underlying data with parallel shapes:
     of `INSURANCE_CARRIERS` tokens (#1358 PR-e). The posture is
     derived from the booleans in priority order: in-network →
     out-of-network → private-pay → please_contact (none set).
-  * `opening` → linked `Clinician` — the
+  * `opening` → linked `ClinicianAffiliation` — the
     `in_network_carriers` list (empty = no in-network) plus the
     `accepts_out_of_network` / `sliding_scale` booleans.
 
@@ -31,7 +31,10 @@ Genders that don't slot in naturally — `prefer_not_to_say`,
 card (`_item.html`) and the detail page (`detail.html`) read from. Each
 kind's underlying detail relationship has a different field set and
 naming — CR holds its own (city, state, zip) location and a single
-gender; PA reads location and insurance from the linked Clinician;
+gender; PA reads location and insurance from the linked
+ClinicianAffiliation (the practice the opening announces, NOT the
+clinician's primary-affiliation proxies — a multi-affiliation
+clinician's opening must show the posting practice's facts);
 program reads identity from the linked Program. The function collapses
 those three shapes into one flat dict so templates iterate over keys
 rather than branching on `post.kind`. Values that don't apply to a
@@ -107,14 +110,20 @@ def insurance_posture_for_post(post) -> str | None:
         return "please_contact"
     if kind == "clinician_opening":
         detail = getattr(post, "opening_detail", None)
-        clinician = getattr(detail, "clinician", None) if detail is not None else None
-        if clinician is None:
+        affiliation = (
+            getattr(detail, "clinician_affiliation", None)
+            if detail is not None
+            else None
+        )
+        if affiliation is None:
             return None
-        if clinician.in_network_carriers:
+        if getattr(affiliation, "in_network_carriers", None):
             return "in_network"
-        if clinician.accepts_out_of_network:
+        if getattr(affiliation, "accepts_out_of_network", None):
             return "out_of_network"
-        if clinician.sliding_scale or clinician.cost:
+        if getattr(affiliation, "sliding_scale", None) or getattr(
+            affiliation, "cost", None
+        ):
             return "self_pay"
         return "please_contact"
     if kind == "program_intake":
@@ -253,8 +262,9 @@ def post_card_view(post) -> dict[str, Any]:
         in_person / virtual: the post's in-person/virtual posture as
             `LOCATION_AVAILABILITY_OPTIONS` values. CR reads them off
             its own detail row; PA reads them from the linked
-            Clinician's session-availability fields. Program has no
-            in-person/virtual posture and returns ``None`` for both.
+            ClinicianAffiliation's session-availability fields. Program
+            has no in-person/virtual posture and returns ``None`` for
+            both.
         services / settings: raw enum lists. PA + program carry
             ``settings``; CR's ``settings`` is empty.
         ages / languages / genders: raw enum lists. CR's single
@@ -267,8 +277,8 @@ def post_card_view(post) -> dict[str, Any]:
             ``insurance_posture_for_post`` returns.
         treatment_modality: free-text modality string or ``None``.
         location_chunk: ``{city, state, zip}`` for CR (from the
-            detail row) and PA (from the linked Clinician) — the
-            demographics-column icon-only row both render. ``None``
+            detail row) and PA (from the linked ClinicianAffiliation) —
+            the demographics-column icon-only row both render. ``None``
             for program (no location of its own; ``state_preference``
             still surfaces via ``header_state``).
         description: free-text description or ``None``. CR's
@@ -278,22 +288,22 @@ def post_card_view(post) -> dict[str, Any]:
             for CR.
         desired_times: raw enum list of desired-time slots; empty if
             unset.
-        practice_link: ``{id, name}`` of PA's linked Clinician's org;
-            ``None`` for other kinds.
+        practice_link: ``{id, name}`` — the linked Clinician's id with
+            the affiliation's org name; ``None`` for other kinds.
         program_link: ``{id, name}`` of program's linked Program;
             ``None`` for other kinds.
         organization_link: ``{id, name}`` of the post's owning
-            Organization (PA reads through ``clinician.org``; program
-            intake reads through ``program.organization``). ``None``
-            for referral (CR has no org linkage in the model). The
-            facts block renders this as a clickable link so any post
+            Organization (PA reads through ``clinician_affiliation.org``;
+            program intake reads through ``program.organization``).
+            ``None`` for referral (CR has no org linkage in the model).
+            The facts block renders this as a clickable link so any post
             is one click from its org's detail page.
         full_address: ``"City, ST ZIP"`` string for the detail page's
             expanded location row. CR reads from its own location;
-            PA reads from the linked Clinician; program returns
-            ``None``.
-        sliding_scale / cost: PA-only fields from the linked Clinician;
-            ``None`` for other kinds.
+            PA reads from the linked ClinicianAffiliation; program
+            returns ``None``.
+        sliding_scale / cost: PA-only fields from the linked
+            ClinicianAffiliation; ``None`` for other kinds.
         accepts_in_network / accepts_out_of_network_superbill /
         accepts_private_pay: CR-only payment-path booleans from the
             detail row; ``None`` for other kinds.
@@ -305,7 +315,8 @@ def post_card_view(post) -> dict[str, Any]:
             empty list both for CR with none specified and for other
             kinds, so templates iterate uniformly via ``{% if view.x %}``.
         in_network_carriers / accepts_out_of_network: PA-only raw
-            values from the linked Clinician. ``in_network_carriers``
+            values from the linked ClinicianAffiliation.
+            ``in_network_carriers``
             comes back as an empty list when unset, matching the
             list/iteration convention; ``accepts_out_of_network`` is
             ``None`` for other kinds.
@@ -407,68 +418,57 @@ def post_card_view(post) -> dict[str, Any]:
             return base
         _forward_detail_passthrough(base, d)
         p = getattr(d, "clinician", None)
-        # #1358 PR-f sub-3: steady-state profile fields read exclusively
-        # from the linked ClinicianAffiliation (and `languages` from the
-        # linked Clinician). The detail row no longer carries these
-        # columns.
+        # Practice-role facts (org, location, sessions, payment) read
+        # from the affiliation the opening announces — NOT through the
+        # Clinician's primary-affiliation proxy properties, which would
+        # show the wrong practice for a multi-affiliation clinician.
+        # `languages` stays person-level on the Clinician (#1358 PR-f
+        # sub-3 dropped the detail-row columns for all of these).
         affiliation = getattr(d, "clinician_affiliation", None)
         for view_key, attr in _OPENING_AFFILIATION_FIELDS:
             base[view_key] = _read_list(affiliation, attr)
         base["languages"] = _read_list(p, "languages")
         _website = _read_scalar(affiliation, "website")
         _instructions = _read_scalar(affiliation, "referral_instructions")
+        _org = _read_scalar(affiliation, "org")
+        _org_name = getattr(_org, "name", None) if _org else None
         _fn = getattr(p, "first_name", None) if p else None
         _ln = getattr(p, "last_name", None) if p else None
         base.update(
             poster_name=" ".join(filter(None, [_fn, _ln])) or None,
-            headline=(p.org.name if p and getattr(p, "org", None) else None),
+            headline=_org_name,
             # `header_state` stays None — opening's location lives in
             # the demographics column via `location_chunk` (same row
             # treatment as referral). Both kinds match on where
             # location surfaces, so the list card's header line stays
             # uncluttered for both.
             header_state=None,
-            location_chunk=(
-                _location_chunk(
-                    getattr(p, "location_city", None),
-                    getattr(p, "location_state", None),
-                    getattr(p, "location_zip", None),
-                )
-                if p
-                else None
+            location_chunk=_location_chunk(
+                _read_scalar(affiliation, "location_city"),
+                _read_scalar(affiliation, "location_state"),
+                _read_scalar(affiliation, "location_zip"),
             ),
-            in_person=(getattr(p, "in_person_sessions", None) if p else None),
-            virtual=(getattr(p, "virtual_sessions", None) if p else None),
+            in_person=_read_scalar(affiliation, "in_person_sessions"),
+            virtual=_read_scalar(affiliation, "virtual_sessions"),
             practice_link=(
-                {"id": p.id, "name": p.org.name}
-                if p and getattr(p, "org", None) and getattr(p, "id", None)
+                {"id": p.id, "name": _org_name}
+                if _org_name and p and getattr(p, "id", None)
                 else None
             ),
             organization_link=(
-                {"id": p.org.id, "name": p.org.name}
-                if p
-                and getattr(p, "org", None)
-                and getattr(p.org, "id", None)
-                and getattr(p.org, "name", None)
+                {"id": _org.id, "name": _org_name}
+                if _org and getattr(_org, "id", None) and _org_name
                 else None
             ),
-            full_address=(
-                full_address(
-                    getattr(p, "location_city", None),
-                    getattr(p, "location_state", None),
-                    getattr(p, "location_zip", None),
-                )
-                if p
-                else None
+            full_address=full_address(
+                _read_scalar(affiliation, "location_city"),
+                _read_scalar(affiliation, "location_state"),
+                _read_scalar(affiliation, "location_zip"),
             ),
-            sliding_scale=(getattr(p, "sliding_scale", None) if p else None),
-            cost=(getattr(p, "cost", None) if p else None),
-            in_network_carriers=(
-                list(getattr(p, "in_network_carriers", None) or []) if p else []
-            ),
-            accepts_out_of_network=(
-                getattr(p, "accepts_out_of_network", None) if p else None
-            ),
+            sliding_scale=_read_scalar(affiliation, "sliding_scale"),
+            cost=_read_scalar(affiliation, "cost"),
+            in_network_carriers=_read_list(affiliation, "in_network_carriers"),
+            accepts_out_of_network=_read_scalar(affiliation, "accepts_out_of_network"),
             referral=_referral_or_none(_website, _instructions),
         )
         return base
@@ -576,7 +576,6 @@ def post_row_summary(post) -> str:
         d = getattr(post, "opening_detail", None)
         if d is None:
             return "Opening"
-        p = getattr(d, "clinician", None)
         affiliation = getattr(d, "clinician_affiliation", None)
         parts = []
         desc = getattr(d, "description", None)
@@ -595,7 +594,7 @@ def post_row_summary(post) -> str:
         settings = _read_list(affiliation, "settings")
         if settings:
             parts.append(TREATMENT_SETTINGS_LABELS.get(settings[0], settings[0]))
-        if p and getattr(p, "sliding_scale", None):
+        if _read_scalar(affiliation, "sliding_scale"):
             parts.append("sliding scale")
         return " · ".join(parts) if parts else "Opening"
 
@@ -652,13 +651,9 @@ def post_feed_headline(post) -> str:
             return "Opening"
         if subject := getattr(d, "subject", None):
             return subject
-        p = getattr(d, "clinician", None)
         affiliation = getattr(d, "clinician_affiliation", None)
-        practice = (
-            p.org.name
-            if p and getattr(p, "org", None) and getattr(p.org, "name", None)
-            else "Opening"
-        )
+        _org = _read_scalar(affiliation, "org")
+        practice = (getattr(_org, "name", None) if _org else None) or "Opening"
         # #1358 PR-f — services/settings read from the linked
         # ClinicianAffiliation.
         services = _read_list(affiliation, "services")

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -67,6 +67,11 @@ def _opening_post(
     post = Post(kind="clinician_opening", owner_id=owner_id)
     detail = make_opening_detail(clinician_id=clinician.id)
     detail.clinician = clinician
+    # Wire the affiliation the opening announces — production posts
+    # always carry it (`_resolve_affiliation_context`), and the view
+    # reads practice facts (org, location, payment) from here, not
+    # through the clinician's primary-affiliation proxies.
+    detail.clinician_affiliation = clinician.primary_clinician_affiliation
     post.opening_detail = detail
     return post
 

--- a/src/domain/templates/posts/_shared/_facts_block.html
+++ b/src/domain/templates/posts/_shared/_facts_block.html
@@ -5,8 +5,8 @@ Each fact is wrapped in a `<div>` so the `<dl>` grid can treat each
 in `base.html`, so the dt/dd still align in the parent's columns).
 Both referral and opening posts surface their location via the
 "Location" row — referral reads it from the post's own detail row,
-opening reads it from the linked clinician (the underlying model
-class is `Clinician`); the rendering treatment is identical.
+opening reads it from the linked `ClinicianAffiliation` (the practice
+the opening announces); the rendering treatment is identical.
 
 The list leads with the services row (`view.kind_verb` — `Seeking`
 for CR, `Providing` for PA/program/intake) when the post has any


### PR DESCRIPTION
## Summary

- The opening branches of `insurance_posture_for_post`, `post_card_view`, `post_row_summary`, and `post_feed_headline` read org, location, session availability, and payment posture through `Clinician`'s primary-affiliation proxy properties (`clinician.py:236-313`). For a multi-affiliation clinician, an opening posted under a non-primary practice displayed the **primary** practice's name, address, and insurance.
- All practice-role facts now read from `opening_detail.clinician_affiliation` — the practice the opening actually announces — matching how the steady-state profile fields (`services`/`settings`/…) already read since #1358 PR-f sub-3. Person-level facts (`poster_name`, `languages`) stay on the Clinician.
- `_opening_post` route-test factory now wires `detail.clinician_affiliation` like production posts do (`_resolve_affiliation_context`); new regression test pins that conflicting clinician-proxy values never leak into the view.

## Test plan

- [x] New regression test: clinician stub carries conflicting primary-practice values; none appear in the view
- [x] `pytest` full suite (2725 passed) + `dev test contract` (39 passed)
- [x] `dev lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)