### PR TITLE
Mark required form fields with `*`, leave optional fields bare

### DIFF
--- a/src/domain/templates/README.md
+++ b/src/domain/templates/README.md
@@ -55,22 +55,25 @@ Every label, legend, help string, button, and intro paragraph in `src/domain/tem
 
 - **Full sentence, period at the end.** `Adding your NPI lets us cross-check your identity against NPPES.` not `Adding your NPI lets us cross-check your identity against NPPES`.
 - **Specific.** Explain *what the value is for*, not that the field exists. `For example: DBT, EMDR, IFS.` beats `Free text.`.
-- **Never write `help="Optional."`.** The `(optional)` indicator on the label is the single canonical signal — see below.
+- **Never write `help="Optional."`.** Optionality is signaled by the *absence* of the required `*` marker — never by prose. See below.
 - If the same help string appears in two or more forms, move it to [`../../framework/templates/_shared/form_copy.html`](../../framework/templates/_shared/form_copy.html) and import it.
 
-### Optional fields
+### Required vs. optional fields
 
-Pass `required=False` to any form-field macro. The macro renders a muted `(optional)` after the label automatically (see `_field_label` in [`../../framework/templates/_shared/form_fields.html`](../../framework/templates/_shared/form_fields.html)).
+Requiredness is owned entirely by the `required=` argument to any form-field macro — never markup it yourself. `_field_label` (in [`../../framework/templates/_shared/form_fields.html`](../../framework/templates/_shared/form_fields.html)) renders an accent-colored `*` after the label of required fields and **nothing** for optional ones. The `*` is `aria-hidden` decoration; the control's own `required` attribute conveys the semantics to assistive tech.
 
 ```jinja
