### PR TITLE
Global nav: + Post button + avatar menu (#1520)

### DIFF
--- a/src/domain/routes/test_chrome_banner.py
+++ b/src/domain/routes/test_chrome_banner.py
@@ -16,6 +16,12 @@ setup links. These tests assert:
 3. The global `#onboarding-banner` is shown for an empty (no clinician/org)
    account and links to both minimal create forms; it goes silent once the
    account holds a provider entity (verified or not).
+4. The authenticated primary nav renders the redesigned shape end-to-end
+   (through the real entity registry, not the template-test stubs): brand →
+   posts collection, a prominent `+ Post` button → the post create form, and
+   the avatar menu's My posts / Account / Sign out items. Structure is pinned
+   at the template level in `framework/templates/test_page_header.py`; this
+   route test pins that the live URL helpers resolve to the expected paths.
 """
 
 import pytest
@@ -253,3 +259,36 @@ async def test_onboarding_banner_hidden_for_org_rep(
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
     assert HTMLParser(response.text).css_first("#onboarding-banner") is None
+
+
+async def test_authenticated_primary_nav_redesign(authenticated_client: AsyncClient):
+    """End-to-end (through the real entity registry) the authenticated nav is:
+    brand → posts collection, a `+ Post` button → the post create form, and an
+    avatar `<details>` menu with My posts / Account / Sign out. "Saved" is
+    deferred and must not appear. Anonymous nav stays brand-only — pinned in
+    `framework/templates/test_views.py`."""
+    response = await authenticated_client.get("/home")
+    assert response.status_code == 200
+    nav = HTMLParser(response.text).css_first('nav[aria-label="Primary"]')
+    assert nav is not None
+
+    # Brand → posts collection (Browse is the default landing surface).
+    brand = nav.css_first("a strong")
+    assert brand is not None and brand.text(strip=True) == "Bedlam Connect"
+    assert brand.parent.attributes.get("href") == "/posts"
+
+    # `+ Post` button → post create form, outside the collapsible menu.
+    ctas = [a for a in nav.css("a[role='button']") if a.text(strip=True) == "+ Post"]
+    assert len(ctas) == 1
+    assert ctas[0].attributes.get("href") == "/posts/form"
+    assert ctas[0].parent.attributes.get("id") == "primary-nav"
+
+    # Avatar menu items.
+    menu = nav.css_first("details#nav-menu")
+    assert menu is not None
+    items = {a.text(strip=True): a for a in menu.css("ul li a")}
+    assert set(items) == {"My posts", "Account", "Sign out"}
+    assert "Saved" not in items
+    assert items["My posts"].attributes.get("href") == "/posts?owner=me"
+    assert items["Account"].attributes.get("href") == "/users/me"
+    assert items["Sign out"].attributes.get("hx-post") == "/auth/sign-out"

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -1208,12 +1208,16 @@ async def test_list_hides_create_cta_for_claimless_user(
 ):
     """The `/posts` toolbar 'Create' button is hidden for a user holding
     no posting-capable claim — clicking it would only land on a server
-    403 / degraded form. Matches the per-kind post gate's universe."""
+    403 / degraded form. Matches the per-kind post gate's universe. Scoped
+    to the toolbar action menu — the global nav `+ Post` button (also an
+    `a[href='/posts/form'][role='button']`) is intentionally always present
+    and is pinned separately in the page-header / nav tests."""
     response = await authenticated_client.get("/posts")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert (
-        tree.css_first("a[href='/posts/form'][role='button']") is None
+        tree.css_first("menu.toolbar-right a[href='/posts/form'][role='button']")
+        is None
     ), "claimless user must not be offered the toolbar Create CTA"
 
 
@@ -1235,7 +1239,8 @@ async def test_list_shows_create_cta_for_claim_a_user(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert (
-        tree.css_first("a[href='/posts/form'][role='button']") is not None
+        tree.css_first("menu.toolbar-right a[href='/posts/form'][role='button']")
+        is not None
     ), "Claim-A user should be offered the toolbar Create CTA"
 
 
@@ -1263,7 +1268,8 @@ async def test_list_shows_create_cta_for_claim_b_org_rep(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     assert (
-        tree.css_first("a[href='/posts/form'][role='button']") is not None
+        tree.css_first("menu.toolbar-right a[href='/posts/form'][role='button']")
+        is not None
     ), "Claim-B org rep must be offered the toolbar Create CTA"
 
 

--- a/src/domain/routes/test_users.py
+++ b/src/domain/routes/test_users.py
@@ -36,13 +36,15 @@ async def test_primary_nav_highlights_active_section(
     authenticated_client: AsyncClient,
     logged_in_user: User,
 ):
-    """The Posts tab lights on its own list page and subpaths."""
+    """The avatar menu's "My posts" entry lights on the posts list page and
+    its subpaths (it is the Posts-family link; the brand `a[href="/posts"]`
+    is not section-highlighted)."""
     posts = await authenticated_client.get("/posts")
     tree = HTMLParser(posts.text)
     assert (
-        tree.css_first('nav[aria-label="Primary"] a[href="/posts"]').attributes.get(
-            "aria-current"
-        )
+        tree.css_first(
+            'nav[aria-label="Primary"] a[href="/posts?owner=me"]'
+        ).attributes.get("aria-current")
         == "page"
     )
 
@@ -219,8 +221,9 @@ async def test_get_users_me_renders_authenticated_self_view(
     logged_in_user: User,
 ):
     """`GET /users/me` for the signed-in user renders the canonical
-    account-hub self-view (#1522): the primary nav with brand +
-    Posts/Profile/Sign-out destinations (Profile marked aria-current),
+    account-hub self-view (#1522): the primary nav with brand + the
+    `+ Post` button + the avatar menu's My posts/Account/Sign-out
+    destinations (Account marked aria-current on this path),
     the lucide font preload <link> for icon-flicker prevention, a
     Sign-out button in the toolbar action menu (htmx POST to
     /auth/jwt/logout with after-request redirect), a body-level
@@ -253,26 +256,32 @@ async def test_get_users_me_renders_authenticated_self_view(
     assert (
         tree.css("#primary-nav a[href='/clinicians/form']") == []
     ), "Create-clinician CTA must be removed from nav (#697)"
+    # Brand → posts collection for an authenticated viewer (Browse is the
+    # default landing surface); anonymous keeps brand → /home (test_users.py
+    # anonymous nav test).
     assert (
-        tree.css_first('#primary-nav > a[href="/home"]') is not None
-    ), "brand link missing in primary nav"
+        tree.css_first('#primary-nav > a[href="/posts"] strong') is not None
+    ), "brand link must point at /posts when authenticated"
+    # Prominent `+ Post` button (outside the avatar menu) → post create form.
     assert (
-        tree.css_first('#primary-nav a[href="/users/me"]') is not None
-    ), "Profile link missing in primary nav"
+        tree.css_first('#primary-nav > a[role="button"][href="/posts/form"]')
+        is not None
+    ), "`+ Post` button missing in primary nav"
+    # The avatar `<details>` menu carries the non-Post destinations.
     nav_hrefs = [a.attributes.get("href") for a in tree.css("#nav-menu ul li a")]
     assert nav_hrefs == [
-        "/posts",
+        "/posts?owner=me",
         "/users/me",
         "#",
     ], f"nav-menu hrefs unexpected: {nav_hrefs}"
 
-    # --- Profile link carries aria-current on this path
+    # --- Account link carries aria-current on this path
     # (was test_primary_nav_marks_profile_active_on_users_me)
-    profile_link = tree.css_first('#primary-nav a[href="/users/me"]')
+    account_link = tree.css_first('#nav-menu a[href="/users/me"]')
     assert (
-        profile_link is not None
-        and profile_link.attributes.get("aria-current") == "page"
-    ), "Profile link must carry aria-current=page on /users/me"
+        account_link is not None
+        and account_link.attributes.get("aria-current") == "page"
+    ), "Account link must carry aria-current=page on /users/me"
 
     # --- Every authenticated page exposes the header sign-out link
     # (was test_authenticated_page_has_sign_out_affordance in

--- a/src/framework/templates/README.md
+++ b/src/framework/templates/README.md
@@ -86,7 +86,7 @@ From top to bottom:
 ```
 ┌───────────────────────────────────────────────────────────┐
 │ <header class="page-header">                              │  ← `_shared/_page_header.html`
-│   primary nav        brand + auth-aware links             │
+│   primary nav        brand · [+ Post] · avatar menu ▾     │
 │   breadcrumb row     ← Resource   (hidden placeholder if none) │  ← captured `{% block breadcrumb %}`
 │   toolbar row        <h1> title              [actions ▶]  │  ← captured `{% block toolbar %}`
 ├───────────────────────────────────────────────────────────┤  ← `border-bottom` on `.page-header`
@@ -106,7 +106,12 @@ From top to bottom:
 
 **Site footer** (`{% block footer %}`) renders on every page from the default body in `base.html` — a centered `<small>` with the copyright line and a `mailto:` to support. Pages can override the block to swap or extend the line; today none do.
 
-**Primary nav** lives in `base.html` and renders on every screen (authed *and* anonymous) as a single `<ul id="primary-nav">`. The brand sits on the left; when authed, inline links push to the right via `margin-left: auto` on the first link: Posts (`/posts`), Profile (`/users/me`), and Sign out (an `<a hx-post="/auth/sign-out">` — the route returns `HX-Redirect`). Anonymous visitors see only the brand; the chrome carries no Login shortcut (visitors enter the auth flow from the landing page CTA). Active state is matched against `request.url.path`. Pages don't extend it.
+**Primary nav** lives in [`_shared/_page_header.html`](_shared/_page_header.html) (composed by `base.html`) and renders on every screen (authed *and* anonymous) as a single `<nav id="primary-nav" aria-label="Primary">`. The brand link sits on the left; for an authenticated viewer it points at the posts collection (`entity_url('post')`) — Browse is the default authenticated landing surface — while anonymous visitors keep the brand → `/home` (the landing page they can actually reach). Anonymous visitors see only the brand; the chrome carries no Login shortcut (visitors enter the auth flow from the landing page CTA). When authed the brand is followed by:
+
+- a prominent **`+ Post`** button — an `<a role="button">` to the post create form (`entity_form_url('post')`), always visible (it sits outside the collapsible menu, so it stays a one-tap action on mobile too);
+- an **avatar `<details>` menu** (`#nav-menu`, an `icon-user` summary on desktop / hamburger-style toggle on mobile) holding the non-Post destinations: **My posts** → `{{ entity_url('post') }}?owner=me` (the viewer's own posts), **Account** → `entity_url('user', id='me')`, and **Sign out** (an `<a hx-post="/auth/sign-out">` — the route returns `HX-Redirect`). "Saved" is intentionally not here (deferred).
+
+Active state is matched against `request.url.path` (the `_on_posts` / `_on_users_me` flags). Pages don't extend it.
 
 The active tab carries `aria-current="page"` plus `class="contrast"`, and `base.html` styles `nav[aria-label="Primary"] a[aria-current="page"]` with a bottom underline + font-weight bump so the section reads at a glance — Pico's default `aria-current` tint alone was too subtle (#589). The rule scopes to the primary nav so breadcrumb / pagination links that also set `aria-current` keep their lighter treatment. Subpaths under each URL family (e.g. `/posts/{id}`, `/posts/form?kind=clinician_opening`) light the parent section tab. `test_views.py` pins the URL → active-tab mapping, and `test_primary_nav_omits_login_link_for_anonymous_visitors` pins the no-Login contract across every anonymous-accessible URL family.
 

--- a/src/framework/templates/_shared/_page_header.html
+++ b/src/framework/templates/_shared/_page_header.html
@@ -18,6 +18,12 @@ inherits the caller's context, so `_on_home` / `_on_posts` /
 `_on_profile` / `is_authenticated` resolve normally. `_on_home` marks
 the brand logo with `aria-current="page"` when the viewer is on /home.
 
+When authenticated, the primary nav is: brand link (→ the posts
+collection, the default landing surface) → a prominent `+ Post` button
+(→ the post create form) → an avatar `<details>` menu (My posts → the
+viewer's own posts via `?owner=me`, Account → the self user page, Sign
+out via `hx-post`). Anonymous visitors get the brand link only.
+
 The band's lower rows (breadcrumb + toolbar) render only when there's
 app chrome to show — any breadcrumb or toolbar content, or an
 authenticated viewer. Anonymous public pages (landing, the `/auth/*`
@@ -34,21 +40,23 @@ and the constant-boundary rationale (one source of truth).
 #}
 <header class="container page-header">
   <nav aria-label="Primary" id="primary-nav">
-    <a href="/home" {% if _on_home %}aria-current="page"{% endif %}><strong>Bedlam Connect</strong></a>
+    <a href="{% if is_authenticated %}{{ entity_url("post") }}{% else %}/home{% endif %}"
+       {% if _on_home %}aria-current="page"{% endif %}><strong>Bedlam Connect</strong></a>
     {% if is_authenticated %}
+      <a href="{{ entity_form_url('post') }}" role="button">+ Post</a>
       <details id="nav-menu">
-        <summary class="nav-menu-toggle" aria-label="Menu">
-          <i class="icon-menu nav-menu-open-icon"></i>
-          <i class="icon-x nav-menu-close-icon"></i>
+        <summary class="nav-menu-toggle" aria-label="Account menu">
+          <i class="icon-user nav-menu-open-icon" aria-hidden="true"></i>
+          <i class="icon-x nav-menu-close-icon" aria-hidden="true"></i>
         </summary>
         <ul>
           <li>
-            <a href="{{ entity_url('post') }}"
-               {% if _on_posts %}aria-current="page"{% endif %}>Posts</a>
+            <a href="{{ entity_url("post") }}?owner=me"
+               {% if _on_posts %}aria-current="page"{% endif %}>My posts</a>
           </li>
           <li>
             <a href="{{ entity_url('user', id='me') }}"
-               {% if _on_users_me %}aria-current="page"{% endif %}>Profile</a>
+               {% if _on_users_me %}aria-current="page"{% endif %}>Account</a>
           </li>
           <li>
             <a href="#" hx-post="/auth/sign-out">Sign out</a>

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -185,6 +185,77 @@ def test_onboarding_banner_is_first_child_of_main() -> None:
     assert tree.css_first("#onboarding-banner") is None
 
 
+def test_authenticated_nav_has_post_cta_and_avatar_menu() -> None:
+    """The authenticated primary nav is: brand → `+ Post` button → avatar
+    `<details>` menu. The brand links to the posts collection (Browse is the
+    default landing surface); the `+ Post` button is an `<a role="button">`
+    pointing at the post create form and lives *outside* the collapsible
+    menu so it stays a one-tap action on every viewport."""
+    env = _make_env()
+    _add_child(env, "detailstub.html", _DETAIL_STUB)
+    tree = HTMLParser(_render(env, "detailstub.html", **_BANNER_CTX))
+
+    nav = tree.css_first('nav[aria-label="Primary"]')
+    assert nav is not None
+
+    # Brand → posts collection (Browse), not a hardcoded "/home" link target.
+    brand = nav.css_first("a strong")
+    assert brand is not None and brand.text(strip=True) == "Bedlam Connect"
+    assert brand.parent.attributes.get("href") == "/posts"
+
+    # `+ Post` is a button-styled anchor to the post create form, and is a
+    # direct child of the nav (not nested inside the avatar `<details>`).
+    post_ctas = [
+        a for a in nav.css("a[role='button']") if a.text(strip=True) == "+ Post"
+    ]
+    assert len(post_ctas) == 1, "exactly one `+ Post` button expected"
+    cta = post_ctas[0]
+    assert cta.attributes.get("href") == "/posts/form"
+    assert cta.parent.attributes.get("id") == "primary-nav", (
+        "`+ Post` must sit outside the collapsible avatar menu so it stays "
+        "visible on mobile"
+    )
+
+
+def test_avatar_menu_items_are_my_posts_account_sign_out() -> None:
+    """The repurposed `<details id="nav-menu">` is the avatar menu. Its
+    items are exactly My posts (→ the viewer's own posts via `?owner=me`),
+    Account (→ the self user page), and Sign out (`hx-post`). "Saved" is
+    deferred and must not appear."""
+    env = _make_env()
+    _add_child(env, "detailstub.html", _DETAIL_STUB)
+    tree = HTMLParser(_render(env, "detailstub.html", **_BANNER_CTX))
+
+    menu = tree.css_first("details#nav-menu")
+    assert menu is not None, "avatar `<details id='nav-menu'>` menu missing"
+    items = menu.css("ul li a")
+    labels = [a.text(strip=True) for a in items]
+    assert labels == ["My posts", "Account", "Sign out"]
+    assert "Saved" not in labels
+
+    by_label = {a.text(strip=True): a for a in items}
+    assert by_label["My posts"].attributes.get("href") == "/posts?owner=me"
+    assert by_label["Account"].attributes.get("href") == "/users/me"
+    assert by_label["Sign out"].attributes.get("hx-post") == "/auth/sign-out"
+
+
+def test_anonymous_nav_is_brand_only() -> None:
+    """Anonymous visitors get the brand link only — no `+ Post` button and
+    no avatar menu."""
+    env = _make_env()
+    _add_child(env, "detailstub.html", _DETAIL_STUB)
+    tree = HTMLParser(_render(env, "detailstub.html", is_authenticated=False))
+
+    nav = tree.css_first('nav[aria-label="Primary"]')
+    assert nav is not None
+    assert nav.css_first("details#nav-menu") is None
+    assert [
+        a for a in nav.css("a[role='button']") if a.text(strip=True) == "+ Post"
+    ] == []
+    # The brand link is still present.
+    assert nav.css_first("a strong").text(strip=True) == "Bedlam Connect"
+
+
 def test_css_pins_no_wrap_truncation_and_reserved_band() -> None:
     """Pin the CSS the band's guarantees rest on: the actions cells never
     wrap (so they don't grow the band), the toolbar `<h1>` truncates rather

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -746,16 +746,17 @@ def test_login_link_color_is_consistent_across_auth_pages() -> None:
 
 
 def test_primary_nav_posts_active_on_posts_list() -> None:
-    """`/posts` is the canonical Posts URL — its tab is active."""
-    assert _active_tab_labels(_render_chrome("/posts")) == ["Posts"]
+    """`/posts` is the canonical Posts URL — the avatar menu's "My posts"
+    entry (the only Posts-family link) is active there."""
+    assert _active_tab_labels(_render_chrome("/posts")) == ["My posts"]
 
 
 def test_primary_nav_posts_active_on_posts_subpath() -> None:
-    """Subpaths under `/posts` (detail, edit, form) keep the Posts tab
-    lit — same path-prefix rule Directory uses."""
-    assert _active_tab_labels(_render_chrome("/posts/42")) == ["Posts"]
-    assert _active_tab_labels(_render_chrome("/posts/42/form")) == ["Posts"]
-    assert _active_tab_labels(_render_chrome("/posts/form")) == ["Posts"]
+    """Subpaths under `/posts` (detail, edit, form) keep the "My posts"
+    avatar-menu entry lit — same path-prefix rule Directory uses."""
+    assert _active_tab_labels(_render_chrome("/posts/42")) == ["My posts"]
+    assert _active_tab_labels(_render_chrome("/posts/42/form")) == ["My posts"]
+    assert _active_tab_labels(_render_chrome("/posts/form")) == ["My posts"]
 
 
 def test_primary_nav_no_tab_active_on_non_journey_paths() -> None:

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -80,7 +80,10 @@ async def test_home_page_no_post_actions_for_no_claim_user(
     # not a live link
     assert "No posts yet." in response.text
     assert tree.css_first('button[aria-disabled="true"]') is not None
-    assert tree.css_first('a[href="/posts/form"]') is None
+    # The page-body / toolbar create affordance is gated to a disabled button
+    # for a no-claim user. The global nav `+ Post` button is always present
+    # (pinned in the nav tests), so scope this to `<main>` to exclude it.
+    assert tree.css_first('main a[href="/posts/form"]') is None
 
 
 async def test_home_page_empty_my_posts_shows_locked_cta_when_unverified(
@@ -156,15 +159,18 @@ async def test_home_page_has_no_inline_feed_verify_notice(
 
 async def test_home_page_shows_primary_nav(authenticated_client: AsyncClient):
     """The home page passes current_user so is_authenticated=True and the
-    primary nav links (Home, Posts, Profile, Sign out) render."""
+    redesigned primary nav renders: brand → posts, a `+ Post` button →
+    the create form, and the avatar menu (My posts / Account / Sign out)."""
     response = await authenticated_client.get("/home")
     assert response.status_code == 200
     tree = HTMLParser(response.text)
     nav = tree.css_first('nav[aria-label="Primary"]')
     assert nav is not None
     links = {a.attributes.get("href") for a in nav.css("a")}
-    assert "/home" in links
+    # Brand → posts collection; `+ Post` → create form; My posts → owner=me.
     assert "/posts" in links
+    assert "/posts/form" in links
+    assert "/posts?owner=me" in links
 
 
 # --- lifespan -----------------------------------------------------------


### PR DESCRIPTION
Closes #1520 (I2 · Global nav: `+ Post` button + avatar menu).

Restructures the authenticated primary nav in `_shared/_page_header.html` into the Direction A shape, reusing existing markup (no new CSS):

- **Brand** → posts collection (`entity_url('post')`) — Browse is the default authenticated landing surface. Anonymous viewers keep brand → `/home`.
- **`+ Post`** — a prominent `a role="button"` to the post create form (`entity_form_url('post')`), sitting outside the collapsible menu so it stays a one-tap action on mobile.
- **Avatar `<details>` menu** (the repurposed nav menu) with My posts → `/posts?owner=me`, Account → `/users/me`, Sign out → `hx-post="/auth/sign-out"`. "Saved" intentionally deferred. `aria-current` handling preserved.

Because the nav `+ Post` is now always present for authenticated viewers, the posting-capability gate applies only to the toolbar/page-body Create CTAs; the tests that pinned "no `/posts/form` link for claimless users" are rescoped to the toolbar action menu / `<main>`.

The `#onboarding-banner` re-enabled by #1525/#1529 is left intact — only the nav was restructured.

Definition of done: chrome README updated, nav structure pinned in `test_page_header.py` + `test_chrome_banner.py` (and adjusted `test_views.py` / `test_users.py` / `test_main.py`). `dev lint`, the full suite (2868 passed), and contract tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)