### PR TITLE
Home redirect, full-width chrome, and post-form/detail cleanups

### DIFF
--- a/src/auth_config.py
+++ b/src/auth_config.py
@@ -112,10 +112,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         response: Optional[Response] = None,
     ):
         print(f"User {user.id} has logged in.")
-        # Post-login lands on the `/posts` browse feed (the default landing
-        # surface) — kept in lockstep with `src/main.py:read_root`'s
-        # redirect target.
-        redirect_url = "/posts"
+        # Post-login lands on `/home`, the signed-in goal hub — kept in
+        # lockstep with `src/main.py:read_root`'s redirect target (`/` →
+        # `/home`). A `?next=` param (set when an auth wall bounced the
+        # user) overrides this default below.
+        redirect_url = "/home"
         next_url = request.query_params.get("next")
         if next_url:
             # Security check: only allow relative URLs that start with "/"

--- a/src/domain/routes/test_auth_routes.py
+++ b/src/domain/routes/test_auth_routes.py
@@ -281,7 +281,7 @@ async def test_post_login_wrapper_htmx_success_sets_cookie_and_hx_redirect(
     test_client: AsyncClient, logged_in_user: User
 ):
     """HTMX-flagged POST + valid credentials → 204 + `Set-Cookie:
-    fastapiusersauth=...` + `HX-Redirect` (default `/posts`
+    fastapiusersauth=...` + `HX-Redirect` (default `/home`
     per `UserManager.on_after_login`). The wrapper converts the
     underlying 302+Location into 204+HX-Redirect for HTMX so the
     browser doesn't auto-follow before HTMX honors the navigation."""
