### PR TITLE
Use singular age-group labels in the referral form

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -28,6 +28,7 @@ from selectolax.parser import HTMLParser
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.domain.models import Clinician, Organization, Post, Program
+from src.domain.models.enums import CLIENT_AGE_GROUP_LABELS_SINGULAR
 from src.domain.models.org_representations.org_representation import OrgRepresentation
 from tests.helpers import (
     create_test_user,
@@ -679,6 +680,34 @@ async def test_referral_form_uses_client_oriented_section_labels(
     assert (
         tree.css_first('input[name="accepts_in_network"]') is not None
     ), "renaming the section must not drop the accepts_in_network field"
+
+
+async def test_referral_form_age_group_options_are_singular(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """A referral describes ONE client, so the age-group `<select>` names
+    a single person: its options are the vocabulary's singular labels
+    ("Child (0–5)"), not the plural listing form used by the multi-valued
+    program/affiliation/search vocabularies. Pins the singular-label wiring
+    in `_form_referral.html` against the vocabulary as the source of truth."""
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
+    response = await authenticated_client.get("/posts/form?kind=referral")
+    assert response.status_code == 200
+    select = HTMLParser(response.text).css_first('select[name="age_groups"]')
+    assert select is not None, "referral form must render an age_groups <select>"
+    # Real options carry a value; the leading placeholder (`value=""`) doesn't.
+    option_texts = {
+        opt.text().strip()
+        for opt in select.css("option")
+        if opt.attributes.get("value")
+    }
+    assert option_texts == set(CLIENT_AGE_GROUP_LABELS_SINGULAR.values())
 
 
 async def test_opening_create_form_renders_practice_profile_preview(

--- a/src/domain/templates/posts/_form_referral.html
+++ b/src/domain/templates/posts/_form_referral.html
@@ -60,10 +60,11 @@ overwhelming corpus default.
       {{ textarea_field("services_other_text", "Other services (describe)", current=d.services_other_text if d else None, required=false, help="Only if you picked 'Other' above.") }}
     {% endcall %}
     {% call form_section("About the client") %}
-      {# A referral describes one client, so age is a single value.
-         The wire shape stays `age_groups: list[str]`; the form renders
-         a single `<select>`. #}
-      {{ select_field("age_groups", "Age group", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=(d.age_groups[0] if d and d.age_groups else None) , placeholder=true) }}
+      {# A referral describes one client, so age is a single value — the
+         options use the singular noun ("Child", not "Children"). The wire
+         shape stays `age_groups: list[str]`; the form renders a single
+         `<select>`. #}
+      {{ select_field("age_groups", "Age group", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS_SINGULAR, current=(d.age_groups[0] if d and d.age_groups else None) , placeholder=true) }}
       {{ multi_select_field("pronouns", "Pronouns", PRONOUNS, labels=PRONOUNS_LABELS, current=d.pronouns if d else None, required=false) }}
       {{ field_for(schema, "languages", "Languages the client speaks", current=d.languages if d else None) }}
       {{ textarea_field("description", "Narrative", current=d.description if d else None, help="The client's story, what you're hoping for in treatment, and what would make a provider a good fit. Please don't include identifying details.") }}


### PR DESCRIPTION
## What

The referral form's age-group `<select>` now uses the **singular** label per option — "Child (0–5)", "Adult (25–64)" — instead of the plural listing form ("Children (0–5)", "Adults (25–64)").

## Why

A referral describes **one** client, and the field is already required-exactly-one on the wire (`RequiredAgeGroupsField`). The picker names a single person, so the plural noun read wrong.

The singular vocabulary already existed on `ClientAgeGroup` (`.singular` / `.label_singular`, surfaced as `CLIENT_AGE_GROUP_LABELS_SINGULAR`) and was already used by the CR card headline composer — this just wires the referral create/edit form to it. No new vocabulary, no schema/wire change.

The plural form stays where it belongs: the multi-valued program/affiliation profiles and the `/posts` search filter, which genuinely describe many people.

## Contract surfaces

Display-label only. No change to storage values, route schemas, persisted shape, or the `age_groups: list[str]` wire shape.

## Tests

- New `test_referral_form_age_group_options_are_singular` asserts the rendered option labels equal `CLIENT_AGE_GROUP_LABELS_SINGULAR.values()` (vocabulary as source of truth).
- `dev lint`, full `src/domain/routes/test_posts.py` (48 passed), and `dev test contract` (40 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)