### PR TITLE
Seed default saved searches on registration (PR 3/3)

### DIFF
--- a/scripts/dev/seed/overrides/__init__.py
+++ b/scripts/dev/seed/overrides/__init__.py
@@ -54,6 +54,7 @@ from . import (  # noqa: E402,F401
     organizations,
     posts,
     programs,
+    saved_searches,
     users,
     verifications,
 )

--- a/scripts/dev/seed/overrides/saved_searches.py
+++ b/scripts/dev/seed/overrides/saved_searches.py
@@ -1,0 +1,38 @@
+"""SavedSearch override — the default searches every user starts with.
+
+The generic generator would emit random one-off saved searches with
+placeholder names and empty filters. That's not representative: in the
+real app every user begins with the two defaults (openings + referrals)
+seeded at registration. This override reproduces that by routing each
+seeded user through the same `seed_default_saved_searches` helper the
+registration hook uses — so dev data matches production behavior and
+there's one source of truth for what the defaults are.
+
+The helper is name-idempotent (skips a default the user already has),
+which doubles as the seed's rerun-idempotency: a second `dev seed`
+adds nothing.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.logic.saved_searches.defaults import seed_default_saved_searches
+from src.domain.models import SavedSearch, User
+
+from ..generators import SeedPool
+from ..rng import SeededRandom
+from . import register
+
+
+@register(SavedSearch)
+async def generate_saved_searches(
+    rng: SeededRandom, pool: SeedPool, session: AsyncSession
+) -> list[SavedSearch]:
+    users: list[User] = pool.all("users")
+    for u in users:
+        await seed_default_saved_searches(session, u.id)
+    # Return the rows so the runner can add them to the pool, matching
+    # the override contract (other overrides return what they inserted).
+    return list((await session.execute(select(SavedSearch))).scalars().all())

--- a/src/auth_config.py
+++ b/src/auth_config.py
@@ -41,7 +41,27 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         Wrapped in try/except because email delivery failures must not
         block registration — the user is already created at this point;
         they can re-request the verify link from the nag banner.
+
+        Every new user is also seeded with the default saved searches
+        (openings + referrals). Lazy-imported (the framework layer
+        shouldn't pull domain modules at import time) and wrapped so a
+        seeding failure — like the email send below — never blocks
+        registration; the user can still create searches by hand. The
+        helper opens its own session and is safe here because
+        fastapi-users has already committed the user row before calling
+        this hook.
         """
+        try:
+            from src.domain.logic.saved_searches.defaults import (
+                seed_default_saved_searches,
+            )
+
+            await seed_default_saved_searches(self.user_db.session, user.id)
+        except Exception:
+            # Defaults are convenience, not correctness — never block
+            # account creation on them.
+            pass
+
         if settings.ENVIRONMENT == "development":
             if request is not None:
                 await self.user_db.update(user, {"is_verified": True})

--- a/src/domain/logic/saved_searches/README.md
+++ b/src/domain/logic/saved_searches/README.md
@@ -8,6 +8,7 @@ Per-user, CRUD-able named filtered views of the post directory. Owned subentity 
 - `repository.py` — `SavedSearchRepository`, a thin `BaseRepository` shell. The owner-scoped listing reuses `BaseRepository.list_owned_by(SavedSearch, user_id, owner_attr="user_id")`.
 - `handlers.py` — `handle_list_saved_searches`, the **only** bespoke verb. The other CRUD verbs are framework-generic.
 - `urls.py` — `posts_url_for_filters(filters)`, the "open" half of the round-trip: renders the stored dict back into a `/posts?…` URL. Registered as a Jinja global in [`../../template_globals.py`](../../template_globals.py); the saved-search list card headline uses it. Serialization mirrors the active-filter query-string builder in `framework/dispatch/mounts/list_.py`.
+- `defaults.py` — `DEFAULT_SAVED_SEARCHES` (openings + referrals) and `seed_default_saved_searches(session, user_id)`. The single source of truth for "what every user starts with", consumed by two paths: `UserManager.on_after_register` (`src/auth_config.py`) seeds every new account on the request session; the dev-seed override (`scripts/dev/seed/overrides/saved_searches.py`) gives each seeded user the same rows. The helper is name-idempotent (skips a default the user already has), which also makes the dev seed rerun-safe. It takes the caller's session — *not* a fresh one — so the seed lands in the same DB the rest of the request uses (and the DB tests override to).
 
 ## The round-trip
 

