### PR TITLE
Add Edit/Clear filters actions to the list results summary

### DIFF
--- a/src/domain/routes/test_posts.py
+++ b/src/domain/routes/test_posts.py
@@ -348,17 +348,23 @@ async def test_list_filter_summary_reads_active_filter_count(
     logged_in_user,
 ):
     """The results column opens with a summary header. Filtering by kind makes
-    it read "Showing results with 1 filter", where the count links to the
-    dedicated search page carrying the live query string."""
+    it read "Showing results with 1 filter." followed by "Edit filters" (to the
+    dedicated search page carrying the live query string) and "Clear filters"
+    (back to the bare list path) actions."""
     response = await authenticated_client.get("/posts?kind=referral")
     assert response.status_code == 200
     summary = HTMLParser(response.text).css_first(".browse-results > header")
     assert summary is not None
     assert "Showing results with" in summary.text()
-    link = summary.css_first("a")
-    assert link is not None
-    assert link.text(strip=True) == "1 filter"
-    assert (link.attributes.get("href") or "").startswith("/posts/search")
+    assert "1 filter" in summary.text()
+    actions = summary.css_first("menu.filter-summary-actions")
+    assert actions is not None
+    links = {
+        a.text(strip=True): a.attributes.get("href") or "" for a in actions.css("a")
+    }
+    assert set(links) == {"Edit filters", "Clear filters"}
+    assert links["Edit filters"].startswith("/posts/search")
+    assert links["Clear filters"] == "/posts"
 
 
 # --- List filter: ?owner=me scopes to the viewer's own posts -------------

--- a/src/domain/static/css/domain.css
+++ b/src/domain/static/css/domain.css
@@ -191,8 +191,13 @@ ul.post-feed-list > li { list-style: none; padding: 0; }
 .filter-sidebar { flex: 0 0 220px; min-width: 0; }
 .browse-results { flex: 1 1 0; min-width: 0; }
 
+/* The results-summary actions ("Edit filters" → the full-page search,
+   "Clear filters" → the bare list path) sit in a row beneath the
+   "Showing results with N filters" line. */
+.filter-summary-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+
 /* Narrow: hide the filter sidebar entirely (filters are reached via the
-   in-results filter link), and drop the inline form. `align-items: stretch`
+   in-results "Edit filters" action), and drop the inline form. `align-items: stretch`
    overrides the base `flex-start`: once the layout stacks into a column,
    cross-axis alignment governs child *width*, and `flex-start` would size
    `.browse-results` to its max-content (the full untruncated feed) instead

--- a/src/framework/templates/test_views.py
+++ b/src/framework/templates/test_views.py
@@ -212,12 +212,17 @@ def test_list_view_never_renders_filter_link_in_toolbar() -> None:
     assert sidebar.css_first("header h2") is None
     summary = tree.css_first(".browse-results > header")
     assert summary is not None
-    # With one active filter, the count ("1 filter") is the link to search.
-    summary_link = summary.css_first("a")
-    assert summary_link is not None
-    assert summary_link.attributes.get("href") == "/clinicians/search?kind=x"
-    assert summary_link.text(strip=True) == "1 filter"
+    # The count is plain text ("1 filter"); the links live in the actions menu.
     assert "Showing results with" in summary.text()
+    assert "1 filter" in summary.text()
+    actions = summary.css_first("menu.filter-summary-actions")
+    assert actions is not None
+    hrefs = [a.attributes.get("href") for a in actions.css("a")]
+    labels = [a.text(strip=True) for a in actions.css("a")]
+    assert labels == ["Edit filters", "Clear filters"]
+    # "Edit filters" opens the full-page search carrying the live query string;
+    # "Clear filters" drops back to the bare list path.
+    assert hrefs == ["/clinicians/search?kind=x", "/"]
 
 
 def test_filter_summary_reads_all_results_when_no_active_filters() -> None:
@@ -251,7 +256,8 @@ def test_filter_summary_reads_all_results_when_no_active_filters() -> None:
     assert summary is not None
     label = summary.css_first("p")
     assert label is not None and label.text(strip=True) == "Showing all results."
-    # No filters active → no count link to the search page.
+    # No filters active → nothing to edit or clear, so no actions menu / links.
+    assert summary.css_first("menu.filter-summary-actions") is None
     assert summary.css_first("a") is None
 
 

--- a/src/framework/templates/views/list.html
+++ b/src/framework/templates/views/list.html
@@ -38,9 +38,10 @@ headings). An accordion renders `open` when its filter is in a dirty
 (active) state — i.e. `filter_values` holds a non-empty value for it — so
 applied filters stay visible on reload. The results column opens with a plain `<header>` that states
 whether the result set is filtered: "Showing all results." when nothing is
-active, else "Showing results with <N filters>" where the count links to the
-dedicated `/<collection>/search` page (mounted automatically whenever
-`filters` is declared) for refining them. Entities with no declared filters
+active, else "Showing results with <N filters>." followed by an "Edit filters"
+link (to the dedicated `/<collection>/search` page, mounted automatically
+whenever `filters` is declared) and a "Clear filters" link (back to the bare
+list path). Entities with no declared filters
 render `list_body` full-width without any sidebar and have no filter UI at
 all.
 
@@ -87,7 +88,8 @@ Child contract:
     active_filter_count, filter_heading, search_url. The sidebar
     form consumes `filters` / `filter_values`; the results-column
     summary `<header>` consumes `active_filter_count` /
-    `search_url`; `pager` is read inside the `item_list` macro.
+    `search_url` (the "Edit filters" link) and `request.url.path`
+    (the "Clear filters" link); `pager` is read inside the `item_list` macro.
     (`active_filters` / `filter_heading` are injected for any
     template that wants them but are not used by this view.)
 
@@ -160,17 +162,29 @@ Child contract:
       <div class="browse-results">
         {#- Filter summary — states what the results column is showing. With
             no active filter it reads "Showing all results."; with one or more,
-            it reads "Showing results with <N filters>", where the count is the
-            link to the dedicated `/<collection>/search` page for refining them.
-            Only `active_filter_count` is rendered (the per-value descriptor
-            pills were dropped); `search_url` is set whenever filters exist. -#}
+            it reads "Showing results with <N filters>." followed by two action
+            links: "Edit filters" opens the dedicated `/<collection>/search` page
+            (carrying the live query string via `search_url`) to refine them, and
+            "Clear filters" links back to the bare list path to drop every active
+            filter. Both actions render only when filters are active — there is
+            nothing to edit or clear otherwise. Only `active_filter_count` is
+            rendered as text (the per-value descriptor pills were dropped);
+            `search_url` is set whenever filters exist. -#}
         {%- if search_url is defined and search_url %}
           <header>
             {%- if active_filter_count is defined and active_filter_count %}
               <p>
                 Showing results with
-                <a href="{{ search_url }}">{{ active_filter_count }} filter{{ "" if active_filter_count == 1 else "s" }}</a>.
+                {{ active_filter_count }} filter{{ "" if active_filter_count == 1 else "s" }}.
               </p>
+              <menu class="filter-summary-actions">
+                <li>
+                  <a href="{{ search_url }}" role="button" class="secondary outline">Edit filters</a>
+                </li>
+                <li>
+                  <a href="{{ request.url.path }}" role="button" class="secondary outline">Clear filters</a>
+                </li>
+              </menu>
             {%- else %}
               <p>Showing all results.</p>
             {%- endif %}


### PR DESCRIPTION
## What

On browse-layout list pages, the results-column summary header previously read *"Showing results with N filters"* where only the count linked to the full-page `/<collection>/search` page. This adds two explicit, named actions beneath that line:

- **Edit filters** → the dedicated `/<collection>/search` page, carrying the live query string (the "full page view of the filters we already have").
- **Clear filters** → the bare list path, dropping every active filter.

Both render only when filters are active — there's nothing to edit or clear otherwise. The count is now plain text; the affordances are the named links.

This also preserves the mobile affordance: the narrow-viewport media query hides the filter sidebar and relies on the in-results link to reach filters — now the explicit "Edit filters" action.

## Changed

- `src/framework/templates/views/list.html` — markup + doc-comment.
- `src/domain/static/css/domain.css` — `.filter-summary-actions` row layout.
- Tests: `src/framework/templates/test_views.py`, `src/domain/routes/test_posts.py` updated to pin the new structure (count-as-text + Edit/Clear links, and absence of the menu when no filters active).

## Verification

`dev lint`, full `src/` suite (2636 passed), and contract tests (41 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)