### PR TITLE
Render saved searches to /posts URLs + capture from posts page (PR 2/3)

### DIFF
--- a/src/domain/logic/saved_searches/README.md
+++ b/src/domain/logic/saved_searches/README.md
@@ -4,9 +4,14 @@ Per-user, CRUD-able named filtered views of the post directory. Owned subentity 
 
 ## Files
 
-- `schema.py` — `SavedSearchCreate` / `SavedSearchUpdate` / `SavedSearchRead`. A saved search is `name` + a `filters` dict (the persisted `filter_values` shape). Filter-vocabulary validation against the live `POST_ENTITY.filters` names is **not** here yet — PR1 round-trips any JSON object; the capture/round-trip PR adds it alongside the URL helpers that consume the dict.
+- `schema.py` — `SavedSearchCreate` / `SavedSearchUpdate` / `SavedSearchRead`. A saved search is `name` + a `filters` dict (the persisted `filter_values` shape). `filters` accepts a real JSON object *or* a JSON string (the posts-page "Save this search" hidden field), then **drops keys that aren't currently-declared `/posts` filters** — the durability contract (a renamed/removed post filter degrades to "ignore that dimension", never a load failure). Values pass through; `/posts` validates them on use.
 - `repository.py` — `SavedSearchRepository`, a thin `BaseRepository` shell. The owner-scoped listing reuses `BaseRepository.list_owned_by(SavedSearch, user_id, owner_attr="user_id")`.
 - `handlers.py` — `handle_list_saved_searches`, the **only** bespoke verb. The other CRUD verbs are framework-generic.
+- `urls.py` — `posts_url_for_filters(filters)`, the "open" half of the round-trip: renders the stored dict back into a `/posts?…` URL. Registered as a Jinja global in [`../../template_globals.py`](../../template_globals.py); the saved-search list card headline uses it. Serialization mirrors the active-filter query-string builder in `framework/dispatch/mounts/list_.py`.
+
+## The round-trip
+
+`/posts` filter form → `filter_values` dict → **capture** ("Save this search" on `posts/list.html`, hidden `filters` JSON) → stored dict → **open** (`posts_url_for_filters`) → `/posts?…`. The dict is canonical; the URL is derived at both ends, so URL-syntax changes never touch stored rows.
 
 ## Why only the list verb is bespoke
 

--- a/src/domain/logic/saved_searches/schema.py
+++ b/src/domain/logic/saved_searches/schema.py
@@ -12,24 +12,62 @@ Audit snapshots are byte-identical to :class:`SavedSearchRead`; the
 `EntitySpec` defaults `audit_snapshot` to `read_schema`, so this module
 declares no separate snapshot class.
 
-Filter-vocabulary validation (rejecting keys that aren't declared
-post-filters) is intentionally **not** here yet — PR1 round-trips any
-JSON object. The capture/round-trip PR adds validation against the live
-`POST_ENTITY.filters` names at the same time it adds the URL helpers
-that consume the dict.
+`filters` accepts either a real JSON object (API/JSON clients) or a
+JSON *string* (the "Save this search" hidden form field on the posts
+page submits the current `filter_values` serialized) — `_coerce_filters`
+normalizes both to a dict. It then **drops keys that aren't currently
+declared `/posts` filters**. Dropping (rather than 422-ing) is the
+durability contract: when a post filter is renamed or removed, an
+existing saved search referencing the old name degrades to "ignore that
+dimension" instead of becoming un-loadable. Values are passed through —
+the `/posts` route validates them on use.
 """
 
+import json
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 
 from src.framework.schema_validators import (
     PartialUpdate,
     ReadProjection,
     WirePayload,
 )
+
+
+def _declared_post_filter_names() -> frozenset[str]:
+    """Names of the filters the `/posts` list currently declares.
+
+    Imported lazily: `POST_ENTITY` construction is unrelated to this
+    module, and a top-level import would couple saved-search schema load
+    to post-spec load order. Cheap enough to recompute per validate."""
+    from src.domain.specs.posts import POST_ENTITY
+
+    return frozenset(f.name for f in POST_ENTITY.declared_filters)
+
+
+def _coerce_filters(value: Any) -> Any:
+    """Normalize a filters payload to a dict scoped to declared post
+    filters. Accepts a dict or a JSON-object string; passes `None`
+    through (the PATCH "leave unchanged" sentinel)."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ValueError("filters must be a JSON object") from exc
+    if not isinstance(value, dict):
+        raise ValueError("filters must be a JSON object")
+    allowed = _declared_post_filter_names()
+    return {k: v for k, v in value.items() if k in allowed}
+
+
+# Shared field type: coerce-and-scope the filter map. Create defaults to
+# `{}` (whole directory); Update layers `| None` for "leave unchanged".
+FiltersField = Annotated[dict[str, Any], BeforeValidator(_coerce_filters)]
 
 
 class SavedSearchRead(ReadProjection):
