### PR TITLE
Simplify the "someone messaged you" email

### DIFF
--- a/src/domain/logic/posts/emails.py
+++ b/src/domain/logic/posts/emails.py
@@ -15,6 +15,7 @@ in one place per email type.
 
 from __future__ import annotations
 
+from src.domain.logic.posts.view import post_feed_headline
 from src.domain.models import Post, User
 from src.framework.config import settings
 from src.framework.email import send_email
@@ -46,14 +47,15 @@ async def send_post_message_email(*, post: Post, sender: User, body: str) -> Non
     no-reply mailbox.
 
     Sender identity in the body is `sender.username` (display name —
-    the email address is in the headers, not duplicated in the body
-    prose). The link back to the post lets the poster re-anchor on
-    what was being asked about.
+    the reply address lives on the `Reply-To:` header, not in the body
+    prose). The post's derived headline (`post_feed_headline`) is the
+    hyperlinked subject line so the poster can re-anchor on what's being
+    asked about in one click.
     """
     post_url = _absolute_url(f"/posts/{post.id}")
     context = {
         "sender_username": sender.username,
-        "sender_email": sender.email,
+        "post_headline": post_feed_headline(post),
         "body": body,
         "post_url": post_url,
     }

--- a/src/domain/logic/posts/test_emails.py
+++ b/src/domain/logic/posts/test_emails.py
@@ -16,12 +16,18 @@ import pytest
 from src.domain.logic.posts.emails import send_post_message_email
 
 
-def _post(owner_email: str = "poster@example.com"):
+def _post(owner_email: str = "poster@example.com", headline: str = "Sunrise Program"):
     """Minimal stand-in for a `Post` row — only the fields the email
-    module reads. `SimpleNamespace` keeps the test off the DB."""
+    module reads. `SimpleNamespace` keeps the test off the DB.
+
+    Shaped as a `program_intake` so the real `post_feed_headline`
+    derives the subject line from the linked program's name — that value
+    becomes the hyperlinked headline in the email."""
     return SimpleNamespace(
         id=uuid.uuid4(),
         owner=SimpleNamespace(email=owner_email),
+        kind="program_intake",
+        intake_detail=SimpleNamespace(program=SimpleNamespace(name=headline)),
     )
 
 
@@ -104,9 +110,9 @@ async def test_body_is_html_escaped_in_html_part(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_email_includes_absolute_post_url(monkeypatch):
-    """The "View the post" link must be absolute (`APP_BASE_URL` +
-    `/posts/{id}`) — email clients can't resolve relative paths since
-    they aren't running in the request scope."""
+    """The post link (hyperlinked from the headline) must be absolute
+    (`APP_BASE_URL` + `/posts/{id}`) — email clients can't resolve
+    relative paths since they aren't running in the request scope."""
     monkeypatch.setattr(
         "src.domain.logic.posts.emails.settings.APP_BASE_URL",
         "https://app.example.com",
@@ -124,11 +130,10 @@ async def test_email_includes_absolute_post_url(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_sender_username_and_email_surface_in_body(monkeypatch):
-    """Both display name (`username`) and the actual reply address
-    (`email`) appear in body prose — the recipient should be able to
-    read the message on a client that hides `Reply-To` and still know
-    who to write back to and at what address."""
+async def test_sender_username_surfaces_in_body(monkeypatch):
+    """The sender's display name (`username`) names who's reaching out
+    and who to reply to. The reply address itself lives only on the
+    `Reply-To:` header, not in the body prose."""
     send_email_mock = AsyncMock()
     monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
 
@@ -138,9 +143,31 @@ async def test_sender_username_and_email_surface_in_body(monkeypatch):
         body="hi",
     )
 
-    text = send_email_mock.call_args.kwargs["text"]
-    assert "alice" in text
-    assert "alice@example.com" in text
+    kwargs = send_email_mock.call_args.kwargs
+    assert "alice" in kwargs["text"]
+    assert "alice" in kwargs["html"]
+    assert "alice@example.com" not in kwargs["text"]
+    assert "alice@example.com" not in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_post_headline_is_the_hyperlinked_subject(monkeypatch):
+    """The post's derived headline (`post_feed_headline`) is the subject
+    line and is hyperlinked to the post in the HTML part."""
+    monkeypatch.setattr(
+        "src.domain.logic.posts.emails.settings.APP_BASE_URL",
+        "https://app.example.com",
+    )
+    send_email_mock = AsyncMock()
+    monkeypatch.setattr("src.domain.logic.posts.emails.send_email", send_email_mock)
+
+    post = _post(headline="Sunrise Program")
+    await send_post_message_email(post=post, sender=_sender(), body="hi")
+
+    kwargs = send_email_mock.call_args.kwargs
+    post_url = f"https://app.example.com/posts/{post.id}"
+    assert "Sunrise Program" in kwargs["text"]
+    assert f'<a href="{post_url}">Sunrise Program</a>' in kwargs["html"]
 
 
 @pytest.mark.asyncio

--- a/src/domain/templates/emails/post_message.html
+++ b/src/domain/templates/emails/post_message.html
@@ -5,7 +5,10 @@
                max-width: 560px;
                margin: 2rem auto;
                line-height: 1.5">
-    <p>{{ sender_username }} sent you a message about your post on Bedlam Connect.</p>
+    <p>
+      {{ sender_username }} is reaching out regarding your post about
+      <a href="{{ post_url }}">{{ post_headline }}</a>.
+    </p>
     <blockquote style="border-left: 3px solid #ccc;
                        margin: 1rem 0;
                        padding: 0.25rem 0 0.25rem 1rem;
@@ -13,13 +16,6 @@
                        white-space: pre-wrap">
       {{ body }}
     </blockquote>
-    <p>
-      Reply directly to this email to respond to {{ sender_username }} at
-      <a href="mailto:{{ sender_email }}">{{ sender_email }}</a>.
-    </p>
-    <p>
-      <a href="{{ post_url }}">View the post</a>
-    </p>
-    <p>— Bedlam Connect</p>
+    <p>Reply directly to this email to respond to {{ sender_username }}.</p>
   </body>
 </html>

--- a/src/domain/templates/emails/post_message.txt
+++ b/src/domain/templates/emails/post_message.txt
@@ -1,11 +1,7 @@
-{{ sender_username }} sent you a message about your post on Bedlam Connect.
+{{ sender_username }} is reaching out regarding your post about {{ post_headline }} ({{ post_url }}).
 
 ---
 {{ body }}
 ---
 
-Reply directly to this email to respond to {{ sender_username }} at {{ sender_email }}.
-
-View the post: {{ post_url }}
-
-— Bedlam Connect
+Reply directly to this email to respond to {{ sender_username }}.


### PR DESCRIPTION
Reduces the post-message email to three beats and nothing else:

- **Who's reaching out** — with the post's derived headline (`post_feed_headline`) as a hyperlinked subject line, replacing the old "sent you a message on Bedlam Connect" opener and the separate "View the post" link.
- **The sender's message**.
- **A one-line reply prompt** — "Reply directly to this email to respond to …". The reply address stays on the `Reply-To:` header (load-bearing) and is no longer duplicated in the body prose. The "— Bedlam Connect" signature is dropped.

### Rendered

```
Dr. Jane Rivera is reaching out regarding your post about Sunrise Program.
  ┃ Hi — I have an adult client who'd be a great fit for your intake...
Reply directly to this email to respond to Dr. Jane Rivera.
```

`send_post_message_email` now supplies `post_headline` and no longer passes `sender_email` into the template context.

### Testing
- `dev test` — 2899 passed
- `dev test contract` — 41 passed
- `dev lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)