### PR TITLE
Chrome: full-width layout via Pico .container-fluid

### DIFF
--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -579,7 +579,7 @@ async def test_get_register_page(test_client: AsyncClient):
     assert "Create an account" in response.text
     assert "Create account" in response.text
     # Form wrapper — `.auth-page` caps the form at 28rem and centers it
-    # so it doesn't stretch to the `<main class="container">` width on
+    # so it doesn't stretch to the `<main>` `.container-fluid` width on
     # tablet/desktop (#584). No card chrome: deliberately not styled as
     # a card. The `.auth-page` rule lives in `base.html`.
     assert '<section class="auth-page">' in response.text

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -5,8 +5,8 @@
    landing-specific extras: vertically center the hero within `<main>` and
    switch the CTA cluster to a natural-width inline row, both at tablet+.
    `<main>` makes itself a centering grid; its sole child is the
-   `.container` that holds the hero, so `align-content: center` centers the
-   hero block. Mobile relies on Pico defaults — `<a role="button">` is
+   `.container-fluid` that holds the hero, so `align-content: center` centers
+   the hero block. Mobile relies on Pico defaults — `<a role="button">` is
    block-level full-width, which is exactly what we want for stacked
    tappable bars. Scoped to `body:has(.landing-hero)` so the rules don't
    leak to any other page. #}

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -535,10 +535,10 @@ dd { margin: 0; }
 /* Page-header band — the top-chrome nav element
    (`_shared/_page_header.html`): the primary nav, closed with a full-width
    `border-bottom`. The band itself is full-width and carries the boundary;
-   its inner `.container` (max-width-capped, centered) holds the nav, so the
-   divider spans the whole page while content stays within the container
-   gutter (matches `<main>` / `<footer>`, which also wrap content in an inner
-   `.container`). The breadcrumb is its own band below; the page `<h1>` +
+   its inner `.container-fluid` (full-width, gutter-padded) holds the nav, so
+   the divider spans the whole page while content fills the viewport width
+   minus the gutter (matches `<main>` / `<footer>`, which also wrap content in
+   an inner `.container-fluid`). The breadcrumb is its own band below; the page `<h1>` +
    actions toolbar lives in `<main>`. Both band dividers use the standard
    subtle `--pico-muted-border-color`. */
 .page-header { border-bottom: 1px solid var(--pico-muted-border-color); color: inherit; }
@@ -662,10 +662,10 @@ td > menu > li > [role="button"] {
   margin-inline: auto;
 }
 /* Page footer (`<footer>` in base.html — sibling of `<header>` and
-   `<main>`, content wrapped in an inner `.container`). Centered chrome
+   `<main>`, content wrapped in an inner `.container-fluid`). Centered chrome
    line, present on every page via the default `{% block footer %}` body.
    `text-align` is set on `<footer>` itself (full width) so it cascades to
-   the centered inner container's text. */
+   the inner container's text. */
 footer { text-align: center; }
 fieldset { border: none; padding: 0; margin: 0 0 1.25rem; }
 legend { font-size: 0.8em; text-transform: uppercase; letter-spacing: 0.06em; color: var(--pico-muted-color); font-weight: 500; padding: 0; }

--- a/src/framework/templates/_shared/_breadcrumb.html
+++ b/src/framework/templates/_shared/_breadcrumb.html
@@ -6,7 +6,7 @@ segment, with Pico drawing the `>` dividers between items — wrapped in its
 OWN `<nav class="breadcrumb-bar">` band. A view template fills the
 `breadcrumb` block; `base.html` captures it and renders the result as a
 body-level sibling of `<header>` / `<main>` / `<footer>` (not inside the
-page-header). The inner `.container` keeps the chain aligned with page
+page-header). The inner `.container-fluid` keeps the chain aligned with page
 content; on narrow viewports the chain scrolls horizontally rather than
 wrapping (see `.breadcrumb-bar` in framework.css).
 
@@ -34,7 +34,7 @@ segment. An empty `items` therefore renders just the Home crumb.
 {% macro breadcrumb(items) -%}
   {%- set _chain = [("Home", entity_url("post"), none)] + (items | list if items else []) -%}
   <nav aria-label="breadcrumb" class="breadcrumb-bar">
-    <div class="container">
+    <div class="container-fluid">
       <ul>
         {%- for _item in _chain %}
           {%- set _label = _item[0] -%}

