### PR TITLE
Profile preview on opening/intake forms + client-oriented referral form copy

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -706,6 +706,122 @@ async def test_referral_create_form_renders_matching_dimension_fields(
     ), "no #clinical-niches-hidden container for the niche splitter"
 
 
+async def test_referral_form_uses_client_oriented_section_labels(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The referral form's structured fields describe the CLIENT (the
+    person being placed), not the referrer — so the section legends and
+    labels say so. Pins the client-oriented copy introduced when the
+    referral/opening data-home split was surfaced in the UI: the payment
+    section is the client's coverage, the provider-attribute fields are
+    grouped under "Provider sought", and the languages label names the
+    client."""
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/posts/form?kind=referral")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    # Parse to text so HTML-escaped apostrophes (`&#39;`) decode.
+    page_text = tree.body.text()
+    assert "Client's coverage" in page_text
+    assert "Provider sought" in page_text
+    assert "Languages the client speaks" in page_text
+    # The checkbox still binds the same wire field; only its label changed.
+    assert "bill the client's carrier" in page_text
+    assert (
+        tree.css_first('input[name="accepts_in_network"]') is not None
+    ), "renaming the section must not drop the accepts_in_network field"
+
+
+async def test_opening_create_form_renders_practice_profile_preview(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The opening create form shows a read-only preview of the selected
+    practice's steady-state profile (the same `affiliation_facts` rows
+    the practice page and the post detail render), so the author sees the
+    full post without navigating away. The default (first) affiliation's
+    card renders visible; the picker's value drives which card the inline
+    script reveals."""
+    clinician = make_clinician_with_org(
+        owner_id=logged_in_user.id, practice_name="Acme Health"
+    )
+    clinician.id = clinician.id or uuid.uuid4()
+    aff = clinician.primary_clinician_affiliation
+    aff.services = ["psychotherapy"]
+    aff.sliding_scale = True
+    aff.website = "https://acme.example.com"
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/posts/form?kind=clinician_opening")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    wrap = tree.css_first('[data-profile-preview="clinician_affiliation_id"]')
+    assert wrap is not None, "no practice-profile preview container on the opening form"
+    card = tree.css_first(f'div[data-preview-for="{aff.id}"]')
+    assert card is not None, "no preview card for the affiliation"
+    # The default (first) affiliation's card is visible without JS.
+    assert "hidden" not in card.attributes, "first preview card should be visible"
+    # Profile rows come from the shared affiliation_facts macro.
+    assert card.css_first('div[data-fact="services"]') is not None
+    assert "Psychotherapy" in card.text()
+    assert "Sliding scale" in card.text()
+    assert "https://acme.example.com" in card.text()
+
+
+async def test_intake_create_form_renders_program_profile_preview(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The intake create form shows a read-only preview of the selected
+    program's steady-state profile via the shared `program_facts` macro.
+    Requires a verified org rep who owns a program (the
+    `check_program_intake` gate)."""
+    org = make_organization_row(owner_id=logged_in_user.id, name="Acme Health")
+    rep = OrgRepresentation(
+        user_id=logged_in_user.id,
+        org_id=org.id,
+        role="coordinator",
+        authority_method="admin_review",
+        authority_status="verified",
+    )
+    program = make_program(
+        owner_id=logged_in_user.id,
+        org_id=org.id,
+        services=["group_therapy"],
+        website="https://riseiop.example.com",
+    )
+    program.organization = org
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(org)
+            session.add(rep)
+            session.add(program)
+
+    response = await authenticated_client.get("/posts/form?kind=program_intake")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+
+    wrap = tree.css_first('[data-profile-preview="program_id"]')
+    assert wrap is not None, "no program-profile preview container on the intake form"
+    card = tree.css_first(f'div[data-preview-for="{program.id}"]')
+    assert card is not None, "no preview card for the program"
+    assert "hidden" not in card.attributes, "first preview card should be visible"
+    assert card.css_first('div[data-fact="services"]') is not None
+    assert "Group therapy" in card.text()
+    assert "https://riseiop.example.com" in card.text()
+
+
 async def test_referral_edit_form_prefills_matching_dimension_fields(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -28,6 +28,7 @@ Clinician) via their own edit pages — see
 
 Field order:
   1. Which practice — establishes context for the whole form
+     (followed by a read-only preview of that practice's profile)
   2. About — description (free-text announcement copy)
   3. Availability — desired times / schedule notes
   4. Subject — optional, auto-generates; last because most users skip it
@@ -43,6 +44,9 @@ Field order:
 {%- from "_shared/forms.html" import entity_form -%}
 {%- from "_shared/form_copy.html" import schedule_notes_help -%}
 {%- from "_shared/actions.html" import actions -%}
+{%- from "_shared/_card.html" import card -%}
+{%- from "_shared/sections.html" import facts_block as profile_facts_block -%}
+{%- from "_shared/_affiliation_facts.html" import affiliation_facts -%}
 {%- macro opening_form(hx_method, action, submit_label=none, post=None, schema=None, current_user=None, cancel_url=None) -%}
   {%- set d = post.opening_detail if post else None -%}
   {# `error_swap=True` lights up the response-targets attrs that swap a
@@ -70,17 +74,65 @@ Field order:
       {%- endfor -%}
     {%- endfor -%}
     {{ composite_select_field("clinician_affiliation_id", "Which practice?", _practices.opts, current=d.clinician_affiliation_id if d else None, default_first=true) }}
-    {# About: free-text announcement copy. Other steady-state profile
+    {# Read-only preview of the steady-state practice profile that renders
+     alongside this opening on its detail page — the same
+     `affiliation_facts` rows the practice page and the post detail show.
+     One card per affiliation is pre-rendered; the script below reveals
+     the one matching the picker so the preview tracks the selection
+     without a server round-trip. The profile is edited on the practice
+     page, never on this announcement form (#1358 PR-f). #}
+    {# The first card renders visible (the picker defaults to the first
+       affiliation via `default_first`); the rest start `hidden` and the
+       script toggles on change. So no-JS authors still see the default
+       practice's profile. #}
+    {%- set _pv = namespace(first=true) -%}
+    <div class="profile-preview"
+         data-profile-preview="clinician_affiliation_id">
+      {%- for c in current_user.clinicians -%}
+        {%- for aff in c.clinician_affiliations -%}
+          {%- set _name = (c.first_name ~ " " ~ c.last_name)|trim -%}
+          <div data-preview-for="{{ aff.id }}"
+               {% if not _pv.first %}hidden{% endif %}>
+            {%- call card(id="opening-preview-" ~ aff.id|string,
+              headline_url=None,
+              headline="Shown with this opening",
+              subtitle="From " ~ ((_name ~ " · " ~ aff.org.name) if aff.org else _name) ~ "’s profile") %}
+              {%- call profile_facts_block() %}{{ affiliation_facts(aff) }}{%- endcall %}
+              {%- endcall %}
+            </div>
+            {%- set _pv.first = false -%}
+          {%- endfor -%}
+        {%- endfor -%}
+      </div>
+      {# About: free-text announcement copy. Other steady-state profile
      fields (referral_instructions, website, services, etc.) are managed
      on the affiliation profile, not on the announcement. #}
-    {% call form_section("About") %}
-      {{ field_for(schema, "description", "Description", current=d.description if d else None) }}
-    {% endcall %}
-    {% call form_section("Availability") %}
-      {{ multi_select_field("desired_times", "Desired times", DESIRED_TIME_SLOTS, labels=DESIRED_TIME_SLOT_LABELS, current=d.desired_times if d else None, required=false) }}
-      {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
-    {% endcall %}
-    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
-    {{ actions(submit_label, cancel_url=cancel_url) }}
-  {%- endcall -%}
-{%- endmacro -%}
+      {% call form_section("About") %}
+        {{ field_for(schema, "description", "Description", current=d.description if d else None) }}
+      {% endcall %}
+      {% call form_section("Availability") %}
+        {{ multi_select_field("desired_times", "Desired times", DESIRED_TIME_SLOTS, labels=DESIRED_TIME_SLOT_LABELS, current=d.desired_times if d else None, required=false) }}
+        {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
+      {% endcall %}
+      {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
+      {{ actions(submit_label, cancel_url=cancel_url) }}
+    {%- endcall -%}
+    {# Reveal the preview card matching the selected practice; re-sync on
+     every picker change so the author always sees the profile that will
+     accompany the opening they're posting. #}
+    <script>
+  (function () {
+    var wrap = document.querySelector('[data-profile-preview="clinician_affiliation_id"]');
+    var select = document.querySelector('select[name="clinician_affiliation_id"]');
+    if (!wrap || !select) return;
+    function sync() {
+      var id = select.value;
+      wrap.querySelectorAll('[data-preview-for]').forEach(function (el) {
+        el.toggleAttribute('hidden', el.getAttribute('data-preview-for') !== id);
+      });
+    }
+    select.addEventListener('change', sync);
+    sync();
+  })();
+    </script>
+  {%- endmacro -%}

--- a/src/domain/templates/posts/_form_program_intake.html
+++ b/src/domain/templates/posts/_form_program_intake.html
@@ -29,6 +29,7 @@ the linked Program — see `src/domain/models/programs/README.md`.
 
 Field order:
   1. Which program — establishes context for the whole form
+     (followed by a read-only preview of that program's profile)
   2. About — description (free-text announcement copy)
   3. Availability — desired times / schedule notes
   4. Subject — optional, auto-generates; last because most users skip it
@@ -43,6 +44,9 @@ Field order:
 {%- from "_shared/forms.html" import entity_form -%}
 {%- from "_shared/form_copy.html" import schedule_notes_help -%}
 {%- from "_shared/actions.html" import actions -%}
+{%- from "_shared/_card.html" import card -%}
+{%- from "_shared/sections.html" import facts_block as profile_facts_block -%}
+{%- from "_shared/_program_facts.html" import program_facts -%}
 {%- macro intake_form(hx_method, action, submit_label=none, post=None, schema=None, current_user=None, cancel_url=None) -%}
   {%- set d = post.intake_detail if post else None -%}
   {# `error_swap=True` lights up the response-targets attrs that swap a
@@ -60,16 +64,57 @@ Field order:
       {%- set _programs.opts = _programs.opts + [(p.id, p.name ~ ' · ' ~ p.organization.name)] -%}
     {%- endfor -%}
     {{ composite_select_field("program_id", "Which program?", _programs.opts, current=d.program_id if d else None) }}
-    {# About: free-text announcement copy. Other steady-state profile
+    {# Read-only preview of the steady-state program profile that renders
+     alongside this intake on its detail page — the same `program_facts`
+     rows the program detail page and the post detail show. One card per
+     program is pre-rendered; the script below reveals the one matching
+     the picker so the preview tracks the selection without a server
+     round-trip. The profile is edited on the program page, never on this
+     announcement form (#1358 PR-f). #}
+    {# The first card renders visible (the picker defaults to the first
+       program); the rest start `hidden` and the script toggles on
+       change, so no-JS authors still see the default program's profile. #}
+    <div class="profile-preview" data-profile-preview="program_id">
+      {%- for p in current_user.programs -%}
+        <div data-preview-for="{{ p.id }}"
+             {% if not loop.first %}hidden{% endif %}>
+          {%- call card(id="intake-preview-" ~ p.id|string,
+            headline_url=None,
+            headline="Shown with this intake",
+            subtitle="From " ~ p.name ~ " · " ~ p.organization.name ~ "’s profile") %}
+            {%- call profile_facts_block() %}{{ program_facts(p) }}{%- endcall %}
+            {%- endcall %}
+          </div>
+        {%- endfor -%}
+      </div>
+      {# About: free-text announcement copy. Other steady-state profile
      fields are managed on the Program, not on the announcement. #}
-    {% call form_section("About") %}
-      {{ field_for(schema, "description", "Description", current=d.description if d else None) }}
-    {% endcall %}
-    {% call form_section("Availability") %}
-      {{ multi_select_field("desired_times", "Desired times", DESIRED_TIME_SLOTS, labels=DESIRED_TIME_SLOT_LABELS, current=d.desired_times if d else None, required=false) }}
-      {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
-    {% endcall %}
-    {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
-    {{ actions(submit_label, cancel_url=cancel_url) }}
-  {%- endcall -%}
-{%- endmacro -%}
+      {% call form_section("About") %}
+        {{ field_for(schema, "description", "Description", current=d.description if d else None) }}
+      {% endcall %}
+      {% call form_section("Availability") %}
+        {{ multi_select_field("desired_times", "Desired times", DESIRED_TIME_SLOTS, labels=DESIRED_TIME_SLOT_LABELS, current=d.desired_times if d else None, required=false) }}
+        {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
+      {% endcall %}
+      {{ text_field("subject", "Subject", required=False, maxlength=120, help="Leave blank to auto-generate.", current=d.subject if d else None) }}
+      {{ actions(submit_label, cancel_url=cancel_url) }}
+    {%- endcall -%}
+    {# Reveal the preview card matching the selected program; re-sync on
+     every picker change so the author always sees the profile that will
+     accompany the intake they're posting. #}
+    <script>
+  (function () {
+    var wrap = document.querySelector('[data-profile-preview="program_id"]');
+    var select = document.querySelector('select[name="program_id"]');
+    if (!wrap || !select) return;
+    function sync() {
+      var id = select.value;
+      wrap.querySelectorAll('[data-preview-for]').forEach(function (el) {
+        el.toggleAttribute('hidden', el.getAttribute('data-preview-for') !== id);
+      });
+    }
+    select.addEventListener('change', sync);
+    sync();
+  })();
+    </script>
+  {%- endmacro -%}

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -17,10 +17,12 @@ Field order:
   3. Client demographics — age, language, gender
   4. Client location — where / what format
   5. Availability — when (split from location; parallels opening/intake)
-  6. Services needed — what kind of help
-  7. Insurance — three independent payment-path booleans + carrier list
-     (`accepts_in_network` / `accepts_out_of_network_superbill` /
-     `accepts_private_pay`; per-corpus they are non-mutually-exclusive)
+  6. Provider sought — services / modalities / acceptable license classes
+  7. Client's coverage — three independent payment-path booleans + carrier
+     list (`accepts_in_network` / `accepts_out_of_network_superbill` /
+     `accepts_private_pay`; per-corpus they are non-mutually-exclusive).
+     These describe the *client's* insurance situation, not the
+     referrer's.
   8. Subject — optional, auto-generates; last because most users skip it
 
 The `desired_times` checkbox grid sends form-encoded data with multiple
@@ -79,14 +81,14 @@ which FastAPI/Pydantic parses as a list.
     <div id="clinical-niches-hidden" hidden></div>
     {% call form_section("Client demographics") %}
       {{ field_for(schema, "age_groups", "Age groups", current=d.age_groups if d else None, help=select_all_help() ) }}
-      {{ field_for(schema, "languages", "Languages spoken", current=d.languages if d else None) }}
+      {{ field_for(schema, "languages", "Languages the client speaks", current=d.languages if d else None) }}
       {{ select_field("gender", "Gender", GENDERS, labels=GENDER_LABELS, current=d.gender if d else None) }}
       {# Affirming-identity request constraints (#1358 PR-a). Symmetric
          to `Clinician.affirming_identities` — the referrer states the
          affordances the client needs, the clinician claims the ones
          they offer. Empty selection = "no preference stated", which is
          the schema default. #}
-      {{ multi_select_field("affirming_identities", "Affirming identities", AFFIRMING_IDENTITIES, labels=AFFIRMING_IDENTITY_LABELS, current=d.affirming_identities if d else None, required=false, help=select_all_help() ) }}
+      {{ multi_select_field("affirming_identities", "Affirming identities", AFFIRMING_IDENTITIES, labels=AFFIRMING_IDENTITY_LABELS, current=d.affirming_identities if d else None, required=false, help="Affordances the client needs — select all that apply.") }}
     {% endcall %}
     {% call form_section("Client location") %}
       {{ text_field("location_city", "City", current=d.location_city if d else None) }}
@@ -98,7 +100,7 @@ which FastAPI/Pydantic parses as a list.
     {% call form_section("Availability") %}
       {{ multi_select_field("desired_times", "Desired times", DESIRED_TIME_SLOTS, labels=DESIRED_TIME_SLOT_LABELS, current=d.desired_times if d else None, required=false) }}
     {% endcall %}
-    {% call form_section("Services needed") %}
+    {% call form_section("Provider sought") %}
       {{ multi_select_field("services", "Services", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None) }}
       {{ multi_select_field("modalities", "Treatment modalities", TREATMENT_MODALITIES, labels=TREATMENT_MODALITY_LABELS, current=d.modalities if d else None, required=false) }}
       {# License-class disjunction on the referred provider (#1358 PR-b).
@@ -116,8 +118,8 @@ which FastAPI/Pydantic parses as a list.
      network is true). A tiny inline script (below) hides the carrier
      multi-select when none of the three checkboxes is "accepts in-
      network", so the form still reads one-thought-per-row. #}
-    {% call form_section("Insurance") %}
-      {{ checkbox_field("accepts_in_network", "In-network — bill the patient's carrier", current=(d.accepts_in_network if d else False) ) }}
+    {% call form_section("Client's coverage") %}
+      {{ checkbox_field("accepts_in_network", "In-network — bill the client's carrier", current=(d.accepts_in_network if d else False) ) }}
       {{ checkbox_field("accepts_out_of_network_superbill", "Out-of-network with superbill", current=(d.accepts_out_of_network_superbill if d else False) ) }}
       {{ checkbox_field("accepts_private_pay", "Private pay (out of pocket)", current=(d.accepts_private_pay if d else False) ) }}
       <div id="insurance-carriers-wrap"


### PR DESCRIPTION
## Summary

- **Opening + intake forms** are thin by design (#1358 PR-f) — they carry only the announcement, while the steady-state profile lives on the linked practice/program. Authors had no way to see the profile that would accompany their post without navigating away. This adds a read-only **profile preview** under each form's picker, composed from the shared `affiliation_facts` / `program_facts` row sets (the same rows the practice/program pages and the post detail render). The default (first) practice/program's card renders visible without JS; a tiny inline script reveals the card matching the picker as the selection changes. No new route — one card per option is pre-rendered and toggled client-side.
- **Referral form copy** now says the structured fields describe the *client*, not the referrer: `Insurance` → **Client's coverage**, `Languages spoken` → **Languages the client speaks**, the provider-attribute fields grouped under **Provider sought**, and the affirming-identities help reframed as the affordances the client needs. Wire field names are unchanged — labels only.

## Test plan

- [x] New route tests: opening form renders the practice-profile preview card (services/sliding-scale/website rows, first card visible); intake form renders the program-profile preview (past the `check_program_intake` gate); referral form uses the client-oriented section labels and keeps the `accepts_in_network` field
- [x] `pytest` full suite (2732 passed) + `dev test contract` (39 passed) + `dev lint`
- [ ] ⚠️ Not browser-verified: same worktree dev-env gap as #1444 (`ENVIRONMENT` not forwarded to the container, so `/dev/login-as-seed-user` 404s). Behavior covered by the route-level rendering tests; a manual look at the opening/intake create forms before merge is worthwhile, especially the picker→preview toggle JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)