### PR TITLE
Hide the "Connect with the provider" panel on your own post

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -450,6 +450,38 @@ async def test_edit_form_route_works_for_each_kind(
     assert response.status_code == 200
 
 
+# --- Connect panel visibility: hidden on your own post -------------------
+
+
+@pytest.mark.parametrize("kind,builder", _KINDS)
+async def test_connect_panel_hidden_on_own_post(
+    kind: str,
+    builder,
+    authenticated_client: AsyncClient,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+    logged_in_user,
+):
+    """The "Connect with the provider" panel is meaningless when the
+    viewer IS the provider — it's hidden on a post the viewer owns
+    (`is_self`) and shown on someone else's post."""
+    mine = builder(owner_id=logged_in_user.id)
+    other_owner = create_test_user(username=f"other-{uuid.uuid4()}")
+    theirs = builder(owner_id=other_owner.id)
+    async with db_test_session_manager() as session:
+        async with session.begin():
+            session.add(other_owner)
+            session.add(mine)
+            session.add(theirs)
+
+    own = await authenticated_client.get(f"/posts/{mine.id}")
+    assert own.status_code == 200
+    assert HTMLParser(own.text).css_first('[data-row-id="connect-panel"]') is None
+
+    other = await authenticated_client.get(f"/posts/{theirs.id}")
+    assert other.status_code == 200
+    assert HTMLParser(other.text).css_first('[data-row-id="connect-panel"]') is not None
+
+
 # --- Referral detail: grouped fact display (mirrors the create/edit form) -
 #
 # These pin the read-side / write-side parity introduced when the

--- a/src/domain/templates/posts/detail.html
+++ b/src/domain/templates/posts/detail.html
@@ -42,8 +42,12 @@
         {%- endif %}
       </div>
       {# Right rail: the "Connect with the provider" panel — the
-               provider's meta rows + the message form (or a locked CTA). #}
-      {% include "posts/_shared/_connect_panel.html" %}
+               provider's meta rows + the message form (or a locked CTA).
+               Hidden on your own post (`is_self`): connecting with the
+               provider is meaningless when you ARE the provider. #}
+      {% if not is_self %}
+        {% include "posts/_shared/_connect_panel.html" %}
+      {% endif %}
     </div>
   </section>
 {% endblock %}

--- a/src/framework/dispatch/mounts/README.md
+++ b/src/framework/dispatch/mounts/README.md
@@ -66,6 +66,29 @@ Shared infrastructure:
   emits the same shape via a different code path because its parent
   row is the requesting user with no PK lookup.
 
+## Detail context: viewer flags
+
+`handle_detail` (in `detail.py`) merges three viewer-derived booleans
+into every detail render's template context. They answer different
+questions — pick by intent, don't reach for the closest one:
+
+- `is_self` — the viewer **is** the subject. `target.<owner_attr> ==
+  viewer.id` (for `owner_attr=None`, the row IS the user, so
+  `target.id == viewer.id`). Use to hide/show something that only makes
+  sense toward *other* people — e.g. a post's "Connect with the
+  provider" panel is gated on `not is_self`, since connecting with
+  yourself is meaningless.
+- `can_edit` — the viewer **may write** the target, via
+  `spec.can_write` (typically `is_owner_or_admin`): owner **or** admin.
+  Gates edit/delete affordances. Broader than `is_self` — an admin
+  passes `can_edit` on someone else's row.
+- `can_admin_actions` — `is_admin(viewer) and not is_self`. Admin
+  affordances the viewer shouldn't aim at their own row.
+
+The uniform `owner_attr` rule (`spec.owner_attr or "id"`) lets every
+entity inherit these without per-entity glue; `test_detail.py` pins
+the `owner_attr`-set vs. `owner_attr=None` cases.
+
 ## Dependency direction
 
 `_spec.py` is the leaf — nothing in this package imports from a verb


### PR DESCRIPTION
## What

On a post detail page, the "Connect with the provider" panel is now hidden when the viewer owns the post. Connecting with the provider is meaningless when you *are* the provider.

## How

Gated the `_connect_panel.html` include in `posts/detail.html` on `not is_self` — the owner-vs-viewer flag `handle_detail` already computes (`target.owner_id == viewer.id`). No backend change; reuses the existing detail-context flag rather than introducing a new owner check in the template.

- `is_self` is the right flag (strict owner check), not `can_edit` — an **admin** viewing someone else's post still sees the panel, matching "belongs to them."

## Tests

- `test_connect_panel_hidden_on_own_post` (parametrized over both post kinds) asserts `[data-row-id="connect-panel"]` is absent on your own post and present on someone else's.
- `dev test`, `dev lint`, and `dev test contract` all green.

## Docs

Added a "Detail context: viewer flags" section to `src/framework/dispatch/mounts/README.md` documenting `is_self` / `can_edit` / `can_admin_actions` so the next author picks by intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)