### PR TITLE
Add dev personas + magic NPI 0000000000 auto-verify

### DIFF
--- a/scripts/dev/seed/README.md
+++ b/scripts/dev/seed/README.md
@@ -83,12 +83,36 @@ literals. Two problems:
 
 ## Login credentials
 
-The first three seeded users are pinned identities so muscle-memory
-logins survive across runs:
+The pinned anchor accounts:
 
-  - `admin@example.com` (is_superuser=True)
-  - `alice@example.com`
-  - `bob@example.com`
+  - `admin@example.com` (`is_superuser=True`) — muscle-memory admin.
+  - Three **persona** anchors — one per auth state the rest of the
+    app branches on. The registry is the single source of truth at
+    [`src/domain/routes/dev_personas.py`](../../../src/domain/routes/dev_personas.py)
+    and the dev login dropdown
+    ([`src/domain/routes/dev_auth.py:DEV_SEED_USERS`](../../../src/domain/routes/dev_auth.py))
+    reads from it:
+
+      - `unverified@example.com` — `User.is_verified=False`, no anchor
+        Clinician.
+      - `clinician-pending@example.com` — email verified, owns a
+        Clinician with `clinician_verified=False`.
+      - `clinician-verified@example.com` — email verified, owns a
+        Clinician with `clinician_verified=True`.
 
 Password for every seeded user: `password`. Visiting
-`/dev/login-as-seed-user` (dev-only route) signs in as the admin.
+`/dev/login-as-seed-user` (dev-only route) signs in as the admin;
+`/dev/login-as?email=<addr>` (also dev-only) signs in as any seeded
+user — that's what the login-page dropdown wires up.
+
+## Dev-only magic NPI
+
+In `ENVIRONMENT=development`, submitting `0000000000` as a clinician's
+NPI short-circuits the NPPES lookup in
+[`src/domain/logic/verifications/handlers.py`](../../../src/domain/logic/verifications/handlers.py)
+and produces a synthetic "verified" Verification row against the
+clinician's own name. Lets local devs and Playwright/MCP automation
+walk the verified-clinician flow without hitting the public NPPES API.
+Never honored outside development — gated by the same
+`settings.ENVIRONMENT == "development"` check that mounts
+`/dev/login-as`.

--- a/scripts/dev/seed/overrides/clinicians.py
+++ b/scripts/dev/seed/overrides/clinicians.py
@@ -31,6 +31,7 @@ from src.domain.models.enums import (
     TREATMENT_SETTINGS,
     US_STATES,
 )
+from src.domain.routes.dev_personas import PERSONAS
 
 from .. import counts
 from ..generators import SeedPool
@@ -43,7 +44,14 @@ from . import register
 async def generate_clinicians(
     rng: SeededRandom, pool: SeedPool, session: AsyncSession
 ) -> list[Clinician]:
-    users: list[User] = pool.all("users")
+    all_users: list[User] = pool.all("users")
+    # Persona users are excluded from the round-robin owner pool so the
+    # only Clinician they own is the persona anchor created below — that
+    # way the capability predicates (`any(...)` over the owned set) read
+    # the persona's intended verification state instead of whatever the
+    # index-driven rotation happened to assign.
+    persona_emails = {p.email for p in PERSONAS}
+    users: list[User] = [u for u in all_users if u.email not in persona_emails]
     out: list[Clinician] = []
     for i in range(counts.CLINICIAN_COUNT):
         cid = deterministic_uuid("Clinician", i)