@@ -49,7 +87,7 @@ class SavedSearchCreate(WirePayload):
     empty object (`{}` = "no filters", i.e. the whole directory)."""
 
     name: str = Field(min_length=1)
-    filters: dict[str, Any] = Field(default_factory=dict)
+    filters: FiltersField = Field(default_factory=dict)
 
 
 class SavedSearchUpdate(PartialUpdate):
@@ -57,4 +95,4 @@ class SavedSearchUpdate(PartialUpdate):
     (`{}`) clears the filters back to "whole directory"."""
 
     name: str | None = Field(default=None, min_length=1)
-    filters: dict[str, Any] | None = None
+    filters: FiltersField | None = None

--- a/src/domain/logic/saved_searches/test_schema.py
+++ b/src/domain/logic/saved_searches/test_schema.py
@@ -32,6 +32,37 @@ def test_create_keeps_structured_filters():
     assert payload.filters == {"kind": "clinician_opening", "state": ["CA"]}
 
 
+def test_create_parses_json_string_filters():
+    """The posts-page "Save this search" form submits `filters` as a
+    JSON string in a hidden field; the coercer parses it to a dict."""
+    payload = SavedSearchCreate(
+        name="From form", filters='{"kind": "referral", "state": ["NY"]}'
+    )
+    assert payload.filters == {"kind": "referral", "state": ["NY"]}
+
+
+def test_create_drops_unknown_filter_keys():
+    """Keys that aren't currently-declared `/posts` filters are dropped
+    (the durability contract — a renamed/removed filter degrades to
+    "ignore that dimension", not a 422)."""
+    payload = SavedSearchCreate(
+        name="Has cruft", filters={"kind": "referral", "not_a_filter": "x"}
+    )
+    assert payload.filters == {"kind": "referral"}
+
+
+def test_create_rejects_non_object_filters():
+    with pytest.raises(ValidationError):
+        SavedSearchCreate(name="x", filters="not json")
+    with pytest.raises(ValidationError):
+        SavedSearchCreate(name="x", filters="[1, 2, 3]")
+
+
+def test_update_scopes_filters_too():
+    payload = SavedSearchUpdate(filters={"kind": "referral", "bogus": 1})
+    assert payload.filters == {"kind": "referral"}
+
+
 def test_create_requires_non_empty_name():
     with pytest.raises(ValidationError):
         SavedSearchCreate(name="")

