### PR TITLE
Model the superuser override inside the capability tree

### DIFF
--- a/src/domain/logic/capabilities.py
+++ b/src/domain/logic/capabilities.py
@@ -29,14 +29,26 @@ so a visible affordance and its server-side gate can't disagree.
 
 Capability trees compose from a small vocabulary of reusable leaves
 held in the `LEAVES` registry (`EMAIL_LEAF`, `CLINICIAN_VERIFIED_LEAF`,
-`ORG_REP_ANY_LEAF`, `OWNS_PROGRAM_LEAF`). Each `Leaf` is the single
-source of truth for its `(label_active, label_done, fix_url)` triple
-and predicate; capability `check_*` functions compose trees by calling
-`leaf.evaluate(actor)` rather than re-declaring `Condition` nodes
-inline. The framework's `LeafRegistry` (see
+`ORG_REP_ANY_LEAF`, `OWNS_PROGRAM_LEAF`, `SUPERUSER_LEAF`). Each `Leaf`
+is the single source of truth for its `(label_active, label_done,
+fix_url)` triple and predicate; capability `check_*` functions compose
+trees by calling `leaf.evaluate(actor)` rather than re-declaring
+`Condition` nodes inline. The framework's `LeafRegistry` (see
 `src/framework/access/capabilities/capabilities.py`) is the DAG node
 table — `LEAVES.all()` is the introspection surface for "every fact
 this app gates on".
+
+**Superuser policy — superusers hold every capability.** The policy has
+one home, the `superuser(user)` predicate. Every boolean `can_*` gate
+consults it first; every tree-based `check_*` composes it via
+`_superuser_gate`, which OR-wraps the real requirement tree with a
+`Superuser` condition *only when the viewer holds it* — normal users
+never see the override branch, superusers see exactly why they're
+granted. `check_superuser` exposes the override as its own capability
+on `/users/me/access/capabilities`, again only for holders (it returns
+``None`` otherwise, which the framework treats as 404/omitted).
+Row-level admin rights (edit/delete another user's rows) are a separate
+authz axis (`src/framework/access/authz`) and are not modeled here.
 
 To add a new entity-dependency leaf:
 
@@ -160,6 +172,23 @@ class ClaimState:
     a: bool = False
     b: frozenset[UUID] = field(default_factory=frozenset)
     lapsed: tuple[str, ...] = ()
+
+
+def superuser(user: Any) -> bool:
+    """Operational override: superusers hold every capability. This is
+    the single home for that policy — every `can_*` predicate consults
+    it first, and the tree-based `check_*` functions compose it via
+    `_superuser_gate` so the capability UI shows the override as an
+    explicit OR branch instead of silently flipping `granted`.
+
+    Deliberately NOT a claim and NOT consulted by the leaf *facts*
+    (`email_verified`, `clinician_verified`, …): being a superuser
+    doesn't make your email verified — it makes the verification
+    unnecessary. Facts stay factual; only capability grants override.
+    """
+    if user is None:
+        return False
+    return bool(getattr(user, "is_superuser", False))
 
 
 def email_verified(user: Any) -> bool:
@@ -299,6 +328,40 @@ OWNS_PROGRAM_LEAF = LEAVES.register(
     )
 )
 
