### PR TITLE
Form section legends read as headings, with a group boundary rule

### DIFF
--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -209,11 +209,34 @@ dd { margin: 0; }
 .entity-form-page form > fieldset {
   display: contents;
 }
-/* Legend becomes a full-width section header in the form grid. */
+/* Legend reads as a SECTION HEADING, not an eyebrow label: larger and
+   heavier than the field labels below it (which stay 1rem/500), full
+   contrast (not muted), normal case. Visual weight mirrors semantic
+   level — the legend titles the group, so it must out-rank its leaves.
+
+   The base `legend` rule dresses every legend as a small uppercase muted
+   filter-label — correct for the search sidebar, where the legend IS a
+   filter's own label and sits beside plain `<label>`s on sibling filters
+   (`_filter_field.html`). Here it titles a field group, so override those
+   base properties back to heading values.
+
+   Grouping (Gestalt common region) is carried by whitespace + a hairline
+   rule. `margin-block-start` opens more space BETWEEN groups than the
+   form's `row-gap` leaves between fields WITHIN a group, and the
+   `border-block-start` draws the boundary the fieldset can't paint
+   itself — it's `display: contents` (see the fieldset rule above), so its
+   own box model is ignored. The rule rides on the legend because the
+   legend is the one full-width grid item at the top of each group. */
 .entity-form-page form > fieldset > legend {
   grid-column: 1 / -1;
+  font-size: 1.05rem;
   font-weight: 600;
-  margin-block-start: var(--pico-spacing);
+  text-transform: none;
+  letter-spacing: normal;
+  color: var(--pico-color);
+  margin-block: calc(var(--pico-spacing) * 1.25) 0;
+  padding-block-start: calc(var(--pico-spacing) * 1.25);
+  border-block-start: var(--pico-border-width) solid var(--pico-muted-border-color);
 }
 /* Every direct child of the form/fieldset that ISN'T a
    `.form-field` spans both columns of the parent grid: legends,

--- a/src/framework/templates/_shared/test_form_fields.py
+++ b/src/framework/templates/_shared/test_form_fields.py
@@ -46,7 +46,7 @@ def _render(env: Environment, body: str) -> str:
     it so tests can stay focused on the macro call under test.
     """
     template = textwrap.dedent(f"""\
-        {{%- from "_shared/form_fields.html" import text_field, textarea_field, url_field, select_field, multi_select_field, entity_select_field, composite_select_field, checkbox_field, conditional_field -%}}
+        {{%- from "_shared/form_fields.html" import text_field, textarea_field, url_field, select_field, multi_select_field, entity_select_field, composite_select_field, checkbox_field, conditional_field, form_section -%}}
         {body}
         """)
     return env.from_string(template).render()
@@ -592,6 +592,34 @@ def test_conditional_field_wraps_caller_in_reveal_div() -> None:
     # The wrapper carries no requiredness of its own; the wrapped field
     # was rendered with required=false so the textarea has no `required`.
     assert "required" not in inner.attributes
+
+
+# --- form_section ---------------------------------------------------------
+
+
+def test_form_section_wraps_caller_in_fieldset_with_legend() -> None:
+    """`form_section(title)` emits a `<fieldset class="form-section">`
+    whose `<legend>` holds the title and which wraps the `{% call %}`
+    body. This is the structural contract the section-heading CSS hooks
+    onto: `.entity-form-page form > fieldset > legend` styles the legend
+    as a section heading and draws the group's boundary rule
+    (framework.css). The `<fieldset>`/`<legend>` pair is also the only
+    correct way to give a *group* of fields an accessible name — a
+    `<label>` names a single control, never a group."""
+    html = _render(
+        _make_env(),
+        '{% call form_section("Coverage") %}'
+        '{{ text_field("plan_name", "Plan name") }}'
+        "{% endcall %}",
+    )
+    tree = HTMLParser(html)
+    fieldset = tree.css_first("fieldset.form-section")
+    assert fieldset is not None
+    legend = fieldset.css_first("legend")
+    assert legend is not None
+    assert legend.text().strip() == "Coverage"
+    # The called body renders inside the same fieldset, after the legend.
+    assert fieldset.css_first('input[name="plan_name"]') is not None
 
 
 # --- error-state contract (pattern, parametrized over every macro) -------


### PR DESCRIPTION
## What

Entity-form `<legend>`s — the `form_section` group titles ("Logistics", "Service type", "About the client", "Coverage") — inherited the base `legend` rule's small/uppercase/muted *eyebrow* styling, so they read **quieter** than the field labels beneath them. That inverts the taxonomy the markup expresses: a legend titles a group; the labels are its leaves. Visual weight should mirror semantic level.

## Change

Scoped to `.entity-form-page form > fieldset > legend`:

1. **Legend → section heading.** Reset the base eyebrow styling back to heading values: `1.05rem` (vs the 1rem labels), weight 600, full-contrast color, normal case. The legend now clearly out-ranks the quiet 1rem/500 labels.
2. **Visible group boundary within the `display: contents` constraint.** The fieldset is `display: contents` (Chrome won't propagate the subgrid label column through a real fieldset box), so it can't paint its own border/background. A hairline `border-block-start` on the legend draws the boundary instead, and an amplified `margin-block-start` opens more space *between* groups than the form's row-gap leaves *within* one (Gestalt common region via proximity + a light rule).
3. **Labels untouched** — stay weight 500, quiet and equal.

## Deliberately not touched

The base `legend` rule, so the **browse/search sidebar** filter legends stay quiet eyebrow labels. There the legend *is* a single filter's own label — a peer to the sibling text/`<select>` `<label>`s — so its semantic level is "label", not "heading-over-labels". Each filter already sits in its own bordered `.checkbox-list` region. Styling those as headings would over-state their level and break parity with the other filters — the same principle, opposite conclusion.

## Tests

- New `test_form_section_wraps_caller_in_fieldset_with_legend` pins the structural contract the CSS hooks onto (`fieldset.form-section` + `<legend>` wrapping the called body).
- `dev lint` + full `dev test` green (2853 passed).

Verified visually on the referral form via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)