### PR TITLE
Account hub: render owner's clinicians + organizations inline on /users/me (#1522)

### DIFF
--- a/src/domain/logic/users/handlers.py
+++ b/src/domain/logic/users/handlers.py
@@ -13,19 +13,25 @@ from src.framework.http.exceptions import NotFoundError
 logger = logging.getLogger(__name__)
 
 
-# `USER_ENTITY.detail_extras_path` target — fetches the clinicians the
-# target user owns and injects them under `clinicians` for the detail
-# template. Viewer-derived flags (`is_self`, `can_admin_actions`,
-# `can_view_private`) and the `target_user` projection are framework-
-# injected by `handle_detail` from `USER_ENTITY.public_fields` /
-# `private_fields` / `private_field_predicate` — defense-in-depth (a
-# forgotten template guard can re-leak; a missing dict key can't) is
-# preserved.
+# `USER_ENTITY.detail_extras_path` target — fetches the clinicians and
+# organizations the target user owns and injects them under
+# `clinicians` / `organizations` for the account-hub detail template,
+# which renders both as inline lists (issue #1522). Viewer-derived flags
+# (`is_self`, `can_admin_actions`, `can_view_private`) and the
+# `target_user` projection are framework-injected by `handle_detail`
+# from `USER_ENTITY.public_fields` / `private_fields` /
+# `private_field_predicate` — defense-in-depth (a forgotten template
+# guard can re-leak; a missing dict key can't) is preserved.
 user_detail_extras = make_detail_extras_handler(
     (
         (
             "clinicians",
             "clinician_repo",
+            lambda repo, target, _user: repo.list_for_user(target.id),
+        ),
+        (
+            "organizations",
+            "organization_repo",
             lambda repo, target, _user: repo.list_for_user(target.id),
         ),
     )

--- a/src/domain/logic/users/test_handlers.py
+++ b/src/domain/logic/users/test_handlers.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.requests import Request
 
 from src.domain.logic.clinicians.repository import ClinicianRepository
+from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.users.handlers import user_detail_extras
 from src.domain.logic.users.repository import UserRepository
 from src.domain.models import User
@@ -66,7 +67,10 @@ async def test_get_user_detail_forbids_stranger(
                 repo=UserRepository(session),
                 requesting_user=stranger,
                 extras=user_detail_extras,
-                extra_kwargs={"clinician_repo": ClinicianRepository(session)},
+                extra_kwargs={
+                    "clinician_repo": ClinicianRepository(session),
+                    "organization_repo": OrganizationRepository(session),
+                },
             )
 
 
@@ -84,7 +88,10 @@ async def test_get_user_detail_includes_private_fields_for_self(
             repo=UserRepository(session),
             requesting_user=target,
             extras=user_detail_extras,
-            extra_kwargs={"clinician_repo": ClinicianRepository(session)},
+            extra_kwargs={
+                "clinician_repo": ClinicianRepository(session),
+                "organization_repo": OrganizationRepository(session),
+            },
         )
 
     target_view = context["target_user"]
@@ -109,7 +116,10 @@ async def test_get_user_detail_includes_private_fields_for_admin(
             repo=UserRepository(session),
             requesting_user=admin,
             extras=user_detail_extras,
-            extra_kwargs={"clinician_repo": ClinicianRepository(session)},
+            extra_kwargs={
+                "clinician_repo": ClinicianRepository(session),
+                "organization_repo": OrganizationRepository(session),
+            },
         )
 
     target_view = context["target_user"]

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -11,7 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from src.domain.models import User
 from src.framework.audit.log import AuditLog
 from src.framework.audit.repository import AuditRepository
-from tests.helpers import create_test_user, make_clinician_with_org, promote_to_admin
+from tests.helpers import (
+    create_test_user,
+    make_clinician_with_org,
+    make_organization_row,
+    promote_to_admin,
+)
 
 # Mark all tests in this module as async
 pytestmark = pytest.mark.asyncio
@@ -210,23 +215,34 @@ def _signout_button(tree: HTMLParser):
 
 async def test_get_users_me_renders_authenticated_self_view(
     authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user: User,
 ):
     """`GET /users/me` for the signed-in user renders the canonical
-    self-view: the primary nav with brand + Posts/Profile/Sign-out
-    destinations (Profile marked aria-current), the lucide font preload
-    <link> for icon-flicker prevention, a Sign-out button in the toolbar
-    action menu (htmx POST to /auth/jwt/logout with after-request
-    redirect), a body-level Favorites link (not in the toolbar), the
-    self-only Email/Access cards, and a picker dispatching to the global
-    Clinician/Organization directories pre-filtered with `?owner=me`.
-    The page hides top-level identity facts (Email/Active/Verified dt
-    entries live on the admin path or the Email card; #597).
+    account-hub self-view (#1522): the primary nav with brand +
+    Posts/Profile/Sign-out destinations (Profile marked aria-current),
+    the lucide font preload <link> for icon-flicker prevention, a
+    Sign-out button in the toolbar action menu (htmx POST to
+    /auth/jwt/logout with after-request redirect), a body-level
+    Favorites link (not in the toolbar), inline Clinicians +
+    Organizations lists (each with a `+ Add` CTA and a per-row Edit
+    link), and a secondary Account picker with the self-only
+    Email/Favorites/Access cards. The page hides top-level identity
+    facts (Email/Active/Verified dt entries live on the admin path or
+    the Email card; #597).
 
     Consolidates 10 previously-separate tests that all rendered this
     same response with the same fixtures (one in `test_auth_routes.py`,
     nine here). Distinct assertion messages preserve the per-bit signal
     on failure."""
+    # Seed one owned clinician + one owned organization so the inline
+    # account-hub lists render rows (not just their empty states).
+    clinician_id = await _seed_user_clinician(
+        db_test_session_manager, user_id=logged_in_user.id, practice_name="My Practice"
+    )
+    org_id = await _seed_user_organization(
+        db_test_session_manager, user_id=logged_in_user.id, name="My Org"
+    )
     response = await authenticated_client.get("/users/me")
     assert response.status_code == 200
     body = response.text
@@ -318,21 +334,59 @@ async def test_get_users_me_renders_authenticated_self_view(
         tree.css_first(f"main {favorites_selector}") is not None
     ), "Favorites link must appear in the page body for the self viewer"
 
-    # --- Picker cards: Clinicians + Organizations dispatched with ?owner=me
-    # (was test_detail_picker_includes_clinicians_and_organizations)
-    headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
-    assert "Clinicians" in headings, "picker missing Clinicians card"
-    assert "Organizations" in headings, "picker missing Organizations card"
+    # --- Inline account-hub lists: Clinicians + Organizations (#1522).
+    # The pre-#1522 dispatching picker cards are replaced by inline
+    # lists rendered from the owner's own clinicians/organizations.
+    section_headings = [el.text(strip=True) for el in tree.css("main section > * h2")]
+    assert "Clinicians" in section_headings, "account hub missing Clinicians section"
     assert (
-        tree.css_first("article.picker-option a[href$='/clinicians?owner=me']")
-        is not None
-    ), "Clinicians picker card must dispatch with ?owner=me"
-    assert (
-        tree.css_first("article.picker-option a[href$='/organizations?owner=me']")
-        is not None
-    ), "Organizations picker card must dispatch with ?owner=me"
+        "Organizations" in section_headings
+    ), "account hub missing Organizations section"
 