+SUPERUSER_LEAF = LEAVES.register(
+    Leaf(
+        name="superuser",
+        # Both label forms are nominal, not imperative — there is no
+        # self-serve path to becoming a superuser, so the leaf never
+        # renders as an actionable step. `fix_url` is empty for the same
+        # reason; the requirements renderer shows a plain label when a
+        # leaf carries no fix link.
+        label_active="Superuser",
+        label_done="Superuser",
+        fix_url="",
+        predicate=superuser,
+    )
+)
+
+
+def _superuser_gate(user: Any, tree: Any) -> Any:
+    """Wrap a capability's requirement tree in the superuser override.
+
+    For a superuser the result is ``Gate(any of: <tree>, Superuser)`` —
+    the capability detail page then shows *why* access is granted as an
+    explicit "any one of these" branch. For everyone else the tree is
+    returned unchanged: the override is an operational fact we don't
+    advertise to users who don't hold it, so their requirement view
+    stays exactly the real, actionable tree.
+    """
+    if not superuser(user):
+        return tree
+    return Gate(
+        label_active=tree.label_active,
+        label_done=tree.label_done,
+        children=(tree, SUPERUSER_LEAF.evaluate(user)),
+    )
+
 
 def check_provider_identity(user: Any) -> CapabilityCheck:
     """Structured capability check for "the user has a verified provider
@@ -317,24 +380,28 @@ def check_provider_identity(user: Any) -> CapabilityCheck:
       `_assert_post_payload_authz`; this check is for surfacing
       identity verification as the gating step in the picker UI.
 
-    Tree: email_verified AND (clinician_verified OR org_rep_verified).
+    Tree: email_verified AND (clinician_verified OR org_rep_verified),
+    OR'd with the superuser override for superusers (`_superuser_gate`).
     `ever_verified_at` retention is intentionally excluded — access
     reverts immediately when the underlying claim lapses.
     """
     return CapabilityCheck(
         name="provider-network",
         description="See full provider details and reach out directly.",
-        tree=Bundle(
-            label_active="Provider network",
-            label_done="Provider network",
-            children=(
-                EMAIL_LEAF.evaluate(user),
-                Gate(
-                    label_active="Verify a clinician or organization",
-                    label_done="Clinician or organization verified",
-                    children=(
-                        CLINICIAN_VERIFIED_LEAF.evaluate(user),
-                        ORG_REP_ANY_LEAF.evaluate(user),
+        tree=_superuser_gate(
+            user,
+            Bundle(
+                label_active="Provider network",
+                label_done="Provider network",
+                children=(
+                    EMAIL_LEAF.evaluate(user),
+                    Gate(
+                        label_active="Verify a clinician or organization",
+                        label_done="Clinician or organization verified",
+                        children=(
+                            CLINICIAN_VERIFIED_LEAF.evaluate(user),
+                            ORG_REP_ANY_LEAF.evaluate(user),
+                        ),
                     ),
                 ),
             ),
@@ -361,49 +428,67 @@ def check_program_intake(user: Any) -> CapabilityCheck:
     return CapabilityCheck(
         name="program-intake",
         description="Publish a program intake on /posts/form.",
-        tree=Bundle(
-            label_active="Program intake",
-            label_done="Program intake",
-            children=(
-                EMAIL_LEAF.evaluate(user),
-                *OWNS_PROGRAM_LEAF.evaluate_chain(user),
+        tree=_superuser_gate(
+            user,
+            Bundle(
+                label_active="Program intake",
+                label_done="Program intake",
+                children=(
+                    EMAIL_LEAF.evaluate(user),
+                    *OWNS_PROGRAM_LEAF.evaluate_chain(user),
+                ),
             ),
         ),
     )
 
 
+def check_superuser(user: Any) -> CapabilityCheck | None:
+    """The superuser override as its own capability — visible ONLY to
+    users who hold it.
+
+    Returns ``None`` for everyone else, which the capability routes
+    treat as "not applicable": omitted from the list page, 404 on the
+    detail page. Superuser is an operational fact, not a step users can
+    work toward, so advertising it to normal users would only confuse
+    the requirements view.
+    """
+    if not superuser(user):
+        return None
+    return CapabilityCheck(
+        name="superuser",
+        description="Operational override — every capability is granted.",
+        tree=Bundle(
+            label_active="Superuser",
+            label_done="Superuser",
+            children=(SUPERUSER_LEAF.evaluate(user),),
+        ),
+    )
+
+
 def can_post_program_intake_picker(user: Any) -> bool:
-    """Picker-tile gate: superuser bypass, otherwise the structured
-    check.
+    """Picker-tile gate: the boolean form of `check_program_intake`.
 
     Symmetric with `can_act_as_provider` — both are the boolean form of
     the matching `check_*` for surfaces that only need granted/not
-    (the picker tile, the locked-CTA branch). Per-row authorization on
-    the post create payload stays with
-    `can_post_program_intake(user, org)` and its caller in
+    (the picker tile, the locked-CTA branch). The superuser override is
+    inside the check's tree (`_superuser_gate`), so no separate bypass
+    is needed here. Per-row authorization on the post create payload
+    stays with `can_post_program_intake(user, org)` and its caller in
     `_assert_post_payload_capability`.
     """
-    if getattr(user, "is_superuser", False):
-        return True
     return check_program_intake(user).granted
 
 
 def can_act_as_provider(user: Any) -> bool:
-    """Feed-teaser gate: superuser bypass, otherwise delegates to
-    `check_provider_identity`.
+    """Feed-teaser gate: the boolean form of `check_provider_identity`.
 
-    Symmetric with `assert_can_act_as_provider` — both forms grant
-    superusers full read access regardless of claim state, so the
-    route-level guard and the template-level affordance can't
-    disagree about what a superuser sees. Without the bypass here,
-    a superuser navigating around would clear the route's 403 check
-    yet still see locked-popover affordances in templates that read
-    `{% if can_act_as_provider %}` or render `entity_link(...)` for
-    a gated entity — a contradictory UX where the chrome treats the
-    viewer as locked while the underlying page is open.
+    Symmetric with `assert_can_act_as_provider` — the route-level guard
+    and the template-level affordance read the same predicate, so they
+    can't disagree about what a viewer sees. The superuser override is
+    inside the check's tree (`_superuser_gate`) — superusers get full
+    read access with the grant visible as an OR branch on the
+    capability detail page, not via a side-channel bypass.
     """
-    if getattr(user, "is_superuser", False):
-        return True
     return check_provider_identity(user).granted
 
 
@@ -450,35 +535,39 @@ VERIFIED_PROVIDER_READ_POLICY: ReadPolicy = ReadPolicy(
 
 def can_post_referral(user: Any) -> bool:
     """Self-path gate: posting a referral as the owning clinician requires
-    Claim A (handoff §4.3). The org-rep authority path in
-    `_assert_post_payload_authz` bypasses this check."""
-    return clinician_verified(user)
+    Claim A (handoff §4.3) — or the superuser override. The org-rep
+    authority path in `_assert_post_payload_authz` bypasses this check."""
+    return superuser(user) or clinician_verified(user)
 
 
 def can_post_opening(user: Any) -> bool:
     """Self-path gate: posting a clinician opening as the owning clinician
-    requires Claim A (handoff §4.3). The org-rep authority path in
-    `_assert_post_payload_authz` bypasses this check."""
-    return clinician_verified(user)
+    requires Claim A (handoff §4.3) — or the superuser override. The
+    org-rep authority path in `_assert_post_payload_authz` bypasses this
+    check."""
+    return superuser(user) or clinician_verified(user)
 
 
 def can_message(user: Any) -> bool:
-    """Responding/messaging requires Claim A (handoff §4.3). The messages
-    cluster does not yet exist; the predicate is shipped so it can be
-    wired into route handlers the moment that cluster lands."""
-    return clinician_verified(user)
+    """Responding/messaging requires Claim A (handoff §4.3) — or the
+    superuser override. The messages cluster does not yet exist; the
+    predicate is shipped so it can be wired into route handlers the
+    moment that cluster lands."""
+    return superuser(user) or clinician_verified(user)
 
 
 def can_post_program_intake(user: Any, org: Any) -> bool:
     """Posting a program intake on behalf of an org requires Claim B for
-    that org. Placeholder: always False until OrgRepresentation lands."""
-    return org_rep_verified(user, org)
+    that org — or the superuser override."""
+    return superuser(user) or org_rep_verified(user, org)
 
 
 def can_post_org_referral(user: Any, org: Any, clinician: Any) -> bool:
     """Posting an org-attributed referral requires Claim B for the org
-    AND the target clinician must have an active ClinicianAffiliation to the org
-    (handoff §4.3 / §10.5)."""
+    AND the target clinician must have an active ClinicianAffiliation to
+    the org (handoff §4.3 / §10.5) — or the superuser override."""
+    if superuser(user):
+        return True
     if not org_rep_verified(user, org):
         return False
     org_id = getattr(org, "id", None)
@@ -496,8 +585,9 @@ def directory_listed(clinician: Any) -> bool:
 
 
 def can_save_favorite(user: Any) -> bool:
-    """Saving a favorite requires email verification only (handoff §4.3)."""
-    return email_verified(user)
+    """Saving a favorite requires email verification only (handoff §4.3)
+    — or the superuser override."""
+    return superuser(user) or email_verified(user)
 
 
 def claim_state(user: Any) -> ClaimState:

--- a/src/domain/logic/test_capabilities.py
+++ b/src/domain/logic/test_capabilities.py
@@ -564,6 +564,7 @@ def test_leaves_registry_names_are_stable():
         "clinician_verified",
         "org_rep_any",
         "owns_program",
+        "superuser",
     }
 
 
@@ -817,7 +818,8 @@ def test_check_program_intake_all_three_leaves_grants():
 
 def test_can_post_program_intake_picker_superuser_bypass():
     """Symmetric with `can_act_as_provider` — admins post any kind even
-    without the underlying leaves."""
+    without the underlying leaves. The grant flows through the tree's
+    `_superuser_gate` OR branch, not a side-channel short-circuit."""
     admin = _user(is_verified=False, is_superuser=True)
     assert capabilities.can_post_program_intake_picker(admin) is True
 
@@ -825,6 +827,93 @@ def test_can_post_program_intake_picker_superuser_bypass():
 def test_can_post_program_intake_picker_tracks_check():
     assert capabilities.can_post_program_intake_picker(None) is False
     assert capabilities.can_post_program_intake_picker(_intake_ready_user()) is True
+
+
+# ---------- superuser override policy --------------------------------------
+#
+# Policy: superusers hold EVERY capability (single home: the
+# `superuser(user)` predicate). The tests below are the by-construction
+# guarantee the old framework-level bypass used to provide: a new
+# capability that forgets the override fails here, not in production.
+
+
+def test_superuser_passes_every_capability_predicate():
+    """Every boolean capability gate grants a superuser with zero claims.
+    Add every new `can_*` predicate to this list — it is the coverage
+    pin for the 'superusers can do everything' policy."""
+    admin = _user(is_verified=False, is_superuser=True)
+    org = _org(org_verified=False)
+    clinician = SimpleNamespace(clinician_affiliations=())
+    assert capabilities.can_act_as_provider(admin) is True
+    assert capabilities.can_post_program_intake_picker(admin) is True
+    assert capabilities.can_post_referral(admin) is True
+    assert capabilities.can_post_opening(admin) is True
+    assert capabilities.can_message(admin) is True
+    assert capabilities.can_save_favorite(admin) is True
+    assert capabilities.can_post_program_intake(admin, org) is True
+    assert capabilities.can_post_org_referral(admin, org, clinician) is True
+
+
+def test_superuser_tree_shows_override_as_or_branch():
+    """For a superuser, each `check_*` tree is Gate(any of: requirements,
+    Superuser) — granted, with the override visible as a met condition
+    and the real requirements preserved unmet."""
+    admin = _user(is_verified=False, is_superuser=True)
+    for check_fn in (
+        capabilities.check_provider_identity,
+        capabilities.check_program_intake,
+    ):
+        check = check_fn(admin)
+        assert check.granted is True
+        assert check.tree.op == "any"
+        requirements, override = check.tree.children
+        assert requirements.met is False  # zero claims — real tree unmet
+        assert override.label_done == "Superuser"
+        assert override.met is True
+        assert override.fix_url == ""  # no self-serve path to superuser
+
+
+def test_normal_user_tree_has_no_superuser_branch():
+    """The override branch is an operational fact we don't advertise:
+    a non-superuser's tree is the plain requirements bundle (op 'all'),
+    with no Superuser condition anywhere."""
+    user = _user(is_verified=True)
+    for check_fn in (
+        capabilities.check_provider_identity,
+        capabilities.check_program_intake,
+    ):
+        tree = check_fn(user).tree
+        assert tree.op == "all"
+
+        def _labels(node):
+            yield node.label_done
+            for child in getattr(node, "children", ()) or ():
+                yield from _labels(child)
+
+        assert "Superuser" not in set(_labels(tree))
+
+
+def test_check_superuser_is_none_for_normal_users():
+    """`check_superuser` returns None for non-superusers — the framework
+    omits it from the capability list and 404s its detail page."""
+    assert capabilities.check_superuser(_user(is_verified=True)) is None
+    assert capabilities.check_superuser(None) is None
+
+
+def test_check_superuser_granted_for_superusers():
+    admin = _user(is_verified=False, is_superuser=True)
+    check = capabilities.check_superuser(admin)
+    assert check is not None
+    assert check.name == "superuser"
+    assert check.granted is True
+
+
+def test_superuser_leaf_canonical_shape():
+    leaf = capabilities.LEAVES.get("superuser")
+    assert leaf is capabilities.SUPERUSER_LEAF
+    cond = leaf.evaluate(_user(is_verified=False, is_superuser=True))
+    assert cond.met is True
+    assert cond.fix_url == ""
 
 
 # ---------- UUID type sanity for claim_state.b ----------------------------

--- a/src/domain/routes/access.py
+++ b/src/domain/routes/access.py
@@ -18,6 +18,10 @@ access_router = APIRouter(prefix="/users/me/access", tags=["access"])
 _CHECKS = {
     "provider-network": capabilities.check_provider_identity,
     "program-intake": capabilities.check_program_intake,
+    # Visible only to superusers — `check_superuser` returns None for
+    # everyone else, which the framework omits from the list and 404s
+    # on the detail page.
+    "superuser": capabilities.check_superuser,
 }
 
 mount_capability_routes(access_router, _CHECKS)

--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -121,22 +121,55 @@ async def test_capability_detail_unauthenticated_redirected(test_client: AsyncCl
     assert response.status_code != 200
 
 
-async def test_capabilities_index_superuser_shows_bypass_label(
+async def test_capabilities_index_superuser_lists_superuser_capability(
     superuser_client: AsyncClient,
 ):
-    """Superusers see 'Available (superuser)' on the capabilities list."""
+    """Superusers see the standalone `superuser` capability in the list,
+    granted — and every other capability reads Available (the override
+    is inside each tree, not a separate badge)."""
     response = await superuser_client.get("/users/me/access/capabilities")
     assert response.status_code == 200
-    assert "Available (superuser)" in response.text
+    assert "/users/me/access/capabilities/superuser" in response.text
+    assert "Available" in response.text
+    assert "Not available yet" not in response.text
 
 
-async def test_capability_detail_superuser_shows_bypass_note(
+async def test_capability_detail_superuser_shows_override_branch(
     superuser_client: AsyncClient,
 ):
-    """Superusers see a bypass note on the capability detail page."""
+    """A superuser's capability detail renders the override as an
+    explicit 'any one of these' branch with a met Superuser condition —
+    the tree explains the grant instead of contradicting it."""
     response = await superuser_client.get(
         "/users/me/access/capabilities/provider-network"
     )
     assert response.status_code == 200
+    assert "Any one of these" in response.text
     assert "Superuser" in response.text
     assert "Available" in response.text
+
+
+async def test_capabilities_index_hides_superuser_from_normal_users(
+    authenticated_client: AsyncClient,
+):
+    """The superuser capability is an operational fact — never advertised
+    to users who don't hold it. Not in the list, 404 on detail."""
+    response = await authenticated_client.get("/users/me/access/capabilities")
+    assert response.status_code == 200
+    assert "/users/me/access/capabilities/superuser" not in response.text
+    assert "Superuser" not in response.text
+
+    detail = await authenticated_client.get("/users/me/access/capabilities/superuser")
+    assert detail.status_code == 404
+
+
+async def test_capability_detail_normal_user_has_no_override_branch(
+    authenticated_client: AsyncClient,
+):
+    """A non-superuser's provider-network detail shows the plain
+    requirements tree — no Superuser condition anywhere."""
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/provider-network"
+    )
+    assert response.status_code == 200
+    assert "Superuser" not in response.text

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -16,10 +16,8 @@
   {% endcall %}
 {% endblock %}
 {% block content %}
-  {% if check.bypass %}
-    <p>
-      <small>Superuser — access granted regardless of requirements below.</small>
-    </p>
-  {% endif %}
+  {# The superuser override renders as an explicit "any one of these"
+     branch inside the tree (see `_superuser_gate`) — no out-of-band
+     bypass note needed. #}
   {{ capability_requirements_panel(check.tree, check.granted, check.description) }}
 {% endblock %}

--- a/src/domain/templates/users/access/capabilities/index.html
+++ b/src/domain/templates/users/access/capabilities/index.html
@@ -23,9 +23,7 @@
           {% if check.description %}<p>{{ check.description }}</p>{% endif %}
         </hgroup>
         <small data-state="{{ 'unlocked' if check.granted else 'locked' }}">
-          {% if check.bypass %}
-            {{ icon_label('check', 'Available (superuser)') }}
-          {% elif check.granted %}
+          {% if check.granted %}
             {{ icon_label('check', 'Available') }}
           {% else %}
             {{ icon_label('lock', 'Not available yet') }}

--- a/src/framework/access/capabilities/capabilities.py
+++ b/src/framework/access/capabilities/capabilities.py
@@ -28,7 +28,6 @@ the tree value types, and the route-mount plumbing.
 
 from __future__ import annotations
 
-import dataclasses
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -86,19 +85,21 @@ class Gate:
 class CapabilityCheck:
     """Evaluated capability tree for a specific user.
 
-    When `bypass` is True (set by the framework for superusers), `granted`
-    returns True regardless of the tree's met state. The tree itself is
-    preserved so templates can still show the real requirement state.
+    `granted` is the tree's own met state — there is no out-of-band
+    override flag. Administrative overrides (superuser) are modeled
+    INSIDE the tree by the domain: the check composes an OR `Gate`
+    whose extra child is the override condition, so the detail page
+    shows *why* access is granted instead of contradicting an unmet
+    tree (see `_superuser_gate` in `src/domain/logic/capabilities.py`).
     """
 
     name: str
     tree: Any  # Condition | Bundle | Gate
     description: str | None = None
-    bypass: bool = False
 
     @property
     def granted(self) -> bool:
-        return self.bypass or self.tree.met
+        return self.tree.met
 
 
 @dataclass(frozen=True)
@@ -230,9 +231,14 @@ def mount_capability_routes(
         returns 404 for unknown names.
 
     ``checks`` is a ``dict[str, Callable]`` mapping capability name to a
-    single-arg predicate ``(user) -> CapabilityCheck``. The framework
-    calls each predicate with the current active user and passes the
-    result to the template; it never inspects the returned tree itself.
+    single-arg predicate ``(user) -> CapabilityCheck | None``. The
+    framework calls each predicate with the current active user and
+    passes the result to the template; it never inspects the returned
+    tree itself. A predicate may return ``None`` to declare the
+    capability *not applicable* to this user — it is omitted from the
+    list page and its detail page 404s, exactly like an unknown name.
+    The domain uses this for operational capabilities (superuser) that
+    should never be advertised to users who don't hold them.
 
     Template context keys:
       - index: ``capabilities_url``
@@ -261,12 +267,11 @@ def mount_capability_routes(
         request: Request,
         user: Any = Depends(current_active_user),
     ):
-        evaluated = {name: fn(user) for name, fn in checks.items()}
-        if user.is_superuser:
-            evaluated = {
-                name: dataclasses.replace(check, bypass=True)
-                for name, check in evaluated.items()
-            }
+        evaluated = {
+            name: check
+            for name, fn in checks.items()
+            if (check := fn(user)) is not None
+        }
         return APIResponse.html_response(
             template_name=capabilities_list_template,
             context={
@@ -288,8 +293,10 @@ def mount_capability_routes(
         if fn is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         check = fn(user)
-        if user.is_superuser:
-            check = dataclasses.replace(check, bypass=True)
+        if check is None:
+            # Not applicable to this user (e.g. the superuser capability
+            # for a non-superuser) — indistinguishable from unknown.
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         return APIResponse.html_response(
             template_name=detail_template,
             context={

--- a/src/framework/access/capabilities/test_capabilities.py
+++ b/src/framework/access/capabilities/test_capabilities.py
@@ -113,26 +113,24 @@ def test_capability_check_granted_uses_gate_met():
     assert CapabilityCheck(name="x", tree=tree_fail).granted is False
 
 
-def test_capability_check_bypass_defaults_false():
-    assert CapabilityCheck(name="x", tree=_unmet()).bypass is False
+def test_capability_check_has_no_out_of_band_override():
+    """`granted` is exactly the tree's met state — no bypass field.
+    Administrative overrides are modeled INSIDE the tree by the domain
+    (an OR `Gate` with the override condition), so the rendered tree
+    can never contradict the granted verdict."""
+    assert CapabilityCheck(name="x", tree=_met()).granted is True
+    assert CapabilityCheck(name="x", tree=_unmet()).granted is False
+    assert not hasattr(CapabilityCheck(name="x", tree=_met()), "bypass")
 
 
-def test_capability_check_bypass_overrides_unmet_tree():
-    """bypass=True grants access even when every condition is unmet."""
-    check = CapabilityCheck(name="x", tree=_unmet(), bypass=True)
+def test_override_modeled_as_gate_grants_with_unmet_requirements():
+    """The in-tree override shape: Gate(requirements, override). An unmet
+    requirements bundle with a met override condition grants — and the
+    tree itself shows why."""
+    tree = Gate(label_active="cap", label_done="cap", children=(_unmet(), _met()))
+    check = CapabilityCheck(name="x", tree=tree)
     assert check.granted is True
-
-
-def test_capability_check_bypass_preserves_tree():
-    """The tree's own met state is unchanged when bypass is set — templates
-    can still render the real requirement state."""
-    check = CapabilityCheck(name="x", tree=_unmet(), bypass=True)
-    assert check.tree.met is False
-
-
-def test_capability_check_bypass_false_still_uses_tree():
-    assert CapabilityCheck(name="x", tree=_met(), bypass=False).granted is True
-    assert CapabilityCheck(name="x", tree=_unmet(), bypass=False).granted is False
+    assert check.tree.children[0].met is False  # real requirements still unmet
 
 
 # ---------- nested tree evaluation ----------------------------------------


### PR DESCRIPTION
## Summary

- Superuser access lived on **three independent axes**: the framework's `CapabilityCheck.bypass` flag (flipped via `dataclasses.replace` in the mounted routes), ad-hoc `is_superuser` short-circuits in `can_act_as_provider` / `can_post_program_intake_picker`, and **nothing** in the remaining `can_*` predicates — so a superuser passed the picker tile but failed `can_post_referral`. The capability detail page also said "granted" while rendering an unmet tree.
- **One home for the policy** (superusers hold every capability): a `superuser(user)` predicate consulted first by every boolean `can_*` gate, plus a registered `SUPERUSER_LEAF` that `_superuser_gate` OR-composes into each `check_*` tree — **only when the viewer holds it**. Normal users see exactly the real, actionable requirements tree; superusers see the grant explained as an explicit "Any one of these" branch.
- **Superuser as its own capability**: `check_superuser` appears at `/users/me/access/capabilities`, visible only to holders. It returns `None` for everyone else — a new framework contract where a check callable may return `None` to mean *not applicable* (omitted from the list, 404 on detail, indistinguishable from unknown).
- `CapabilityCheck.bypass` and both route-level replace blocks are **deleted**; `granted` is just `tree.met` again — the rendered tree can never contradict the verdict. Facts stay factual: the leaf predicates (`email_verified`, `clinician_verified`, …) are deliberately NOT overridden, only capability grants are.
- Row-level admin authz (entity hooks, `assert_self_or_admin`, repo row-filters) is a separate axis and intentionally untouched.

## Test plan

- [x] Coverage pin: a zero-claims superuser passes **every** `can_*` predicate (the by-construction guarantee the framework bypass used to provide)
- [x] Tree shape: superuser → `Gate(any of: requirements, Superuser)` with requirements preserved unmet; normal user → plain bundle, no Superuser label anywhere
- [x] Routes: superuser sees the standalone capability + override branch; normal users get no mention and 404 on `/capabilities/superuser`
- [x] Framework: no `bypass` attr; override-as-Gate grants with unmet requirements
- [x] `pytest` full suite (2738) + `dev test contract` (39) + `dev lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)