--- a/src/domain/logic/saved_searches/test_urls.py
+++ b/src/domain/logic/saved_searches/test_urls.py
@@ -1,0 +1,41 @@
+"""Coverage for `posts_url_for_filters` — the saved-search → `/posts?…`
+render (the "open" half of the round-trip)."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlsplit
+
+from src.domain.logic.saved_searches.urls import POSTS_PATH, posts_url_for_filters
+
+
+def test_empty_filters_render_bare_posts_path():
+    assert posts_url_for_filters({}) == POSTS_PATH
+    assert posts_url_for_filters(None) == POSTS_PATH
+
+
+def test_scalar_filter_renders_single_param():
+    assert posts_url_for_filters({"kind": "clinician_opening"}) == (
+        "/posts?kind=clinician_opening"
+    )
+
+
+def test_multi_value_filter_repeats_param():
+    url = posts_url_for_filters({"state": ["CA", "NY"]})
+    qs = parse_qs(urlsplit(url).query)
+    assert qs["state"] == ["CA", "NY"]
+
+
+def test_empty_and_none_values_are_dropped():
+    url = posts_url_for_filters(
+        {"kind": "referral", "q": "", "state": [], "city": None}
+    )
+    qs = parse_qs(urlsplit(url).query)
+    assert qs == {"kind": ["referral"]}
+
+
+def test_roundtrips_through_posts_query_parser_shape():
+    """The rendered query string parses back to the same logical
+    filter set the `/posts` list would receive."""
+    filters = {"kind": "clinician_opening", "state": ["CA", "NY"], "q": "trauma"}
+    qs = parse_qs(urlsplit(posts_url_for_filters(filters)).query)
+    assert qs == {"kind": ["clinician_opening"], "state": ["CA", "NY"], "q": ["trauma"]}

--- a/src/domain/logic/saved_searches/urls.py
+++ b/src/domain/logic/saved_searches/urls.py
@@ -1,0 +1,49 @@
+"""Render a saved search's `filter_values` dict back into a `/posts?…` URL.
+
+This is the "open" half of the saved-search round-trip and the reason
+the model stores structured filters rather than a URL string: the
+canonical shareable URL is *derived* here, on demand, so URL-syntax
+churn (how multi-values serialize, the `/posts` path itself) never
+touches stored data — only this function changes.
+
+Serialization mirrors the active-filter query-string builder in
+`src/framework/dispatch/mounts/list_.py::handle_list` (multi-value
+filters repeat the param; empty / None / `[]` values are dropped), so a
+saved search opens to exactly the URL the posts filter form would have
+produced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlencode
+
+# The post directory's list path. Kept as a module constant (not
+# hardcoded at each call site) so a future `/posts` rename is one edit.
+POSTS_PATH = "/posts"
+
+
+def filter_query_pairs(filters: dict[str, Any] | None) -> list[tuple[str, str]]:
+    """Flatten a `filter_values` dict into urlencode-ready pairs.
+
+    Multi-value filters (lists) fan out to one pair per value; empty /
+    None / `[]` / `""` values are dropped (an absent param means "no
+    filter on this dimension")."""
+    pairs: list[tuple[str, str]] = []
+    for name, value in (filters or {}).items():
+        if value is None or value == "" or value == []:
+            continue
+        if isinstance(value, (list, tuple)):
+            for one in value:
+                pairs.append((name, str(one)))
+        else:
+            pairs.append((name, str(value)))
+    return pairs
+
+
+def posts_url_for_filters(filters: dict[str, Any] | None) -> str:
+    """`{"kind": "clinician_opening", "state": ["CA", "NY"]}` →
+    ``/posts?kind=clinician_opening&state=CA&state=NY``. Empty filters →
+    bare ``/posts`` (the whole directory)."""
+    qs = urlencode(filter_query_pairs(filters))
+    return f"{POSTS_PATH}?{qs}" if qs else POSTS_PATH

