### PR TITLE
Isolate docker-health-check stack from machine-global collisions

### DIFF
--- a/deployment/docker/docker-compose.test.yml
+++ b/deployment/docker/docker-compose.test.yml
@@ -1,10 +1,25 @@
+# Smoke-test stack for the queue-tier `docker-health-check` CI job
+# (`.github/workflows/ci-queue.yml`): build the image, boot it, hit
+# `/health` + `/docs/`.
+#
+# Every collidable resource is parameterized so two runs can coexist on one
+# host (e.g. parallel agent worktrees) — CI runners are isolated and just use
+# the defaults. To run a second copy concurrently, give it a distinct project
+# name and host port:
+#
+#     COMPOSE_PROJECT_NAME=health-b TEST_HOST_PORT=8010 TEST_IMAGE=test-image-b \
+#       docker compose -f deployment/docker/docker-compose.test.yml up -d
+#
+# The container is intentionally NOT given a fixed `container_name`: an
+# explicit name is machine-global and ignores the project, so a second `up`
+# fails with "name already in use". Leaving it unset lets Compose derive a
+# project-scoped name (`<project>-bedlam-connect-test-1`).
 services:
   bedlam-connect-test:
-    image: test-image
-    container_name: bedlam-connect-test
+    image: ${TEST_IMAGE:-test-image}
     restart: 'no' # Don't restart in CI
     ports:
-      - '8000:8000'
+      - '${TEST_HOST_PORT:-8000}:8000'
     environment:
       - SECRET=${SECRET}
       - ACCESS_TOKEN_EXPIRE_MINUTES=${ACCESS_TOKEN_EXPIRE_MINUTES}


### PR DESCRIPTION
Second of two stacked follow-ups from the ephemeral-ports PR (#1489) retro.
**Stacked on #1491** — review/merge that first; this PR retargets to `main` once it lands.

## Problem

The queue-tier `docker-health-check` job binds machine-global resources — a fixed `container_name: bedlam-connect-test`, host port `8000`, and image tag `test-image`. Two runs on one host (parallel agent worktrees, or an agent mirroring CI locally) collide. The explicit `container_name` is the hard blocker: Compose ignores the project name for it, so a second `up` fails with *"name already in use"*. Invisible in CI (isolated runner VMs) — same class as the contract-test port collision #1489 fixed.

## Fix

Parameterize every collidable knob in `docker-compose.test.yml` with **CI-identical defaults**:
- Drop the fixed `container_name` → Compose derives a project-scoped name (`<project>-bedlam-connect-test-1`), distinct per `COMPOSE_PROJECT_NAME`.
- `image: ${TEST_IMAGE:-test-image}`
- host port `${TEST_HOST_PORT:-8000}:8000`

CI sets none of these, so the queue-tier job's behavior is byte-for-byte unchanged. A file-header comment documents running a second copy concurrently.

## Verification

- `docker compose config` with CI defaults renders `image: test-image`, `published: 8000`, no `container_name`.
- Two stacks booted concurrently (`health-a:8000`, `health-b:8010`) — both reached `healthy`, both served `/health` → 200, distinct project-scoped container names, no collision.
- The queue-tier `docker-health-check` job itself re-runs this compose file in CI, validating the happy path before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)