### PR TITLE
Defer head htmx scripts so they stop blocking first paint

### DIFF
--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -44,13 +44,24 @@
        nav, `<main>` for the page body) to get Pico's max-width centering. #}
     <link rel="stylesheet" href="/static/fw/css/framework.css" />
     <link rel="stylesheet" href="/static/domain/css/domain.css" />
+    {# `defer` keeps the HTML parser unblocked while these scripts
+       download — they execute in document order after parsing
+       completes, just before `DOMContentLoaded`, which is the event
+       htmx wires its initial scan to. Without `defer` the head scripts
+       are render-blocking on every page; with it, first paint can
+       start while htmx + the extensions are still in-flight. Order
+       across the three is still preserved (deferred scripts execute
+       in source order), so the extensions register against htmx-core
+       before any hx-wired form fires. Pinned by `test_base_html.py`.
+       See https://developer.chrome.com/docs/performance/insights/render-blocking. #}
     <script src="https://unpkg.com/htmx.org@2.0.4"
             integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"
-            crossorigin="anonymous"></script>
+            crossorigin="anonymous"
+            defer></script>
     {# htmx 2 ships extensions as separate npm packages — the in-tree
        `dist/ext/json-enc.js` is the htmx-1 build and logs a "v1 extension
        with htmx 2" console warning. Use the htmx-2 package instead. #}
-    <script src="https://unpkg.com/htmx-ext-json-enc@2.0.2/json-enc.js"></script>
+    <script src="https://unpkg.com/htmx-ext-json-enc@2.0.2/json-enc.js" defer></script>
     {# `response-targets` extension lets a form swap the response into a
        target on a 4xx response (htmx's default response handler only
        swaps on 2xx). With it, form-error rerenders can return *proper*
@@ -64,7 +75,8 @@
        behavior for forms that don't declare a 4xx target.
 
        https://htmx.org/extensions/response-targets/ #}
-    <script src="https://unpkg.com/htmx-ext-response-targets@2.0.4/response-targets.js"></script>
+    <script src="https://unpkg.com/htmx-ext-response-targets@2.0.4/response-targets.js"
+            defer></script>
     {% block head %}{% endblock %}
     {% if is_development %}
       <!-- LiveReload script for development hot reloading -->

--- a/src/framework/templates/test_base_html.py
+++ b/src/framework/templates/test_base_html.py
@@ -1,0 +1,74 @@
+"""Tests for `base.html` — the document-shell template every page extends.
+
+These pin contracts that live on the `<head>` itself (not on a particular
+view-type chrome): the head scripts must not render-block the initial
+paint. `_page_header.html` band tests live in `test_page_header.py`;
+view-type chrome tests live in `test_views.py`.
+"""
+
+from __future__ import annotations
+
+from jinja2 import Environment
+from selectolax.parser import HTMLParser
+
+from src.framework.templates._test_env import add_child as _add_child
+from src.framework.templates._test_env import make_test_env as _make_env_impl
+
+
+def _make_env() -> Environment:
+    return _make_env_impl()
+
+
+class _RequestStub:
+    class _Url:
+        path = "/"
+
+    url = _Url()
+    query_params: dict[str, str] = {}
+
+
+def _request_stub() -> _RequestStub:
+    return _RequestStub()
+
+
+_STUB = """
+    {% extends "base.html" %}
+    {% block content %}<p>body</p>{% endblock %}
+"""
+
+
+def test_head_scripts_carry_defer_so_first_paint_is_not_render_blocked() -> None:
+    """Every external `<script src=...>` inside `<head>` must declare
+    `defer` (or `async`) — otherwise the parser blocks while the
+    script downloads + executes, delaying first paint on every page.
+
+    htmx attaches its initial DOM scan to `DOMContentLoaded`, so
+    `defer` is the supported pattern: scripts run in document order
+    after parsing completes but before that event fires.
+
+    See https://developer.chrome.com/docs/performance/insights/render-blocking.
+    """
+    env = _make_env()
+    _add_child(env, "stub.html", _STUB)
+    html = env.get_template("stub.html").render(
+        request=_request_stub(),
+        is_authenticated=False,
+        is_development=False,
+        observability_frontend=None,
+    )
+
+    tree = HTMLParser(html)
+    head = tree.css_first("head")
+    assert head is not None
+
+    offenders = [
+        node.attributes.get("src")
+        for node in head.css("script")
+        if node.attributes.get("src")
+        and "defer" not in node.attributes
+        and "async" not in node.attributes
+    ]
+    assert not offenders, (
+        "Head scripts missing defer/async (each adds render-blocking "
+        f"latency to every page): {offenders}"
+    )


### PR DESCRIPTION
## Summary
- The three htmx `<script src>` tags in `base.html`'s `<head>` were parser-blocking — first paint waited on htmx-core + both extensions before any pixels could land.
- `defer` keeps the parser flowing. Deferred scripts run in document order after parsing completes, just before `DOMContentLoaded` — which is exactly when htmx wires its initial scan, so the extensions still register against htmx-core before any `hx-*` form fires. No behavior change.
- Pinned by a colocated `test_base_html.py` that asserts every external `<script src>` in `<head>` carries `defer` (or `async`), so a future un-deferred head script regresses LCP visibly instead of silently.

Picked off the front of an ad-hoc render-blocking audit prompted by Chrome's [Render blocking requests](https://developer.chrome.com/docs/performance/insights/render-blocking) insight. Follow-up candidates (separate PRs): self-host or `preconnect` the pico + lucide CDNs, concatenate `framework.css` + `domain.css`, preload pico the same way we preload the lucide woff2, and decide what to do about the Sentry browser SDK in prod.

## Test plan
- [x] `dev test` — 2751 passed, 99 skipped
- [x] `dev lint` — clean
- [ ] Smoke-check a real page in the browser and confirm htmx-wired forms still submit (the contract that breaks if defer is misused is "extension registers after htmx-core" — every existing form is a check on that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)