--- a/src/domain/routes/test_saved_searches.py
+++ b/src/domain/routes/test_saved_searches.py
@@ -139,6 +139,71 @@ async def test_delete_removes(
 
 
 @pytest.mark.asyncio
+async def test_create_captures_json_filters_from_form(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """The posts-page "Save this search" form posts `name` + a hidden
+    `filters` JSON string; the create handler parses + scopes it."""
+    response = await authenticated_client.post(
+        f"/users/{logged_in_user.id}/saved_searches",
+        data={
+            "name": "CA openings",
+            "filters": '{"kind": "clinician_opening", "state": ["CA"], "bogus": 1}',
+        },
+    )
+    assert response.status_code in (200, 201), response.text
+    async with db_test_session_manager() as session:
+        row = (
+            (
+                await session.execute(
+                    select(SavedSearch).where(SavedSearch.user_id == logged_in_user.id)
+                )
+            )
+            .scalars()
+            .one()
+        )
+    # JSON parsed; unknown key dropped.
+    assert row.filters == {"kind": "clinician_opening", "state": ["CA"]}
+
+
+@pytest.mark.asyncio
+async def test_posts_page_shows_save_search_when_filtered(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+):
+    filtered = await authenticated_client.get("/posts?kind=clinician_opening")
+    assert filtered.status_code == 200
+    assert "Save this search" in filtered.text
+
+    unfiltered = await authenticated_client.get("/posts")
+    assert unfiltered.status_code == 200
+    assert "Save this search" not in unfiltered.text
+
+
+@pytest.mark.asyncio
+async def test_list_card_links_to_rendered_posts_url(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A saved-search card's headline opens the rendered `/posts?…`
+    URL — the "open" half of the round-trip."""
+    await _seed_search(
+        db_test_session_manager,
+        user_id=logged_in_user.id,
+        name="CA openings",
+        filters={"kind": "clinician_opening", "state": ["CA"]},
+    )
+    response = await authenticated_client.get(
+        f"/users/{logged_in_user.id}/saved_searches"
+    )
+    assert response.status_code == 200, response.text
+    assert "/posts?kind=clinician_opening&amp;state=CA" in response.text
+
+
+@pytest.mark.asyncio
 async def test_list_forbidden_for_other_user(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],

--- a/src/domain/template_globals.py
+++ b/src/domain/template_globals.py
@@ -29,6 +29,7 @@ from src.domain.logic.posts.view import (
     post_row_summary,
     referral_headline,
 )
+from src.domain.logic.saved_searches.urls import posts_url_for_filters
 from src.domain.logic.users.view import onboarding_readiness
 from src.domain.models import enums
 from src.domain.models.posts.post_kinds import POST_KINDS
@@ -134,6 +135,10 @@ register_template_globals(
     # `post_feed_headline(post)` — two-part "<identity> — <focus>" headline
     # for the feed-row component in home and browse list views.
     post_feed_headline=post_feed_headline,
+    # `posts_url_for_filters(filters)` renders a saved search's stored
+    # filter_values dict back into a `/posts?…` URL — the "open" half of
+    # the saved-search round-trip. See `src.domain.logic.saved_searches.urls`.
+    posts_url_for_filters=posts_url_for_filters,
     # `clinician_card_view(clinician)` is the unified view-model
     # `clinicians/detail.html` reads from — see its docstring in
     # `src.domain.logic.clinicians.view`.

--- a/src/domain/templates/posts/list.html
+++ b/src/domain/templates/posts/list.html
@@ -2,6 +2,9 @@
 {%- from "_shared/_feed_row.html" import post_feed_row, post_feed_empty with context -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {%- from "_shared/_locked.html" import locked_action -%}
+{%- from "_shared/forms.html" import entity_form -%}
+{%- from "_shared/form_fields.html" import text_field with context -%}
+{%- from "_shared/actions.html" import actions -%}
 {% block actions %}
   {% if can_act_as_provider %}
     <li>
@@ -22,4 +25,28 @@
     {{ item_list(posts, post_feed_row, "posts-list", "post-feed-list",
         empty=_empty,
         pager=pager) }}
+  {% endblock %}
+  {% block after_content %}
+    {#- "Save this search" — persists the *current* filter set as a named
+      SavedSearch owned by the viewer. Only shown to a signed-in user
+      with at least one active filter (saving the unfiltered directory is
+      pointless). The hidden `filters` field carries the live
+      `filter_values` dict as JSON; `SavedSearchCreate._coerce_filters`
+      parses the string and scopes it to declared post filters. Posts to
+      the viewer's own collection — the framework's create handler runs
+      `assert_self_or_admin` against the URL's user. -#}
+    {%- if current_user and active_filter_count %}
+      <details class="save-search">
+        <summary>Save this search</summary>
+        <section class="entity-form-page">
+          {%- call entity_form(entity_url('user', id=current_user.id) ~ "/saved_searches",
+            method="post") %}
+            <input type="hidden" name="filters" value='{{ filter_values | tojson }}'>
+            {{ text_field("name", "Name", required=true, maxlength=200,
+                        help="Give this filter set a name to find it later.") }}
+            {{ actions("Save search") }}
+          {%- endcall %}
+        </section>
+      </details>
+    {%- endif %}
   {% endblock %}

--- a/src/domain/templates/saved_searches/list.html
+++ b/src/domain/templates/saved_searches/list.html
@@ -1,18 +1,17 @@
 {# `/users/{user_id}/saved_searches` — canonical list of a user's saved
    searches.
 
-   PR1 (skeleton CRUD): each card links to its edit form, where rename
-   and delete live. The "open this search" link — the card headline
-   navigating to the rendered `/posts?…` URL — arrives with the URL
-   render/capture PR, alongside the "Save this search" affordance on
-   the posts page. For now `filters` is shown only as a count.
+   The card headline is the **open** action: it navigates to the
+   rendered `/posts?…` URL (`posts_url_for_filters(s.filters)`), so
+   clicking a saved search runs it. Rename / delete live behind the
+   secondary "Edit" link in the card footer, which goes to the row's
+   edit form.
 
-   Renders via the shared `subresource_card` (headline + subtitle +
-   short fact-list), the same primitive the clinician credential lists
-   use — see `_shared/_card.html`.
+   Renders via the shared `card` primitive (headline + subtitle +
+   caller-supplied footer) — see `_shared/_card.html`.
 #}
 {% extends "views/list.html" %}
-{%- from "_shared/_card.html" import subresource_card -%}
+{%- from "_shared/_card.html" import card -%}
 {%- from "_shared/_item_list.html" import item_list -%}
 {% block resource_label %}Saved searches{% endblock %}
 {% block actions %}
@@ -22,10 +21,18 @@
   </li>
 {% endblock %}
 {%- macro saved_search_card(s) %}
-  {{ subresource_card(id=s.id,
-    headline_url=entity_url('user', id=user_id) ~ "/saved_searches/" ~ s.id|string ~ "/form",
-  headline=s.name,
-  subtitle_parts=[(s.filters|length ~ " filter" ~ ("" if s.filters|length == 1 else "s"))]) }}
+  {%- set count = s.filters|length -%}
+  {%- set subtitle %}<span>{{ count }} filter{{ "" if count == 1 else "s" }}</span>{%- endset %}
+  {%- call card(id=s.id,
+    headline_url=posts_url_for_filters(s.filters),
+    headline=s.name,
+    subtitle=subtitle) -%}
+    <footer>
+      <a href="{{ entity_url('user', id=user_id) }}/saved_searches/{{ s.id|string }}/form"
+         role="button"
+         class="secondary outline">Edit</a>
+    </footer>
+  {%- endcall %}
 {%- endmacro %}
 {% block list_body %}
   {{ item_list(rows, saved_search_card, "saved-searches-list",


### PR DESCRIPTION
Second of three stacked PRs (PR 1 #1483 already merged). Adds the saved-search round-trip on top of the PR-1 entity skeleton.

## Open (render)
`posts_url_for_filters(filters)` renders a stored `filter_values` dict back into a `/posts?…` URL — registered as a Jinja global; the saved-search list card headline links to it, so clicking a saved search runs it. Serialization mirrors the posts filter form's query string, so a search opens to exactly the view it captured.

## Capture
A "Save this search" disclosure on `posts/list.html` (shown to a signed-in viewer with ≥1 active filter) posts the current `filter_values` as a hidden JSON field to the viewer's own saved-searches collection. The create handler gates `assert_self_or_admin` against the URL user.

## Wire contract
`SavedSearchCreate/Update.filters` now accepts a JSON object **or** a JSON string and scopes it to currently-declared `/posts` filter names. Unknown keys are **dropped, not rejected** — the durability contract: a renamed/removed post filter degrades a saved search to "ignore that dimension" rather than making it un-loadable.

## Tests
Full suite + contract + lint clean. New: URL render (multi-value, empty-drop, round-trip shape), JSON-string coercion + unknown-key drop, posts-page capture, "Save this search" visibility, card→`/posts` link.

Next: **PR 3** — seed two defaults (openings, referrals) on registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)