-    # --- Access card (was test_users_me_access_card_links_to_access_page)
+    # Each list renders the owner's seeded row through the shared card
+    # (selected by data-row-id so it survives card-internal markup
+    # changes).
+    assert (
+        tree.css_first(
+            f"#account-clinicians-list article[data-row-id='{clinician_id}']"
+        )
+        is not None
+    ), "owned clinician must render as an inline card in the account hub"
+    assert (
+        tree.css_first(f"#account-organizations-list article[data-row-id='{org_id}']")
+        is not None
+    ), "owned organization must render as an inline card in the account hub"
+
+    # Add CTAs point at the global create forms.
+    assert (
+        tree.css_first("#account-clinicians a[role='button'][href='/clinicians/form']")
+        is not None
+    ), "Clinicians section missing the + Add clinician CTA -> /clinicians/form"
+    assert (
+        tree.css_first(
+            "#account-organizations a[role='button'][href='/organizations/form']"
+        )
+        is not None
+    ), "Organizations section missing the + Add organization CTA -> /organizations/form"
+
+    # Per-row Edit links point at the row's own edit form.
+    assert (
+        tree.css_first(
+            f"#account-clinicians-list a[href='/clinicians/{clinician_id}/form']"
+        )
+        is not None
+    ), "clinician row missing per-row Edit link -> /clinicians/:id/form"
+    assert (
+        tree.css_first(
+            f"#account-organizations-list a[href='/organizations/{org_id}/form']"
+        )
+        is not None
+    ), "organization row missing per-row Edit link -> /organizations/:id/form"
+
+    # --- Secondary Account picker retains Email / Favorites / Access ---
+    headings = [el.text(strip=True) for el in tree.css(".picker-option h2")]
+
+    # Access card (was test_users_me_access_card_links_to_access_page)
     assert "Access" in headings, "/users/me is missing the Access card"
     assert (
         tree.css_first("article.picker-option a[href$='/users/me/access']") is not None
@@ -341,7 +395,7 @@ async def test_get_users_me_renders_authenticated_self_view(
         "Network access" not in body
     ), "capability status must not be embedded on /users/me — lives on /users/me/access"
 
-    # --- Email card (was test_users_me_email_card_links_to_email_form)
+    # Email card (was test_users_me_email_card_links_to_email_form)
     assert "Email" in headings, "/users/me is missing the Email card"
     assert (
         tree.css_first("article.picker-option a[href$='/users/me/email/form']")
@@ -444,12 +498,19 @@ async def test_get_users_id_renders_admin_view_of_other_user(
         "Verification" not in headings
     ), "Verification card must not appear on another user's profile"
 
-    # Inline Clinicians section
-    # (was test_detail_no_inline_clinicians_section_for_other_user) —
-    # removed entirely from the user detail page.
+    # Inline account-hub sections (#1522) are self-only — an admin
+    # auditing another user sees neither the inline Clinicians nor the
+    # inline Organizations list, and no Add CTAs.
     assert (
-        "Clinicians" not in headings
+        tree.css_first("#account-clinicians") is None
     ), "no inline Clinicians section on another user's profile"
+    assert (
+        tree.css_first("#account-organizations") is None
+    ), "no inline Organizations section on another user's profile"
+    assert (
+        tree.css_first("a[href='/clinicians/form']") is None
+        and tree.css_first("a[href='/organizations/form']") is None
+    ), "self-only Add CTAs must not render on another user's profile"
 
 
 async def test_non_admin_forbidden_on_other_user_detail(
@@ -750,6 +811,20 @@ async def _seed_user_clinician(
             session.add(clinician)
         await session.refresh(clinician)
         return clinician.id
+
+
+async def _seed_user_organization(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    *,
+    user_id: uuid.UUID,
+    name: str,
+) -> uuid.UUID:
+    org = make_organization_row(owner_id=user_id, name=name)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(org)
+        await session.refresh(org)
+        return org.id
 
 
 async def test_get_my_clinicians_empty_state(

--- a/src/domain/specs/user.py
+++ b/src/domain/specs/user.py
@@ -20,6 +20,7 @@ from typing import Final
 
 from src.auth_config import current_active_user
 from src.domain.logic.clinicians.repository import ClinicianRepository
+from src.domain.logic.organizations.repository import OrganizationRepository
 from src.domain.logic.users.repository import get_user_repository
 from src.domain.logic.users.schema import (
     UserActivationAuditSnapshot,
@@ -106,5 +107,8 @@ USER_ENTITY: Final[EntitySpec] = EntitySpec(
     # dotted-path trick the state-axis / subresource handlers use —
     # `specs/user.py` never statically imports `src.logic.users`.
     detail_extras_path="src.domain.logic.users.handlers.user_detail_extras",
-    detail_extras_repos=(("clinician_repo", ClinicianRepository),),
+    detail_extras_repos=(
+        ("clinician_repo", ClinicianRepository),
+        ("organization_repo", OrganizationRepository),
+    ),
 )

--- a/src/domain/templates/users/detail.html
+++ b/src/domain/templates/users/detail.html
@@ -1,7 +1,10 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/sections.html" import fact, facts_block -%}
 {%- from "_shared/_picker.html" import picker -%}
-{%- from "_shared/_locked.html" import locked_name -%}
+{%- from "_shared/_locked.html" import locked_name, locked_field -%}
+{%- from "_shared/_card.html" import card -%}
+{%- from "_shared/_item_list.html" import item_list -%}
+{%- from "_shared/_clinician_card.html" import clinician_card with context -%}
 {% block resource_label %}Users{% endblock %}
 {# Redact the username H1 when the viewer lacks provider-network access
    and isn't this user themselves. `is_self` is computed by
@@ -35,22 +38,61 @@
   {% endif %}
   {% include "users/_admin_actions.html" %}
 {% endblock %}
-{# User detail: identity facts (email/active) + navigational picker
- (Email, Clinicians, Organizations, Favorites, Access). The picker
- species here is a *dispatching picker* — each card points OUT to a
- self-sub-page or directory where the user actually manages that
- surface. Headers + descriptions read as a self-explanatory dashboard;
- whole-card click is the affordance. The identity-facts article above
- stays plain-data (not a picker option) because it shows the email
- value rather than navigating.
+{# Account hub ("Your practice"). The self-view is an account hub
+ (issue #1522): the owner's clinicians and organizations render as
+ INLINE lists — one account · many clinicians · many orgs · clinicians
+ ↔ orgs is many-to-many — each with a `+ Add` CTA and a per-row Edit
+ link. The lists are sourced exactly like `/clinicians?owner=me` and
+ `/organizations?owner=me` (via `repo.list_for_user(target.id)` in
+ `user_detail_extras`). Email, Favorites, and Access fold into a
+ secondary "Account" picker below — kept, not removed; the mock omits
+ them but they remain reachable here.
 
- Clinicians + Organizations dispatch to the global `/clinicians` and
- `/organizations` directories. Those collections are no longer
- read-policy-gated; non-network viewers see them redacted with the
- viewer's own rows un-redacted (see `_clinician_card.html` and the
- organizations list/detail templates). #}
-{% block content %}
-  {# Private rows (email, active) are gated by `can_view_private`,
+ Other-user views (admin auditing someone else) render only the
+ identity facts + admin actions: no inline lists, no self-only Account
+ picker. The inline-list row macros below reuse the shared
+ `_clinician_card` / `_card` cards so a clinician/organization renders
+ identically here and on its directory page; the Edit footer is the
+ only per-row addition. #}
+{# Per-row Edit link — secondary-outline treatment per the actions.html
+   vocabulary (Edit = `class="outline"`). Owner-only: these lists only
+   render on the self-view, so every row is the viewer's own. #}
+{%- macro _edit_footer(name, id) -%}
+  <footer>
+    <a href="{{ entity_form_url(name, id=id) }}"
+       role="button"
+       class="outline">Edit</a>
+  </footer>
+{%- endmacro -%}
+{# Clinician row: shared card + Edit footer. #}
+{%- macro clinician_row(clinician) -%}
+  {{ clinician_card(clinician) }}
+  {{ _edit_footer('clinician', clinician.id) }}
+{%- endmacro -%}
+{# Organization row: mirrors `organizations/list.html`'s `org_card`
+   (same `_redacted` rule, same NPI fact) plus the Edit footer. #}
+{%- macro organization_row(org) -%}
+  {%- set _org_redacted = not can_act_as_provider
+    and org.owner_id != current_user_id
+    and org.id not in viewer_rep_org_ids -%}
+  {%- call card(
+    id=org.id,
+    headline_url=None if _org_redacted else entity_url('organization', id=org.id),
+    headline=locked_name("Doe Health Group") if _org_redacted else org.name) -%}{# title-case-ignore: placeholder org name #}
+    {%- if org.npi %}
+      {%- call facts_block() %}
+        {% if _org_redacted %}
+          {%- call fact('npi', 'NPI') %}{{ locked_field(capabilities.REASON_NOT_A_VERIFIED_PROVIDER) }}{%- endcall %}
+          {% else %}
+            {{ fact('npi', 'NPI', org.npi) }}
+          {% endif %}
+        {%- endcall %}
+      {%- endif %}
+      {{ _edit_footer('organization', org.id) }}
+    {%- endcall %}
+  {%- endmacro -%}
+  {% block content %}
+    {# Private rows (email, active) are gated by `can_view_private`,
    computed in handle_get_user_detail as `is_self OR is_admin(viewer)`.
    The handler also omits these fields from the `target_user`
    projection for non-authorized viewers, so a forgotten guard here
@@ -68,36 +110,55 @@
    every account is permanently False; showing it was misleading.
    Verification status and the resend action live at
    /users/me/email/form (linked in the Email card below). #}
-  {% if can_view_private and not is_self %}
-    <article>
-      {%- call facts_block() %}
-        {{ fact('email', 'Email', target_user.email) }}
-        {{ fact('active', 'Active', "Yes" if target_user.is_active else "No") }}
-      {%- endcall %}
-    </article>
-  {% endif %}
-  {# Self-only navigation. Each option dispatches to a sub-page or
-   directory where the user actually manages that surface — Email
-   verification, their clinicians, their organizations, the private
-   Favorites list, the capability tree. Order is identity → content →
-   roles → access. #}
-  {% if is_self %}
-    {{ picker([
-        {"href": entity_url('user', id='me') + "/email/form",
-    "heading": "Email",
-    "description": "Manage your email address and verification."},
-    {"href": entity_url('clinician') + "?owner=me",
-    "heading": "Clinicians",
-    "description": "Clinician entries you own."},
-    {"href": entity_url('organization') + "?owner=me",
-    "heading": "Organizations",
-    "description": "Organizations you own or represent."},
-    {"href": entity_url('user_favorite'),
-    "heading": "Favorites",
-    "description": "Posts you've saved to revisit."},
-    {"href": entity_url('user', id='me') + "/access",
-    "heading": "Access",
-    "description": "Review your account's capabilities and what's gated."},
-    ]) }}
-  {% endif %}
-{% endblock %}
+    {% if can_view_private and not is_self %}
+      <article>
+        {%- call facts_block() %}
+          {{ fact('email', 'Email', target_user.email) }}
+          {{ fact('active', 'Active', "Yes" if target_user.is_active else "No") }}
+        {%- endcall %}
+      </article>
+    {% endif %}
+    {# Self-view account hub: inline Clinicians + Organizations, then a
+   secondary Account picker (Email, Favorites, Access). #}
+    {% if is_self %}
+      <section id="account-clinicians">
+        <header>
+          <h2>Clinicians</h2>
+          <a href="{{ entity_form_url('clinician') }}" role="button">+ Add clinician</a>
+        </header>
+        {%- set _clinicians_empty %}
+          <p id="account-clinicians-empty">You have not added any clinicians yet.</p>
+        {%- endset %}
+        {{ item_list(clinicians, clinician_row, "account-clinicians-list",
+                empty=_clinicians_empty) }}
+      </section>
+      <section id="account-organizations">
+        <header>
+          <h2>Organizations</h2>
+          <a href="{{ entity_form_url('organization') }}" role="button">+ Add organization</a>
+        </header>
+        {%- set _organizations_empty %}
+          <p id="account-organizations-empty">You have not added any organizations yet.</p>
+        {%- endset %}
+        {{ item_list(organizations, organization_row, "account-organizations-list",
+                empty=_organizations_empty) }}
+      </section>
+      {# Secondary section: Email, Favorites, and Access — kept from the
+     pre-#1522 picker, folded below the practice lists. Each dispatches
+     to the sub-page where the user manages that surface. #}
+      <section id="account-secondary">
+        <h2>Account</h2>
+        {{ picker([
+                {"href": entity_url('user', id='me') + "/email/form",
+        "heading": "Email",
+        "description": "Manage your email address and verification."},
+        {"href": entity_url('user_favorite'),
+        "heading": "Favorites",
+        "description": "Posts you've saved to revisit."},
+        {"href": entity_url('user', id='me') + "/access",
+        "heading": "Access",
+        "description": "Review your account's capabilities and what's gated."},
+        ]) }}
+      </section>
+    {% endif %}
+  {% endblock %}


### PR DESCRIPTION
Closes #1522 (Redesign I4 · Account hub).

Turn the self-view of `/users/me` from a dispatching picker into an account hub that mirrors the Direction A mock (§7.1): the owner's clinicians and organizations render as **inline** lists — *one account · many clinicians · many orgs · clinicians ↔ orgs is many-to-many* — each with a `+ Add` CTA and a per-row Edit link.

## What changed
- **`specs/user.py`** — register `organization_repo` in `detail_extras_repos`.
- **`logic/users/handlers.py`** — `user_detail_extras` now also fetches the owner's organizations via `OrganizationRepository.list_for_user`, the same source as `/organizations?owner=me`.
- **`templates/users/detail.html`** — inline Clinicians + Organizations sections reuse the shared `_clinician_card` / `_card` cards (a clinician/org renders identically here and on its directory page); the Edit footer is the only per-row addition. Add CTAs point at `/clinicians/form` and `/organizations/form`; Edit links at `/clinicians/:id/form` and `/organizations/:id/form`. Email, Favorites, and Access fold into a secondary "Account" picker — **kept, not removed**.
- Other-user (admin audit) views are unchanged: no inline lists, no self-only Account picker.

## Reuse, not rewrite
No new components: `item_list`, `_card`, `_clinician_card`, the org-card pattern from `organizations/list.html`, and the existing `list_for_user` queries. Semantic HTML + Pico defaults only — no custom CSS.

## Tests
`src/domain/routes/test_users.py` pins the inline lists (rows selected by `data-row-id`), the `+ Add` CTAs, the per-row Edit links, and the retained Email/Favorites/Access cards; the other-user view asserts the self-only sections + CTAs stay absent. `src/domain/logic/users/test_handlers.py` updated to inject `organization_repo`. `dev test`, `dev test contract`, and `dev lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)