-{# OK — `(optional)` is rendered automatically #}
+{# Required (the default for most macros) — `*` is rendered automatically #}
+{{ text_field("last_name", "Last name", help="As it appears on your license.") }}
+
+{# Optional — pass required=False; no marker, no "Optional." prose #}
 {{ text_field("npi", "NPI", required=False, help="Adding your NPI lets us cross-check your identity against NPPES.") }}
 
-{# Bad — duplicates the (optional) indicator with prose #}
+{# Bad — restates optionality the missing `*` already conveys #}
 {{ text_field("npi", "NPI", required=False, help="Optional. Adding your NPI lets us cross-check your identity against NPPES.") }}
 ```
 
-Fieldset-level "everything below is optional" lines (the previous `<small>Both lists optional.</small>` pattern) are gone — every field carries its own indicator now.
+Fieldset-level "everything below is optional" lines (the previous `<small>Both lists optional.</small>` pattern) are gone — required fields are marked and optional ones are bare.
 
 ### Buttons
 

--- a/src/domain/templates/test_copy_conventions.py
+++ b/src/domain/templates/test_copy_conventions.py
@@ -7,8 +7,9 @@ a test failure here rather than as a code-review note.
 The rules pinned (see [`./README.md` § "Copy style guide"](README.md)
 for the full statement of each):
 
-  1. `help="Optional."` is forbidden — the `(optional)` indicator
-     rendered by `_field_label` is the single canonical signal.
+  1. `help="Optional."` is forbidden — optionality is signaled by the
+     *absence* of the required `*` marker rendered by `_field_label`,
+     never by prose.
   2. `help="Optional. ..."` (period-as-prose-prefix) is forbidden for
      the same reason.
   3. The app-internal abbreviation `Org` is forbidden in user-facing
@@ -44,13 +45,14 @@ def _all_template_files() -> list[Path]:
     [
         (
             r'help=["\']Optional\.?["\']',
-            'help="Optional." duplicates the (optional) indicator',
+            'help="Optional." restates optionality already signaled by the '
+            "absence of the required `*` marker",
         ),
         (
             r'help=["\']Optional\.\s',
-            'help="Optional. ..." duplicates the (optional) indicator — '
-            "use `required=False` and put the explanation in help= without "
-            'the "Optional." prefix',
+            'help="Optional. ..." restates optionality already signaled by '
+            "the absence of the required `*` marker — use `required=False` "
+            'and put the explanation in help= without the "Optional." prefix',
         ),
         (
             r"\(root — no parent\)",

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -236,18 +236,18 @@ dd { margin: 0; }
   border: 0;
 }
 .form-field-label { font-weight: 500; }
-/* "(optional)" indicator rendered by every form-field macro when
-   `required=False`. Reads as muted secondary text next to the
-   label so it's visually clear the field can be left blank
-   without competing with the label itself. Replaces the previous
-   per-form `help="Optional."` pattern (single source of truth in
-   `_field_label` — see `_shared/form_fields.html`). The
-   label-to-"(optional)" gap is owned here — `_field_label` emits
-   no literal whitespace between the two. */
-.form-field-optional {
+/* Required `*` marker rendered by every form-field macro when
+   `required` (the default for most macros). Reads as an accent-colored
+   asterisk next to the label so required fields stand out while optional
+   ones carry no marker at all — the single source of truth lives in
+   `_field_label` (see `_shared/form_fields.html`). The marker is
+   `aria-hidden` decoration; the control's own `required` attribute
+   conveys requiredness to assistive tech. The label-to-`*` gap is owned
+   here — `_field_label` emits no literal whitespace between the two. */
+.form-field-required {
   font-weight: 400;
-  color: var(--pico-muted-color);
-  margin-inline-start: 0.5em;
+  color: var(--pico-color-red-600);
+  margin-inline-start: 0.2em;
 }
 .entity-form-page form .form-field > input,
 .entity-form-page form .form-field > select,

--- a/src/framework/templates/_shared/form_fields.html
+++ b/src/framework/templates/_shared/form_fields.html
@@ -128,18 +128,25 @@ emitted attribute string. #}
   {%- if error %}<small id="{{ name }}-helper">{{ error }}</small>
   {%- elif help %}<small id="{{ name }}-helper">{{ help|safe }}</small>{%- endif %}
 {%- endmacro %}
-{# Field label + optional indicator. Every macro funnels its label through
-   here so the "(optional)" marker is the *only* way an optional field is
-   communicated visually — there is no `help="Optional."` pattern anymore
-   (the per-field marker beats a help line both visually and in terms of
-   discoverability). The gap between the label and "(optional)" is owned
-   by `.form-field-optional { margin-inline-start }` in `base.html` — do
+{# Field label + required indicator. Every macro funnels its label through
+   here so the required `*` marker is the *only* way requiredness is
+   communicated visually — required fields get the marker, optional fields
+   get nothing (no `help="Optional."`, no `(optional)` text). Callers never
+   render the marker themselves; passing `required=` to any field macro is
+   the whole contract.
+
+   The marker is `aria-hidden` decoration: requiredness is conveyed to
+   assistive tech by the control's own `required` attribute (every text-like
+   macro emits it when `required`), so the `*` is purely visual. The gap
+   between the label and the `*` is owned by
+   `.form-field-required { margin-inline-start }` in `framework.css` — do
    not introduce literal whitespace here (spacing belongs in CSS, not
-   markup). Pinned by ``src/domain/templates/test_copy_conventions.py``
-   (copy) and ``test_form_fields.py`` (no literal-space markup).
+   markup). Pinned by ``test_form_fields.py`` (marker presence + no
+   literal-space markup) and ``src/domain/templates/test_copy_conventions.py``
+   (no prose duplicating the marker).
 #}
 {% macro _field_label(label, required) -%}
-  {{ label }}{%- if not required -%}<small class="form-field-optional">(optional)</small>{%- endif -%}
+  {{ label }}{%- if required -%}<span class="form-field-required" aria-hidden="true">*</span>{%- endif -%}
 {%- endmacro %}
 {# ---- text-like inputs --------------------------------------------- #}
 {% macro text_field(name, label, current=None, required=True, pattern=None, maxlength=None, help=None, invalid=None, error=None, type="text", autocomplete=None) -%}
@@ -226,9 +233,10 @@ emitted attribute string. #}
 
    Required: `required=False` by default ("any subset, including the
    empty set" is the canonical semantic — no in-network carriers, no
-   featured services). Callers can pass `required=True` to surface the
-   `(optional)` marker is hidden, but HTML can't natively require "at
-   least one of these checkboxes" — server-side validation owns that. #}
+   featured services), so no `*` marker is shown. Callers can pass
+   `required=True` to surface the `*` marker, but HTML can't natively
+   require "at least one of these checkboxes" — server-side validation
+   owns that (there's no native `required` attribute to lean on here). #}
 {% macro multi_select_field(name, label, options, labels=None, current=None, required=False, help=None, invalid=None, error=None) -%}
   {%- set _form_errors = form_errors|default({}, true) -%}
   {%- set _form_values = form_values|default({}, true) -%}

--- a/src/framework/templates/_shared/test_form_fields.py
+++ b/src/framework/templates/_shared/test_form_fields.py
@@ -403,38 +403,52 @@ def test_composite_select_field_current_wins_over_default_first() -> None:
     assert selected[0].attributes.get("value") == "b"
 
 
-# --- optional indicator ---------------------------------------------------
+# --- required indicator ---------------------------------------------------
 
 
-def test_optional_marker_has_no_literal_space_before_small() -> None:
-    """Spacing between the label text and the `(optional)` marker is
-    owned by `.form-field-optional { margin-inline-start }` in
-    `base.html` — the macro must not emit a literal space character
-    before `<small class="form-field-optional">`. Whitespace-as-spacing
+def test_required_marker_has_no_literal_space_before_marker() -> None:
+    """Spacing between the label text and the required `*` marker is
+    owned by `.form-field-required { margin-inline-start }` in
+    `framework.css` — the macro must not emit a literal space character
+    before `<span class="form-field-required">`. Whitespace-as-spacing
     in markup is the anti-pattern this test pins against regression.
     """
-    html = _render(_make_env(), '{{ text_field("zip", "ZIP", required=false) }}')
-    # The label text and the `<small>` must be flush in the rendered
+    html = _render(_make_env(), '{{ text_field("name", "Name", required=true) }}')
+    # The label text and the `<span>` must be flush in the rendered
     # source — no run of one-or-more whitespace chars between them.
-    assert "ZIP<small" in html, (
-        "Expected label text flush against `<small>` (CSS owns the "
+    assert "Name<span" in html, (
+        "Expected label text flush against `<span>` (CSS owns the "
         f"gap). Rendered HTML: {html!r}"
     )
 
 
-def test_optional_marker_renders_inside_form_field_label_span() -> None:
-    """Sanity-check the structural contract while we're here: when
-    `required=false`, the `<small class="form-field-optional">` lives
-    inside the `<span class="form-field-label">` next to the label
-    text. This is what lets the CSS rule key off `.form-field-optional`
-    without any additional selector specificity."""
+def test_required_marker_renders_inside_form_field_label_span() -> None:
+    """When `required=true`, the `<span class="form-field-required">`
+    lives inside the `<span class="form-field-label">` next to the label
+    text. This is what lets the CSS rule key off `.form-field-required`
+    without any additional selector specificity. The marker is
+    `aria-hidden` decoration (the control's `required` attribute carries
+    the semantics for assistive tech)."""
+    html = _render(_make_env(), '{{ text_field("name", "Name", required=true) }}')
+    tree = HTMLParser(html)
+    span = tree.css_first("span.form-field-label")
+    assert span is not None
+    marker = span.css_first("span.form-field-required")
+    assert marker is not None
+    assert marker.text().strip() == "*"
+    assert marker.attributes.get("aria-hidden") == "true"
+
+
+def test_optional_field_has_no_required_marker() -> None:
+    """The flip side of the contract: when `required=false`, no marker
+    is rendered at all — optional fields are signaled by the *absence*
+    of the `*`, not by any `(optional)` text."""
     html = _render(_make_env(), '{{ text_field("zip", "ZIP", required=false) }}')
     tree = HTMLParser(html)
     span = tree.css_first("span.form-field-label")
     assert span is not None
-    small = span.css_first("small.form-field-optional")
-    assert small is not None
-    assert small.text().strip() == "(optional)"
+    assert span.css_first("span.form-field-required") is None
+    assert "(optional)" not in html
 
 
 # --- checkbox_field -------------------------------------------------------
@@ -540,17 +554,16 @@ def test_checkbox_field_with_help_emits_small_linked_via_aria() -> None:
     assert "Useful note." in small.text()
 
 
-def test_checkbox_field_required_false_by_default_shows_optional_marker() -> None:
+def test_checkbox_field_required_false_by_default_shows_no_marker() -> None:
     """Checkbox fields default to `required=False` because the
     overwhelming use case is feature flags (where "unchecked" is a
-    meaningful answer). The `(optional)` marker appears in the label
-    accordingly."""
+    meaningful answer). Being optional, the label carries no required
+    `*` marker."""
     html = _render(_make_env(), '{{ checkbox_field("x", "X") }}')
     tree = HTMLParser(html)
     span = tree.css_first("span.form-field-label")
     assert span is not None
-    small = span.css_first("small.form-field-optional")
-    assert small is not None
+    assert span.css_first("span.form-field-required") is None
 
 
 # --- error-state contract (pattern, parametrized over every macro) -------
@@ -691,10 +704,9 @@ def test_input_macro_no_error_no_help_omits_describedby_and_small(
         "aria-describedby" not in control.attributes
     ), f"{macro_name}: aria-describedby must be absent without help/error"
     # `<small id="x-helper">` is the helper/error slot; the macros also
-    # emit a sibling `<small class="form-field-optional">(optional)</small>`
-    # inside the label when `required=False` (so multi_select_field +
-    # any other defaulted-optional field carries one). Only the helper
-    # slot must be absent.
+    # emit a sibling `<span class="form-field-required">*</span>` inside
+    # the label when `required` (so required fields carry the marker).
+    # Only the helper slot must be absent.
     assert (
         tree.css_first("small#x-helper") is None
     ), f"{macro_name}: <small id='x-helper'> must be absent without help/error"


### PR DESCRIPTION
## What

Standardizes the required/optional field convention across the site and component library: **required fields get an accent-colored `*`; optional fields get nothing.**

This *inverts* the previous convention, where the library marked *optional* fields with a muted `(optional)` and left required ones unmarked.

## Enforced at the component level

The whole point of the request: requiredness UX is owned by the library, not the call site. Every field macro funnels its label through `_field_label(label, required)`, so a template author only ever passes `required=` — the `*` markup, accent styling, and accessibility wiring are produced by the shared macro. There is no way to render the marker by hand, and no per-form prose (`help="Optional."` stays forbidden by the copy-convention guard).

```jinja
{{ text_field("last_name", "Last name") }}              {# required → "Last name*" #}
{{ text_field("npi", "NPI", required=False) }}          {# optional → "NPI" #}
```

## Accessibility

The `*` is `aria-hidden` decoration. Requiredness reaches assistive tech through each control's native `required` attribute (already emitted by every text-like macro), so the visual marker doesn't double-announce.

## Changes

- `_field_label` emits `<span class="form-field-required">*</span>` when required instead of `<small class="form-field-optional">(optional)</small>`.
- Renamed/restyled `.form-field-optional` → `.form-field-required` (red accent) in `framework.css`.
- Updated the form-field unit tests (added positive `*`-present + optional-bare coverage), the copy-convention guard, and the form-field READMEs.

## Tests

`dev test` (2723 passed) and `dev lint` green. Contract suite passes per-file in isolation; full-suite contract flakiness (Playwright `wait_for_selector` timeouts on a no-form delete-button test) is pre-existing environment contention, unrelated to this markup-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)