### PR TITLE
Opening/intake detail pages render the post's own profile as grouped facts

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -1356,11 +1356,11 @@ async def test_opening_detail_splits_post_facts_from_practice_profile_card(
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """Opening detail renders the post's own facts (schedule notes) in
-    the top facts block and the steady-state practice *context* inside the
-    `provider-profile` owner-context card — the affiliation now models
-    only insurance posture + how-to-refer (website), so those rows live in
-    the card, structurally separate from the announcement copy."""
+    """Opening detail renders the post's own self-describing profile
+    (services / cohort / cost / schedule) in the grouped facts up top, and
+    the steady-state practice *context* (insurance posture + how-to-refer
+    website) inside the `provider-profile` owner-context card —
+    structurally separate from the announcement profile."""
     # A verified viewer so the provider identity links render un-redacted.
     viewer_clinician = make_clinician_with_org(
         owner_id=logged_in_user.id, npi="1234567890"
@@ -1375,6 +1375,9 @@ async def test_opening_detail_splits_post_facts_from_practice_profile_card(
     aff.website = "https://acme.example.com"
     post = _opening_post(owner_id=author.id, clinician=clinician)
     post.opening_detail.schedule_text = "Mornings only"
+    post.opening_detail.services = ["therapy_individual"]
+    post.opening_detail.age_groups = ["adults_25_64"]
+    post.opening_detail.cost = "$150/session"
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(viewer_clinician)
@@ -1407,9 +1410,15 @@ async def test_opening_detail_splits_post_facts_from_practice_profile_card(
             card.css_first(f'div[data-fact="{fact_key}"]') is not None
         ), f"{fact_key} should render inside the provider-profile card"
     assert "Sliding scale" in card.text()
-    # ...post-own facts live outside it, in the top facts block.
-    row = tree.css_first('div[data-fact="schedule_notes"]')
-    assert row is not None, "schedule_notes should render on the detail page"
+    # The opening's own self-describing profile renders in the grouped
+    # facts up top — NOT through the owner-context card.
+    for fact_key in ("services", "ages", "cost", "schedule_notes"):
+        row = tree.css_first(f'div[data-fact="{fact_key}"]')
+        assert row is not None, f"{fact_key} should render on the detail page"
+        assert (
+            card.css_first(f'div[data-fact="{fact_key}"]') is None
+        ), f"{fact_key} is the post's own profile, not steady-state context"
+    assert "Therapy — Individual" in tree.text()
 
 
 async def test_intake_detail_renders_program_profile_card(
@@ -1464,6 +1473,16 @@ async def test_intake_detail_renders_program_profile_card(
         card.css_first('div[data-fact="website"]') is not None
     ), "website should render inside the provider-profile card"
     assert "https://riseiop.example.com" in card.text()
+    # The intake's own self-describing profile (services / cohort) renders
+    # in the grouped facts up top — NOT through the owner-context card.
+    # `_intake_post` seeds services=["therapy_group"], age_groups=[adolescents].
+    for fact_key in ("services", "ages"):
+        row = tree.css_first(f'div[data-fact="{fact_key}"]')
+        assert row is not None, f"{fact_key} should render on the intake detail page"
+        assert (
+            card.css_first(f'div[data-fact="{fact_key}"]') is None
+        ), f"{fact_key} is the post's own profile, not Program context"
+    assert "Therapy — Group" in tree.text()
 
 
 # --- POST /posts/{id}/message (in-app contact form) --------------------------

--- a/src/domain/templates/posts/_shared/_provider_post_facts.html
+++ b/src/domain/templates/posts/_shared/_provider_post_facts.html
@@ -1,0 +1,74 @@
+{# Provider-post (clinician_opening + program_intake) DETAIL-page fact
+   display — grouped to mirror the create/edit form
+   (`_form_clinician_opening.html` / `_form_program_intake.html`).
+
+   The post's own **self-describing** profile renders here; the
+   steady-state provider *context* (location, insurance, how-to-refer)
+   renders in the owner-context card in `posts/detail.html`. The read view
+   and the write view tell the same story in the same order — the form's
+   sections, in the form's order:
+
+     1. Service type    — services offered (+ "other" free text)
+     2. Clients served  — the cohort (ages, genders)
+     3. About           — the announcement narrative
+     4. Availability    — schedule notes + cost
+
+   Delivery (in-person/virtual) is NOT a section here: it's shown in the
+   `.post-meta` modality chips above (and `location_summary` carries it on
+   the list card), so repeating it would be noise.
+
+   The sections live inside ONE `facts_grid()` so their key/value columns
+   align across every section (the read-side mirror of the form's single
+   aligned grid). Each section is a `fact_group("Title")` heading plus a
+   `fact_rows()` `<dl>`; a section with no values suppresses itself
+   (heading included) via the `{% if %}` guards.
+
+   No per-row icons: the section headings carry the organization.
+   Multi-value rows (services, ages, genders) stack one item per line via
+   `fact_list`. Reads from `view` (the `post_card_view` dict);
+   `CLIENT_AGE_GROUP_LABELS` / `GENDER_LABELS` are Jinja globals, and the
+   services row reuses `services_fact` so its priority-sort matches the
+   list card exactly. #}
+{%- from "_shared/sections.html" import fact, fact_list, facts_grid, fact_group, fact_rows -%}
+{%- from "posts/_shared/_facts_block.html" import services_fact -%}
+{% macro provider_post_facts(view) -%}
+  {%- call facts_grid() %}
+    {%- if view.services or view.services_other_text %}
+      {{ fact_group("Service type") }}
+      {%- call fact_rows() %}
+        {{ services_fact(view, multiline=True) }}
+        {%- if view.services_other_text %}
+          {{ fact('services_other_text', 'Other services', view.services_other_text) }}
+        {%- endif %}
+      {%- endcall %}
+    {%- endif %}
+    {%- if view.ages or view.genders %}
+      {{ fact_group("Clients served") }}
+      {%- call fact_rows() %}
+        {%- if view.ages %}
+          {%- set _ages = [] -%}
+          {%- for g in view.ages -%}{%- set _ = _ages.append(CLIENT_AGE_GROUP_LABELS[g]) -%}{%- endfor -%}
+            {{ fact_list('ages', 'Ages', _ages) }}
+          {%- endif %}
+          {%- if view.genders %}
+            {%- set _gs = [] -%}
+            {%- for g in view.genders -%}{%- set _ = _gs.append(GENDER_LABELS[g]) -%}{%- endfor -%}
+              {{ fact_list('genders', 'Genders', _gs) }}
+            {%- endif %}
+          {%- endcall %}
+        {%- endif %}
+        {%- if view.description %}
+          {{ fact_group("About") }}
+          {%- call fact_rows() %}
+            {{ fact('narrative', 'Narrative', view.description) }}
+          {%- endcall %}
+        {%- endif %}
+        {%- if view.schedule_text or view.cost %}
+          {{ fact_group("Availability") }}
+          {%- call fact_rows() %}
+            {%- if view.schedule_text %}{{ fact('schedule_notes', 'Schedule notes', view.schedule_text) }}{%- endif %}
+              {%- if view.cost %}{{ fact('cost', 'Cost', view.cost) }}{%- endif %}
+              {%- endcall %}
+            {%- endif %}
+          {%- endcall %}
+        {%- endmacro %}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -1,6 +1,7 @@
 {% extends "views/detail.html" %}
 {%- from "posts/_shared/_modality_chips.html" import modality_chips -%}
 {%- from "posts/_shared/_referral_facts.html" import referral_facts -%}
+{%- from "posts/_shared/_provider_post_facts.html" import provider_post_facts -%}
 {%- from "_shared/_card.html" import card -%}
 {%- from "_shared/sections.html" import fact, fact_list, facts_block as entity_facts -%}
 {%- from "_shared/_affiliation_facts.html" import affiliation_facts -%}
@@ -76,15 +77,17 @@
           {%- endcall %}
         {%- endif -%}
       {%- endmacro %}
-      {# Detail-page layout. Referral detail is the grouped fact display
-   (`_referral_facts` — Narrative / Logistics / Service type / About the
-   client / Coverage, mirroring the create/edit form's sections); its
+      {# Detail-page layout. Every kind leads with a grouped fact display
+   mirroring its create/edit form's sections: referrals via
+   `_referral_facts` (Logistics / Service type / About the client /
+   Coverage), openings + intakes via `_provider_post_facts` (Service type /
+   Clients served / About / Availability). For provider posts the
+   steady-state provider context (insurance, address, languages,
+   how-to-refer) then renders in the owner-context card; the referral's
    referring clinician is the linked `provider_ref` in the meta line, not
-   an owner card. Opening/intake detail splits two ways: the post's own
-   facts (the announcement delta — schedule notes) up top, then the
-   owner-context card. Per-kind logic lives in `post_card_view` (one
-   place); every visual element reads from `view` (plus the linked
-   affiliation/program model rows the shared facts macros render
+   an owner card. Per-kind logic lives in `post_card_view` (one place);
+   every visual element reads from `view` (plus the linked
+   affiliation/program model rows the owner-context macro renders
    directly). #}
       {% block content %}
         <section data-kind="{{ post.kind }}">
@@ -113,12 +116,11 @@
                  reference in the `.post-meta` line above, not an owner card. #}
             {{ referral_facts(view, redacted=not can_act_as_provider) }}
           {%- else %}
-            {%- if view.description %}<p>{{ view.description }}</p>{%- endif %}
-            {%- if view.schedule_text %}
-              {%- call entity_facts() %}
-                {{ fact('schedule_notes', 'Schedule notes', view.schedule_text) }}
-              {%- endcall %}
-            {%- endif %}
+            {# The provider post's own self-describing profile (services /
+                 cohort / narrative / cost), grouped to mirror its form —
+                 then the steady-state provider context (insurance, address,
+                 languages, how-to-refer) in the owner-context card below. #}
+            {{ provider_post_facts(view) }}
             {{ owner_context(view, post, redacted=not can_act_as_provider) }}
           {%- endif %}
           <footer>


### PR DESCRIPTION
Closes the detail-page gap that #1511 / #1513 left open: **openings and intakes now surface their self-describing profile (services / cohort / narrative / cost) on the detail page**, instead of only description + schedule + the provider-context card.

## What
- New `_provider_post_facts(view)` macro mirrors the referral detail's grouped layout (`facts_grid` + per-section `fact_group`/`fact_rows`), following the provider form's section order: **Service type → Clients served → About → Availability**.
- Delivery (in-person/virtual) stays in the post-meta modality chips — not repeated here.
- The steady-state provider *context* (insurance, address, languages, how-to-refer) still renders in the owner-context card below — structurally separate from the announcement.

## Surface
Presentation-only — `post_card_view` already exposes every key; no schema/model/route changes. Pinned by the opening + intake detail route tests (services/ages/cost render in the grouped facts, *not* the context card).

`dev test` (2848), `dev test contract` (41), `dev lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)