--- a/src/framework/templates/_shared/_page_header.html
+++ b/src/framework/templates/_shared/_page_header.html
@@ -1,6 +1,7 @@
 {# Unified page-header band — the app's permanent top chrome.
 
-Renders one `<header class="container page-header">` whose rows, top to
+Renders one `<header class="page-header">` (with an inner `.container-fluid`)
+whose rows, top to
 bottom, are: primary nav → breadcrumb slot → page-title/toolbar slot.
 The band's `border-bottom` is the page's one horizontal boundary and
 sits at the same Y on every app page at a given screen size: the
@@ -39,13 +40,13 @@ See `templates/README.md` § "Page chrome contract" for the slot list
 and the constant-boundary rationale (one source of truth).
 #}
 <header class="page-header">
-  {# `.container` lives INSIDE the band (not on `<header>`) so the band's
-     `border-bottom` spans the full page width while the nav content stays
-     max-width-capped and centered. Same pattern on `<main>` and `<footer>`
-     in base.html. The breadcrumb is no longer part of this band — it is its
-     own `<nav class="breadcrumb-bar">` rendered as a body-level sibling in
-     base.html. #}
-  <div class="container">
+  {# `.container-fluid` lives INSIDE the band (not on `<header>`) so the band's
+     `border-bottom` spans the full page width while the nav content fills the
+     viewport width minus Pico's horizontal gutter. Same pattern on `<main>`
+     and `<footer>` in base.html. The breadcrumb is no longer part of this
+     band — it is its own `<nav class="breadcrumb-bar">` rendered as a
+     body-level sibling in base.html. #}
+  <div class="container-fluid">
     {# Canonical Pico nav: a brand `<ul>` (left) and an actions `<ul>`
      (right). `Post` is a visible link `<li>`; the profile menu is a Pico
      dropdown (https://picocss.com/docs/nav) — `<details class="dropdown">`

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -50,11 +50,12 @@
 <link rel="stylesheet" href="/static/fw/fonts/lucide-icons.css{% if static_version %}?v={{ static_version }}{% endif %}" />
 {# Density overrides and component styles live in two static CSS files
        split by framework/domain boundary — see `src/framework/static/css/`
-       and `src/domain/static/css/`. The classful Pico build needs
-       `class="container"` for max-width centering; each layout band
-       (`<header>`, the breadcrumb `<nav>`, `<main>`, `<footer>`) wraps its
-       content in an inner `.container` so the band spans full width (its
-       divider edge-to-edge) while the content stays centered. #}
+       and `src/domain/static/css/`. The classful Pico build uses
+       `class="container-fluid"` for the full-width gutter layout; each layout
+       band (`<header>`, the breadcrumb `<nav>`, `<main>`, `<footer>`) wraps
+       its content in an inner `.container-fluid` so the band spans full width
+       (its divider edge-to-edge) and the content fills the viewport width
+       (minus Pico's horizontal gutter), rather than being max-width-capped. #}
 <link rel="stylesheet" href="/static/fw/css/framework.css{% if static_version %}?v={{ static_version }}{% endif %}" />
 <link rel="stylesheet" href="/static/domain/css/domain.css{% if static_version %}?v={{ static_version }}{% endif %}" />
 {# `defer` keeps the HTML parser unblocked while these scripts
@@ -204,7 +205,7 @@
        sibling of `<header>` / `<main>` / `<footer>` (NOT inside the
        page-header). The `breadcrumb()` macro emits the full Pico chain (a
        Home root + the page's segments) wrapped in `<nav>` + inner
-       `.container`. Always present on authenticated app pages: a page-
+       `.container-fluid`. Always present on authenticated app pages: a page-
        supplied chain (detail / form / search / subresource list) when set,
        otherwise just the Home crumb (`breadcrumb([])`). Absent for anonymous
        pages (landing / `/auth/*`). #}
@@ -213,11 +214,11 @@
 {%- else %}{{ breadcrumb([]) }}{%- endif %}
 {%- endif %}
 <main>
-{# `.container` wraps the content INSIDE `<main>` (not on `<main>` itself)
-         so any full-bleed chrome on `<main>` spans the page while the content
-         stays max-width-capped and centered. Mirrors `<header>` (the
-         page-header band) and `<footer>`. #}
-<div class="container">
+{# `.container-fluid` wraps the content INSIDE `<main>` (not on `<main>`
+         itself) so any full-bleed chrome on `<main>` spans the page while the
+         content fills the full viewport width minus Pico's horizontal gutter.
+         Mirrors `<header>` (the page-header band) and `<footer>`. #}
+<div class="container-fluid">
 {# Page toolbar — the page `<h1>` plus its action cluster (Edit, Delete,
          Favorite, Create, ...). Historically this lived inside the
          `.page-header` band; it now renders at the top of `<main>` so the
@@ -268,13 +269,13 @@ or
 {# Page footer slot — outside `<main>` so the footer is the
        document's `<footer>` (semantic site-level role) rather than a
        child of the main content. Content is wrapped in an inner
-       `.container` (not on `<footer>` itself) so the footer band can span
-       the full page while its text stays max-width-capped and centered —
-       same pattern as `<header>` and `<main>`. The default body is a
-       site-wide copyright / contact line shown on every page; pages can
-       override by redefining `{% raw %}{% block footer %}{% endraw %}`. #}
+       `.container-fluid` (not on `<footer>` itself) so the footer band can
+       span the full page and its text fills the viewport width minus Pico's
+       horizontal gutter — same pattern as `<header>` and `<main>`. The
+       default body is a site-wide copyright / contact line shown on every
+       page; pages can override by redefining `{% raw %}{% block footer %}{% endraw %}`. #}
 <footer>
-<div class="container">
+<div class="container-fluid">
 {% block footer %}
 <small>&copy; 2026 Bedlam Health &middot; <a href="mailto:support@bedlamhealth.com">support@bedlamhealth.com</a></small>
 {% endblock %}

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -6,8 +6,8 @@ The chrome is three full-width bands stacked above the content, each a
 body-level layout row:
 
   1. ``<header class="page-header">`` — the primary nav only. Its inner
-     ``.container`` caps + centers the nav; the band's ``border-bottom`` spans
-     the full page.
+     ``.container-fluid`` lays the nav out full-width (minus Pico's gutter);
+     the band's ``border-bottom`` spans the full page.
   2. ``<nav class="breadcrumb-bar">`` — its OWN body-level band (a sibling of
      ``<header>``/``<main>``/``<footer>``, NOT nested in the header). Always
      shows a real, visible crumb on authenticated pages — a page-supplied
@@ -97,8 +97,8 @@ def test_detail_toolbar_in_main_and_breadcrumb_is_its_own_band() -> None:
     bar = tree.css_first("body > nav.breadcrumb-bar")
     assert bar is not None
     assert bar.attributes.get("aria-label") == "breadcrumb"
-    # Full Pico chain in a `.container > ul`: Home › Collection › <resource>.
-    crumbs = [li.text(strip=True) for li in bar.css("div.container ul li")]
+    # Full Pico chain in a `.container-fluid > ul`: Home › Collection › <resource>.
+    crumbs = [li.text(strip=True) for li in bar.css("div.container-fluid ul li")]
     assert crumbs == ["Home", "Clinicians", "Sunrise Therapy"]
 
 
@@ -112,7 +112,7 @@ def test_list_page_shows_visible_home_breadcrumb_no_placeholder() -> None:
 
     bar = tree.css_first("body > nav.breadcrumb-bar")
     assert bar is not None
-    crumbs = bar.css("div.container ul li")
+    crumbs = bar.css("div.container-fluid ul li")
     # Home links to the feed; the collection itself is the current leaf.
     assert [li.text(strip=True) for li in crumbs] == ["Home", "Clinicians"]
     assert crumbs[0].css_first("a").attributes.get("href") == "/posts"


### PR DESCRIPTION
## What

Switches every chrome band's inner wrapper from Pico's `.container` (max-width-capped, centered) to `.container-fluid` (full viewport width minus the horizontal gutter):

- page-header nav (`_page_header.html`)
- breadcrumb bar (`_breadcrumb.html`)
- `<main>` content wrapper (`base.html`)
- footer (`base.html`)

Page content now fills the viewport width instead of being capped/centered.

## Why
Requested: "replace all `.container`s with `.container-fluid`." All four `class="container"` occurrences are swapped; no `.container` element remains.

## Docs / tests
- Layout-rationale comments updated where they described the old centered cap: `base.html`, `_page_header.html`, `_breadcrumb.html`, `framework.css`, `landing.html`.
- `test_page_header.py`: breadcrumb `div.container` selectors → `div.container-fluid`.
- `test_auth_routes.py`: auth-page width note updated.

`dev test` (2864 passed), `dev test contract` (41 passed), `dev lint` all green.

## Note
Anonymous auth pages are unaffected in feel — `.auth-page` still caps the form at 28rem. Independent of #1548 (posts browse rework); no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)