@@ -82,6 +90,39 @@ async def generate_clinicians(
             npi_match_status=match_status,
             npi_verified_at=verified_ts,
             clinician_verified=clinician_verified,
+            verified_at=verified_ts,
+            ever_verified_at=verified_ts,
+        )
+        await session.merge(row)
+        out.append(row)
+
+    # Persona overrides — anchor a Clinician row for each persona that
+    # declares one (`clinician_verified is not None`). Persona users
+    # are excluded from the generic round-robin above, so this anchor
+    # is the only Clinician they own. Persona registry lives in
+    # `src/domain/routes/dev_personas.py`.
+    persona_users_by_email = {u.email: u for u in all_users}
+    for persona in PERSONAS:
+        if persona.clinician_verified is None:
+            continue
+        user = persona_users_by_email.get(persona.email)
+        if user is None:
+            continue
+        verified_ts = (
+            rng.date_within_years(years_back=1, years_forward=0)
+            if persona.clinician_verified
+            else None
+        )
+        row = Clinician(
+            id=deterministic_uuid("PersonaClinician", persona.username),
+            owner_id=user.id,
+            npi=None,
+            first_name=persona.username.replace("-", " ").title(),
+            last_name="Persona",
+            languages=["en"],
+            npi_match_status="matched" if persona.clinician_verified else "none",
+            npi_verified_at=verified_ts,
+            clinician_verified=persona.clinician_verified,
             verified_at=verified_ts,
             ever_verified_at=verified_ts,
         )

--- a/scripts/dev/seed/overrides/users.py
+++ b/scripts/dev/seed/overrides/users.py
@@ -6,9 +6,8 @@ Direct `session.add(User(...))` would bypass all of that. So the seed
 goes through the same manager the HTTP register flow uses.
 
 Idempotency: matched by `email` (the stable deterministic
-`clinician_NNN@example.com` shape). First three slots are pinned to
-`admin@example.com` / `alice@example.com` / `bob@example.com` so
-login muscle memory survives.
+`clinician_NNN@example.com` shape). The leading anchor slots are
+pinned so login muscle memory survives — see ``_ANCHOR_USERS`` below.
 """
 
 from __future__ import annotations
@@ -20,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.auth_config import UserManager
 from src.domain.logic.users.schema import UserCreate
 from src.domain.models import User
+from src.domain.routes.dev_personas import PERSONAS
 
 from .. import counts
 from ..generators import SeedPool
@@ -28,12 +28,24 @@ from . import register
 
 SHARED_PASSWORD = "password"
 
-# First three slots — pinned identities. Anything after these is
-# `clinician_NNN@example.com` / `clinician_NNN`.
+# Pinned anchor slots — anything after these is the deterministic
+# `clinician_NNN@example.com` / `clinician_NNN` shape.
+#
+# Slot 0: the admin superuser. Slots 1+: persona anchors, sourced from
+# the single-source-of-truth registry in
+# `src/domain/routes/dev_personas.py` so adding or renaming a persona
+# only touches that file.
 _ANCHOR_USERS: list[dict] = [
     {"email": "admin@example.com", "username": "admin", "is_superuser": True},
-    {"email": "alice@example.com", "username": "alice", "is_superuser": False},
-    {"email": "bob@example.com", "username": "bob", "is_superuser": False},
+    *(
+        {
+            "email": p.email,
+            "username": p.username,
+            "is_superuser": False,
+            "is_verified": p.is_verified,
+        }
+        for p in PERSONAS
+    ),
 ]
 
 
@@ -63,13 +75,20 @@ async def generate_users(
         if existing_user is not None:
             out.append(existing_user)
             continue
+        # `is_verified` defaults to True for every seed user except the
+        # `unverified@example.com` persona, which exercises the
+        # "verify your email" nag-banner code path. Whatever we pass
+        # here sticks: `UserManager.on_after_register` only auto-verifies
+        # when a `Request` is present (i.e. browser-initiated
+        # registration), so programmatic callers like this one own
+        # `is_verified` directly via `UserCreate`.
         user = await manager.create(
             UserCreate(
                 email=fixture["email"],
                 password=SHARED_PASSWORD,
                 username=fixture["username"],
                 is_superuser=fixture["is_superuser"],
-                is_verified=True,
+                is_verified=fixture.get("is_verified", True),
             ),
             safe=False,
         )

--- a/scripts/dev/seed/runner.py
+++ b/scripts/dev/seed/runner.py
@@ -136,7 +136,7 @@ async def seed_all() -> int:
         f"\n✅ Seed complete — {total} rows across {len(metadata.sorted_tables)} tables."
     )
     print(
-        "   Login: admin@example.com / alice@example.com / bob@example.com  (password: password)"
+        "   Login: admin@example.com or any /dev/login-as persona  (password: password)"
     )
     return 0
 

--- a/src/auth_config.py
+++ b/src/auth_config.py
@@ -23,12 +23,19 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_register(self, user: User, request: Optional[Request] = None):
         """Trigger the verify-email flow on new-account creation.
 