@@ -293,10 +293,10 @@ async def test_post_login_wrapper_htmx_success_sets_cookie_and_hx_redirect(
     assert response.status_code == 204
     assert "fastapiusersauth=" in response.headers.get("Set-Cookie", "")
     # `Location` is popped (auto-follow guard for HTMX); HX-Redirect
-    # takes over. `on_after_login` defaults to `/posts` when no `?next=`
+    # takes over. `on_after_login` defaults to `/home` when no `?next=`
     # is set.
     assert "Location" not in response.headers
-    assert response.headers.get("HX-Redirect") == "/posts"
+    assert response.headers.get("HX-Redirect") == "/home"
 
 
 async def test_post_login_wrapper_non_htmx_success_returns_302_redirect(
@@ -311,7 +311,7 @@ async def test_post_login_wrapper_non_htmx_success_returns_302_redirect(
         data={"username": logged_in_user.email, "password": "password123"},
     )
     assert response.status_code == 302
-    assert response.headers.get("Location") == "/posts"
+    assert response.headers.get("Location") == "/home"
     assert "fastapiusersauth=" in response.headers.get("Set-Cookie", "")
 
 
@@ -581,7 +581,7 @@ async def test_get_register_page(test_client: AsyncClient):
     assert "Create an account" in response.text
     assert "Create account" in response.text
     # Form wrapper — `.auth-page` caps the form at 28rem and centers it
-    # so it doesn't stretch to the `<main>` `.container-fluid` width on
+    # so it doesn't stretch to the `<main>` `.container` width on
     # tablet/desktop (#584). No card chrome: deliberately not styled as
     # a card. The `.auth-page` rule lives in `base.html`.
     assert '<section class="auth-page">' in response.text
@@ -794,7 +794,7 @@ async def test_post_verify_with_valid_token_verifies_and_auto_logs_in(
         follow_redirects=False,
     )
     # Non-HTMX POST → 302 + Location to the clinician-create form
-    # (NOT `on_after_login`'s default `/posts`).
+    # (NOT `on_after_login`'s default `/home`).
     assert response.status_code == 302
     assert response.headers["location"] == "/clinicians/form"
     # Session cookie was minted.

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -723,8 +723,9 @@ async def test_referral_detail_links_referring_clinician_in_meta_not_a_card(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    # No owner-context card on a referral detail page.
-    assert tree.css_first('article[data-row-id="provider-profile"]') is None
+    # No owner-context section on a referral detail page.
+    assert tree.css_first("section#provider-profile") is None
+    assert "About this provider" not in tree.body.text()
     # The referring clinician is a linked reference in the .post-meta line.
     meta = tree.css_first(".post-meta")
     assert meta is not None, ".post-meta identity line should render"
@@ -1118,26 +1119,20 @@ async def test_referral_form_age_group_options_are_singular(
     assert option_texts == set(CLIENT_AGE_GROUP_LABELS_SINGULAR.values())
 
 
-async def test_opening_create_form_renders_practice_profile_preview(
+async def test_opening_create_form_omits_practice_profile_preview(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """The opening create form shows a read-only preview of the selected
-    practice's steady-state *context* (the `affiliation_facts` rows — now
-    insurance posture + how-to-refer only), so the author sees the
-    practice context without navigating away. The self-describing
-    announcement profile (services / age groups / etc.) is entered in the
-    form's own sections, not previewed here. The default (first)
-    affiliation's card renders visible; the picker's value drives which
-    card the inline script reveals."""
+    """The opening create form no longer renders the read-only practice-
+    profile preview (removed). The picker still selects the practice, and
+    the announcement's own self-describing sections (services / delivery /
+    clients-served / cost) remain the form body."""
     clinician = make_clinician_with_org(
         owner_id=logged_in_user.id, practice_name="Acme Health"
     )
     clinician.id = clinician.id or uuid.uuid4()
     aff = clinician.primary_clinician_affiliation
-    aff.sliding_scale = True
-    aff.website = "https://acme.example.com"
     async with db_test_session_manager() as session:
         async with session.begin():
             session.add(clinician)
@@ -1146,18 +1141,13 @@ async def test_opening_create_form_renders_practice_profile_preview(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    wrap = tree.css_first('[data-profile-preview="clinician_affiliation_id"]')
-    assert wrap is not None, "no practice-profile preview container on the opening form"
-    card = tree.css_first(f'div[data-preview-for="{aff.id}"]')
-    assert card is not None, "no preview card for the affiliation"
-    # The default (first) affiliation's card is visible without JS.
-    assert "hidden" not in card.attributes, "first preview card should be visible"
-    # Context rows come from the shared affiliation_facts macro (insurance
-    # posture + website); the opening's own services are NOT previewed here.
-    assert "Sliding scale" in card.text()
-    assert "https://acme.example.com" in card.text()
+    # Preview is gone: no container, no per-affiliation preview cards.
+    assert (
+        tree.css_first('[data-profile-preview="clinician_affiliation_id"]') is None
+    ), "practice-profile preview should be removed from the opening form"
+    assert tree.css_first(f'div[data-preview-for="{aff.id}"]') is None
 
-    # The opening is self-describing now: the form carries its own
+    # The opening is self-describing: the form carries its own
     # service-type / delivery / clients-served / cost sections, on the
     # same vocabularies the referral request side uses.
     page_text = tree.body.text()
@@ -1169,18 +1159,16 @@ async def test_opening_create_form_renders_practice_profile_preview(
         ), f"opening form must render a {field_name!r} input"
 
 
-async def test_intake_create_form_renders_program_profile_preview(
+async def test_intake_create_form_omits_program_profile_preview(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """The intake create form shows a read-only preview of the selected
-    program's steady-state *context* (the `program_facts` rows — now
-    website + referral_instructions only), so the author sees the program
-    context without navigating away. The self-describing announcement
-    profile (services / age groups / etc.) is entered in the form's own
-    sections, not previewed here. Requires a verified org rep who owns a
-    program (the `check_program_intake` gate)."""
+    """The intake create form no longer renders the read-only program-
+    profile preview (removed). The picker still selects the program, and
+    the announcement's own self-describing sections (services /
+    clients-served / cost) remain the form body. Requires a verified org
+    rep who owns a program (the `check_program_intake` gate)."""
     org = make_organization_row(owner_id=logged_in_user.id, name="Acme Health")
     rep = OrgRepresentation(
         user_id=logged_in_user.id,
@@ -1205,14 +1193,11 @@ async def test_intake_create_form_renders_program_profile_preview(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    wrap = tree.css_first('[data-profile-preview="program_id"]')
-    assert wrap is not None, "no program-profile preview container on the intake form"
-    card = tree.css_first(f'div[data-preview-for="{program.id}"]')
-    assert card is not None, "no preview card for the program"
-    assert "hidden" not in card.attributes, "first preview card should be visible"
-    # Context rows come from the shared program_facts macro (website +
-    # referral instructions); the intake's own services are NOT previewed.
-    assert "https://riseiop.example.com" in card.text()
+    # Preview is gone: no container, no per-program preview cards.
+    assert (
+        tree.css_first('[data-profile-preview="program_id"]') is None
+    ), "program-profile preview should be removed from the intake form"
+    assert tree.css_first(f'div[data-preview-for="{program.id}"]') is None
 
     # The intake is self-describing now: the form carries its own
     # service-type / clients-served / cost sections, on the same
@@ -1393,7 +1378,7 @@ async def test_detail_shows_identity_rows_for_verified_viewer(
     assert tree.css_first("button.locked-ghost-btn") is None
 
 
-async def test_opening_detail_splits_post_facts_from_practice_profile_card(
+async def test_opening_detail_splits_post_facts_from_practice_profile_section(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
@@ -1401,7 +1386,7 @@ async def test_opening_detail_splits_post_facts_from_practice_profile_card(
     """Opening detail renders the post's own self-describing profile
     (services / cohort / cost / schedule) in the grouped facts up top, and
     the steady-state practice *context* (insurance posture + how-to-refer
-    website) inside the `provider-profile` owner-context card —
+    website) inside the `provider-profile` "About this provider" section —
     structurally separate from the announcement profile."""
     # A verified viewer so the provider identity links render un-redacted.
     viewer_clinician = make_clinician_with_org(
@@ -1430,11 +1415,12 @@ async def test_opening_detail_splits_post_facts_from_practice_profile_card(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    card = tree.css_first('article[data-row-id="provider-profile"]')
-    assert card is not None, "owner-context card should render"
+    section = tree.css_first("section#provider-profile")
+    assert section is not None, "owner-context section should render"
+    assert "About this provider" in section.text()
     # The provider identity row carries the clinician (linked) followed
     # by the org (linked) — the shared `provider_ref` denotation.
-    provider_dd = card.css_first('div[data-fact="provider"] dd')
+    provider_dd = section.css_first('div[data-fact="provider"] dd')
     assert provider_dd is not None, "provider identity row should render"
     assert (
         provider_dd.css_first(f"a[href='/clinicians/{clinician.id}']") is not None
@@ -1443,38 +1429,38 @@ async def test_opening_detail_splits_post_facts_from_practice_profile_card(
         provider_dd.css_first(f"a[href='/organizations/{clinician.org.id}']")
         is not None
     ), "org name should link to the organization detail page"
-    # Steady-state context rows live inside the card (insurance posture +
+    # Steady-state context rows live inside the section (insurance posture +
     # how-to-refer website). The opening's self-describing profile
     # (services / age groups / etc.) is no longer on the affiliation, so
-    # it isn't rendered through this card.
+    # it isn't rendered through this section.
     for fact_key in ("insurance", "website"):
         assert (
-            card.css_first(f'div[data-fact="{fact_key}"]') is not None
-        ), f"{fact_key} should render inside the provider-profile card"
-    assert "Sliding scale" in card.text()
+            section.css_first(f'div[data-fact="{fact_key}"]') is not None
+        ), f"{fact_key} should render inside the provider-profile section"
+    assert "Sliding scale" in section.text()
     # The opening's own self-describing profile renders in the grouped
-    # facts up top — NOT through the owner-context card.
+    # facts up top — NOT through the owner-context section.
     for fact_key in ("services", "ages", "cost", "schedule_notes"):
         row = tree.css_first(f'div[data-fact="{fact_key}"]')
         assert row is not None, f"{fact_key} should render on the detail page"
         assert (
-            card.css_first(f'div[data-fact="{fact_key}"]') is None
+            section.css_first(f'div[data-fact="{fact_key}"]') is None
         ), f"{fact_key} is the post's own profile, not steady-state context"
     assert "Therapy — Individual" in tree.text()
 
 
-async def test_intake_detail_renders_program_profile_card(
+async def test_intake_detail_renders_program_profile_section(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
     """Intake detail renders the program's steady-state *context* inside
-    the `provider-profile` owner-context card via `program_facts` — the
-    Program now models only how-to-refer (website / referral_instructions),
-    so those rows live in the card. The provider identity row links the
-    program and its org. The intake's self-describing profile (services /
-    age groups / etc.) is no longer on the Program, so it isn't rendered
-    through this card."""
+    the `provider-profile` "About this provider" section via `program_facts`
+    — the Program now models only how-to-refer (website /
+    referral_instructions), so those rows live in the section. The provider
+    identity row links the program and its org. The intake's self-describing
+    profile (services / age groups / etc.) is no longer on the Program, so
+    it isn't rendered through this section."""
     # A verified viewer so the provider identity links render un-redacted.
     viewer_clinician = make_clinician_with_org(
         owner_id=logged_in_user.id, npi="1234567890"
@@ -1500,9 +1486,10 @@ async def test_intake_detail_renders_program_profile_card(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    card = tree.css_first('article[data-row-id="provider-profile"]')
-    assert card is not None, "program owner-context card should render"
-    provider_dd = card.css_first('div[data-fact="provider"] dd')
+    section = tree.css_first("section#provider-profile")
+    assert section is not None, "program owner-context section should render"
+    assert "About this provider" in section.text()
+    provider_dd = section.css_first('div[data-fact="provider"] dd')
     assert provider_dd is not None, "provider identity row should render"
     assert (
         provider_dd.css_first(f"a[href='/programs/{program.id}']") is not None
@@ -1510,19 +1497,19 @@ async def test_intake_detail_renders_program_profile_card(
     assert (
         provider_dd.css_first(f"a[href='/organizations/{org.id}']") is not None
     ), "org name should link to the organization detail page"
-    # Steady-state context row lives inside the card (how-to-refer website).
+    # Steady-state context row lives inside the section (how-to-refer website).
     assert (
-        card.css_first('div[data-fact="website"]') is not None
-    ), "website should render inside the provider-profile card"
-    assert "https://riseiop.example.com" in card.text()
+        section.css_first('div[data-fact="website"]') is not None
+    ), "website should render inside the provider-profile section"
+    assert "https://riseiop.example.com" in section.text()
     # The intake's own self-describing profile (services / cohort) renders
-    # in the grouped facts up top — NOT through the owner-context card.
+    # in the grouped facts up top — NOT through the owner-context section.
     # `_intake_post` seeds services=["therapy_group"], age_groups=[adolescents].
     for fact_key in ("services", "ages"):
         row = tree.css_first(f'div[data-fact="{fact_key}"]')
         assert row is not None, f"{fact_key} should render on the intake detail page"
         assert (
-            card.css_first(f'div[data-fact="{fact_key}"]') is None
+            section.css_first(f'div[data-fact="{fact_key}"]') is None
         ), f"{fact_key} is the post's own profile, not Program context"
     assert "Therapy — Group" in tree.text()
 

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -180,10 +180,11 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .filter-sidebar { flex: 0 0 220px; min-width: 0; }
 .browse-results { flex: 1 1 0; min-width: 0; }
 
-/* Narrow: stack sidebar full-width above results; hide inline form */
+/* Narrow: hide the filter sidebar entirely (filters are reached via the
+   in-results filter link), and drop the inline form. */
 @media (max-width: 640px) {
   .browse-layout { flex-direction: column; }
-  .filter-sidebar { flex: unset; width: 100%; }
+  .filter-sidebar { display: none; }
   .filter-form { display: none; }
 }
 

--- a/src/domain/templates/home.html
+++ b/src/domain/templates/home.html
@@ -1,13 +1,17 @@
 {% extends "base.html" %}
-{%- from "_shared/_picker.html" import picker -%}
-{# Signed-in home: an opinionated launchpad organized by goal. When the
+{# Signed-in home: a consolidated launchpad organized by goal. When the
    account can't post yet, the next setup step is surfaced as the
    top-priority action (`readiness.next_*`, from `onboarding_readiness`
-   in `read_home`). Below it, the key intents are grouped into three Pico
-   `.grid` columns; each column renders its CTAs through the shared
-   `picker()` cards. Reached at `/home` for authenticated viewers only;
-   anonymous visitors get the public `landing.html` instead (see
-   `read_home` in `src/main.py`). #}
+   in `read_home`).
+
+   Below it, three Pico `.grid` columns map to the goals a signed-in
+   user comes here for ("Refer a patient" / "Find your next client" /
+   "Manage"). Each column is a plain `<ul>` of links — no cards, no
+   descriptions — so the whole hub stays scannable at a glance.
+
+   Reached at `/home` for authenticated viewers only; anonymous visitors
+   get the public `landing.html` instead (see `read_home` in
+   `src/main.py`). #}
 {% block content %}
   {# Greeting + setup nudge as a Pico hgroup (header + muted subheading,
      styled by pico.css — no custom CSS). The greeting keys off network
@@ -34,39 +38,39 @@
   <div class="grid">
     <section>
       <h2>Refer a patient</h2>
-      {{ picker([
-            {"href": entity_form_url('post') ~ "?kind=referral",
-      "heading": "Post a referral",
-      "description": "Describe the patient you're trying to place."},
-      {"href": entity_url('clinician'),
-      "heading": "Find a clinician to refer to",
-      "description": "Search and filter the clinician directory."},
-      ]) }}
+      <ul>
+        <li>
+          <a href="{{ entity_form_url('post') ~ '?kind=referral' }}">Post a referral</a>
+        </li>
+        <li>
+          <a href="{{ entity_url('post') ~ '?kind=clinician_opening' }}">Browse recent openings</a>
+        </li>
+      </ul>
     </section>
     <section>
       <h2>Find your next client</h2>
-      {{ picker([
-            {"href": entity_form_url('post') ~ "?kind=clinician_opening",
-      "heading": "Post an opening",
-      "description": "Tell the network you're accepting clients."},
-      {"href": entity_url('post') ~ "?kind=referral",
-      "heading": "Find patients looking for care",
-      "description": "Browse open referrals from other clinicians."},
-      ]) }}
+      <ul>
+        <li>
+          <a href="{{ entity_form_url('post') ~ '?kind=clinician_opening' }}">Post an opening</a>
+        </li>
+        <li>
+          <a href="{{ entity_url('post') ~ '?kind=referral' }}">Browse recent referrals</a>
+        </li>
+      </ul>
     </section>
     <section>
-      <h2>Manage your presence</h2>
-      {{ picker([
-            {"href": entity_url('post') ~ "?owner=me",
-      "heading": "Manage your posts",
-      "description": "Edit the referrals and openings you've shared."},
-      {"href": entity_url('clinician') ~ "?owner=me",
-      "heading": "Manage your profile",
-      "description": "Update the clinician profile you've created."},
-      {"href": entity_url('user', id='me'),
-      "heading": "Manage your account",
-      "description": "Update your email, access, and settings."},
-      ]) }}
+      <h2>Manage</h2>
+      <ul>
+        <li>
+          <a href="{{ entity_url('post') ~ '?owner=me' }}">Your posts</a>
+        </li>
+        <li>
+          <a href="{{ entity_url('clinician') ~ '?owner=me' }}">Your profile</a>
+        </li>
+        <li>
+          <a href="{{ entity_url('user', id='me') }}">Your account</a>
+        </li>
+      </ul>
     </section>
   </div>
 {% endblock %}

--- a/src/domain/templates/landing.html
+++ b/src/domain/templates/landing.html
@@ -5,7 +5,7 @@
    landing-specific extras: vertically center the hero within `<main>` and
    switch the CTA cluster to a natural-width inline row, both at tablet+.
    `<main>` makes itself a centering grid; its sole child is the
-   `.container-fluid` that holds the hero, so `align-content: center` centers
+   `.container` that holds the hero, so `align-content: center` centers
    the hero block. Mobile relies on Pico defaults — `<a role="button">` is
    block-level full-width, which is exactly what we want for stacked
    tappable bars. Scoped to `body:has(.landing-hero)` so the rules don't

--- a/src/domain/templates/posts/_form_clinician_opening.html
+++ b/src/domain/templates/posts/_form_clinician_opening.html
@@ -22,10 +22,10 @@ The opening is **self-describing** (like a referral): it carries its own
 service lines, delivery format, the cohort it serves, and cost. Only
 steady-state context — location, insurance, how-to-refer — lives on the
 linked ClinicianAffiliation (and `languages` on the Clinician), managed
-through their own edit pages; the picker shows a read-only preview of it.
+through their own edit pages.
 
 Field order (referral-aligned):
-  1. Which practice — establishes context (with a read-only preview)
+  1. Which practice — establishes context
   2. Service type — services multi-select + "Other" free-text
   3. Delivery — session format
   4. Clients served — age groups + genders
@@ -43,9 +43,6 @@ Field order (referral-aligned):
 {%- from "_shared/form_meta.html" import form_with_errors with context -%}
 {%- from "_shared/form_copy.html" import schedule_notes_help -%}
 {%- from "_shared/actions.html" import actions -%}
-{%- from "_shared/_card.html" import card -%}
-{%- from "_shared/sections.html" import facts_block as profile_facts_block -%}
-{%- from "_shared/_affiliation_facts.html" import affiliation_facts -%}
 {%- macro opening_form(hx_method, action, submit_label=none, post=None, schema=None, current_user=None, cancel_url=None) -%}
   {%- set d = post.opening_detail if post else None -%}
   {# `form_with_errors` lights up the response-targets attrs that swap a
@@ -74,79 +71,31 @@ Field order (referral-aligned):
       {%- endfor -%}
     {%- endfor -%}
     {{ composite_select_field("clinician_affiliation_id", "Which practice?", _practices.opts, current=d.clinician_affiliation_id if d else None, default_first=true) }}
-    {# Read-only preview of the steady-state practice profile that renders
-     alongside this opening on its detail page — the same
-     `affiliation_facts` rows the practice page and the post detail show.
-     One card per affiliation is pre-rendered; the script below reveals
-     the one matching the picker so the preview tracks the selection
-     without a server round-trip. The profile is edited on the practice
-     page, never on this announcement form (#1358 PR-f). #}
-    {# The first card renders visible (the picker defaults to the first
-       affiliation via `default_first`); the rest start `hidden` and the
-       script toggles on change. So no-JS authors still see the default
-       practice's profile. #}
-    {%- set _pv = namespace(first=true) -%}
-    <div class="profile-preview"
-         data-profile-preview="clinician_affiliation_id">
-      {%- for c in current_user.clinicians -%}
-        {%- for aff in c.clinician_affiliations -%}
-          {%- set _name = (c.first_name ~ " " ~ c.last_name)|trim -%}
-          <div data-preview-for="{{ aff.id }}"
-               {% if not _pv.first %}hidden{% endif %}>
-            {%- call card(id="opening-preview-" ~ aff.id|string,
-              headline_url=None,
-              headline="Shown with this opening",
-              subtitle="From " ~ ((_name ~ " · " ~ aff.org.name) if aff.org else _name) ~ "’s profile") %}
-              {%- call profile_facts_block() %}{{ affiliation_facts(aff) }}{%- endcall %}
-              {%- endcall %}
-            </div>
-            {%- set _pv.first = false -%}
-          {%- endfor -%}
-        {%- endfor -%}
-      </div>
-      {# The opening describes itself. `services` uses the same
+    {# The opening describes itself. `services` uses the same
        `ReferralService` vocab as the request side; `other` reveals the
        free-text via the shared `services:other` conditional rule. #}
-      {% call form_section("Service type") %}
-        {{ multi_select_field("services", "Services offered", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None, required=false) }}
-        {% call conditional_field("services:other") %}
-          {{ textarea_field("services_other_text", "Other services (describe)", current=d.services_other_text if d else None, required=false) }}
-        {% endcall %}
+    {% call form_section("Service type") %}
+      {{ multi_select_field("services", "Services offered", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None, required=false) }}
+      {% call conditional_field("services:other") %}
+        {{ textarea_field("services_other_text", "Other services (describe)", current=d.services_other_text if d else None, required=false) }}
       {% endcall %}
-      {% call form_section("Delivery") %}
-        {{ multi_select_field("session_format", "Session format", SESSION_FORMATS, labels=SESSION_FORMAT_LABELS, current=d.session_format if d else None, required=false) }}
-      {% endcall %}
-      {# Clients served — the cohort this opening is for (multi-valued,
+    {% endcall %}
+    {% call form_section("Delivery") %}
+      {{ multi_select_field("session_format", "Session format", SESSION_FORMATS, labels=SESSION_FORMAT_LABELS, current=d.session_format if d else None, required=false) }}
+    {% endcall %}
+    {# Clients served — the cohort this opening is for (multi-valued,
        unlike a referral's single client). #}
-      {% call form_section("Clients served") %}
-        {{ multi_select_field("age_groups", "Age groups", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.age_groups if d else None, required=false) }}
-        {{ multi_select_field("genders", "Genders", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None, required=false) }}
-      {% endcall %}
-      {% call form_section("About") %}
-        {{ field_for(schema, "description", "Description", current=d.description if d else None) }}
-      {% endcall %}
-      {% call form_section("Availability") %}
-        {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
-        {{ text_field("cost", "Cost", current=d.cost if d else None, required=false, help="Per-session fee or fee range for this opening.") }}
-      {% endcall %}
-      {{ actions(submit_label, cancel_url=cancel_url) }}
-    {%- endcall -%}
-    {# Reveal the preview card matching the selected practice; re-sync on
-     every picker change so the author always sees the profile that will
-     accompany the opening they're posting. #}
-    <script>
-  (function () {
-    var wrap = document.querySelector('[data-profile-preview="clinician_affiliation_id"]');
-    var select = document.querySelector('select[name="clinician_affiliation_id"]');
-    if (!wrap || !select) return;
-    function sync() {
-      var id = select.value;
-      wrap.querySelectorAll('[data-preview-for]').forEach(function (el) {
-        el.toggleAttribute('hidden', el.getAttribute('data-preview-for') !== id);
-      });
-    }
-    select.addEventListener('change', sync);
-    sync();
-  })();
-    </script>
-  {%- endmacro -%}
+    {% call form_section("Clients served") %}
+      {{ multi_select_field("age_groups", "Age groups", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.age_groups if d else None, required=false) }}
+      {{ multi_select_field("genders", "Genders", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None, required=false) }}
+    {% endcall %}
+    {% call form_section("About") %}
+      {{ field_for(schema, "description", "Description", current=d.description if d else None) }}
+    {% endcall %}
+    {% call form_section("Availability") %}
+      {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
+      {{ text_field("cost", "Cost", current=d.cost if d else None, required=false, help="Per-session fee or fee range for this opening.") }}
+    {% endcall %}
+    {{ actions(submit_label, cancel_url=cancel_url) }}
+  {%- endcall -%}
+{%- endmacro -%}

--- a/src/domain/templates/posts/_form_program_intake.html
+++ b/src/domain/templates/posts/_form_program_intake.html
@@ -25,10 +25,10 @@ The intake is **self-describing** (like the opening): it carries its own
 service lines, the cohort it serves, and cost. It has no session-format
 section — a Program is a single group offering with no in-person/virtual
 axis. Only steady-state context — state served, languages, how-to-refer —
-lives on the linked Program; the picker shows a read-only preview of it.
+lives on the linked Program.
 
 Field order (opening-aligned):
-  1. Which program — establishes context (with a read-only preview)
+  1. Which program — establishes context
   2. Service type — services multi-select + "Other" free-text
   3. Clients served — age groups + genders
   4. About — description (free-text announcement copy)
@@ -44,9 +44,6 @@ Field order (opening-aligned):
 {%- from "_shared/form_meta.html" import form_with_errors with context -%}
 {%- from "_shared/form_copy.html" import schedule_notes_help -%}
 {%- from "_shared/actions.html" import actions -%}
-{%- from "_shared/_card.html" import card -%}
-{%- from "_shared/sections.html" import facts_block as profile_facts_block -%}
-{%- from "_shared/_program_facts.html" import program_facts -%}
 {%- macro intake_form(hx_method, action, submit_label=none, post=None, schema=None, current_user=None, cancel_url=None) -%}
   {%- set d = post.intake_detail if post else None -%}
   {# `form_with_errors` lights up the response-targets attrs that swap a
@@ -65,68 +62,27 @@ Field order (opening-aligned):
       {%- set _programs.opts = _programs.opts + [(p.id, p.name ~ ' · ' ~ p.organization.name)] -%}
     {%- endfor -%}
     {{ composite_select_field("program_id", "Which program?", _programs.opts, current=d.program_id if d else None) }}
-    {# Read-only preview of the steady-state program profile that renders
-     alongside this intake on its detail page — the same `program_facts`
-     rows the program detail page and the post detail show. One card per
-     program is pre-rendered; the script below reveals the one matching
-     the picker so the preview tracks the selection without a server
-     round-trip. The profile is edited on the program page, never on this
-     announcement form (#1358 PR-f). #}
-    {# The first card renders visible (the picker defaults to the first
-       program); the rest start `hidden` and the script toggles on
-       change, so no-JS authors still see the default program's profile. #}
-    <div class="profile-preview" data-profile-preview="program_id">
-      {%- for p in current_user.programs -%}
-        <div data-preview-for="{{ p.id }}"
-             {% if not loop.first %}hidden{% endif %}>
-          {%- call card(id="intake-preview-" ~ p.id|string,
-            headline_url=None,
-            headline="Shown with this intake",
-            subtitle="From " ~ p.name ~ " · " ~ p.organization.name ~ "’s profile") %}
-            {%- call profile_facts_block() %}{{ program_facts(p) }}{%- endcall %}
-            {%- endcall %}
-          </div>
-        {%- endfor -%}
-      </div>
-      {# The intake describes itself. `services` uses the same
+    {# The intake describes itself. `services` uses the same
        `ReferralService` vocab as the referral + opening sides; `other`
        reveals the free-text via the shared `services:other` rule. #}
-      {% call form_section("Service type") %}
-        {{ multi_select_field("services", "Services offered", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None, required=false) }}
-        {% call conditional_field("services:other") %}
-          {{ textarea_field("services_other_text", "Other services (describe)", current=d.services_other_text if d else None, required=false) }}
-        {% endcall %}
+    {% call form_section("Service type") %}
+      {{ multi_select_field("services", "Services offered", REFERRAL_SERVICES, labels=REFERRAL_SERVICE_LABELS, current=d.services if d else None, required=false) }}
+      {% call conditional_field("services:other") %}
+        {{ textarea_field("services_other_text", "Other services (describe)", current=d.services_other_text if d else None, required=false) }}
       {% endcall %}
-      {# Clients served — the cohort this intake is for (multi-valued). #}
-      {% call form_section("Clients served") %}
-        {{ multi_select_field("age_groups", "Age groups", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.age_groups if d else None, required=false) }}
-        {{ multi_select_field("genders", "Genders", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None, required=false) }}
-      {% endcall %}
-      {% call form_section("About") %}
-        {{ field_for(schema, "description", "Description", current=d.description if d else None) }}
-      {% endcall %}
-      {% call form_section("Availability") %}
-        {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
-        {{ text_field("cost", "Cost", current=d.cost if d else None, required=false, help="Per-session fee or fee range for this intake.") }}
-      {% endcall %}
-      {{ actions(submit_label, cancel_url=cancel_url) }}
-    {%- endcall -%}
-    {# Reveal the preview card matching the selected program; re-sync on
-     every picker change so the author always sees the profile that will
-     accompany the intake they're posting. #}
-    <script>
-  (function () {
-    var wrap = document.querySelector('[data-profile-preview="program_id"]');
-    var select = document.querySelector('select[name="program_id"]');
-    if (!wrap || !select) return;
-    function sync() {
-      var id = select.value;
-      wrap.querySelectorAll('[data-preview-for]').forEach(function (el) {
-        el.toggleAttribute('hidden', el.getAttribute('data-preview-for') !== id);
-      });
-    }
-    select.addEventListener('change', sync);
-    sync();
-  })();
-    </script>
-  {%- endmacro -%}
+    {% endcall %}
+    {# Clients served — the cohort this intake is for (multi-valued). #}
+    {% call form_section("Clients served") %}
+      {{ multi_select_field("age_groups", "Age groups", CLIENT_AGE_GROUPS, labels=CLIENT_AGE_GROUP_LABELS, current=d.age_groups if d else None, required=false) }}
+      {{ multi_select_field("genders", "Genders", GENDERS, labels=GENDER_LABELS, current=d.genders if d else None, required=false) }}
+    {% endcall %}
+    {% call form_section("About") %}
+      {{ field_for(schema, "description", "Description", current=d.description if d else None) }}
+    {% endcall %}
+    {% call form_section("Availability") %}
+      {{ field_for(schema, "schedule_text", "Schedule notes", current=d.schedule_text if d else None, help=schedule_notes_help() ) }}
+      {{ text_field("cost", "Cost", current=d.cost if d else None, required=false, help="Per-session fee or fee range for this intake.") }}
+    {% endcall %}
+    {{ actions(submit_label, cancel_url=cancel_url) }}
+  {%- endcall -%}
+{%- endmacro -%}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -2,8 +2,7 @@
 {%- from "posts/_shared/_modality_chips.html" import modality_chips -%}
 {%- from "posts/_shared/_referral_facts.html" import referral_facts -%}
 {%- from "posts/_shared/_provider_post_facts.html" import provider_post_facts -%}
-{%- from "_shared/_card.html" import card -%}
-{%- from "_shared/sections.html" import fact, fact_list, facts_block as entity_facts -%}
+{%- from "_shared/sections.html" import fact, fact_list, facts_grid, fact_group, fact_rows -%}
 {%- from "_shared/_affiliation_facts.html" import affiliation_facts -%}
 {%- from "_shared/_program_facts.html" import program_facts -%}
 {%- from "_shared/_provider_ref.html" import provider_ref -%}
@@ -25,11 +24,13 @@
 {% block actions %}
   {% include "posts/_shared/_owner_actions.html" %}
 {% endblock %}
-{# Owner-context card — the steady-state profile of the provider behind
+{# Owner-context section — the steady-state profile of the provider behind
    the post (the clinician + practice for an opening, the program for an
-   intake), rendered as a visually separate read-only card below the
-   post's own facts. Referrals don't use this card: their referring
-   clinician is a linked `provider_ref` reference in the meta line.
+   intake), rendered as an "About this provider" heading + fact rows below
+   the post's own facts (a sibling `facts_grid` section, same shape as the
+   post's own grouped facts — not a card). Referrals don't use this
+   section: their referring clinician is a linked `provider_ref` reference
+   in the meta line.
 
    The identity row is the shared `provider_ref` denotation — the
    canonical hyperlinked "<name> · <org>" the feed byline and form
@@ -51,8 +52,9 @@
     {%- set ctx.prog = post.intake_detail.program -%}
   {%- endif -%}
   {%- if view.kind in ("clinician_opening", "program_intake") and view.provider_ref and (view.provider_ref.name or view.provider_ref.id) -%}
-    {%- call card(id="provider-profile", headline_url=None, headline="About this provider") %}
-      {%- call entity_facts() %}
+    {%- call facts_grid(id="provider-profile") %}
+      {{ fact_group("About this provider") }}
+      {%- call fact_rows() %}
         {%- call fact('provider', 'Provider') %}{{ provider_ref(view.provider_ref, redacted=redacted) }}
         {% endcall %}
         {%- if view.owner_address %}
@@ -83,9 +85,9 @@
    Coverage), openings + intakes via `_provider_post_facts` (Service type /
    Clients served / About / Availability). For provider posts the
    steady-state provider context (insurance, address, languages,
-   how-to-refer) then renders in the owner-context card; the referral's
-   referring clinician is the linked `provider_ref` in the meta line, not
-   an owner card. Per-kind logic lives in `post_card_view` (one place);
+   how-to-refer) then renders in the "About this provider" section; the
+   referral's referring clinician is the linked `provider_ref` in the meta
+   line, not an owner section. Per-kind logic lives in `post_card_view` (one place);
    every visual element reads from `view` (plus the linked
    affiliation/program model rows the owner-context macro renders
    directly). #}
@@ -113,13 +115,14 @@
           {%- if view.kind == "referral" %}
             {# Referral leads with its Narrative section (inside
                  `referral_facts`); the referring clinician is the linked
-                 reference in the `.post-meta` line above, not an owner card. #}
+                 reference in the `.post-meta` line above, not an owner section. #}
             {{ referral_facts(view, redacted=not can_act_as_provider) }}
           {%- else %}
             {# The provider post's own self-describing profile (services /
                  cohort / narrative / cost), grouped to mirror its form —
                  then the steady-state provider context (insurance, address,
-                 languages, how-to-refer) in the owner-context card below. #}
+                 languages, how-to-refer) in the "About this provider"
+                 section below. #}
             {{ provider_post_facts(view) }}
             {{ owner_context(view, post, redacted=not can_act_as_provider) }}
           {%- endif %}

--- a/src/framework/static/css/framework.css
+++ b/src/framework/static/css/framework.css
@@ -40,6 +40,20 @@ html { scrollbar-gutter: stable; font-size: 14px; }
   --color-warning: #b45309;
   --color-success: #166534;
 }
+/* Container width — one flat cap instead of Pico's five per-breakpoint
+   max-widths (510 / 700 / 950 / 1200 / 1450px). Below the cap the
+   container is full-bleed (Pico's `width: 100%`) with a small gutter;
+   at/above it, it centers (Pico's `margin: auto`) and caps at this one
+   width. A single non-media rule is enough: it loads after Pico (see
+   base.html), so on equal specificity it overrides every Pico
+   `@media (min-width: …) .container` cap — and re-asserts the gutter
+   that Pico zeroes at ≥576px. Tune the layout by changing this one
+   number. */
+.container {
+  max-width: 1280px;
+  padding-right: var(--pico-spacing);
+  padding-left: var(--pico-spacing);
+}
 /* Heading scale — tight, not shouting. Set Pico's per-heading custom
    properties rather than raw `font-size`/`font-weight` on the element:
    Pico v2 drives headings from `--pico-font-size` / `--pico-font-weight`
@@ -535,10 +549,10 @@ dd { margin: 0; }
 /* Page-header band — the top-chrome nav element
    (`_shared/_page_header.html`): the primary nav, closed with a full-width
    `border-bottom`. The band itself is full-width and carries the boundary;
-   its inner `.container-fluid` (full-width, gutter-padded) holds the nav, so
-   the divider spans the whole page while content fills the viewport width
-   minus the gutter (matches `<main>` / `<footer>`, which also wrap content in
-   an inner `.container-fluid`). The breadcrumb is its own band below; the page `<h1>` +
+   its inner `.container` (centered, max-width-capped) holds the nav, so
+   the divider spans the whole page while the content is centered and capped
+   at Pico's container max-width (matches `<main>` / `<footer>`, which also
+   wrap content in an inner `.container`). The breadcrumb is its own band below; the page `<h1>` +
    actions toolbar lives in `<main>`. Both band dividers use the standard
    subtle `--pico-muted-border-color`. */
 .page-header { border-bottom: 1px solid var(--pico-muted-border-color); color: inherit; }
@@ -662,7 +676,7 @@ td > menu > li > [role="button"] {
   margin-inline: auto;
 }
 /* Page footer (`<footer>` in base.html — sibling of `<header>` and
-   `<main>`, content wrapped in an inner `.container-fluid`). Centered chrome
+   `<main>`, content wrapped in an inner `.container`). Centered chrome
    line, present on every page via the default `{% block footer %}` body.
    `text-align` is set on `<footer>` itself (full width) so it cascades to
    the inner container's text. */

--- a/src/framework/templates/_shared/_breadcrumb.html
+++ b/src/framework/templates/_shared/_breadcrumb.html
@@ -6,7 +6,7 @@ segment, with Pico drawing the `>` dividers between items — wrapped in its
 OWN `<nav class="breadcrumb-bar">` band. A view template fills the
 `breadcrumb` block; `base.html` captures it and renders the result as a
 body-level sibling of `<header>` / `<main>` / `<footer>` (not inside the
-page-header). The inner `.container-fluid` keeps the chain aligned with page
+page-header). The inner `.container` keeps the chain aligned with page
 content; on narrow viewports the chain scrolls horizontally rather than
 wrapping (see `.breadcrumb-bar` in framework.css).
 
@@ -34,7 +34,7 @@ chain, so callers pass only the ancestors + current segment. An empty
 {% macro breadcrumb(items) -%}
   {%- set _chain = [("Home", "/home", none)] + (items | list if items else []) -%}
   <nav aria-label="breadcrumb" class="breadcrumb-bar">
-    <div class="container-fluid">
+    <div class="container">
       <ul>
         {%- for _item in _chain %}
           {%- set _label = _item[0] -%}

--- a/src/framework/templates/_shared/_page_header.html
+++ b/src/framework/templates/_shared/_page_header.html
@@ -1,6 +1,6 @@
 {# Unified page-header band — the app's permanent top chrome.
 
-Renders one `<header class="page-header">` (with an inner `.container-fluid`)
+Renders one `<header class="page-header">` (with an inner `.container`)
 whose rows, top to
 bottom, are: primary nav → breadcrumb slot → page-title/toolbar slot.
 The band's `border-bottom` is the page's one horizontal boundary and
@@ -42,13 +42,13 @@ and the constant-boundary rationale (one source of truth).
 #}
 {%- from "_shared/icon_label.html" import icon_label -%}
 <header class="page-header">
-  {# `.container-fluid` lives INSIDE the band (not on `<header>`) so the band's
-     `border-bottom` spans the full page width while the nav content fills the
-     viewport width minus Pico's horizontal gutter. Same pattern on `<main>`
-     and `<footer>` in base.html. The breadcrumb is no longer part of this
+  {# `.container` lives INSIDE the band (not on `<header>`) so the band's
+     `border-bottom` spans the full page width while the nav content is
+     centered and capped at Pico's container max-width. Same pattern on
+     `<main>` and `<footer>` in base.html. The breadcrumb is no longer part of this
      band — it is its own `<nav class="breadcrumb-bar">` rendered as a
      body-level sibling in base.html. #}
-  <div class="container-fluid">
+  <div class="container">
     {# Canonical Pico nav: a brand `<ul>` (left) and an actions `<ul>`
      (right). `Post` is a visible link `<li>` (`plus` glyph + label via `icon_label`); the profile menu is a Pico
      dropdown (https://picocss.com/docs/nav) — `<details class="dropdown">`

--- a/src/framework/templates/_shared/sections.html
+++ b/src/framework/templates/_shared/sections.html
@@ -75,9 +75,12 @@
      {% endcall %}
 
    A single ungrouped `facts_block()` doesn't need this — it's only for
-   splitting one aligned grid into titled sections. #}
-{% macro facts_grid() -%}
-  <section class="entity-facts facts-grid">
+   splitting one aligned grid into titled sections.
+
+   `id` is optional: pass it when a caller needs a stable selector for the
+   whole panel (e.g. a detail-page section other templates/tests scope to). #}
+{% macro facts_grid(id=None) -%}
+  <section class="entity-facts facts-grid"{% if id %} id="{{ id }}"{% endif %}>
     {{ caller() }}
   </section>
 {%- endmacro %}

--- a/src/framework/templates/base.html
+++ b/src/framework/templates/base.html
@@ -51,11 +51,12 @@
 {# Density overrides and component styles live in two static CSS files
        split by framework/domain boundary — see `src/framework/static/css/`
        and `src/domain/static/css/`. The classful Pico build uses
-       `class="container-fluid"` for the full-width gutter layout; each layout
-       band (`<header>`, the breadcrumb `<nav>`, `<main>`, `<footer>`) wraps
-       its content in an inner `.container-fluid` so the band spans full width
-       (its divider edge-to-edge) and the content fills the viewport width
-       (minus Pico's horizontal gutter), rather than being max-width-capped. #}
+       `class="container"` for the centered, max-width-capped layout; each
+       layout band (`<header>`, the breadcrumb `<nav>`, `<main>`, `<footer>`)
+       is a full-width element that wraps its content in an inner
+       `.container` — so the band itself spans full width (its divider
+       edge-to-edge) while the content is centered and capped at Pico's
+       container max-width. #}
 <link rel="stylesheet" href="/static/fw/css/framework.css{% if static_version %}?v={{ static_version }}{% endif %}" />
 <link rel="stylesheet" href="/static/domain/css/domain.css{% if static_version %}?v={{ static_version }}{% endif %}" />
 {# `defer` keeps the HTML parser unblocked while these scripts
@@ -205,7 +206,7 @@
        sibling of `<header>` / `<main>` / `<footer>` (NOT inside the
        page-header). The `breadcrumb()` macro emits the full Pico chain (a
        Home root + the page's segments) wrapped in `<nav>` + inner
-       `.container-fluid`. Always present on authenticated app pages: a page-
+       `.container`. Always present on authenticated app pages: a page-
        supplied chain (detail / form / search / subresource list) when set,
        otherwise just the Home crumb (`breadcrumb([])`). Absent for anonymous
        pages (landing / `/auth/*`). #}
@@ -214,11 +215,11 @@
 {%- else %}{{ breadcrumb([]) }}{%- endif %}
 {%- endif %}
 <main>
-{# `.container-fluid` wraps the content INSIDE `<main>` (not on `<main>`
-         itself) so any full-bleed chrome on `<main>` spans the page while the
-         content fills the full viewport width minus Pico's horizontal gutter.
+{# `.container` wraps the content INSIDE `<main>` (not on `<main>` itself)
+         so the full-width `<main>` band can carry any full-bleed chrome while
+         the content is centered and capped at Pico's container max-width.
          Mirrors `<header>` (the page-header band) and `<footer>`. #}
-<div class="container-fluid">
+<div class="container">
 {# Page toolbar — the page `<h1>` plus its action cluster (Edit, Delete,
          Favorite, Create, ...). Historically this lived inside the
          `.page-header` band; it now renders at the top of `<main>` so the
@@ -269,13 +270,13 @@ or
 {# Page footer slot — outside `<main>` so the footer is the
        document's `<footer>` (semantic site-level role) rather than a
        child of the main content. Content is wrapped in an inner
-       `.container-fluid` (not on `<footer>` itself) so the footer band can
-       span the full page and its text fills the viewport width minus Pico's
-       horizontal gutter — same pattern as `<header>` and `<main>`. The
+       `.container` (not on `<footer>` itself) so the footer band can span
+       the full page while its text is centered and capped at Pico's
+       container max-width — same pattern as `<header>` and `<main>`. The
        default body is a site-wide copyright / contact line shown on every
        page; pages can override by redefining `{% raw %}{% block footer %}{% endraw %}`. #}
 <footer>
-<div class="container-fluid">
+<div class="container">
 {% block footer %}
 <small>&copy; 2026 Bedlam Health &middot; <a href="mailto:support@bedlamhealth.com">support@bedlamhealth.com</a></small>
 {% endblock %}

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -6,7 +6,7 @@ The chrome is three full-width bands stacked above the content, each a
 body-level layout row:
 
   1. ``<header class="page-header">`` — the primary nav only. Its inner
-     ``.container-fluid`` lays the nav out full-width (minus Pico's gutter);
+     ``.container`` centers and caps the nav at Pico's container max-width;
      the band's ``border-bottom`` spans the full page.
   2. ``<nav class="breadcrumb-bar">`` — its OWN body-level band (a sibling of
      ``<header>``/``<main>``/``<footer>``, NOT nested in the header). Always
@@ -97,8 +97,8 @@ def test_detail_toolbar_in_main_and_breadcrumb_is_its_own_band() -> None:
     bar = tree.css_first("body > nav.breadcrumb-bar")
     assert bar is not None
     assert bar.attributes.get("aria-label") == "breadcrumb"
-    # Full Pico chain in a `.container-fluid > ul`: Home › Collection › <resource>.
-    crumbs = [li.text(strip=True) for li in bar.css("div.container-fluid ul li")]
+    # Full Pico chain in a `.container > ul`: Home › Collection › <resource>.
+    crumbs = [li.text(strip=True) for li in bar.css("div.container ul li")]
     assert crumbs == ["Home", "Clinicians", "Sunrise Therapy"]
 
 
@@ -112,7 +112,7 @@ def test_list_page_shows_visible_home_breadcrumb_no_placeholder() -> None:
 
     bar = tree.css_first("body > nav.breadcrumb-bar")
     assert bar is not None
-    crumbs = bar.css("div.container-fluid ul li")
+    crumbs = bar.css("div.container ul li")
     # Home links to /home; the collection itself is the current leaf.
     assert [li.text(strip=True) for li in crumbs] == ["Home", "Clinicians"]
     assert crumbs[0].css_first("a").attributes.get("href") == "/home"

--- a/src/test_auth_config.py
+++ b/src/test_auth_config.py
@@ -53,3 +53,49 @@ async def test_current_optional_user_tags_when_present():
         result = await auth_config.current_optional_user(user=user)
     assert result is user
     mock_obs.set_user.assert_called_once_with("uid-3", "opt@example.com")
+
+
+def _login_manager() -> auth_config.UserManager:
+    """A `UserManager` whose `__init__` we bypass — `on_after_login`
+    only touches `request`/`response`, never instance state."""
+    return auth_config.UserManager.__new__(auth_config.UserManager)
+
+
+@pytest.mark.asyncio
+async def test_on_after_login_defaults_to_home():
+    """No `?next=` → post-login lands on `/home`, the signed-in hub, in
+    lockstep with `src/main.py:read_root`'s `/` → `/home` redirect."""
+    request = SimpleNamespace(query_params={})
+    response = SimpleNamespace(status_code=None, headers={})
+    await _login_manager().on_after_login(
+        user=SimpleNamespace(id="uid"), request=request, response=response
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/home"
+
+
+@pytest.mark.asyncio
+async def test_on_after_login_honors_safe_next_param():
+    """A relative `?next=` overrides the `/home` default so an auth wall
+    can bounce the user back to where they were headed."""
+    request = SimpleNamespace(query_params={"next": "/users/me"})
+    response = SimpleNamespace(status_code=None, headers={})
+    await _login_manager().on_after_login(
+        user=SimpleNamespace(id="uid"), request=request, response=response
+    )
+    assert response.headers["Location"] == "/users/me"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "evil_next", ["//evil.com", "https://evil.com", "javascript://x"]
+)
+async def test_on_after_login_rejects_offsite_next(evil_next: str):
+    """Protocol-relative / absolute `next` values are ignored — they
+    could redirect to an attacker site — falling back to `/home`."""
+    request = SimpleNamespace(query_params={"next": evil_next})
+    response = SimpleNamespace(status_code=None, headers={})
+    await _login_manager().on_after_login(
+        user=SimpleNamespace(id="uid"), request=request, response=response
+    )
+    assert response.headers["Location"] == "/home"

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -48,20 +48,21 @@ async def test_authenticated_home_renders_quicklinks(
     authenticated_client: AsyncClient,
 ):
     """An authenticated viewer hitting `/home` gets the goal hub — NOT a
-    redirect. It renders the opinionated intent CTAs in three columns,
-    and (because a fresh account can't post yet) surfaces the dynamic
-    `#home-setup` task at the top."""
+    redirect. It renders the intent CTAs as three columns of plain links
+    (Refer a patient / Find your next client / Manage), and (because a
+    fresh account can't post yet) surfaces the dynamic `#home-setup` task
+    at the top."""
     response = await authenticated_client.get("/home", follow_redirects=False)
     assert response.status_code == 200
     body = response.text
     for href in (
         # Refer a patient
-        "/clinicians",
         "/posts/form?kind=referral",
+        "/posts?kind=clinician_opening",
         # Find your next client
         "/posts/form?kind=clinician_opening",
         "/posts?kind=referral",
-        # Manage your presence
+        # Manage
         "/posts?owner=me",
         "/clinicians?owner=me",
         "/users/me",


### PR DESCRIPTION
## Summary

A batch of UI/layout cleanups, landed together.

### Post-login + `/home`
- Redirect post-login to `/home` (was `/posts`), in lockstep with `/` → `/home`. Added colocated `on_after_login` coverage (default, safe `next`, offsite `next` rejection).
- `/home` hub: fixed "find a clinician to refer to" to browse opening posts (`/posts?kind=clinician_opening`) instead of the raw `/clinicians` directory; consolidated the hub to three columns of plain links (no cards).

### Chrome / layout
- Reverted the chrome bands from `.container-fluid` back to `.container`.
- Replaced Pico's five per-breakpoint container caps with one flat `max-width: 1280px` (full-bleed below, centered + capped above).
- Hide the filter sidebar on small screens (≤640px).

### Posts forms + detail
- Removed the read-only profile-preview component from the opening and program-intake forms (markup + sync script + now-unused imports).
- De-carded the "About this provider" section on post detail — now a `facts_grid` heading + fact rows matching the post's own sections; added an optional `id` to the `facts_grid` macro for a stable selector.

## Test plan
- `dev test` — 2864 passed
- `dev test contract` — 41 passed
- `dev lint` — clean
- Verified in-browser: home hub, opening form (no preview), opening detail ("About this provider" as a section), container widths at 600/800/1280/1600px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)