### PR TITLE
Clinician profile: consolidate read summary + visitor Message action (#1523)

### DIFF
--- a/src/domain/routes/test_clinicians.py
+++ b/src/domain/routes/test_clinicians.py
@@ -364,6 +364,164 @@ async def test_get_clinician_hides_delete_button_for_non_owner(
     assert _delete_clinician_button(tree, clinician_id) is None
 
 
+# --- Consolidated read summary (I5 / #1523) -------------------------------
+
+
+async def test_get_clinician_detail_surfaces_consolidated_summary(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """The detail page leads with a consolidated read summary (mock §6):
+    a non-redacted viewer sees the clinician's licenses and affiliation
+    surfaced inline (drawn from the sub-resources) so the page reads
+    like a profile, without having to click into each sub-resource list.
+    The summary is keyed by stable `data-fact` selectors per the
+    `sections.html::fact` contract."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager,
+        user_id=logged_in_user.id,
+        practice_name="Acme Therapy",
+    )
+    licensure = make_clinician_licensure(
+        clinician_id=clinician_id, license_type="lcsw", issuing_state="IL"
+    )
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(licensure)
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}")
+
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    licenses = tree.css_first('[data-fact="summary_licenses"]')
+    assert licenses is not None, "consolidated summary must surface Licenses"
+    assert "Licensed Clinical Social Worker (LCSW)" in licenses.text()
+    assert "(IL)" in licenses.text()
+    affiliation = tree.css_first('[data-fact="summary_affiliation"]')
+    assert affiliation is not None, "consolidated summary must surface Affiliation"
+    assert "Acme Therapy" in affiliation.text()
+    # Additive: the management picker is still reachable below the summary.
+    assert len(tree.css("main article.picker-option")) == 4
+
+
+async def test_get_clinician_detail_summary_redacts_location_for_non_network_viewer(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """Redaction is preserved (mock §6): a non-owner viewer who isn't a
+    verified provider sees the locked name and no identifying Location /
+    Insurance rows in the summary, matching the `_clinician_card.html`
+    redaction contract. The non-identifying credential rows (Licenses)
+    still render."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager, user_id=other.id, practice_name="Acme Therapy"
+    )
+    licensure = make_clinician_licensure(clinician_id=clinician_id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(licensure)
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}")
+
+    assert response.status_code == 200
+    tree = HTMLParser(response.text)
+    # Identifying practice facts are withheld from a non-network visitor.
+    assert tree.css_first('[data-fact="summary_location"]') is None
+    assert tree.css_first('[data-fact="summary_insurance"]') is None
+    # Non-identifying credentials still surface.
+    assert tree.css_first('[data-fact="summary_licenses"]') is not None
+
+
+# --- Owner-vs-visitor toolbar action (I5 / #1523) -------------------------
+
+
+async def test_get_clinician_owner_sees_edit_not_message(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """The owner's toolbar carries the management Edit action and no
+    visitor Message affordance — the owner manages, they don't message
+    themselves (mock §6)."""
+    clinician_id = await _seed_clinician_for(
+        db_test_session_manager, user_id=logged_in_user.id
+    )
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}")
+    tree = HTMLParser(response.text)
+    assert tree.css_first(f'a[href="/clinicians/{clinician_id}/form"]') is not None
+    toolbar = tree.css_first("menu.toolbar-right")
+    assert toolbar is not None
+    assert "Message" not in toolbar.text()
+
+
+async def test_get_clinician_non_owner_non_provider_sees_locked_message(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A non-owner viewer who isn't a verified provider sees the Message
+    affordance in its locked state — reusing the same `_locked` gating
+    the post detail footer applies. Clicking opens the verify-to-message
+    popover rather than messaging directly."""
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+    clinician_id = await _seed_clinician_for(db_test_session_manager, user_id=other.id)
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}")
+    tree = HTMLParser(response.text)
+    toolbar = tree.css_first("menu.toolbar-right")
+    assert toolbar is not None
+    assert "Message" in toolbar.text()
+    locked = toolbar.css_first("[data-locked-cta]")
+    assert locked is not None, "non-provider Message must be the locked affordance"
+    assert locked.attributes.get("data-locked-cta") == "network_unverified"
+    # No Edit link for a non-owner.
+    assert tree.css_first(f'a[href="/clinicians/{clinician_id}/form"]') is None
+
+
+async def test_get_clinician_non_owner_provider_sees_live_message(
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user: User,
+):
+    """A non-owner viewer who clears `can_act_as_provider` (a verified
+    clinician, but not an admin) sees a live Message action linking to
+    the target clinician's owner — where contact happens. No locked
+    state, no Edit link (they aren't the owner). We make the viewer a
+    verified provider by giving them their *own* verified clinician
+    (`make_clinician_with_org` defaults `clinician_verified=True`), which
+    flips `can_act_as_provider` without granting edit rights on the
+    clinician they're viewing — exactly the verified-visitor case."""
+    # Viewer's own verified clinician → `can_act_as_provider` True.
+    await _seed_clinician_for(
+        db_test_session_manager, user_id=logged_in_user.id, practice_name="My Practice"
+    )
+    other = create_test_user(username=f"other-{uuid.uuid4()}")
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other)
+    clinician_id = await _seed_clinician_for(db_test_session_manager, user_id=other.id)
+
+    response = await authenticated_client.get(f"/clinicians/{clinician_id}")
+    tree = HTMLParser(response.text)
+    toolbar = tree.css_first("menu.toolbar-right")
+    assert toolbar is not None
+    message_link = toolbar.css_first(f'a[href="/users/{other.id}"]')
+    assert message_link is not None, "verified visitor must get a live Message link"
+    assert "Message" in message_link.text()
+    assert message_link.css_first("[data-locked-cta]") is None
+    assert tree.css_first(f'a[href="/clinicians/{clinician_id}/form"]') is None
+
+
 # --- Clinician listing -----------------------------------------------------
 
 

--- a/src/domain/templates/clinicians/detail.html
+++ b/src/domain/templates/clinicians/detail.html
@@ -1,6 +1,6 @@
 {% extends "views/detail.html" %}
 {%- from "_shared/actions.html" import actions, favorite_toggle -%}
-{%- from "_shared/_locked.html" import locked_name -%}
+{%- from "_shared/_locked.html" import locked_name, locked_action -%}
 {%- from "_shared/_picker.html" import picker -%}
 {%- from "_shared/icon_label.html" import icon_label -%}
 {%- from "_shared/sections.html" import fact, facts_block -%}
@@ -40,15 +40,27 @@
   {% endif %}
 {% endblock %}
 {% block actions %}
-  {# Primary resource actions (Favorite toggle, Edit, Delete) live in
-   the toolbar — see the "every page's toolbar is the home for
+  {# Primary resource actions (Favorite toggle, Edit, Message, Delete)
+   live in the toolbar — see the "every page's toolbar is the home for
    resource actions" rule in
    [`../../../framework/templates/README.md`](../../../framework/templates/README.md).
    `can_edit` and `is_favorited` are computed by
    handle_get_clinician_detail; templates do not re-derive
    authorization predicates inline. Each action is a `<li>` because
    the toolbar's right zone is a `<menu class="toolbar-right">` of
-   commands. #}
+   commands.
+
+   Owner-vs-visitor split (mock §6): the same URL serves everyone, so
+   the toolbar branches on who's looking. The owner gets the
+   management cluster (Edit / Delete). A non-owner is a *visitor* and
+   gets a Message action instead — gated by the same
+   `can_act_as_provider` / `_locked` pattern the post detail footer
+   uses (`posts/detail.html`): a verified provider gets a live
+   Message link to the clinician's owner profile (where contact
+   happens); everyone else gets the locked affordance whose popover
+   nudges them to verify. This mirrors — and reuses — the post
+   "Message the poster" gating exactly, so the two surfaces can't
+   disagree about who may reach out. #}
   {% if is_authenticated %}{{ favorite_toggle(clinician.id, is_favorited) }}{% endif %}
   {% if can_edit %}
     {{ actions(wrapper="toolbar",
@@ -57,6 +69,16 @@
     delete_url=entity_url('clinician', id=clinician.id),
     delete_confirm="Permanently delete this clinician? Credentials attached to them will be removed too. This cannot be undone.",
     ) }}
+  {% elif is_authenticated %}
+    <li>
+      {% if can_act_as_provider %}
+        <a href="{{ entity_url('user', id=clinician.owner_id) }}"
+           role="button"
+           class="outline">{{ icon_label('message-circle', 'Message') }}</a>
+      {% else %}
+        {{ locked_action(capabilities.REASON_NOT_A_VERIFIED_PROVIDER, "Message", extra_class="secondary") }}
+      {% endif %}
+    </li>
   {% endif %}
 {% endblock %}
 {# The detail page is a *dispatching picker* (#704 / #1330 pattern):
@@ -69,6 +91,45 @@
    land on the sub-resource list pages and see those pages' own
    redaction rules. #}
 {% block content %}
+  {# Consolidated read summary (mock §6). The page is still a
+     dispatching picker underneath, but a visitor lands on a profile —
+     so we lead with the key facts (Licenses, Affiliation, Location,
+     Insurance) drawn from the sub-resources rather than making the
+     reader click into each list page to learn them. This is a READ
+     surface only; full management still lives behind the picker cards
+     below, unchanged. Every row guards on its source so an unset field
+     suppresses cleanly.
+
+     Redaction: Location and Insurance are identifying practice facts,
+     so they follow the same `_redacted` gate as the H1 name — a
+     non-network visitor sees the locked name and no address, matching
+     the `_clinician_card.html` redaction contract. Licenses and the
+     practice/affiliation name are the clinician's public credentials
+     (the same facts the verification badge attests) and render for
+     every viewer, like the identity cluster below. #}
+  {%- set _license_lines = [] -%}
+  {%- for lic in view.licensures -%}
+    {%- set _lt = LICENSE_TYPES_LABELS.get(lic.license_type, lic.license_type) -%}
+    {%- set _ = _license_lines.append(_lt ~ " (" ~ lic.issuing_state ~ ")") -%}
+  {%- endfor -%}
+  {%- if _license_lines or view.practice_name or (not _redacted and (view.full_address or view.insurance_summary)) %}
+    {% call facts_block() %}
+      {%- if _license_lines %}
+        {{ fact('summary_licenses', 'Licenses', _license_lines | join(", ") , icon='award') }}
+      {%- endif %}
+      {%- if view.practice_name %}
+        {%- call fact('summary_affiliation', 'Affiliation', icon='stethoscope') -%}
+          {%- if view.practice_url -%}<a href="{{ view.practice_url }}">{{ view.practice_name }}</a>{%- else -%}{{ view.practice_name }}{%- endif -%}
+        {%- endcall %}
+      {%- endif %}
+      {%- if not _redacted and view.full_address %}
+        {{ fact('summary_location', 'Location', view.full_address, icon='map-pin') }}
+      {%- endif %}
+      {%- if not _redacted and view.insurance_summary %}
+        {{ fact('summary_insurance', 'Insurance', view.insurance_summary, icon='shield') }}
+      {%- endif %}
+    {% endcall %}
+  {%- endif %}
   {# Person-level identity cluster (#1358 PR-a/c/f). Affirming identities,
      languages, and clinical niches are *person* attributes — they move
      with the clinician across affiliations, the same way credentials


### PR DESCRIPTION
Closes #1523 (I5 · Clinician profile: consolidate facts + visitor "Message").

Additive restructure of `/clinicians/:id` so it reads like the Direction A mock (§6) without removing any management flow.

## What changed
- **Consolidated read summary.** `detail.html` now leads with a `facts_block` of key facts — Licenses (from the licensure sub-resource), Affiliation (the practice/org), Location, and Insurance — drawn from the existing `clinician_card_view` view-model and rendered through the shared `sections.html::fact` macros. A visitor learns the essentials without clicking into each sub-resource list. The existing identity cluster and the four-card dispatching picker (Practices / Licensures / Education / Certifications) remain unchanged, reachable below.
- **Owner-vs-visitor toolbar action.** The owner keeps the management cluster (Edit / Delete). A non-owner *visitor* gets a Message action gated by the same `can_act_as_provider` / `_locked` pattern the post detail footer uses: a verified provider gets a live Message link to the clinician's owner profile; everyone else gets the locked Message affordance whose popover nudges them to verify.
- **Redaction preserved exactly.** Identifying summary rows (Location, Insurance) follow the same `_redacted` gate as the H1 name, so a non-network visitor sees the locked name and no address — matching the `_clinician_card.html` contract. Non-identifying credentials (Licenses, Affiliation) render for everyone.

## Tests
New colocated tests in `src/domain/routes/test_clinicians.py` pin: the consolidated summary surfaces Licenses + Affiliation; identifying rows are redacted for a non-network viewer; and the three toolbar states (owner Edit + no Message, verified-visitor live Message, non-verified-visitor locked Message).

`dev test`, `dev lint`, and `dev test contract` all pass.

## Notes / scope
- No new routes: the verified-visitor Message links to the owner's existing user profile (where off-platform contact happens); wiring a dedicated clinician message *send* endpoint would touch posts/route layers and is out of this template-only PR's scope.
- Icons restricted to the bundled Lucide subset (`award`, `stethoscope`, `map-pin`, `shield`, `message-circle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)