### PR TITLE
Post detail: symmetric seeking/providing layout + identity-only Connect panel

### DIFF
--- a/scripts/dev/template_component_check.py
+++ b/scripts/dev/template_component_check.py
@@ -59,6 +59,10 @@ ALLOWLIST: frozenset[str] = frozenset(
         # Message-the-poster micro-form swaps itself in place on send;
         # the swap-self contract doesn't match `inline_add_form`.
         "posts/_shared/_message_form.html",
+        # "Connect with the provider" detail-page panel: a bespoke
+        # `<article>` + `<h2>` rail (the `card` macro's header is an `<h3>`
+        # list-item heading; this panel wants an `<h2>` section heading).
+        "posts/_shared/_connect_panel.html",
         # Capability-tree cards have a status badge inside the heading
         # band that the `picker` macro doesn't model.
         "users/access/capabilities/index.html",

--- a/scripts/dev/test_template_component_check.py
+++ b/scripts/dev/test_template_component_check.py
@@ -224,6 +224,7 @@ def test_allowlist_only_contains_known_carveouts() -> None:
         "users/detail.html",
         "users/email_form.html",
         "posts/_shared/_message_form.html",
+        "posts/_shared/_connect_panel.html",
         "users/access/capabilities/index.html",
     }
     assert ALLOWLIST == expected

