### PR TITLE
Posts: add ?owner=me owner filter (#1519)

### DIFF
--- a/src/domain/logic/posts/repository.py
+++ b/src/domain/logic/posts/repository.py
@@ -31,6 +31,10 @@ class PostRepository(BaseRepository):
     Filter axes declared on ``POST_ENTITY.filters``:
 
     * ``kind`` (Choice) — exact match on ``Post.kind``.
+    * ``owner`` (Choice, radio) — ``owner="me"`` scopes to the viewer's
+      own posts (``Post.owner_id == self._requesting_user.id``); any
+      other value is ignored. The viewer-id is the one ``handle_list``
+      stamps on the repo. Powers the "My posts" view.
     * ``q`` (Text) — ILIKE substring over both detail tables'
       ``description``.
     * ``posted_by`` (Text) — ILIKE substring over the owner's
@@ -73,6 +77,7 @@ class PostRepository(BaseRepository):
         *,
         kind: str | list[str] | None = None,
         q: str | None = None,
+        owner: str | None = None,
         posted_by: str | None = None,
         state: list[str] | None = None,
         city: str | None = None,
@@ -165,6 +170,17 @@ class PostRepository(BaseRepository):
                     OpeningDetail.description.ilike(needle),
                 )
             )
+        if owner == "me":
+            # `?owner=me` scopes to the viewer's own posts. The viewer is
+            # the id `BaseRepository._requesting_user` carries — stamped by
+            # `handle_list` on every list mount so viewer-relative filters
+            # resolve without re-resolving the auth dep. Any other `owner`
+            # value is silently ignored (the only supported sentinel today).
+            # Powers the "My posts" view; an unauthenticated read (no
+            # `_requesting_user`) yields no rows rather than every row.
+            viewer = self._requesting_user
+            viewer_id = getattr(viewer, "id", None) if viewer is not None else None
+            stmt = stmt.filter(Post.owner_id == viewer_id)
         if posted_by:
             stmt = stmt.filter(User.username.ilike(f"%{posted_by}%"))
         if state:

