### PR TITLE
Guide capability setup with a next-step banner over the requirement tree

### DIFF
--- a/src/domain/routes/test_access.py
+++ b/src/domain/routes/test_access.py
@@ -102,6 +102,37 @@ async def test_capability_detail_shows_status(
     assert "Available" in response.text or "Not available yet" in response.text
 
 
+async def test_capability_detail_shows_next_step_banner(
+    authenticated_client: AsyncClient,
+):
+    """The detail page guides, not just explains: an email-verified
+    non-provider is at the identity step (2 of 2), offered as a choice
+    between verifying a clinician (default) or an organization — each a
+    link to its own fix route."""
+    response = await authenticated_client.get(
+        "/users/me/access/capabilities/provider-network"
+    )
+    assert response.status_code == 200
+    assert "Your next step" in response.text
+    assert "Step 2 of 2" in response.text
+    # Default branch + switchable alternative, each deep-linking its form.
+    assert "/clinicians/form" in response.text
+    assert "/organizations/form" in response.text
+
+
+async def test_capability_detail_granted_shows_done_banner(
+    superuser_client: AsyncClient,
+):
+    """When the capability is already granted, the banner confirms there's
+    nothing left to do rather than pointing at a next step."""
+    response = await superuser_client.get(
+        "/users/me/access/capabilities/provider-network"
+    )
+    assert response.status_code == 200
+    assert "Your next step" not in response.text
+    assert "nothing left to do" in response.text
+
+
 async def test_capability_detail_nonexistent_returns_404(
     authenticated_client: AsyncClient,
 ):

--- a/src/domain/templates/users/access/capabilities/detail.html
+++ b/src/domain/templates/users/access/capabilities/detail.html
@@ -2,6 +2,7 @@
 {%- from "_shared/_toolbar.html" import page_toolbar -%}
 {%- from "_shared/_breadcrumb.html" import breadcrumb -%}
 {%- from "_shared/_capability_requirements.html" import capability_requirements_panel -%}
+{%- from "_shared/_capability_next_step.html" import capability_next_step -%}
 {% block title %}{{ check.tree.label_active }}{% endblock %}
 {% block breadcrumb %}
   {{ breadcrumb([
@@ -16,8 +17,12 @@
   {% endcall %}
 {% endblock %}
 {% block content %}
-  {# The superuser override renders as an explicit "any one of these"
-     branch inside the tree (see `_superuser_gate`) — no out-of-band
-     bypass note needed. #}
+  {# The next-step banner *guides* (one action); the requirements panel
+     *explains* (the whole tree). Both read the same evaluated `check`,
+     so they can't disagree — the banner's CTA is always the tree's first
+     unmet, actionable leaf. The superuser override renders as an explicit
+     "any one of these" branch inside the tree (see `_superuser_gate`), and
+     surfaces as a granted "done" step — no out-of-band bypass note needed. #}
+  {{ capability_next_step(step) }}
   {{ capability_requirements_panel(check.tree, check.granted, check.description) }}
 {% endblock %}

--- a/src/framework/access/capabilities/capabilities.py
+++ b/src/framework/access/capabilities/capabilities.py
@@ -15,6 +15,14 @@ Two layers, in order:
    makes "which capabilities depend on leaf X" a one-liner instead of a
    grep.
 
+3. **Traversal** — `WizardStep` + `wizard_step(check)`. A pure projection
+   of an evaluated tree into "what should the user do next": the first
+   unmet requirement, or the open branches of an unmet `Gate` (a choice),
+   or done. This is what lets a capability page *guide* (one next action)
+   as well as *explain* (the whole requirement tree). It reads the same
+   `met`/`fix_url` the renderer uses, so guidance can't disagree with the
+   tree.
+
 Domain code:
 - Registers each `Leaf` once with its labels, fix URL, and a predicate.
 - Builds capability `check_*` functions whose trees compose registered
@@ -100,6 +108,123 @@ class CapabilityCheck:
     @property
     def granted(self) -> bool:
         return self.tree.met
+
+
+@dataclass(frozen=True)
+class WizardStep:
+    """The user's current position walking a capability tree toward granted.
+
+    Produced by `wizard_step(check)` — a pure projection of an evaluated
+    `CapabilityCheck` into "what to do next", rendered as a single
+    call-to-action above the full requirement tree.
+
+    `kind`:
+      - ``"done"`` — the capability is granted; `options` is empty.
+      - ``"condition"`` — one actionable requirement is next; `options`
+        holds exactly that `Condition` (its `fix_url` is the CTA).
+      - ``"choice"`` — the next unmet requirement is an OR (`Gate`) with
+        more than one open branch; `options` holds one representative
+        `Condition` per open branch, `options[0]` being the default and
+        the rest offered as "or do this instead" switches.
+      - ``"blocked"`` — ungranted but nothing open is self-serviceable
+        (every unmet leaf lacks a `fix_url`); `options` is empty. Not
+        reachable for user-facing capabilities today (the only
+        fix-URL-less leaf is `superuser`, whose gate is always met when
+        present), but the walker reports it honestly rather than "done".
+
+    `index`/`total` place the step among the root's direct requirements
+    ("step 2 of 2") for a progress rail; both are 1 for a single-node or
+    root-`Gate` tree.
+    """
+
+    kind: str
+    options: tuple[Condition, ...]
+    index: int
+    total: int
+
+    @property
+    def primary(self) -> Condition | None:
+        """The default action — `options[0]`, or `None` when done/blocked."""
+        return self.options[0] if self.options else None
+
+    @property
+    def alternatives(self) -> tuple[Condition, ...]:
+        """Non-default choice branches (empty unless `kind == "choice"`)."""
+        return self.options[1:]
+
+    @property
+    def is_choice(self) -> bool:
+        return self.kind == "choice"
+
+    @property
+    def done(self) -> bool:
+        return self.kind == "done"
+
+
+def _unmet_children(node: Any) -> tuple:
+    return tuple(c for c in node.children if not c.met)
+
+
+def _representative(node: Any) -> Condition | None:
+    """The first self-serviceable `Condition` in `node`'s unmet subtree,
+    following the default (first-unmet) branch at each level, or `None`
+    if the subtree is met or has no leaf carrying a `fix_url`."""
+    if node.met:
+        return None
+    if isinstance(node, Condition):
+        return node if node.fix_url else None
+    for child in _unmet_children(node):
+        rep = _representative(child)
+        if rep is not None:
+            return rep
+    return None
+
+
+def _actionable(node: Any) -> tuple[Condition, ...]:
+    """The actionable option(s) at `node`'s current step: one `Condition`
+    for a `Bundle`/`Condition` (its first unmet, self-serviceable
+    requirement), or one representative per open branch of an unmet
+    `Gate` (the choice). Empty when met or wholly non-actionable."""
+    if node.met:
+        return ()
+    if isinstance(node, Condition):
+        return (node,) if node.fix_url else ()
+    if isinstance(node, Gate):
+        return tuple(rep for c in _unmet_children(node) if (rep := _representative(c)))
+    # Bundle (AND): advance into the first unmet child.
+    return _actionable(_unmet_children(node)[0])
+
+
+def _progress(tree: Any) -> tuple[int, int]:
+    """Position among the root's direct requirements as `(index, total)`,
+    1-based. `total` is the count of top-level requirements (root
+    `Bundle` children, else 1); `index` is the first unmet one, clamped
+    to `total` once all are met."""
+    children = getattr(tree, "children", None)
+    if not children or isinstance(tree, Gate):
+        return (1, 1)
+    total = len(children)
+    met = sum(1 for c in children if c.met)
+    return (min(met + 1, total), total)
+
+
+def wizard_step(check: CapabilityCheck) -> WizardStep:
+    """Walk an evaluated capability tree to the user's next action.
+
+    Pure projection over `check.tree` — see `WizardStep` for the return
+    shape. Superuser overrides need no special-casing: the override is
+    modeled in-tree as a met `Gate` branch, so a granted superuser
+    reports ``"done"`` like anyone else.
+    """
+    tree = check.tree
+    index, total = _progress(tree)
+    if check.granted:
+        return WizardStep(kind="done", options=(), index=total, total=total)
+    options = _actionable(tree)
+    if not options:
+        return WizardStep(kind="blocked", options=(), index=index, total=total)
+    kind = "choice" if len(options) > 1 else "condition"
+    return WizardStep(kind=kind, options=options, index=index, total=total)
 
 
 @dataclass(frozen=True)
@@ -243,7 +368,8 @@ def mount_capability_routes(
     Template context keys:
       - index: ``capabilities_url``
       - list: ``checks`` (dict[str, CapabilityCheck]), ``capability_base_url``, ``access_index_url``
-      - detail: ``check`` (CapabilityCheck), ``access_index_url``, ``capabilities_url``
+      - detail: ``check`` (CapabilityCheck), ``step`` (WizardStep — the
+        guided next action for `check`), ``access_index_url``, ``capabilities_url``
     """
     _access_index_url = str(router.prefix)
     _capability_base_url = f"{router.prefix}/capabilities"
@@ -301,6 +427,7 @@ def mount_capability_routes(
             template_name=detail_template,
             context={
                 "check": check,
+                "step": wizard_step(check),
                 "access_index_url": _access_index_url,
                 "capabilities_url": _capability_base_url,
             },

--- a/src/framework/access/capabilities/test_capabilities.py
+++ b/src/framework/access/capabilities/test_capabilities.py
@@ -16,6 +16,8 @@ from src.framework.access.capabilities.capabilities import (
     Gate,
     Leaf,
     LeafRegistry,
+    WizardStep,
+    wizard_step,
 )
 
 
@@ -344,3 +346,131 @@ def test_registry_all_snapshot_unaffected_by_later_register():
     reg.register(_leaf(name="b"))
     assert len(early) == 1
     assert len(reg.all()) == 2
+
+
+# ---------- wizard_step traversal ------------------------------------------
+
+
+def _cond(label: str, *, met: bool, fix_url: str = "/fix") -> Condition:
+    return Condition(label_active=label, label_done=label, met=met, fix_url=fix_url)
+
+
+def _check(tree) -> CapabilityCheck:
+    return CapabilityCheck(name="cap", tree=tree)
+
+
+def test_wizard_step_granted_is_done():
+    tree = Bundle(label_active="b", label_done="b", children=(_met(), _met()))
+    step = wizard_step(_check(tree))
+    assert step.kind == "done"
+    assert step.done is True
+    assert step.primary is None
+    assert step.options == ()
+
+
+def test_wizard_step_first_unmet_condition_is_the_step():
+    """A `Bundle` reports its first unmet child as the next action, and
+    positions it in the rail."""
+    email = _cond("email", met=False, fix_url="/email")
+    identity = _cond("identity", met=False, fix_url="/identity")
+    step = wizard_step(
+        _check(Bundle(label_active="b", label_done="b", children=(email, identity)))
+    )
+    assert step.kind == "condition"
+    assert step.primary is email
+    assert step.alternatives == ()
+    assert (step.index, step.total) == (1, 2)
+
+
+def test_wizard_step_advances_past_met_children():
+    """Once the first requirement is met, the walker moves to the next
+    unmet one and the rail index advances."""
+    email = _cond("email", met=True, fix_url="/email")
+    identity = _cond("identity", met=False, fix_url="/identity")
+    step = wizard_step(
+        _check(Bundle(label_active="b", label_done="b", children=(email, identity)))
+    )
+    assert step.kind == "condition"
+    assert step.primary is identity
+    assert (step.index, step.total) == (2, 2)
+
+
+def test_wizard_step_unmet_gate_is_a_choice():
+    """An unmet `Gate` with more than one open branch is a choice: the
+    first branch is the default, the rest are switchable alternatives."""
+    clinician = _cond("clinician", met=False, fix_url="/clinicians/form")
+    org = _cond("org", met=False, fix_url="/organizations/form")
+    gate = Gate(label_active="g", label_done="g", children=(clinician, org))
+    step = wizard_step(_check(gate))
+    assert step.kind == "choice"
+    assert step.is_choice is True
+    assert step.primary is clinician
+    assert step.alternatives == (org,)
+    assert step.options == (clinician, org)
+
+
+def test_wizard_step_provider_network_shape_offers_the_identity_choice():
+    """The real provider-network shape: email AND (clinician OR org).
+    With email met, the next step is the clinician/org choice at rail
+    position 2 of 2."""
+    email = _cond("email", met=True, fix_url="/email")
+    clinician = _cond("clinician", met=False, fix_url="/clinicians/form")
+    org = _cond("org", met=False, fix_url="/organizations/form")
+    gate = Gate(label_active="g", label_done="g", children=(clinician, org))
+    tree = Bundle(label_active="b", label_done="b", children=(email, gate))
+    step = wizard_step(_check(tree))
+    assert step.kind == "choice"
+    assert step.options == (clinician, org)
+    assert (step.index, step.total) == (2, 2)
+
+
+def test_wizard_step_choice_skips_non_actionable_branch():
+    """A branch whose only unmet leaf has no `fix_url` isn't offered — so
+    a two-branch gate with one dead branch collapses to a single
+    actionable condition, not a choice."""
+    dead = _cond("superuser", met=False, fix_url="")
+    org = _cond("org", met=False, fix_url="/organizations/form")
+    gate = Gate(label_active="g", label_done="g", children=(dead, org))
+    step = wizard_step(_check(gate))
+    assert step.kind == "condition"
+    assert step.options == (org,)
+
+
+def test_wizard_step_choice_descends_nested_branch_to_representative():
+    """A gate branch that is itself a `Bundle` surfaces its first unmet,
+    actionable leaf as that branch's representative option."""
+    inner = Bundle(
+        label_active="inner",
+        label_done="inner",
+        children=(_cond("a", met=True), _cond("b", met=False, fix_url="/b")),
+    )
+    org = _cond("org", met=False, fix_url="/organizations/form")
+    gate = Gate(label_active="g", label_done="g", children=(inner, org))
+    step = wizard_step(_check(gate))
+    assert step.kind == "choice"
+    assert [c.fix_url for c in step.options] == ["/b", "/organizations/form"]
+
+
+def test_wizard_step_blocked_when_nothing_is_self_serviceable():
+    """Ungranted but every open leaf lacks a fix URL — reported as
+    ``blocked``, never a lying ``done``."""
+    tree = Bundle(
+        label_active="b",
+        label_done="b",
+        children=(_cond("superuser", met=False, fix_url=""),),
+    )
+    step = wizard_step(_check(tree))
+    assert step.kind == "blocked"
+    assert step.options == ()
+    assert step.done is False
+
+
+def test_wizard_step_single_condition_tree_is_one_of_one():
+    step = wizard_step(_check(_cond("solo", met=False, fix_url="/solo")))
+    assert step.kind == "condition"
+    assert (step.index, step.total) == (1, 1)
+
+
+def test_wizard_step_returns_wizard_step_type():
+    step = wizard_step(_check(_cond("solo", met=True)))
+    assert isinstance(step, WizardStep)

--- a/src/framework/templates/_shared/_capability_next_step.html
+++ b/src/framework/templates/_shared/_capability_next_step.html
@@ -1,0 +1,51 @@
+{# Capability next-step guidance banner.
+
+   Renders the `WizardStep` produced by `wizard_step(check)` as a single
+   call-to-action above the requirement tree, so a capability page
+   *guides* (one next action) as well as *explains* (the whole tree).
+
+   Usage: {{ capability_next_step(step) }}
+     step — a `WizardStep` (see
+            `framework/access/capabilities/capabilities.py`):
+            `.kind`, `.primary`, `.alternatives`, `.index`, `.total`.
+
+   By `kind`:
+     - done      — a positive confirmation; the tree below shows the met
+                   requirements.
+     - condition — the one next action as a primary link (its `fix_url`).
+     - choice    — the default branch as the primary link, plus each
+                   alternative as an "or" switch to its own `fix_url`.
+     - blocked   — an honest "nothing to do here yourself" note (not
+                   reachable for user-facing capabilities today). #}
+{% from "_shared/icon_label.html" import icon_label %}
+{% macro capability_next_step(step) %}
+  {% if step.done %}
+    <article data-state="unlocked">
+      <p>{{ icon_label('check', 'You have this capability — nothing left to do.') }}</p>
+    </article>
+  {% elif step.kind == "blocked" %}
+    <article data-state="locked">
+      <p>{{ icon_label('lock', 'This capability is granted by an administrator; there are no self-serve steps.') }}</p>
+    </article>
+  {% else %}
+    <article data-state="locked">
+      <header>
+        <hgroup>
+          <h3>Your next step</h3>
+          <p>Step {{ step.index }} of {{ step.total }}</p>
+        </hgroup>
+      </header>
+      <p>
+        <a href="{{ step.primary.fix_url }}" role="button">{{ step.primary.label_active }}</a>
+      </p>
+      {% if step.is_choice %}
+        <p>
+          <small>or</small>
+          {% for alt in step.alternatives %}
+            <a href="{{ alt.fix_url }}" role="button" class="secondary outline">{{ alt.label_active }}</a>
+          {% endfor %}
+        </p>
+      {% endif %}
+    </article>
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
## What

The capability detail page (`/users/me/access/capabilities/{name}`) showed the full requirement graph but did nothing to **guide** the user through satisfying it. This adds a guided next-step banner above the existing tree.

## How

- **`wizard_step(check)`** (framework, `access/capabilities/capabilities.py`) — a pure general walker over an evaluated `CapabilityCheck.tree`, projecting it into `WizardStep`:
  - `condition` — the first unmet actionable leaf (its `fix_url` is the CTA)
  - `choice` — an unmet `Gate` with >1 open branch: default (`options[0]`) + switchable alternatives
  - `done` — granted (superuser overrides fold in via the in-tree Gate)
  - `blocked` — ungranted but nothing self-serviceable (honest, not a lying "done")
  - plus `index`/`total` for a "step N of M" rail
- **`_capability_next_step.html`** (framework `_shared`) renders the banner; the domain `detail.html` leads with it, then the existing requirements panel. Both read the same `check`, so guidance can't disagree with the tree.

For **provider-network** this surfaces *Verify your email* → then a *clinician-or-organization* choice (clinician default, org as an "or" switch), each deep-linking its own form.

## Design notes

- **Tree walker, not a parallel step-registry.** The tree stays the single source of truth (the old `/profile` step-wizard and its `OnboardingStep` tuple were deliberately removed in #1189; this doesn't reintroduce that).
- **Advance = recompute from live state**, so the email step (which completes out-of-band via the inbox link) works without a POST/303 completion endpoint.
- Auto-advance return-threading through the shared fix routes (`?flow=`) was intentionally scoped out — the page recomputes on return, which already covers the out-of-band email step.

## Tests

- `test_capabilities.py` — 11 walker cases (done/condition/choice/blocked, rail index/total, nested-branch representative, non-actionable branch skipped).
- `test_access.py` — end-to-end renders: choice banner (2 of 2, both fix links) for an email-verified non-provider; done banner for a granted superuser.
- Full suite (2897) + contract (41) + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)