--- a/src/domain/logic/posts/test_view.py
+++ b/src/domain/logic/posts/test_view.py
@@ -1313,8 +1313,8 @@ def test_provider_ref_intake_is_program_then_org():
 def test_provider_ref_referral_is_referring_clinician_then_affiliation_org():
     """A referral resolves to the referring clinician (#1454 FK) with
     the affiliation's org as the second part — the same `provider_ref`
-    shape openings use, which the detail page renders as the "Referred by"
-    linked reference in the meta line (hyperlinked identity + org)."""
+    shape openings use, which the detail page renders in the "Connect with
+    the provider" card (hyperlinked identity + org)."""
     v = post_card_view(_make_cr_post())
     assert v["provider_ref"] == {
         "name": "Carlos Rivera",

--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -568,9 +568,10 @@ async def test_referral_detail_meta_omits_modality_chips(
 ):
     """The referral detail's Logistics group carries the modality in its
     consolidated location row ("· Telehealth"), so the `.post-meta` identity
-    line no longer repeats it as chips — only the type pill, date, and
-    referring clinician live there. (Opening/intake keep the chips; that's
-    covered by their own kinds, not pinned here.)"""
+    line no longer repeats it as chips — only the type pill and date live
+    there (the referring provider moved to the about-provider section).
+    (Opening/intake keep the chips; that's covered by their own kinds, not
+    pinned here.)"""
     viewer = _verified_provider_clinician(logged_in_user.id)
     author = create_test_user(username=f"author-{uuid.uuid4()}")
     post = _referral_post(owner_id=author.id, session_format=["in_person", "virtual"])
@@ -692,14 +693,15 @@ async def test_referral_detail_narrative_is_row_of_about_the_client(
     assert "Teen seeking DBT" in narrative.text()
 
 
-async def test_referral_detail_links_referring_clinician_in_meta_not_a_card(
+async def test_referral_detail_shows_referring_provider_in_connect_card(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """A referral surfaces its referring clinician as a linked reference
-    in the meta line ("Referred by <name>"), NOT as an owner-context
-    card — that card is for openings/intakes only."""
+    """A referral surfaces its referring clinician in the shared
+    "Connect with the provider" card (the `connect-panel` right rail every
+    kind uses) — identity only, alongside the message form — and NOT in
+    the meta line."""
     viewer = _verified_provider_clinician(logged_in_user.id)
     author = create_test_user(username=f"author-{uuid.uuid4()}")
     referring = make_clinician_with_org(
@@ -723,16 +725,26 @@ async def test_referral_detail_links_referring_clinician_in_meta_not_a_card(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    # No owner-context section on a referral detail page.
-    assert tree.css_first("section#provider-profile") is None
-    assert "About this provider" not in tree.body.text()
-    # The referring clinician is a linked reference in the .post-meta line.
+    # The referring provider moved OUT of the meta line.
     meta = tree.css_first(".post-meta")
     assert meta is not None, ".post-meta identity line should render"
-    assert "Referred by" in meta.text(), meta.text()
+    assert "Referred by" not in meta.text(), meta.text()
+
+    # ...and INTO the "Connect with the provider" card, where the provider
+    # row links the referring clinician.
+    panel = tree.css_first('article[data-row-id="connect-panel"]')
+    assert panel is not None, "referral should render the connect-with-provider card"
+    assert "Connect with the provider" in panel.text()
+    provider_dd = panel.css_first('div[data-fact="provider"] dd')
+    assert provider_dd is not None, "provider identity row should render"
     assert (
-        meta.css_first(f'a[href="/clinicians/{referring.id}"]') is not None
+        provider_dd.css_first(f'a[href="/clinicians/{referring.id}"]') is not None
     ), "referring clinician name should link to the clinician detail page"
+    # Identity only: a referral suppresses the practice-marketing rows.
+    assert panel.css_first('div[data-fact="address"]') is None
+    assert panel.css_first('div[data-fact="insurance"]') is None
+    # The card also holds the message form (viewer is a verified provider).
+    assert panel.css_first("#post-message") is not None
 
 
 # --- Owner authz invariants ----------------------------------------------
@@ -1352,7 +1364,8 @@ async def test_detail_shows_identity_rows_for_verified_viewer(
     logged_in_user,
 ):
     """A verified viewer (can read the full feed) sees the real practice /
-    organization links and the full address — no locked placeholders."""
+    organization links (in the Connect panel) and the un-redacted location
+    (in the body's Logistics row) — no locked placeholders."""
     viewer_clinician = make_clinician_with_org(
         owner_id=logged_in_user.id, npi="1234567890"
     )
@@ -1374,20 +1387,25 @@ async def test_detail_shows_identity_rows_for_verified_viewer(
     tree = HTMLParser(response.text)
 
     assert tree.css_first(f"a[href='/clinicians/{clinician.id}']") is not None
-    assert "Springfield, IL" in response.text
+    # Location renders un-redacted in the body's Logistics row (a
+    # `location_summary` — state always present, city only when in-person).
+    address_dd = tree.css_first('[data-fact="address"] dd')
+    assert address_dd is not None, "Logistics location row should render"
+    assert "IL" in address_dd.text(), address_dd.text()
     assert tree.css_first("button.locked-ghost-btn") is None
 
 
-async def test_opening_detail_splits_post_facts_from_practice_profile_section(
+async def test_opening_detail_renders_practice_context_in_body_not_panel(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
     """Opening detail renders the post's own self-describing profile
-    (services / cohort / cost / schedule) in the grouped facts up top, and
-    the steady-state practice *context* (insurance posture + how-to-refer
-    website) inside the `provider-profile` "About this provider" section —
-    structurally separate from the announcement profile."""
+    (services / cohort / cost / schedule) AND the steady-state practice
+    *context* (insurance posture + how-to-refer website) in the body — the
+    providing-side mirror of the referral. The `connect-panel` is
+    identity-only: the provider links + the message form, no practice
+    context."""
     # A verified viewer so the provider identity links render un-redacted.
     viewer_clinician = make_clinician_with_org(
         owner_id=logged_in_user.id, npi="1234567890"
@@ -1415,12 +1433,12 @@ async def test_opening_detail_splits_post_facts_from_practice_profile_section(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    section = tree.css_first("section#provider-profile")
-    assert section is not None, "owner-context section should render"
-    assert "About this provider" in section.text()
+    panel = tree.css_first('article[data-row-id="connect-panel"]')
+    assert panel is not None, "connect-with-provider card should render"
+    assert "Connect with the provider" in panel.text()
     # The provider identity row carries the clinician (linked) followed
     # by the org (linked) — the shared `provider_ref` denotation.
-    provider_dd = section.css_first('div[data-fact="provider"] dd')
+    provider_dd = panel.css_first('div[data-fact="provider"] dd')
     assert provider_dd is not None, "provider identity row should render"
     assert (
         provider_dd.css_first(f"a[href='/clinicians/{clinician.id}']") is not None
@@ -1429,38 +1447,37 @@ async def test_opening_detail_splits_post_facts_from_practice_profile_section(
         provider_dd.css_first(f"a[href='/organizations/{clinician.org.id}']")
         is not None
     ), "org name should link to the organization detail page"
-    # Steady-state context rows live inside the section (insurance posture +
-    # how-to-refer website). The opening's self-describing profile
-    # (services / age groups / etc.) is no longer on the affiliation, so
-    # it isn't rendered through this section.
+    # The panel is identity-only — the practice context is NOT in it.
+    assert panel.css_first('div[data-fact="insurance"]') is None
+    assert panel.css_first('div[data-fact="website"]') is None
+    # Insurance posture + how-to-refer website render in the body's Coverage
+    # section (the providing-side mirror of the referral's Coverage).
+    main = tree.css_first("div.post-detail-main")
+    assert main is not None
+    assert "Coverage" in main.text()
     for fact_key in ("insurance", "website"):
         assert (
-            section.css_first(f'div[data-fact="{fact_key}"]') is not None
-        ), f"{fact_key} should render inside the provider-profile section"
-    assert "Sliding scale" in section.text()
-    # The opening's own self-describing profile renders in the grouped
-    # facts up top — NOT through the owner-context section.
+            main.css_first(f'div[data-fact="{fact_key}"]') is not None
+        ), f"{fact_key} should render in the opening body"
+    assert "Sliding scale" in main.text()
+    # The opening's own self-describing profile renders in the body too.
     for fact_key in ("services", "ages", "cost", "schedule_notes"):
-        row = tree.css_first(f'div[data-fact="{fact_key}"]')
-        assert row is not None, f"{fact_key} should render on the detail page"
         assert (
-            section.css_first(f'div[data-fact="{fact_key}"]') is None
-        ), f"{fact_key} is the post's own profile, not steady-state context"
+            main.css_first(f'div[data-fact="{fact_key}"]') is not None
+        ), f"{fact_key} should render in the opening body"
     assert "Therapy — Individual" in tree.text()
 
 
-async def test_intake_detail_renders_program_profile_section(
+async def test_intake_detail_renders_program_context_in_body_not_panel(
     authenticated_client: AsyncClient,
     db_test_session_manager: async_sessionmaker[AsyncSession],
     logged_in_user,
 ):
-    """Intake detail renders the program's steady-state *context* inside
-    the `provider-profile` "About this provider" section via `program_facts`
-    — the Program now models only how-to-refer (website /
-    referral_instructions), so those rows live in the section. The provider
-    identity row links the program and its org. The intake's self-describing
-    profile (services / age groups / etc.) is no longer on the Program, so
-    it isn't rendered through this section."""
+    """Intake detail renders the program's how-to-refer context (website /
+    referral_instructions) in the body's "How to refer" section via
+    `program_facts`. The `connect-panel` is identity-only: the provider
+    links + the message form. The intake's self-describing profile
+    (services / age groups) renders in the body too."""
     # A verified viewer so the provider identity links render un-redacted.
     viewer_clinician = make_clinician_with_org(
         owner_id=logged_in_user.id, npi="1234567890"
@@ -1486,10 +1503,10 @@ async def test_intake_detail_renders_program_profile_section(
     assert response.status_code == 200
     tree = HTMLParser(response.text)
 
-    section = tree.css_first("section#provider-profile")
-    assert section is not None, "program owner-context section should render"
-    assert "About this provider" in section.text()
-    provider_dd = section.css_first('div[data-fact="provider"] dd')
+    panel = tree.css_first('article[data-row-id="connect-panel"]')
+    assert panel is not None, "program connect-with-provider card should render"
+    assert "Connect with the provider" in panel.text()
+    provider_dd = panel.css_first('div[data-fact="provider"] dd')
     assert provider_dd is not None, "provider identity row should render"
     assert (
         provider_dd.css_first(f"a[href='/programs/{program.id}']") is not None
@@ -1497,20 +1514,23 @@ async def test_intake_detail_renders_program_profile_section(
     assert (
         provider_dd.css_first(f"a[href='/organizations/{org.id}']") is not None
     ), "org name should link to the organization detail page"
-    # Steady-state context row lives inside the section (how-to-refer website).
+    # The panel is identity-only — the how-to-refer context is NOT in it.
+    assert panel.css_first('div[data-fact="website"]') is None
+    # Website renders in the body's "How to refer" section.
+    main = tree.css_first("div.post-detail-main")
+    assert main is not None
+    assert "How to refer" in main.text()
     assert (
-        section.css_first('div[data-fact="website"]') is not None
-    ), "website should render inside the provider-profile section"
-    assert "https://riseiop.example.com" in section.text()
+        main.css_first('div[data-fact="website"]') is not None
+    ), "website should render in the intake body"
+    assert "https://riseiop.example.com" in main.text()
     # The intake's own self-describing profile (services / cohort) renders
-    # in the grouped facts up top — NOT through the owner-context section.
-    # `_intake_post` seeds services=["therapy_group"], age_groups=[adolescents].
+    # in the body too. `_intake_post` seeds services=["therapy_group"],
+    # age_groups=[adolescents].
     for fact_key in ("services", "ages"):
-        row = tree.css_first(f'div[data-fact="{fact_key}"]')
-        assert row is not None, f"{fact_key} should render on the intake detail page"
         assert (
-            section.css_first(f'div[data-fact="{fact_key}"]') is None
-        ), f"{fact_key} is the post's own profile, not Program context"
+            main.css_first(f'div[data-fact="{fact_key}"]') is not None
+        ), f"{fact_key} should render in the intake body"
     assert "Therapy — Group" in tree.text()
 
 

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -188,6 +188,21 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
   .filter-form { display: none; }
 }
 
+/* ---- Post detail two-column layout --------------------------------------
+   The post's own facts fill the left 2/3; a "Connect with the provider"
+   card (provider meta + the message form) sits in the right 1/3 rail. On
+   narrow screens the rail stacks below the facts. */
+.post-detail-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+.post-detail-main { min-width: 0; }
+@media (max-width: 768px) {
+  .post-detail-grid { grid-template-columns: 1fr; }
+}
+
 /* ── Profile step cards ───────────────────────────────────────
    Verification step cards used on profile-adjacent surfaces.
    Status badges surface completion state; border-left accents mark

--- a/src/domain/templates/posts/_shared/_connect_panel.html
+++ b/src/domain/templates/posts/_shared/_connect_panel.html
@@ -1,0 +1,37 @@
+{# "Connect with the provider" panel — the right rail of the post detail
+   grid (`posts/detail.html`). One `<article>` that pairs the provider's
+   identity with the message form, so reaching the person behind a post is
+   a single self-contained unit on every kind.
+
+   Identity-only on EVERY kind: just the `provider` row + the message form.
+   The provider's practice context (location, insurance, languages,
+   how-to-refer) lives in the post body (`_provider_post_facts` for
+   openings/intakes, `_referral_facts` for referrals), so the seeking
+   (referral) and providing (opening/intake) detail pages stay symmetric —
+   the panel is purely the connection point.
+
+   Hand-rolls `<article>` + `<h2>` (allowlisted in
+   `template_component_check`) rather than composing `card()`: the `card`
+   macro's header is an `<h3>` list-item heading, and this detail-page
+   panel wants an `<h2>` section heading that sits level with the post's
+   own fact-group headings on the left.
+
+   Reads `view` / `post` / `can_act_as_provider` / `capabilities` from the
+   including context (detail.html). #}
+{%- from "_shared/sections.html" import fact, facts_block -%}
+{%- from "_shared/_provider_ref.html" import provider_ref -%}
+{%- from "_shared/_locked.html" import locked_action -%}
+<article data-row-id="connect-panel" data-kind="{{ post.kind }}">
+  <h2>Connect with the provider</h2>
+  {%- if view.provider_ref and (view.provider_ref.name or view.provider_ref.id) %}
+    {%- call facts_block() %}
+      {%- call fact('provider', 'Provider') %}{{ provider_ref(view.provider_ref, redacted=not can_act_as_provider) }}
+      {% endcall %}
+    {%- endcall %}
+  {%- endif %}
+  {% if can_act_as_provider %}
+    {% include "posts/_shared/_message_form.html" %}
+  {% else %}
+    {{ locked_action(capabilities.REASON_NOT_A_VERIFIED_PROVIDER, "Message", extra_class="secondary") }}
+  {% endif %}
+</article>

--- a/src/domain/templates/posts/_shared/_message_form.html
+++ b/src/domain/templates/posts/_shared/_message_form.html
@@ -14,20 +14,27 @@
 
    Gating: rendered only when the viewer clears `can_act_as_provider`
    (the post detail template applies the gate); the route handler
-   enforces the same predicate server-side. #}
+   enforces the same predicate server-side.
+
+   Lives inside the "Connect with the provider" card on the post detail
+   page (the card header carries the title), so this fragment is just the
+   message field + submit. #}
 <form id="post-message"
       hx-post="{{ entity_url(entity_name, id=post.id, subresource='message') }}"
       hx-target="this"
       hx-swap="outerHTML"
       hx-target-4xx="this"
       hx-ext="json-enc">
+  {# Empty `<label>` wrapper — no visible text (the card's "Connect with
+     the provider" heading is the field's context), but it keeps Pico's
+     label-wrapped field spacing. `aria-label` names it for screen readers. #}
   <label>
-    Message to the poster
     <textarea name="body"
               rows="5"
               maxlength="2000"
               required
-              placeholder="Introduce yourself and ask whatever you'd like — the poster will get your message by email and can reply to you directly."></textarea>
+              aria-label="Your message"
+              placeholder="Say hi and what you're hoping to connect about — a sentence or two is plenty. They'll receive it as an email and can reply straight to your inbox."></textarea>
   </label>
-  <button type="submit">Send message</button>
+  <button type="submit">Connect</button>
 </form>

--- a/src/domain/templates/posts/_shared/_provider_post_facts.html
+++ b/src/domain/templates/posts/_shared/_provider_post_facts.html
@@ -1,38 +1,69 @@
 {# Provider-post (clinician_opening + program_intake) DETAIL-page fact
-   display — grouped to mirror the create/edit form
-   (`_form_clinician_opening.html` / `_form_program_intake.html`).
+   display — the PROVIDING side of the network, structured to mirror the
+   SEEKING side (`_referral_facts.html`) so the two read as two halves of
+   one connection:
 
-   The post's own **self-describing** profile renders here; the
-   steady-state provider *context* (location, insurance, how-to-refer)
-   renders in the owner-context card in `posts/detail.html`. The read view
-   and the write view tell the same story in the same order — the form's
-   sections, in the form's order:
+     1. Logistics      — provider location + modality (the same
+                         `location_summary` row referrals use)
+     2. Service type   — services offered (+ "other" free text)
+     3. Clients served — the cohort (ages, genders) + languages spoken
+     4. About          — the announcement narrative
+     5. Coverage       — (opening) the affiliation's insurance posture
+        / How to refer    (intake) the program's website + how-to-refer
+     6. Availability   — schedule notes + cost (providing-only; no
+                         referral twin)
 
-     1. Service type    — services offered (+ "other" free text)
-     2. Clients served  — the cohort (ages, genders)
-     3. About           — the announcement narrative
-     4. Availability    — schedule notes + cost
+   The provider IDENTITY is not here — it lives in the "Connect with the
+   provider" panel (`_connect_panel.html`). Everything that describes the
+   practice itself (location, insurance, languages, how-to-refer) lives in
+   this body, leaving the panel as a pure connection point, symmetric with
+   the referral.
 
-   Delivery (in-person/virtual) is NOT a section here: it's shown in the
-   `.post-meta` modality chips above (and `location_summary` carries it on
-   the list card), so repeating it would be noise.
+   Steady-state practice context reads off the linked affiliation
+   (opening) or program (intake) via `post`; the announcement profile
+   (services / cohort / narrative / availability) reads off `view`.
+   `redacted` locks the location row for non-network viewers, same as the
+   referral's Logistics row.
 
    The sections live inside ONE `facts_grid()` so their key/value columns
-   align across every section (the read-side mirror of the form's single
-   aligned grid). Each section is a `fact_group("Title")` heading plus a
-   `fact_rows()` `<dl>`; a section with no values suppresses itself
-   (heading included) via the `{% if %}` guards.
-
-   No per-row icons: the section headings carry the organization.
-   Multi-value rows (services, ages, genders) stack one item per line via
-   `fact_list`. Reads from `view` (the `post_card_view` dict);
-   `CLIENT_AGE_GROUP_LABELS` / `GENDER_LABELS` are Jinja globals, and the
-   services row reuses `services_fact` so its priority-sort matches the
-   list card exactly. #}
+   align. Each is a `fact_group("Title")` heading + a `fact_rows()` `<dl>`;
+   a section with no values suppresses itself (heading included) via the
+   `{% if %}` guards. Multi-value rows (services, ages, genders, languages)
+   stack one item per line via `fact_list`. Display-label dicts
+   (`CLIENT_AGE_GROUP_LABELS`, `GENDER_LABELS`, `LANGUAGE_LABELS`) and
+   `location_summary` are Jinja globals; the services row reuses
+   `services_fact` so its priority-sort matches the list card exactly. #}
 {%- from "_shared/sections.html" import fact, fact_list, facts_grid, fact_group, fact_rows -%}
+{%- from "_shared/_affiliation_facts.html" import affiliation_facts -%}
+{%- from "_shared/_program_facts.html" import program_facts -%}
+{%- from "_shared/_locked.html" import locked_field -%}
 {%- from "posts/_shared/_facts_block.html" import services_fact -%}
-{% macro provider_post_facts(view) -%}
+{% macro provider_post_facts(view, post, redacted=False) -%}
+  {%- set ctx = namespace(aff=None, prog=None) -%}
+  {%- if view.kind == "clinician_opening" -%}
+    {%- set ctx.aff = post.opening_detail.clinician_affiliation -%}
+  {%- elif view.kind == "program_intake" -%}
+    {%- set ctx.prog = post.intake_detail.program -%}
+  {%- endif -%}
   {%- call facts_grid() %}
+    {%- set _location = location_summary(view) -%}
+    {%- if view.full_address or _location %}
+      {{ fact_group("Logistics") }}
+      {%- call fact_rows() %}
+        {#- One consolidated location row via the shared `location_summary`
+          global (state, then "In-person in <city>" and/or "Telehealth") —
+          the providing-side mirror of the referral's Logistics row, and
+          why the meta line no longer repeats the modality chips. Locked
+          for non-network viewers (the row still renders so they know a
+          location exists); `data-fact` stays `address`. -#}
+        {% if redacted %}
+          {%- call fact('address', 'Location') %}{{ locked_field(capabilities.REASON_NOT_A_VERIFIED_PROVIDER) }}
+          {% endcall %}
+        {% elif _location %}
+          {{ fact('address', 'Location', _location, icon='map-pin') }}
+        {% endif %}
+      {%- endcall %}
+    {%- endif %}
     {%- if view.services or view.services_other_text %}
       {{ fact_group("Service type") }}
       {%- call fact_rows() %}
@@ -42,7 +73,7 @@
         {%- endif %}
       {%- endcall %}
     {%- endif %}
-    {%- if view.ages or view.genders %}
+    {%- if view.ages or view.genders or view.languages or view.languages_other_text %}
       {{ fact_group("Clients served") }}
       {%- call fact_rows() %}
         {%- if view.ages %}
@@ -55,20 +86,46 @@
             {%- for g in view.genders -%}{%- set _ = _gs.append(GENDER_LABELS[g]) -%}{%- endfor -%}
               {{ fact_list('genders', 'Genders', _gs) }}
             {%- endif %}
-          {%- endcall %}
-        {%- endif %}
-        {%- if view.description %}
-          {{ fact_group("About") }}
-          {%- call fact_rows() %}
-            {{ fact('narrative', 'Narrative', view.description) }}
-          {%- endcall %}
-        {%- endif %}
-        {%- if view.schedule_text or view.cost %}
-          {{ fact_group("Availability") }}
-          {%- call fact_rows() %}
-            {%- if view.schedule_text %}{{ fact('schedule_notes', 'Schedule notes', view.schedule_text) }}{%- endif %}
-              {%- if view.cost %}{{ fact('cost', 'Cost', view.cost) }}{%- endif %}
-              {%- endcall %}
-            {%- endif %}
-          {%- endcall %}
-        {%- endmacro %}
+            {%- if view.languages %}
+              {%- set _langs = [] -%}
+              {%- for l in view.languages -%}{%- set _ = _langs.append(LANGUAGE_LABELS[l]) -%}{%- endfor -%}
+                {{ fact_list('languages', 'Languages', _langs) }}
+              {%- endif %}
+              {%- if view.languages_other_text %}
+                {{ fact('languages_other_text', 'Other language', view.languages_other_text) }}
+              {%- endif %}
+            {%- endcall %}
+          {%- endif %}
+          {%- if view.description %}
+            {{ fact_group("About") }}
+            {%- call fact_rows() %}
+              {{ fact('narrative', 'Narrative', view.description) }}
+            {%- endcall %}
+          {%- endif %}
+          {#- Steady-state practice context. Opening → the affiliation's insurance
+      posture under "Coverage" (mirrors the referral's Coverage), plus its
+      how-to-refer note. Intake → the program's website + how-to-refer (a
+      Program has no insurance) under "How to refer". -#}
+          {%- if ctx.aff and (ctx.aff.in_network_carriers or ctx.aff.accepts_out_of_network or ctx.aff.sliding_scale or ctx.aff.website or ctx.aff.referral_instructions) %}
+            {{ fact_group("Coverage") }}
+            {%- call fact_rows() %}
+              {{ affiliation_facts(ctx.aff) }}
+              {%- if ctx.aff.referral_instructions %}
+                {{ fact('referral_instructions', 'Referral instructions', ctx.aff.referral_instructions) }}
+              {%- endif %}
+            {%- endcall %}
+          {%- elif ctx.prog and (ctx.prog.website or ctx.prog.referral_instructions) %}
+            {{ fact_group("How to refer") }}
+            {%- call fact_rows() %}
+              {{ program_facts(ctx.prog) }}
+            {%- endcall %}
+          {%- endif %}
+          {%- if view.schedule_text or view.cost %}
+            {{ fact_group("Availability") }}
+            {%- call fact_rows() %}
+              {%- if view.schedule_text %}{{ fact('schedule_notes', 'Schedule notes', view.schedule_text) }}{%- endif %}
+                {%- if view.cost %}{{ fact('cost', 'Cost', view.cost) }}{%- endif %}
+                {%- endcall %}
+              {%- endif %}
+            {%- endcall %}
+          {%- endmacro %}

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -1,13 +1,7 @@
 {% extends "views/detail.html" %}
-{%- from "posts/_shared/_modality_chips.html" import modality_chips -%}
 {%- from "posts/_shared/_referral_facts.html" import referral_facts -%}
 {%- from "posts/_shared/_provider_post_facts.html" import provider_post_facts -%}
-{%- from "_shared/sections.html" import fact, fact_list, facts_grid, fact_group, fact_rows -%}
-{%- from "_shared/_affiliation_facts.html" import affiliation_facts -%}
-{%- from "_shared/_program_facts.html" import program_facts -%}
-{%- from "_shared/_provider_ref.html" import provider_ref -%}
 {%- from "_shared/_post_type_tag.html" import post_type_tag -%}
-{%- from "_shared/_locked.html" import locked_action, locked_field -%}
 {%- set view = post_card_view(post) -%}
 {% block resource_label %}Posts{% endblock %}
 {# The toolbar H1 is the kind-specific derived headline (demographics for
@@ -24,114 +18,35 @@
 {% block actions %}
   {% include "posts/_shared/_owner_actions.html" %}
 {% endblock %}
-{# Owner-context section — the steady-state profile of the provider behind
-   the post (the clinician + practice for an opening, the program for an
-   intake), rendered as an "About this provider" heading + fact rows below
-   the post's own facts (a sibling `facts_grid` section, same shape as the
-   post's own grouped facts — not a card). Referrals don't use this
-   section: their referring clinician is a linked `provider_ref` reference
-   in the meta line.
-
-   The identity row is the shared `provider_ref` denotation — the
-   canonical hyperlinked "<name> · <org>" the feed byline and form
-   pickers also use, so the format and the links live in one place. The
-   profile rows come from the shared `affiliation_facts` / `program_facts`
-   row sets (the same macros the practices list and program detail page
-   compose), so a profile fact renders identically on every surface and
-   is edited in exactly one place — the entity's own page. The `provider`
-   and `address` rows keep their `data-fact` keys and `redacted`
-   treatment: the row renders, the value is withheld via
-   `provider_ref`'s `locked_name` / `locked_field`. The address row reads
-   `view.owner_address` (the provider's address — distinct from
-   `view.full_address`, which is the client location for referrals). #}
-{%- macro owner_context(view, post, redacted) -%}
-  {%- set ctx = namespace(aff=None, prog=None) -%}
-  {%- if view.kind == "clinician_opening" -%}
-    {%- set ctx.aff = post.opening_detail.clinician_affiliation -%}
-  {%- elif view.kind == "program_intake" -%}
-    {%- set ctx.prog = post.intake_detail.program -%}
-  {%- endif -%}
-  {%- if view.kind in ("clinician_opening", "program_intake") and view.provider_ref and (view.provider_ref.name or view.provider_ref.id) -%}
-    {%- call facts_grid(id="provider-profile") %}
-      {{ fact_group("About this provider") }}
-      {%- call fact_rows() %}
-        {%- call fact('provider', 'Provider') %}{{ provider_ref(view.provider_ref, redacted=redacted) }}
-        {% endcall %}
-        {%- if view.owner_address %}
-          {% if redacted %}
-            {%- call fact('address', 'Address') %}{{ locked_field(capabilities.REASON_NOT_A_VERIFIED_PROVIDER) }}
-            {% endcall %}
-          {% else %}
-            {{ fact('address', 'Address', view.owner_address) }}
-          {% endif %}
+{# Detail-page layout — a two-column grid: the post's own grouped facts on
+   the left (referrals via `_referral_facts`, openings/intakes via
+   `_provider_post_facts`), and the "Connect with the provider" panel
+   (`_connect_panel.html`) on the right rail. Per-kind logic lives in
+   `post_card_view` (one place). #}
+{% block content %}
+  <section data-kind="{{ post.kind }}">
+    {# Identity line — just the type pill + date on every kind. Location +
+       modality now live in the body's Logistics section (both sides), and
+       the provider identity lives in the Connect panel, so the meta line
+       stays minimal. No `<small>` — `.post-meta` owns the muted treatment
+       via Pico's `--pico-muted-color`. #}
+    <section class="post-meta">
+      {{ post_type_tag(view.kind) }}
+      <span class="meta">
+        <span>{{ post.created_at | format_post_date }}</span>
+      </span>
+    </section>
+    <div class="post-detail-grid">
+      <div class="post-detail-main">
+        {%- if view.kind == "referral" %}
+          {{ referral_facts(view, redacted=not can_act_as_provider) }}
+        {%- else %}
+          {{ provider_post_facts(view, post, redacted=not can_act_as_provider) }}
         {%- endif %}
-        {%- if ctx.aff %}{{ affiliation_facts(ctx.aff) }}{%- endif %}
-          {%- if ctx.prog %}{{ program_facts(ctx.prog) }}{%- endif %}
-            {%- if view.languages %}
-              {%- set langs = [] -%}
-              {%- for l in view.languages -%}{%- set _ = langs.append(LANGUAGE_LABELS[l]) -%}{%- endfor -%}
-                {{ fact_list('languages', 'Languages', langs) }}
-              {%- endif %}
-              {%- if ctx.aff and ctx.aff.referral_instructions %}
-                {{ fact('referral_instructions', 'Referral instructions', ctx.aff.referral_instructions) }}
-              {%- endif %}
-            {%- endcall %}
-          {%- endcall %}
-        {%- endif -%}
-      {%- endmacro %}
-      {# Detail-page layout. Every kind leads with a grouped fact display
-   mirroring its create/edit form's sections: referrals via
-   `_referral_facts` (Logistics / Service type / About the client /
-   Coverage), openings + intakes via `_provider_post_facts` (Service type /
-   Clients served / About / Availability). For provider posts the
-   steady-state provider context (insurance, address, languages,
-   how-to-refer) then renders in the "About this provider" section; the
-   referral's referring clinician is the linked `provider_ref` in the meta
-   line, not an owner section. Per-kind logic lives in `post_card_view` (one place);
-   every visual element reads from `view` (plus the linked
-   affiliation/program model rows the owner-context macro renders
-   directly). #}
-      {% block content %}
-        <section data-kind="{{ post.kind }}">
-          {# Identity line — the detail-page counterpart to the feed row's
-             header, sharing the `post_type_tag` pill + `provider_ref`
-             byline. Type pill, then a `.meta` span (mid-dot-joined) of the
-             date plus, per kind, the referring clinician (referral) or the
-             modality chips (opening/intake). No `<small>` — `.post-meta`
-             owns the muted treatment via Pico's `--pico-muted-color`. #}
-          <section class="post-meta">
-            {{ post_type_tag(view.kind) }}
-            <span class="meta">
-              <span>{{ post.created_at | format_post_date }}</span>
-              {%- if view.kind == "referral" -%}
-                {%- if view.provider_ref and (view.provider_ref.name or view.provider_ref.id) -%}
-                  <span>Referred by {{ provider_ref(view.provider_ref, redacted=not can_act_as_provider) }}</span>
-                {%- endif -%}
-              {%- else -%}
-                {{ modality_chips(view.in_person, view.virtual) }}
-              {%- endif -%}
-            </span>
-          </section>
-          {%- if view.kind == "referral" %}
-            {# Referral leads with its Narrative section (inside
-                 `referral_facts`); the referring clinician is the linked
-                 reference in the `.post-meta` line above, not an owner section. #}
-            {{ referral_facts(view, redacted=not can_act_as_provider) }}
-          {%- else %}
-            {# The provider post's own self-describing profile (services /
-                 cohort / narrative / cost), grouped to mirror its form —
-                 then the steady-state provider context (insurance, address,
-                 languages, how-to-refer) in the "About this provider"
-                 section below. #}
-            {{ provider_post_facts(view) }}
-            {{ owner_context(view, post, redacted=not can_act_as_provider) }}
-          {%- endif %}
-          <footer>
-            {% if can_act_as_provider %}
-              {% include "posts/_shared/_message_form.html" %}
-            {% else %}
-              {{ locked_action(capabilities.REASON_NOT_A_VERIFIED_PROVIDER, "Message", extra_class="secondary") }}
-            {% endif %}
-          </footer>
-        </section>
-      {% endblock %}
+      </div>
+      {# Right rail: the "Connect with the provider" panel — the
+               provider's meta rows + the message form (or a locked CTA). #}
+      {% include "posts/_shared/_connect_panel.html" %}
+    </div>
+  </section>
+{% endblock %}

--- a/src/framework/templates/_shared/sections.html
+++ b/src/framework/templates/_shared/sections.html
@@ -75,12 +75,9 @@
      {% endcall %}
 
    A single ungrouped `facts_block()` doesn't need this — it's only for
-   splitting one aligned grid into titled sections.
-
-   `id` is optional: pass it when a caller needs a stable selector for the
-   whole panel (e.g. a detail-page section other templates/tests scope to). #}
-{% macro facts_grid(id=None) -%}
-  <section class="entity-facts facts-grid"{% if id %} id="{{ id }}"{% endif %}>
+   splitting one aligned grid into titled sections. #}
+{% macro facts_grid() -%}
+  <section class="entity-facts facts-grid">
     {{ caller() }}
   </section>
 {%- endmacro %}


### PR DESCRIPTION
## Summary

Restructures the post detail page into a two-column grid where the **seeking** (referral) and **providing** (opening/intake) sides mirror each other, and reduces the "Connect with the provider" panel to identity-only on every kind.

### Connect panel (`_connect_panel.html`, new)
- A right-rail `<article>` (h2 + provider identity row + message form), **identity-only** on every kind.
- Bespoke allowlisted partial because the `card` macro's header is an `<h3>` and this wants an `<h2>` section heading.

### Opening/intake body (`_provider_post_facts`) — mirrors the referral
- **Logistics** (new) — location + modality via the shared `location_summary` row.
- **Service type** — unchanged.
- **Clients served** — ages, genders, **+ languages** (moved out of the panel).
- **About** — narrative.
- **Coverage** (new, openings) — affiliation insurance posture + how-to-refer (moved out of the panel). Intakes get a **How to refer** section instead (a Program has no insurance).
- **Availability** — schedule, cost.

### Other
- Meta line is now type pill + date on **every** kind (modality → Logistics, provider → panel).
- Message form: **"Send message" → "Connect"**, dropped the visible label (empty `<label>` + `aria-label` keeps spacing/a11y), clearer placeholder that spells out the email reply flow.
- Two-column `.post-detail-grid` (2fr/1fr, stacks ≤768px).

## Test plan
- `dev test` — 2864 passed
- `dev test contract` — 41 passed
- `dev lint` — clean (incl. component check + allowlist pinning test)
- Verified in-browser on referral / opening / intake details at desktop + narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)