### PR TITLE
Fix posts feed horizontal overflow on mobile

### DIFF
--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -115,6 +115,17 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Same `min-width: 0` escape hatch, one level up, for the ≤640px mobile
+   collapse. There the framework flips `dl > div` from `display: contents`
+   to `display: block` (facts stack dt-over-dd), so the wrapper <div> — not
+   the <dd> — becomes the grid item. Its default `min-width: auto` measures
+   the nowrap <dd> inside at full length, blowing the `1fr` track (and the
+   whole feed) past the viewport. Zero it so the track collapses and the
+   <dd> above truncates instead. Harmless above 640px, where the <div> is
+   `display: contents` and has no box to size. */
+.post-feed-row .entity-facts dl > div {
+  min-width: 0;
+}
 /* Header line — pill · timestamp (pushed to opposite ends) */
 .post-feed-header {
   display: flex;
@@ -181,9 +192,14 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .browse-results { flex: 1 1 0; min-width: 0; }
 
 /* Narrow: hide the filter sidebar entirely (filters are reached via the
-   in-results filter link), and drop the inline form. */
+   in-results filter link), and drop the inline form. `align-items: stretch`
+   overrides the base `flex-start`: once the layout stacks into a column,
+   cross-axis alignment governs child *width*, and `flex-start` would size
+   `.browse-results` to its max-content (the full untruncated feed) instead
+   of the viewport — pushing the page into a horizontal scroll. Stretching
+   pins it to the container so `min-width: 0` can do its job. */
 @media (max-width: 640px) {
-  .browse-layout { flex-direction: column; }
+  .browse-layout { flex-direction: column; align-items: stretch; }
   .filter-sidebar { display: none; }
   .filter-form { display: none; }
 }


### PR DESCRIPTION
## What

On small screens (≤640px) the `/posts` feed overflowed the viewport horizontally — the whole results column ballooned to its max-content width and the page scrolled sideways.

## Why

Two compounding bugs, both in the mobile branch of the browse layout, both in `domain.css`:

1. **`.browse-layout` never stretches in column mode.** The `@media (max-width: 640px)` rule flips it to `flex-direction: column` but left the base `align-items: flex-start`. In a column flexbox the cross axis is *width*, so `flex-start` sized `.browse-results` to its max-content (the full untruncated feed) instead of the container. → `align-items: stretch`.

2. **The fact-row `div` grid item can't shrink.** The framework's mobile fact-collapse flips `dl > div` from `display: contents` to `display: block`, making each `div[data-fact]` the grid item. Its default `min-width: auto` measured the `white-space: nowrap` `<dd>` inside at full length, blowing the `1fr` track (and the feed) past the viewport. The existing `min-width: 0` sat on the `<dd>` — no longer the grid item on mobile. → add `min-width: 0` on the wrapper `<div>`.

## Verification

Reproduced and fixed in a real browser (Playwright) at 320 / 375 / 1200px:
- ≤640px: `document.scrollWidth == viewport`, zero overflowing elements, fact values truncate with an ellipsis, sidebar hidden.
- Desktop (1200px): two-column layout unchanged (220px sidebar + flexible results).

No test added: this is a CSS-property-only change with no markup/logic surface, and the repo has no visual/CSS test harness (contract tests are Pact-based, no stylelint). The inline comments in `domain.css` are the doc-of-record and were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)