### PR TITLE
Re-enable onboarding nudge: empty account → add a clinician or org (#1525)

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -1,16 +1,21 @@
 """Pins the verification status and chrome banner contract.
 
 The global chrome carries one chrome signal (`#onboarding-banner`, copy in
-`base.html`, gated on `onboarding_incomplete` from `base_context` →
-`onboarding_checklist`). The old `/profile` hub has been removed; the
-verification card on `/users/me` is the new home for claim setup links.
-These tests assert:
+`base.html`, gated on `needs_provider_entity` from `base_context`). It is a
+derived gate (`RESOURCE_GRAMMAR.md` §"Derived gates"): shown only when an
+authenticated account holds neither a clinician profile nor an org rep — so
+no post can be authored yet — and it dispatches into the two minimal create
+forms (`/clinicians/form`, `/organizations/form`). The old `/profile` hub has
+been removed; the verification card on `/users/me` is the new home for claim
+setup links. These tests assert:
 
 1. `/home` shows no per-page finish-setup card for a no-claim user — the
    post-action row is suppressed entirely and the only nudge is the chrome
    `#onboarding-banner`.
 2. Post CTAs on `/home` are gated on `can_act_as_provider` (clinician or org rep).
-3. The global `#onboarding-banner` is currently disabled (absent on all pages).
+3. The global `#onboarding-banner` is shown for an empty (no clinician/org)
+   account and links to both minimal create forms; it goes silent once the
+   account holds a provider entity (verified or not).
 """
 
 import pytest
@@ -37,8 +42,9 @@ async def test_new_user_sees_no_finish_setup_card_on_home(
     assert tree.css_first("#finish-setup-card") is None
     assert "Open Profile" not in response.text
     assert "+ Post a referral" not in response.text
-    # Banner temporarily disabled.
-    assert tree.css_first("#onboarding-banner") is None
+    # The chrome onboarding banner is the single finish-setup nudge for an
+    # account with no clinician/org.
+    assert tree.css_first("#onboarding-banner") is not None
 
 
 async def test_home_shows_network_section_with_empty_state_when_no_recent_posts(
@@ -162,39 +168,87 @@ async def test_home_shows_active_post_actions_for_claim_b_org_rep(
     ), "No disabled post buttons expected for a network-verified user"
 
 
-async def test_onboarding_banner_shown_off_profile_for_incomplete_user(
+async def test_onboarding_banner_shown_for_empty_account(
     authenticated_client: AsyncClient,
 ):
-    """Banner temporarily disabled — assert it is absent."""
+    """A fresh account (no clinician profile, no org rep) sees the global
+    `#onboarding-banner` nudging it to add a provider entity."""
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
-    assert HTMLParser(response.text).css_first("#onboarding-banner") is None
+    banner = HTMLParser(response.text).css_first("#onboarding-banner")
+    assert banner is not None
+    assert "start posting" in banner.text()
+
+
+async def test_onboarding_banner_links_to_both_minimal_create_forms(
+    authenticated_client: AsyncClient,
+):
+    """The banner is a derived gate, not a wizard: it dispatches into the two
+    existing minimal create forms (`/clinicians/form`, `/organizations/form`)."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    banner = HTMLParser(response.text).css_first("#onboarding-banner")
+    assert banner is not None
+    hrefs = {a.attributes.get("href") for a in banner.css("a")}
+    assert "/clinicians/form" in hrefs
+    assert "/organizations/form" in hrefs
 
 
 async def test_onboarding_banner_renders_inside_main(
     authenticated_client: AsyncClient,
 ):
-    """Banner temporarily disabled — assert it is absent."""
+    """The banner lives inside the page `<main>` band (not the header)."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    banner = tree.css_first("main #onboarding-banner")
+    assert banner is not None
+
+
+async def test_onboarding_banner_hidden_once_clinician_added(
+    authenticated_client: AsyncClient,
+    db_test_session_manager,
+    logged_in_user,
+):
+    """The banner keys on entity existence, not verification: once the account
+    holds a clinician profile (even an unverified one) the global banner is
+    silent — the residual verify-to-post step lives on `/users/me`."""
+    from tests.helpers import make_clinician_with_org
+
+    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(clinician)
+
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
     assert HTMLParser(response.text).css_first("#onboarding-banner") is None
 
 
-async def test_onboarding_banner_hidden_once_claim_verified(
+async def test_onboarding_banner_hidden_for_org_rep(
     authenticated_client: AsyncClient,
     db_test_session_manager,
     logged_in_user,
 ):
-    """A verified clinician has completed onboarding, so the global banner
-    is silent."""
-    from tests.helpers import make_clinician_with_org
+    """An account that holds an org representation (no clinician) also clears
+    the banner — "clinician OR org" satisfies the derived gate."""
+    from src.domain.models.org_representations.org_representation import (
+        OrgRepresentation,
+    )
+    from tests.helpers import make_organization_row
 
-    clinician = make_clinician_with_org(owner_id=logged_in_user.id, npi="1234567890")
-    clinician.npi_match_status = "matched"
-    clinician.clinician_verified = True
+    org = make_organization_row(owner_id=logged_in_user.id)
+    rep = OrgRepresentation(
+        user_id=logged_in_user.id,
+        org_id=org.id,
+        role="coordinator",
+        authority_method="admin_review",
+        authority_status="verified",
+    )
     async with db_test_session_manager() as session:
         async with session.begin():
-            session.add(clinician)
+            session.add(org)
+            session.add(rep)
 
     response = await authenticated_client.get("/home")
     assert response.status_code == 200

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -835,11 +835,15 @@ async def test_create_form_gate_shown_when_no_clinician_profile(
     authenticated_client: AsyncClient,
     logged_in_user,
 ):
-    """GET /posts/form?kind=<kind> shows the clinician-profile gate when the
-    requesting user has no clinician profiles, not the create form."""
+    """GET /posts/form?kind=<kind> shows the provider-entity gate when the
+    requesting user has no clinician profiles, not the create form. The gate
+    copy (`posts/_shared/_require_clinician_profile.html`) nudges toward a
+    clinician *or* org, matching the global #onboarding-banner."""
     response = await authenticated_client.get(f"/posts/form?kind={kind}")
     assert response.status_code == 200
-    assert "Create your clinician profile" in response.text
+    assert "Add a clinician or organization first." in response.text
+    assert "/clinicians/form" in response.text
+    assert "/organizations/form" in response.text
     # The post-create form fields should not be rendered.
     assert 'name="kind"' not in response.text
 
@@ -861,7 +865,7 @@ async def test_create_form_shown_when_clinician_profile_exists(
     response = await authenticated_client.get(f"/posts/form?kind={kind}")
     assert response.status_code == 200
     assert 'name="kind"' in response.text
-    assert "Create your clinician profile" not in response.text
+    assert "Add a clinician or organization first." not in response.text
 
 
 # Both clinician-authored kinds now expose a single practice picker named

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -507,6 +507,12 @@ async def test_get_users_id_renders_admin_view_of_other_user(
     assert (
         tree.css_first("#account-organizations") is None
     ), "no inline Organizations section on another user's profile"
+    # The global onboarding banner (#1525) is chrome — it links to the create
+    # forms for the *viewing* user's own incomplete setup and legitimately
+    # appears site-wide. Strip it before asserting the self-only account-hub
+    # Add CTAs (the inline sections above) don't leak onto another user's page.
+    for _banner in tree.css("#onboarding-banner"):
+        _banner.decompose()
     assert (
         tree.css_first("a[href='/clinicians/form']") is None
         and tree.css_first("a[href='/organizations/form']") is None

--- a/src/domain/templates/posts/_shared/_require_clinician_profile.html
+++ b/src/domain/templates/posts/_shared/_require_clinician_profile.html
@@ -1,7 +1,14 @@
-{# Shown when `current_user` has no clinician profiles, blocking post creation.
-   Include this partial inside the `{% if not current_user.clinicians %}` branch
-   of any create-form template that requires a clinician profile to proceed.
-   Relies on `entity_form_url` from the calling template's context. #}
+{# Shown when `current_user` has no provider entity (no clinician profile
+   and no org), blocking post creation. Include this partial inside the
+   "no provider entity" branch of any create-form template that requires a
+   clinician or org to proceed. Frames the gate as "clinician OR org" to
+   match the global #onboarding-banner (base.html) and the derived-gate
+   model (RESOURCE_GRAMMAR.md §"Derived gates"): it only dispatches into
+   the existing minimal create forms. Relies on `entity_form_url` from the
+   calling template's context. #}
 <p>
-  Set up your clinician profile first. <a href="{{ entity_form_url('clinician') }}">Create your clinician profile.</a>
+  Add a clinician or organization first.
+  <a href="{{ entity_form_url('clinician') }}">Add a clinician</a>
+  or
+  <a href="{{ entity_form_url('organization') }}">Add an organization</a>.
 </p>

--- a/src/framework/http/responses.py
+++ b/src/framework/http/responses.py
@@ -49,20 +49,37 @@ def base_context(user: Actor | None) -> dict:
     own — "own" for an Organization includes verified-rep affiliation,
     matching message-1 "owns/is affiliated to". Empty set for anonymous
     or anyone without rep status.
+
+    `needs_provider_entity` drives the global `#onboarding-banner` in
+    `base.html`. It is the derived-gate signal (`RESOURCE_GRAMMAR.md`
+    §"Derived gates"): True only for an authenticated account that holds
+    **neither** a clinician profile **nor** any org representation — i.e.
+    has no provider entity to author a post against, so the create flow
+    is dead-ended until one exists. It keys on entity *existence*, not
+    verification: once the account adds a clinician or org the banner
+    goes silent and the remaining "verify to post" step lives on the
+    `/users/me` card (coordinated with I4), so the two surfaces don't
+    double-nag. Anonymous visitors and stubs without the relationships
+    read as not-needing (the banner is for signed-in, empty accounts).
     """
     from src.domain.logic.capabilities import can_act_as_provider, claim_state
 
+    has_clinician = bool(getattr(user, "clinicians", None))
+    has_org_rep = bool(getattr(user, "org_representations", None))
     return {
         "is_authenticated": user is not None,
         "is_admin": is_admin(user),
         "current_username": user.username if user is not None else None,
         "current_user_id": user.id if user is not None else None,
-        "has_clinician_profile": bool(getattr(user, "clinicians", None)),
+        "has_clinician_profile": has_clinician,
         "current_user_is_verified": (
             True if user is None else bool(getattr(user, "is_verified", True))
         ),
         "can_act_as_provider": can_act_as_provider(user),
         "viewer_rep_org_ids": claim_state(user).b,
+        "needs_provider_entity": (
+            user is not None and not has_clinician and not has_org_rep
+        ),
     }
 
 

--- a/src/framework/http/test_responses.py
+++ b/src/framework/http/test_responses.py
@@ -31,6 +31,8 @@ def test_base_context_anonymous():
         "can_act_as_provider": False,
         # No org-rep affiliations.
         "viewer_rep_org_ids": frozenset(),
+        # Anonymous visitors never see the onboarding banner.
+        "needs_provider_entity": False,
     }
 
 
@@ -48,7 +50,36 @@ def test_base_context_regular_user():
         "current_user_is_verified": True,
         "can_act_as_provider": False,
         "viewer_rep_org_ids": frozenset(),
+        # Authenticated account with neither clinician nor org rep — the
+        # onboarding banner fires.
+        "needs_provider_entity": True,
     }
+
+
+def test_base_context_needs_provider_entity_false_with_clinician():
+    """Holding a clinician profile (even unverified) clears the banner gate —
+    the account has a provider entity to author posts against."""
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        username="alice",
+        is_superuser=False,
+        clinicians=[SimpleNamespace(id=uuid.uuid4())],
+        org_representations=[],
+    )
+    assert base_context(user)["needs_provider_entity"] is False
+
+
+def test_base_context_needs_provider_entity_false_with_org_rep():
+    """Holding an org representation (no clinician) also clears the banner gate
+    — "clinician OR org" satisfies the derived gate."""
+    user = SimpleNamespace(
+        id=uuid.uuid4(),
+        username="dana",
+        is_superuser=False,
+        clinicians=[],
+        org_representations=[SimpleNamespace(org_id=uuid.uuid4())],
+    )
+    assert base_context(user)["needs_provider_entity"] is False
 
 
 def test_base_context_can_act_as_provider_true_for_verified_clinician():

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -90,13 +90,15 @@ From top to bottom:
 │   breadcrumb row     ← Resource   (hidden placeholder if none) │  ← captured `{% block breadcrumb %}`
 │   toolbar row        <h1> title              [actions ▶]  │  ← captured `{% block toolbar %}`
 ├───────────────────────────────────────────────────────────┤  ← `border-bottom` on `.page-header`
-│ (onboarding banner removed)                               │
+│ onboarding banner    "Add a clinician or organization…"   │  ← `#onboarding-banner`, gated on `needs_provider_entity` (`base_context`)
 │ subtitle (optional)  NPI · Verified                       │  ← `{% block subtitle %}` (rendered below the boundary, top of `<main>`)
 │ page content                                              │  ← `{% block content %}`
 ├───────────────────────────────────────────────────────────┤
 │ <footer> site chrome           &copy; … · support@ …      │  ← `{% block footer %}` (default body in `base.html`)
 └───────────────────────────────────────────────────────────┘
 ```
+
+**Onboarding banner.** `#onboarding-banner` is a global derived gate ([`../../domain/routes/RESOURCE_GRAMMAR.md`](../../domain/routes/RESOURCE_GRAMMAR.md) §"Derived gates") — not a resource or wizard, just a chrome nudge that dispatches into the two minimal create forms (`entity_form_url('clinician')` / `('organization')`). It renders at the top of `<main>` only when `needs_provider_entity` is set in `base_context` (an authenticated account holding **neither** a clinician profile **nor** an org rep, so no post can be authored yet). It keys on entity *existence*, not verification: adding a clinician or org silences it, and the residual "verify to post" step lives on the `/users/me` card. The matching create-time copy is `posts/_shared/_require_clinician_profile.html`. Contract pinned in [`../../domain/routes/test_chrome_banner.py`](../../domain/routes/test_chrome_banner.py).
 
 `{% include %}` can't see the including template's blocks, so `base.html` captures the `breadcrumb` / `toolbar` / `subtitle` block output into context vars and hands the pre-rendered HTML to the band partial. Children still just override `{% block breadcrumb %}` / `{% block toolbar %}` / `{% block subtitle %}` — the capture indirection is transparent. The band's lower rows render only when there's app chrome to show (any breadcrumb/toolbar content, or an authenticated viewer), so anonymous public pages (landing, the `/auth/*` flow) keep their bare brand nav.
 

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -199,7 +199,25 @@
 {% endset -%}
 {% include "_shared/_page_header.html" %}
 <main class="container">
-{# Onboarding banner removed. #}
+{# Global onboarding nudge. A derived gate (RESOURCE_GRAMMAR.md
+         §"Derived gates") — not a resource, just a chrome signal that
+         dispatches into the existing minimal create forms. Shown when
+         `needs_provider_entity` (from `base_context`): an authenticated
+         account holding neither a clinician profile nor an org rep, so a
+         post can't yet be authored. It links straight to the two minimal
+         create forms (`entity_form_url('clinician')` / `('organization')`)
+         rather than any wizard. Goes silent the moment one entity exists;
+         the residual "verify to post" step lives on `/users/me` (I4), so
+         the surfaces don't double-nag. #}
+{% if needs_provider_entity %}
+<aside role="status" id="onboarding-banner">
+<strong>Add a clinician or organization to start posting.</strong>
+You can browse freely, but authoring a post needs a provider profile.
+<a href="{{ entity_form_url('clinician') }}">Add a clinician</a>
+or
+<a href="{{ entity_form_url('organization') }}">Add an organization</a>.
+</aside>
+{% endif %}
 {# Subtitle slot — a one-line muted meta string rendered directly
          below the page-header band's rule, above content (e.g. a
          clinician's "NPI · Verified", a profile-mode line). The block is


### PR DESCRIPTION
Closes #1525 (I7 · Onboarding nudge: minimal-first-info to post).

## What changed
The global `#onboarding-banner` returns as a **derived gate** (`RESOURCE_GRAMMAR.md` §"Derived gates") — not a resource, not a wizard. An authenticated account holding **neither** a clinician profile **nor** an org rep sees *"Add a clinician or organization to start posting"*, linking straight to the two existing minimal create forms (`/clinicians/form`, `/organizations/form`).

It keys on entity **existence**, not verification: adding either entity silences the banner immediately. The residual "verify to post" step stays on the `/users/me` verification card (coordinated with I4), so the two surfaces don't double-nag.

## Details
- `base_context` gains `needs_provider_entity` (authenticated ∧ no clinician ∧ no org rep) — the single chrome-safe signal the banner reads.
- `base.html` renders `#onboarding-banner` at the top of `<main>` on that signal (semantic `<aside role="status">`, Pico defaults, no custom CSS).
- `posts/_shared/_require_clinician_profile.html` reframed from clinician-only to "clinician **or** org", with both create-form links — matching the banner copy.
- `test_chrome_banner.py` contract flipped from "banner absent on all pages" to pin the re-enabled nudge, both dispatch targets, the in-`<main>` placement, and the entity-existence trigger (shown for empty accounts; silent once a clinician *or* org rep exists). `test_responses.py` pins the new scalar. Templates README updated to note the banner is enabled and its trigger.

## Scope
Nav structure in `_page_header.html` (owned by I2) untouched; no users/clinicians/organizations/posts pages or `main.py` changes.

## Tests
`dev test` (full suite), `dev test contract` (41 passed), and `dev lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)