### PR TITLE
Filter sidebar: reorg by form grammar; session_format + services replace geography/telehealth

### DIFF
--- a/src/domain/logic/posts/repository.py
+++ b/src/domain/logic/posts/repository.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from datetime import datetime
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import or_, select
 
 from src.domain.models import (
     Clinician,
@@ -50,14 +50,14 @@ class PostRepository(BaseRepository):
       ``ReferralDetail.languages``, ``Clinician.languages``
       (opening-side, person-level), and ``Program.languages``
       (intake-side, program-level).
-    * ``geography`` (Text) — ILIKE across city and state on both
-      ``ReferralDetail`` (its own location) and ``ClinicianAffiliation``
-      (opening/intake's linked practice location). No ZIP — neither side
-      models one.
-    * ``include_telehealth`` (Flag) — when present, expands the
-      ``geography`` filter to also include openings whose own
-      ``session_format`` contains ``virtual`` and whose linked
-      affiliation is licensed in CA.
+    * ``session_format`` (Choice, multi) — JSON-array contains check on
+      ``ReferralDetail.session_format`` + ``OpeningDetail.session_format``
+      (in-person / virtual). Intakes carry no session-format axis, so they
+      never match this filter.
+    * ``services`` (Choice, multi) — the unified "what care" axis: JSON
+      contains check on ``services`` across all three detail rows
+      (``ReferralDetail`` / ``OpeningDetail`` / ``IntakeDetail``), every
+      kind on the same ``ReferralService`` vocabulary.
     * ``insurance`` (Choice, multi) — ``insurance_carriers`` JSON-array
       contains check on ``ReferralDetail`` OR ``in_network_carriers``
       JSON-contains on linked ``ClinicianAffiliation`` (#1358 PR-e —
@@ -78,8 +78,8 @@ class PostRepository(BaseRepository):
         city: str | None = None,
         age_group: list[str] | None = None,
         language: list[str] | None = None,
-        geography: str | None = None,
-        include_telehealth: str | None = None,
+        session_format: list[str] | None = None,
+        services: list[str] | None = None,
         insurance: list[str] | None = None,
         since: datetime | None = None,
         exclude_owner_id: int | None = None,
@@ -97,8 +97,8 @@ class PostRepository(BaseRepository):
                 city,
                 age_group,
                 language,
-                geography,
-                include_telehealth,
+                session_format,
+                services,
                 insurance,
             )
         )
@@ -110,11 +110,11 @@ class PostRepository(BaseRepository):
         # ``languages``; ``Clinician`` joins only for the opening's
         # person-level ``languages``; ``IntakeDetail`` joins for the
         # intake's own ``age_groups`` (and as the ``Program`` join key).
-        needs_clinician_join = bool(
-            state or city or geography or include_telehealth or insurance
-        )
+        needs_clinician_join = bool(state or city or insurance)
         needs_owner_join = bool(posted_by)
-        needs_intake_join = bool(age_group or language)
+        # ``services`` reads ``IntakeDetail.services`` too, so it needs the
+        # intake-detail join alongside the referral/opening detail join.
+        needs_intake_join = bool(age_group or language or services)
         needs_program_join = bool(language)
         needs_person_join = bool(language)
 
@@ -211,32 +211,39 @@ class PostRepository(BaseRepository):
                 )
             )
 