--- a/src/domain/logic/saved_searches/defaults.py
+++ b/src/domain/logic/saved_searches/defaults.py
@@ -1,0 +1,63 @@
+"""The saved searches every user starts with, and the seeding helper.
+
+Each new user begins with two saved searches — the post directory
+filtered to openings and to referrals — so the feature is non-empty on
+day one. The same `DEFAULT_SAVED_SEARCHES` tuple is the single source
+of truth for both seed paths:
+
+  - **Registration** — `seed_default_saved_searches` runs from
+    `UserManager.on_after_register` for every new account.
+  - **Dev seed** — `scripts/dev/seed/overrides/saved_searches.py` gives
+    each seeded user the same two rows.
+
+The filter `kind` values are `POST_KINDS` discriminator keys; the
+colocated test pins them against `POST_KINDS.names` so a kind rename
+fails loudly here rather than silently producing a dead default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.domain.models import SavedSearch
+
+# (name, filters) for each default. Names are the user-visible labels;
+# filters are `filter_values` dicts (see the model README). Ordered:
+# Openings first, Referrals second.
+DEFAULT_SAVED_SEARCHES: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("Openings", {"kind": "clinician_opening"}),
+    ("Referrals", {"kind": "referral"}),
+)
+
+
+async def seed_default_saved_searches(session: AsyncSession, user_id: UUID) -> None:
+    """Create the default saved searches for ``user_id`` if absent.
+
+    Takes the caller's session rather than opening its own — the
+    registration hook passes the request session that already holds the
+    just-committed user, so the seed lands in the same transaction/DB
+    the rest of the request uses (and the same DB tests override to).
+    Idempotent: skips any default whose name the user already has, so a
+    re-run or double-fire can't trip the ``(user_id, name)`` UNIQUE.
+    """
+    existing = set(
+        (
+            await session.execute(
+                select(SavedSearch.name).where(SavedSearch.user_id == user_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    added = False
+    for name, filters in DEFAULT_SAVED_SEARCHES:
+        if name in existing:
+            continue
+        session.add(SavedSearch(user_id=user_id, name=name, filters=dict(filters)))
+        added = True
+    if added:
+        await session.commit()

--- a/src/domain/logic/saved_searches/test_defaults.py
+++ b/src/domain/logic/saved_searches/test_defaults.py
@@ -1,0 +1,87 @@
+"""Coverage for the default saved searches + their seeding helper."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from src.domain.logic.saved_searches.defaults import (
+    DEFAULT_SAVED_SEARCHES,
+    seed_default_saved_searches,
+)
+from src.domain.models import SavedSearch, User
+from src.domain.models.posts.post_kinds import POST_KINDS
+
+
+@pytest_asyncio.fixture
+async def session(db_test_session_manager: async_sessionmaker):
+    async with db_test_session_manager() as s:
+        yield s
+
+
+async def _make_user(session) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        username=f"ss-def-{uuid.uuid4()}",
+        email=f"{uuid.uuid4()}@example.com",
+        hashed_password="not-a-password",
+        is_active=True,
+        is_verified=True,
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+def test_default_kinds_are_valid_post_kinds():
+    """Each default filters on a real `POST_KINDS` discriminator value —
+    pins the defaults against a kind rename."""
+    for _name, filters in DEFAULT_SAVED_SEARCHES:
+        assert filters["kind"] in POST_KINDS.names
+
+
+def test_defaults_are_openings_and_referrals():
+    names = [name for name, _ in DEFAULT_SAVED_SEARCHES]
+    assert names == ["Openings", "Referrals"]
+
+
+@pytest.mark.asyncio
+async def test_seed_creates_both_defaults(session):
+    user = await _make_user(session)
+    await seed_default_saved_searches(session, user.id)
+    rows = (
+        (
+            await session.execute(
+                select(SavedSearch).where(SavedSearch.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_name = {r.name: r.filters for r in rows}
+    assert by_name == {
+        "Openings": {"kind": "clinician_opening"},
+        "Referrals": {"kind": "referral"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(session):
+    """Re-running doesn't duplicate or trip the (user_id, name) UNIQUE."""
+    user = await _make_user(session)
+    await seed_default_saved_searches(session, user.id)
+    await seed_default_saved_searches(session, user.id)
+    count = len(
+        (
+            await session.execute(
+                select(SavedSearch).where(SavedSearch.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert count == len(DEFAULT_SAVED_SEARCHES)

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -54,6 +54,37 @@ async def test_register(
         assert created_user.email == email_to_test
 
 
+async def test_register_seeds_default_saved_searches(
+    test_client: AsyncClient, db_test_session_manager: async_sessionmaker[AsyncSession]
+):
+    """`on_after_register` seeds every new user with the default saved
+    searches (openings + referrals) via `seed_default_saved_searches`."""
+    import uuid
+
+    from src.domain.logic.saved_searches.defaults import DEFAULT_SAVED_SEARCHES
+    from src.domain.models import SavedSearch
+
+    response = await test_client.post(
+        "/auth/register",
+        json={"email": "seeded@example.com", "password": "password123"},
+    )
+    assert response.status_code == 201, response.text
+    user_id = uuid.UUID(response.json()["id"])
+
+    async with db_test_session_manager() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(SavedSearch).where(SavedSearch.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    by_name = {r.name: r.filters for r in rows}
+    assert by_name == {name: filters for name, filters in DEFAULT_SAVED_SEARCHES}
+
+
 async def test_register_prod_mode_leaves_user_unverified(
     test_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],


### PR DESCRIPTION
Final of three stacked PRs (PR 1 #1483 and PR 2 #1485 merged). Every new user now starts with two saved searches — the post directory filtered to **openings** and to **referrals** — so the feature is non-empty on day one.

## Single source of truth
`DEFAULT_SAVED_SEARCHES` + `seed_default_saved_searches(session, user_id)` in `logic/saved_searches/defaults.py`, consumed by two paths:
- **Registration** — `UserManager.on_after_register` seeds every new account. Wrapped so a seed failure never blocks account creation (matching the verify-email side-effect's contract). It passes the **request session** (not a fresh one) so rows land in the same DB the rest of the request — and tests — use; safe because fastapi-users has already committed the user row before the hook fires.
- **Dev seed** — an `overrides/saved_searches.py` routes each seeded user through the same helper, so `dev seed` data matches production.

The helper is **name-idempotent** (skips a default the user already has), which also makes the dev seed rerun-safe.

## Scope
No backfill for existing users — pre-production, per the agreed decision (existing data is disposable).

## Tests
Full suite (2812), contract (39), lint clean. New: defaults are valid `POST_KINDS` + openings/referrals, helper creates both + is idempotent, registration end-to-end seeds the two defaults, dev-seed override covered by the seed smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)