-        In development, the user is auto-verified — local dev creates
-        throw-away accounts and shouldn't have to click an email link
-        just to skip the nag banner (also lets Playwright/MCP automation
-        register users without intercepting the verify email). In any
-        other environment, call `self.request_verify(user, request)`
-        which generates a token and triggers `on_after_request_verify`
+        In development, browser-initiated registrations are auto-verified
+        — local dev creates throw-away accounts and shouldn't have to
+        click an email link just to skip the nag banner (also lets
+        Playwright/MCP automation register users without intercepting
+        the verify email). We gate the auto-verify on ``request is not
+        None``: programmatic callers (the seed, test fixtures) pass no
+        request and own ``is_verified`` directly via ``UserCreate``, so
+        they get whatever they asked for. Notably this lets the
+        ``unverified@example.com`` persona seed land an actually-
+        unverified row (see ``scripts/dev/seed/overrides/personas.py``).
+
+        Outside development, call ``self.request_verify(user, request)``
+        which generates a token and triggers ``on_after_request_verify``
         to send the email.
 
         Wrapped in try/except because email delivery failures must not
@@ -36,7 +43,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         they can re-request the verify link from the nag banner.
         """
         if settings.ENVIRONMENT == "development":
-            await self.user_db.update(user, {"is_verified": True})
+            if request is not None:
+                await self.user_db.update(user, {"is_verified": True})
             return
 
         try:

--- a/src/domain/logic/verifications/handlers.py
+++ b/src/domain/logic/verifications/handlers.py
@@ -36,6 +36,7 @@ from src.domain.logic.verifications.scoring import (
 from src.domain.models import Clinician, Organization, User, Verification
 from src.framework.audit.core import record_audit_for
 from src.framework.audit.repository import AuditRepository
+from src.framework.config import settings
 from src.framework.http.exceptions import ForbiddenError, NotFoundError
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,17 @@ HTTP_TIMEOUT_SECONDS = 10.0
 _NPPES_SKIPPED_FLAG = "nppes_skipped"
 _NPPES_ORG_NAME_THRESHOLD = 0.80
 _SKIPPED_NPPES = NppesResult(found=False, first_name=None, last_name=None, raw=None)
+
+# Dev-only magic NPI: when `ENVIRONMENT=development`, submitting this NPI
+# short-circuits the NPPES lookup and produces a synthetic "matched"
+# result against whatever name is on the Clinician / Organization. Lets
+# Playwright/MCP automation and local devs walk the verified-clinician
+# flow without hitting the public NPPES API (which is rate-limit-free
+# but slow and flaky in CI). Never honored outside development — the
+# gate is the same one that mounts `/dev/login-as` (see
+# `src/domain/routes/dev_auth.py`).
+DEV_MAGIC_NPI = "0000000000"
+_DEV_MAGIC_FLAG = "dev_magic_npi"
 
 
 def npi_failure_message(verification: Verification) -> str:
@@ -139,7 +151,20 @@ async def run_clinician_verification(
     first_name, last_name = _clinician_names(clinician, owner)
 
     extra_flags: list[str] = []
-    if clinician.npi:
+    if clinician.npi == DEV_MAGIC_NPI and settings.ENVIRONMENT == "development":
+        # Magic-NPI short-circuit: skip NPPES, fabricate a "matched"
+        # result against the clinician's own name so the downstream
+        # scorer lands on `status='verified'`. Tagged with a flag so the
+        # audit row is unmistakable (this is the only `nppes_result.raw`
+        # the pipeline produces that wasn't fetched from the registry).
+        nppes_result = NppesResult(
+            found=True,
+            first_name=first_name,
+            last_name=last_name,
+            raw={"dev_magic_npi": True},
+        )
+        extra_flags.append(_DEV_MAGIC_FLAG)
+    elif clinician.npi:
         nppes_result = await nppes_lookup(clinician.npi, http=http)
     else:
         nppes_result = _SKIPPED_NPPES

--- a/src/domain/logic/verifications/test_handlers.py
+++ b/src/domain/logic/verifications/test_handlers.py
@@ -368,6 +368,84 @@ async def test_run_raises_not_found_for_missing_clinician(
                 )
 
 
+async def test_run_short_circuits_on_dev_magic_npi(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`ENVIRONMENT=development` + `npi=0000000000` (the magic string)
+    bypasses NPPES entirely and lands on `verified`. The mocked
+    `httpx.AsyncClient` is configured to fail any actual call so the
+    test pins "no HTTP request was made"."""
+    from src.framework.config import settings
+
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+
+    clinician, _ = await _seed_clinician(
+        db_test_session_manager,
+        npi="0000000000",
+        first_name="Magic",
+        last_name="Persona",
+    )
+
+    def fail_handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(
+            "magic NPI must short-circuit before NPPES is called; "
+            f"got {request.method} {request.url}"
+        )
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(fail_handler))
+
+    async with db_test_session_manager() as session:
+        async with http:
+            verification = await run_clinician_verification(
+                clinician_id=clinician.id,
+                verification_repo=VerificationRepository(session),
+                clinician_repo=ClinicianRepository(session),
+                audit_repo=AuditRepository(session),
+                http=http,
+                actor_id=None,
+            )
+
+    assert verification.status == "verified"
+    assert "dev_magic_npi" in verification.flags
+    assert verification.nppes_result == {"dev_magic_npi": True}
+
+
+async def test_run_does_not_short_circuit_on_magic_npi_outside_development(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The magic-NPI short-circuit is dev-only — even in
+    `ENVIRONMENT=production` the orchestrator must fall through to
+    NPPES. Pins the canary against the backdoor leaking into prod."""
+    from src.framework.config import settings
+
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+
+    clinician, _ = await _seed_clinician(
+        db_test_session_manager,
+        npi="0000000000",
+        first_name="Magic",
+        last_name="Persona",
+    )
+    # NPPES says "not found" for this NPI in prod.
+    http = _mock_http({"0000000000": {"results": []}})
+
+    async with db_test_session_manager() as session:
+        async with http:
+            verification = await run_clinician_verification(
+                clinician_id=clinician.id,
+                verification_repo=VerificationRepository(session),
+                clinician_repo=ClinicianRepository(session),
+                audit_repo=AuditRepository(session),
+                http=http,
+                actor_id=None,
+            )
+
+    assert verification.status == "failed"
+    assert "dev_magic_npi" not in verification.flags
+
+
 async def test_run_with_commit_false_does_not_persist_until_caller_commits(
     db_test_session_manager: async_sessionmaker[AsyncSession],
 ):

--- a/src/domain/routes/dev_auth.py
+++ b/src/domain/routes/dev_auth.py
@@ -35,16 +35,26 @@ from fastapi_users.manager import BaseUserManager
 
 from src.auth_config import auth_backend, get_strategy, get_user_manager
 from src.domain.models import User
+from src.domain.routes.dev_personas import PERSONAS
 from src.framework.config import settings
 
 router = APIRouter(tags=["dev"])
 
-# Mirrors the anchor rows in scripts/dev/seed/overrides/users.py.
 # Shown in the login-page quick-sign-in dropdown when ENVIRONMENT=development.
+#
+# Admin (superuser) plus one entry per auth-state persona from
+# ``src/domain/routes/dev_personas.py``:
+#
+# - ``unverified@example.com`` — ``User.is_verified=False``. Surfaces the
+#   "verify your email" nag banner and gates email-verified flows.
+# - ``clinician-pending@example.com`` — ``User.is_verified=True`` plus a
+#   ``Clinician`` row with ``clinician_verified=False``. Exercises the
+#   "claim NPI" path and verification-gated capabilities.
+# - ``clinician-verified@example.com`` — same as above but the linked
+#   ``Clinician`` has ``clinician_verified=True``. Full-access persona.
 DEV_SEED_USERS: list[dict[str, str]] = [
     {"email": "admin@example.com", "label": "admin (superuser)"},
-    {"email": "alice@example.com", "label": "alice"},
-    {"email": "bob@example.com", "label": "bob"},
+    *({"email": p.email, "label": p.label} for p in PERSONAS),
 ]
 
 

--- a/src/domain/routes/dev_personas.py
+++ b/src/domain/routes/dev_personas.py
@@ -1,0 +1,79 @@
+"""Persona registry — single source of truth for the dev-login personas.
+
+A persona is one of the auth-state fixtures the rest of the app
+branches on. Each ``Persona`` carries everything the three downstream
+consumers need:
+
+  - ``scripts/dev/seed/overrides/users.py`` — to build the User row
+    with the right ``is_verified`` / ``is_superuser``.
+  - ``scripts/dev/seed/overrides/clinicians.py`` — to optionally
+    anchor a Clinician owned by this persona with the right
+    ``clinician_verified`` state.
+  - ``src/domain/routes/dev_auth.py`` — to surface the persona in the
+    quick-sign-in dropdown with a human-readable label.
+
+If a persona is renamed or a new one is added, this is the only file
+that needs to change. The three consumers iterate ``PERSONAS`` and
+read the fields they care about — no cross-file string-matching, no
+re-export constants.
+
+Lives under ``src/`` (and not ``scripts/``) because seed code is
+allowed to import from ``src``, but ``src`` never imports from
+``scripts`` — that's the direction the dependency graph runs.
+
+The capability predicates in ``src/domain/logic/capabilities.py`` are
+``any(...)`` over the owned set, so the persona's anchor clinician
+must be the *only* Clinician the user owns — otherwise the
+round-robin rotation in ``scripts/dev/seed/overrides/clinicians.py``
+could assign a clinician whose state contradicts the persona. The
+seed therefore excludes persona users from the generic round-robin
+owner pool.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Persona:
+    """One auth-state fixture.
+
+    ``clinician_verified`` is tri-valued: ``True`` / ``False`` anchor a
+    Clinician owned by this persona with the named verification state;
+    ``None`` means "don't anchor a Clinician" (e.g. the
+    ``email-unverified`` persona — no clinician needed, since
+    ``email_verified(user)`` short-circuits False before any
+    clinician-side state is consulted).
+    """
+
+    email: str
+    username: str
+    label: str
+    is_verified: bool
+    clinician_verified: bool | None
+
+
+PERSONAS: tuple[Persona, ...] = (
+    Persona(
+        email="unverified@example.com",
+        username="unverified",
+        label="persona: email unverified",
+        is_verified=False,
+        clinician_verified=None,
+    ),
+    Persona(
+        email="clinician-pending@example.com",
+        username="clinician-pending",
+        label="persona: email verified, clinician unverified",
+        is_verified=True,
+        clinician_verified=False,
+    ),
+    Persona(
+        email="clinician-verified@example.com",
+        username="clinician-verified",
+        label="persona: email verified, clinician verified",
+        is_verified=True,
+        clinician_verified=True,
+    ),
+)

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -83,6 +83,43 @@ async def test_register_prod_mode_leaves_user_unverified(
     assert response.json()["is_verified"] is False
 
 
+async def test_dev_auto_verify_skipped_for_programmatic_create(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """Programmatic callers (seed, test fixtures) hit `UserManager.create`
+    with `request=None`. The dev-mode auto-verify only fires for
+    browser-initiated registration (request present), so a programmatic
+    `UserCreate(is_verified=False)` lands an actually-unverified row —
+    the persona seed in `scripts/dev/seed/overrides/personas.py`
+    depends on this."""
+    from src.auth_config import UserManager
+    from src.domain.logic.users.schema import UserCreate
+
+    async with db_test_session_manager() as session:
+        user_db = SQLAlchemyUserDatabase(session, User)
+        manager = UserManager(user_db)
+        created = await manager.create(
+            UserCreate(
+                email="programmatic-unverified@example.com",
+                password="password",
+                username="programmatic-unverified",
+                is_verified=False,
+            ),
+            safe=False,
+            request=None,
+        )
+        await session.commit()
+
+    async with db_test_session_manager() as session:
+        user_db = SQLAlchemyUserDatabase(session, User)
+        refreshed = await user_db.get(created.id)
+    assert refreshed is not None
+    assert refreshed.is_verified is False, (
+        "request=None + is_verified=False must land False in dev — the "
+        "auto-verify is gated on a Request being present"
+    )
+
+
 async def test_register_via_htmx_sets_cookie_and_redirects(test_client: AsyncClient):
     """HTMX register should auto-login (cookie) and redirect, not return JSON."""
     payload = {

--- a/src/domain/routes/test_dev_auth.py
+++ b/src/domain/routes/test_dev_auth.py
@@ -27,6 +27,21 @@ from src.domain.routes import dev_auth
 from src.framework.config import settings
 from tests.fixtures import create_test_user
 
+# --- DEV_SEED_USERS dropdown contents -----------------------------------
+
+
+def test_dev_seed_users_includes_three_persona_anchors():
+    """The login-page quick-sign-in dropdown advertises one entry per
+    auth state the rest of the app branches on. Pins the persona shape
+    so a future muscle-memory rename of an anchor email here also
+    forces the matching seed-override change in
+    `scripts/dev/seed/overrides/users.py`."""
+    emails = {u["email"] for u in dev_auth.DEV_SEED_USERS}
+    assert "unverified@example.com" in emails
+    assert "clinician-pending@example.com" in emails
+    assert "clinician-verified@example.com" in emails
+
+
 # --- mount_dev_routes: env-gated router registration --------------------
 
 


### PR DESCRIPTION
## Summary

Two developer-only features for walking auth-gated flows without manual setup:

- **Persona auto-login.** Three new anchor users — `unverified@example.com`, `clinician-pending@example.com`, `clinician-verified@example.com` — one per auth state the rest of the app branches on. Surfaced in the `/login` dev dropdown. The registry lives at [`src/domain/routes/dev_personas.py`](../tree/fix/dev-personas-magic-npi/src/domain/routes/dev_personas.py) and is the single source of truth: the seed overrides and the dropdown both iterate it. Persona users are excluded from the round-robin clinician-owner pool so each persona's single anchor clinician fully defines the capability outcome.

- **Magic NPI `0000000000`.** In `ENVIRONMENT=development`, submitting `0000000000` as a clinician's NPI short-circuits the NPPES lookup in `run_clinician_verification` and produces a synthetic verified Verification row against the clinician's own name. Lets dev / Playwright walk the verified-clinician flow without hitting the public NPPES API. Gated by the same env check that mounts `/dev/login-as`, with a regression test pinning that the backdoor cannot leak into prod.

Also folded in two retro fixes:

- `UserManager.on_after_register`'s dev auto-verify is now gated on `request is not None` — browser registers still auto-verify, but programmatic callers (seed, fixtures) own `is_verified` via `UserCreate` directly.
- `alice@example.com` / `bob@example.com` dropped from the seed anchors and the dropdown; only `admin` survives alongside the three persona accounts.

## Test plan

- [x] `dev test` (2752 passed, 99 skipped)
- [x] `dev lint`
- [x] `dev seed` on a fresh DB; verified each persona's `email_verified()` + `clinician_verified()` capability outcomes match its label
- [ ] Spot-check `/login` dropdown in a browser to confirm the four entries render
- [ ] Walk the NPI-claim form with `0000000000` from the `clinician-pending` persona to confirm it transitions to verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)