-        if geography:
-            needle = f"%{geography}%"
-            geo_clauses = [
-                ReferralDetail.location_city.ilike(needle),
-                ReferralDetail.location_state.ilike(needle),
-                ClinicianAffiliation.location_city.ilike(needle),
-                ClinicianAffiliation.location_state.ilike(needle),
-            ]
-            if include_telehealth:
-                # Telehealth is now per-announcement (the opening's
-                # `session_format`), paired with the affiliation's CA
-                # licensing state.
-                geo_clauses.append(
-                    and_(
-                        OpeningDetail.session_format.like('%"virtual"%'),
-                        ClinicianAffiliation.location_state == "CA",
-                    )
+        if session_format:
+            # Per-announcement delivery format — ReferralDetail (the
+            # client's preference) and OpeningDetail (the opening's). Intake
+            # has no session_format axis (a Program is one group offering),
+            # so intakes never match this filter.
+            stmt = stmt.filter(
+                _json_array_contains_any_multi(
+                    session_format,
+                    (
+                        (ReferralDetail, "session_format"),
+                        (OpeningDetail, "session_format"),
+                    ),
                 )
-            stmt = stmt.filter(or_(*geo_clauses))
-        # include_telehealth alone (no geography) adds no constraint — it
-        # only expands the geography filter when both are active.
+            )
 
-        # `level_of_care` (settings) and `modality` filters were removed:
-        # no post kind models treatment settings or modalities anymore —
-        # services collapsed onto the single `ReferralService` "what care"
-        # axis across all three kinds.
+        if services:
+            # The unified "what care" axis — every kind carries its own
+            # ``services`` list on the same ``ReferralService`` vocabulary.
+            stmt = stmt.filter(
+                _json_array_contains_any_multi(
+                    services,
+                    (
+                        (ReferralDetail, "services"),
+                        (OpeningDetail, "services"),
+                        (IntakeDetail, "services"),
+                    ),
+                )
+            )
+
+        # `geography` (free-text location) and the `include_telehealth` flag
+        # were folded into the structured `state` / `city` / `session_format`
+        # filters. `level_of_care` / `modality` were removed when settings /
+        # modalities collapsed onto the single `ReferralService` axis.
 
         if insurance:
             clauses = []

--- a/src/domain/logic/posts/test_repository_filters.py
+++ b/src/domain/logic/posts/test_repository_filters.py
@@ -1,19 +1,18 @@
 """Tests for PostRepository.list_posts() filter dimensions.
 
-Covers: geography, include_telehealth, insurance, age_group, language.
-Each dimension is tested in isolation, then multi-value OR-within-field
-cases are pinned. Absent params are verified to skip the WHERE clause
-(all posts returned).
+Covers: session_format, services, insurance, age_group, language. Each
+dimension is tested in isolation, then multi-value OR-within-field cases
+are pinned. Absent params are verified to skip the WHERE clause (all posts
+returned).
 
-After the program-intake remodel every post kind is self-describing on
-its own detail row: ``age_group`` matches ``ReferralDetail.age_groups``,
-``OpeningDetail.age_groups``, AND ``IntakeDetail.age_groups`` (no longer
-the linked ``Program``); ``include_telehealth`` matches
-``OpeningDetail.session_format`` containing ``virtual``. The
-``level_of_care`` / ``modality`` axes were removed entirely — no post
-kind models treatment settings or modalities anymore (services collapsed
-onto the single ``ReferralService`` "what care" axis across all three
-kinds).
+Every post kind is self-describing on its own detail row, so the
+per-announcement filters read across all three: ``age_group`` and
+``services`` match ``ReferralDetail`` / ``OpeningDetail`` / ``IntakeDetail``;
+``session_format`` matches ReferralDetail + OpeningDetail (intakes have no
+delivery axis). The old free-text ``geography`` + ``include_telehealth``
+flag folded into the structured ``state`` / ``city`` / ``session_format``
+filters; ``level_of_care`` / ``modality`` were removed when settings /
+modalities collapsed onto the single ``services`` axis.
 """
 
 from __future__ import annotations
@@ -72,242 +71,6 @@ async def _list(db_test_session_manager, **kwargs) -> list[Post]:
 
 
 # ---------------------------------------------------------------------------
-# geography filter
-# ---------------------------------------------------------------------------
-
-
-async def test_geography_matches_referral_city(db_test_session_manager):
-    owner = await _seed_user(db_test_session_manager)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            clinician = make_clinician_with_org(owner_id=owner.id)
-            session.add(clinician)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            match = await _add_post(
-                session,
-                owner.id,
-                make_referral_detail(
-                    referring_clinician_id=clinician.id,
-                    location_city="Portland",
-                    location_state="OR",
-                ),
-                "referral_detail",
-            )
-            no_match = await _add_post(
-                session,
-                owner.id,
-                make_referral_detail(
-                    referring_clinician_id=clinician.id,
-                    location_city="Denver",
-                    location_state="CO",
-                ),
-                "referral_detail",
-            )
-
-    results = await _list(db_test_session_manager, geography="Portland")
-    ids = {p.id for p in results}
-    assert match.id in ids
-    assert no_match.id not in ids
-
-
-async def test_geography_matches_referral_state(db_test_session_manager):
-    owner = await _seed_user(db_test_session_manager)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            clinician = make_clinician_with_org(owner_id=owner.id)
-            session.add(clinician)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            match = await _add_post(
-                session,
-                owner.id,
-                make_referral_detail(
-                    referring_clinician_id=clinician.id,
-                    location_city="Eugene",
-                    location_state="OR",
-                ),
-                "referral_detail",
-            )
-            no_match = await _add_post(
-                session,
-                owner.id,
-                make_referral_detail(
-                    referring_clinician_id=clinician.id,
-                    location_city="Boise",
-                    location_state="ID",
-                ),
-                "referral_detail",
-            )
-
-    results = await _list(db_test_session_manager, geography="OR")
-    ids = {p.id for p in results}
-    assert match.id in ids
-    assert no_match.id not in ids
-
-
-async def test_geography_matches_opening_affiliation_city(db_test_session_manager):
-    owner = await _seed_user(db_test_session_manager)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            match_clinician = make_clinician_with_org(
-                owner_id=owner.id,
-                location_city="Berkeley",
-                location_state="CA",
-            )
-            no_match_clinician = make_clinician_with_org(
-                owner_id=owner.id,
-                location_city="Oakland",
-                location_state="CA",
-                practice_name="Other Practice",
-            )
-            session.add(match_clinician)
-            session.add(no_match_clinician)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            match = await _add_post(
-                session,
-                owner.id,
-                make_opening_detail(clinician_id=match_clinician.id),
-                "opening_detail",
-            )
-            no_match = await _add_post(
-                session,
-                owner.id,
-                make_opening_detail(clinician_id=no_match_clinician.id),
-                "opening_detail",
-            )
-
-    results = await _list(db_test_session_manager, geography="Berkeley")
-    ids = {p.id for p in results}
-    assert match.id in ids
-    assert no_match.id not in ids
-
-
-async def test_geography_absent_returns_all(db_test_session_manager):
-    owner = await _seed_user(db_test_session_manager)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            clinician = make_clinician_with_org(owner_id=owner.id)
-            session.add(clinician)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            p1 = await _add_post(
-                session,
-                owner.id,
-                make_referral_detail(
-                    referring_clinician_id=clinician.id, location_city="Austin"
-                ),
-                "referral_detail",
-            )
-            p2 = await _add_post(
-                session,
-                owner.id,
-                make_referral_detail(
-                    referring_clinician_id=clinician.id, location_city="Miami"
-                ),
-                "referral_detail",
-            )
-
-    results = await _list(db_test_session_manager, geography=None)
-    ids = {p.id for p in results}
-    assert p1.id in ids
-    assert p2.id in ids
-
-
-# ---------------------------------------------------------------------------
-# include_telehealth + geography
-# ---------------------------------------------------------------------------
-
-
-async def test_include_telehealth_expands_geography_to_virtual_ca(
-    db_test_session_manager,
-):
-    """A virtual/CA opening appears when geography='CA' + include_telehealth='1',
-    even though the affiliation city doesn't match the search term."""
-    owner = await _seed_user(db_test_session_manager)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            # Clinician in a different CA city. Telehealth is now a
-            # per-announcement attribute (the opening's `session_format`),
-            # not a clinician/affiliation column — set below on the post.
-            virtual_ca = make_clinician_with_org(
-                owner_id=owner.id,
-                location_city="San Francisco",
-                location_state="CA",
-                practice_name="Virtual CA Practice",
-            )
-            # Clinician in a different state — should not appear
-            out_of_state = make_clinician_with_org(
-                owner_id=owner.id,
-                location_city="Seattle",
-                location_state="WA",
-                practice_name="WA Virtual Practice",
-            )
-            session.add(virtual_ca)
-            session.add(out_of_state)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            ca_post = await _add_post(
-                session,
-                owner.id,
-                make_opening_detail(
-                    clinician_id=virtual_ca.id, session_format=["virtual"]
-                ),
-                "opening_detail",
-            )
-            wa_post = await _add_post(
-                session,
-                owner.id,
-                make_opening_detail(
-                    clinician_id=out_of_state.id, session_format=["virtual"]
-                ),
-                "opening_detail",
-            )
-
-    # geography="CA" matches location_state; include_telehealth also adds
-    # the virtual+CA clause — the CA clinician matches on both paths.
-    results = await _list(
-        db_test_session_manager, geography="CA", include_telehealth="1"
-    )
-    ids = {p.id for p in results}
-    assert ca_post.id in ids
-    assert wa_post.id not in ids
-
-
-async def test_include_telehealth_alone_adds_no_constraint(db_test_session_manager):
-    """include_telehealth with no geography param returns all posts."""
-    owner = await _seed_user(db_test_session_manager)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            clinician = make_clinician_with_org(owner_id=owner.id)
-            session.add(clinician)
-
-    async with db_test_session_manager() as session:
-        async with session.begin():
-            p = await _add_post(
-                session,
-                owner.id,
-                make_referral_detail(referring_clinician_id=clinician.id),
-                "referral_detail",
-            )
-
-    results = await _list(db_test_session_manager, include_telehealth="1")
-    assert p.id in {post.id for post in results}
-
-
-# ---------------------------------------------------------------------------
 # Shared intake-seed helpers (a Program needs an Org parent; the intake's
 # own profile — services / age_groups / genders / cost — lives on its
 # IntakeDetail, not the Program).
@@ -335,6 +98,129 @@ async def _seed_program(db_test_session_manager, owner_id, org_id, **program_kwa
             )
             session.add(program)
         return program.id
+
+
+# ---------------------------------------------------------------------------
+# session_format filter (replaces the old free-text geography + telehealth)
+# ---------------------------------------------------------------------------
+
+
+async def test_session_format_matches_referral_and_opening(db_test_session_manager):
+    """``session_format`` matches the per-announcement delivery format on
+    ReferralDetail + OpeningDetail (both carry the list); intakes have no
+    session-format axis, so they never match."""
+    owner = await _seed_user(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            clinician = make_clinician_with_org(owner_id=owner.id)
+            session.add(clinician)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            ref_match = await _add_post(
+                session,
+                owner.id,
+                make_referral_detail(
+                    referring_clinician_id=clinician.id, session_format=["virtual"]
+                ),
+                "referral_detail",
+            )
+            ref_no = await _add_post(
+                session,
+                owner.id,
+                make_referral_detail(
+                    referring_clinician_id=clinician.id, session_format=["in_person"]
+                ),
+                "referral_detail",
+            )
+            open_match = await _add_post(
+                session,
+                owner.id,
+                make_opening_detail(
+                    clinician_id=clinician.id, session_format=["in_person", "virtual"]
+                ),
+                "opening_detail",
+            )
+
+    results = await _list(db_test_session_manager, session_format=["virtual"])
+    ids = {p.id for p in results}
+    assert ref_match.id in ids
+    assert open_match.id in ids
+    assert ref_no.id not in ids
+
+
+async def test_session_format_absent_returns_all(db_test_session_manager):
+    owner = await _seed_user(db_test_session_manager)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            clinician = make_clinician_with_org(owner_id=owner.id)
+            session.add(clinician)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            p = await _add_post(
+                session,
+                owner.id,
+                make_referral_detail(referring_clinician_id=clinician.id),
+                "referral_detail",
+            )
+    results = await _list(db_test_session_manager)
+    assert p.id in {post.id for post in results}
+
+
+# ---------------------------------------------------------------------------
+# services filter — the unified "what care" axis across every kind
+# ---------------------------------------------------------------------------
+
+
+async def test_services_matches_across_all_kinds(db_test_session_manager):
+    """``services`` matches the ``ReferralService`` token on each kind's own
+    detail row — ReferralDetail, OpeningDetail, and IntakeDetail."""
+    owner = await _seed_user(db_test_session_manager)
+    org_id = await _seed_org(db_test_session_manager, owner.id)
+    pid = await _seed_program(db_test_session_manager, owner.id, org_id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            clinician = make_clinician_with_org(owner_id=owner.id)
+            session.add(clinician)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            ref_match = await _add_post(
+                session,
+                owner.id,
+                make_referral_detail(
+                    referring_clinician_id=clinician.id,
+                    services=["medication_management"],
+                ),
+                "referral_detail",
+            )
+            open_match = await _add_post(
+                session,
+                owner.id,
+                make_opening_detail(
+                    clinician_id=clinician.id, services=["medication_management"]
+                ),
+                "opening_detail",
+            )
+            intake_match = await _add_post(
+                session,
+                owner.id,
+                make_intake_detail(program_id=pid, services=["medication_management"]),
+                "intake_detail",
+            )
+            no_match = await _add_post(
+                session,
+                owner.id,
+                make_referral_detail(
+                    referring_clinician_id=clinician.id, services=["therapy_group"]
+                ),
+                "referral_detail",
+            )
+
+    results = await _list(db_test_session_manager, services=["medication_management"])
+    ids = {p.id for p in results}
+    assert {ref_match.id, open_match.id, intake_match.id} <= ids
+    assert no_match.id not in ids
 
 
 # ---------------------------------------------------------------------------

--- a/src/domain/specs/posts.py
+++ b/src/domain/specs/posts.py
@@ -34,6 +34,10 @@ from src.domain.models.enums import (
     INSURANCE_CARRIERS,
     LANGUAGE_LABELS,
     LANGUAGES,
+    REFERRAL_SERVICE_LABELS,
+    REFERRAL_SERVICES,
+    SESSION_FORMAT_LABELS,
+    SESSION_FORMATS,
     US_STATES,
 )
 from src.framework.audit.core import make_audited_resource
@@ -44,7 +48,7 @@ from src.framework.dispatch.entity_spec import (
     RouteSet,
     Templates,
 )
-from src.framework.dispatch.filters import ChoiceFilter, FlagFilter, TextFilter
+from src.framework.dispatch.filters import ChoiceFilter, TextFilter
 from src.framework.dispatch.redirects import Redirects
 
 POST_AUDITED_RESOURCE: Final = make_audited_resource(
@@ -80,6 +84,14 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
     # ``/posts``. Each kind's display label comes from `POST_KINDS[k].noun`
     # — the same SOT the /posts/form picker headings and the H1 / CTA
     # chain read from.
+    # Order mirrors the post forms' own grammar — Type, then where
+    # (state / city / session format), then what (services), then who
+    # (age / languages), then coverage (insurance) — with the broad
+    # free-text filters (keyword, posted-by) trailing at the bottom. The
+    # old free-text ``geography`` + the ``include_telehealth`` flag were
+    # folded into the structured ``state`` / ``city`` / ``session_format``
+    # filters; ``level_of_care`` / ``modality`` were dropped when settings /
+    # modalities collapsed onto the single ``services`` axis.
     filters=(
         ChoiceFilter(
             name="kind",
@@ -87,17 +99,27 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
             choices=tuple((k, POST_KINDS[k].noun) for k in POST_KINDS.names),
             multi=True,
         ),
-        TextFilter(name="q", label="Description", placeholder="Search descriptions…"),
-        TextFilter(
-            name="posted_by", label="Posted by", placeholder="Username contains…"
-        ),
         ChoiceFilter(
             name="state",
             label="State",
             choices=tuple((s, s) for s in US_STATES),
             multi=True,
         ),
-        TextFilter(name="city", label="City", placeholder="City contains…"),
+        TextFilter(
+            name="city", label="City or area", placeholder="City or area contains…"
+        ),
+        ChoiceFilter(
+            name="session_format",
+            label="Session format",
+            choices=tuple((v, SESSION_FORMAT_LABELS[v]) for v in SESSION_FORMATS),
+            multi=True,
+        ),
+        ChoiceFilter(
+            name="services",
+            label="Services",
+            choices=tuple((v, REFERRAL_SERVICE_LABELS[v]) for v in REFERRAL_SERVICES),
+            multi=True,
+        ),
         ChoiceFilter(
             name="age_group",
             label="Age groups",
@@ -110,21 +132,17 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
             choices=tuple((v, LANGUAGE_LABELS[v]) for v in LANGUAGES),
             multi=True,
         ),
-        TextFilter(
-            name="geography",
-            label="Location",
-            placeholder="City, state, or ZIP…",
-        ),
-        FlagFilter(
-            name="include_telehealth",
-            label="Telehealth",
-            label_checked="Include telehealth in CA",
-        ),
         ChoiceFilter(
             name="insurance",
             label="Insurance",
             choices=tuple((v, INSURANCE_CARRIER_LABELS[v]) for v in INSURANCE_CARRIERS),
             multi=True,
+        ),
+        # Broad free-text filters trail at the bottom — reached for less
+        # often than the structured facets above.
+        TextFilter(name="q", label="Keyword", placeholder="Search descriptions…"),
+        TextFilter(
+            name="posted_by", label="Posted by", placeholder="Username contains…"
         ),
     ),
     templates=Templates(


### PR DESCRIPTION
Final piece of the post-remodel series — adapts the `/posts` filter sidebar to the new post model (your original ask: "the sidebar for filtering posts should also adapt").

## Filters
- **Add `session_format`** (In-person / Virtual) and **`services`** — the unified `ReferralService` "what care" axis, matching across all three kinds' detail rows. Services was the biggest missing dimension.
- **Remove** the free-text `geography` filter and the `include_telehealth` flag — folded into the structured `state` / `city` / `session_format` facets. (`level_of_care` / `modality` were already removed in #1513.)
- **Reorder** by the post forms' own grammar: **Type → where** (state / city / session format) **→ what** (services) **→ who** (age / languages) **→ coverage** (insurance), with the broad free-text filters (Keyword, Posted by) trailing at the bottom. `city` relabeled "City or area"; `q` → "Keyword".

## Surface
URL-param only — old saved-search / bookmarked filter URLs carrying `geography`/`include_telehealth` are ignored (no error). No schema/model changes; the sidebar regenerates from the spec's `filters`. `list_posts` swaps the params + filter logic; new session_format/services tests pin the cross-kind matching.

`dev test` (2845), `dev test contract` (41), `dev lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)