--- a/src/domain/logic/posts/test_repository_filters.py
+++ b/src/domain/logic/posts/test_repository_filters.py
@@ -461,6 +461,93 @@ async def test_age_group_matches_intake_age_groups(db_test_session_manager):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# owner filter — `?owner=me` scopes to the viewer's own posts. The viewer
+# is `BaseRepository._requesting_user`, which `handle_list` stamps on the
+# repo before calling `list_posts`; the test stamps it the same way.
+# ---------------------------------------------------------------------------
+
+
+async def _list_as(db_test_session_manager, viewer, **kwargs) -> list[Post]:
+    """Run `list_posts` with `viewer` stamped as the requesting user, the
+    same field `handle_list` sets so viewer-relative filters resolve."""
+    async with db_test_session_manager() as session:
+        repo = PostRepository(session)
+        repo._requesting_user = viewer
+        return list(await repo.list_posts(**kwargs))
+
+
+async def test_owner_me_scopes_to_viewer_owned_posts(db_test_session_manager):
+    """``owner="me"`` returns only the viewer's own posts; another user's
+    post is excluded even though it would otherwise list."""
+    viewer = await _seed_user(db_test_session_manager)
+    stranger = await _seed_user(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            viewer_clinician = make_clinician_with_org(owner_id=viewer.id)
+            stranger_clinician = make_clinician_with_org(owner_id=stranger.id)
+            session.add(viewer_clinician)
+            session.add(stranger_clinician)
+        viewer_cid = viewer_clinician.id
+        stranger_cid = stranger_clinician.id
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            mine = await _add_post(
+                session,
+                viewer.id,
+                make_referral_detail(referring_clinician_id=viewer_cid),
+                "referral_detail",
+            )
+            theirs = await _add_post(
+                session,
+                stranger.id,
+                make_referral_detail(referring_clinician_id=stranger_cid),
+                "referral_detail",
+            )
+
+    results = await _list_as(db_test_session_manager, viewer, owner="me")
+    ids = {p.id for p in results}
+    assert mine.id in ids
+    assert theirs.id not in ids
+
+
+async def test_owner_absent_returns_all_posts(db_test_session_manager):
+    """Without ``owner`` (or with any non-``me`` value) the scope is not
+    applied — both owners' posts list."""
+    viewer = await _seed_user(db_test_session_manager)
+    stranger = await _seed_user(db_test_session_manager)
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            viewer_clinician = make_clinician_with_org(owner_id=viewer.id)
+            stranger_clinician = make_clinician_with_org(owner_id=stranger.id)
+            session.add(viewer_clinician)
+            session.add(stranger_clinician)
+        viewer_cid = viewer_clinician.id
+        stranger_cid = stranger_clinician.id
+
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            mine = await _add_post(
+                session,
+                viewer.id,
+                make_referral_detail(referring_clinician_id=viewer_cid),
+                "referral_detail",
+            )
+            theirs = await _add_post(
+                session,
+                stranger.id,
+                make_referral_detail(referring_clinician_id=stranger_cid),
+                "referral_detail",
+            )
+
+    results = await _list_as(db_test_session_manager, viewer)
+    ids = {p.id for p in results}
+    assert {mine.id, theirs.id} <= ids
+
+
 async def test_language_matches_clinician_languages(db_test_session_manager):
     """Opening side: ``languages`` lives on ``Clinician`` (person-
     level), distinct from the other steady-state fields which live on

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -302,6 +302,51 @@ async def test_list_kind_filter_narrows_to_one_kind(
     }, f"/posts?kind=referral returned: {kinds_filtered!r}"
 
 
+# --- List filter: ?owner=me scopes to the viewer's own posts -------------
+
+
+async def test_list_owner_me_scopes_to_viewer_owned_posts(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """`/posts?owner=me` narrows the feed to posts the viewer owns — the
+    foundation of the "My posts" view. Without the filter both owners'
+    posts list; with it, only the viewer's. Mirrors the clinician/org
+    `?owner=me` radio."""
+    author = create_test_user(username=f"a-{uuid.uuid4()}")
+    mine = _referral_post(owner_id=logged_in_user.id, description="mine")
+    theirs = _referral_post(owner_id=author.id, description="theirs")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(author)
+            session.add(mine)
+            session.add(theirs)
+
+    # Feed rows carry no `data-row-id`; each row's headline links to
+    # `/posts/{id}`, so resolve which posts rendered by their detail hrefs.
+    def _rendered_ids(html: str) -> set[str]:
+        return {
+            a.attributes.get("href", "").rsplit("/", 1)[-1]
+            for a in HTMLParser(html).css(
+                "#posts-list .post-feed-row a.post-feed-headline-text"
+            )
+        }
+
+    # No filter → both owners' posts visible.
+    response = await authenticated_client.get("/posts")
+    assert response.status_code == 200
+    ids_unfiltered = _rendered_ids(response.text)
+    assert {str(mine.id), str(theirs.id)} <= ids_unfiltered
+
+    # `?owner=me` → only the viewer's own post.
+    response = await authenticated_client.get("/posts?owner=me")
+    assert response.status_code == 200
+    ids_filtered = _rendered_ids(response.text)
+    assert str(mine.id) in ids_filtered
+    assert str(theirs.id) not in ids_filtered
+
+
 # --- Detail / edit-form route works across kinds -------------------------
 
 

--- a/src/domain/specs/posts.py
+++ b/src/domain/specs/posts.py
@@ -93,6 +93,21 @@ POST_ENTITY: Final[EntitySpec] = EntitySpec(
     # filters; ``level_of_care`` / ``modality`` were dropped when settings /
     # modalities collapsed onto the single ``services`` axis.
     filters=(
+        # `?owner=me` scopes the list to posts the viewer owns
+        # (``Post.owner_id == self._requesting_user.id``) — the same
+        # single-toggle radio clinicians/orgs expose. Rendered first so
+        # the viewer-relative scope sits above the structured facets;
+        # the viewer-id resolution happens in
+        # ``PostRepository.list_posts`` via the ``_requesting_user``
+        # field ``handle_list`` stamps on the repo. Powers the "My
+        # posts" view (`/posts?owner=me`, each row → Edit).
+        ChoiceFilter(
+            name="owner",
+            label="Owner",
+            choices=(("me", "Owned by me"),),
+            multi=False,
+            radio=True,
+        ),
         ChoiceFilter(
             name="kind",
             label="Type",

--- a/src/domain/specs/test_posts.py
+++ b/src/domain/specs/test_posts.py
@@ -45,6 +45,18 @@ def test_post_entity_exposes_kind_filter_for_every_registered_kind():
     assert filter_values == set(POST_KINDS.names)
 
 
+def test_post_entity_exposes_owner_me_radio_filter():
+    """`?owner=me` is the viewer-relative scope filter powering the "My
+    posts" view — a single-toggle radio (`multi=False`, `radio=True`)
+    with exactly the `("me", …)` choice, mirroring the clinician/org
+    owner filter. The repo resolves `owner="me"` to the viewer's own
+    posts; the filter declaration is what makes the toggle render."""
+    owner_filter = next(f for f in POST_ENTITY.filters if f.name == "owner")
+    assert owner_filter.multi is False
+    assert owner_filter.radio is True
+    assert {value for value, _label in owner_filter.choices} == {"me"}
+
+
 def test_post_entity_audit_resource_type_is_post():
     """Audit rows record `resource_type="post"` regardless of kind —
     the supertype shape is what survives across the polymorphic split."""


### PR DESCRIPTION
## What

Adds an `owner` ChoiceFilter (radio: *Anyone* / *Owned by me*) to the posts entity, mirroring the existing `owner=me` radio on clinicians/organizations. This is the foundation issue (#1519) that I2 ("My posts" menu) and I3 (browse owner filter) depend on.

## How

- **Spec** (`src/domain/specs/posts.py`): declares the `owner` ChoiceFilter (`multi=False`, `radio=True`, single `("me", "Owned by me")` choice), placed first so the viewer-relative scope sits above the structured facets — exactly the clinician/org shape.
- **Repository** (`src/domain/logic/posts/repository.py`): `list_posts` gains an `owner` param; `owner="me"` filters `Post.owner_id == self._requesting_user.id` (the viewer `handle_list` stamps on the repo). Any other value is ignored; an unauthenticated read yields no rows.
- Filter renders automatically through the existing sidebar (`_filter_field.html`) and `/posts/search` — no template work.

## Tests

- `test_posts.py` (spec): pins the `owner` radio filter declaration.
- `test_repository_filters.py`: `owner="me"` scopes to the viewer's posts; absent `owner` returns all.
- `test_posts.py` (route): `/posts?owner=me` narrows the rendered feed to the viewer's own posts end-to-end.
- `dev test` (2849 passed), `dev test contract` (41 passed), and `dev lint` all green.

## Contract surface

Adds an optional query param — **compatible**; existing `/posts` clients are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)