### PR TITLE
Gitignore runtime artifact dirs data/ and .playwright-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,10 @@ dmypy.json
 bedlam-connect.db
 test_bedlam-connect.db
 
+# Runtime artifacts
+data/
+.playwright-mcp/
+
 */**/log
 */**/artifacts
 *.log


### PR DESCRIPTION
Both directories are runtime-generated — `data/` holds the local SQLite DB, `.playwright-mcp/` holds Playwright MCP console logs. They were untracked but unignored, so they showed up as noise in `git status` and were one `git add .` away from being committed.

First PR of a small repo-reorganization sequence (docs reduction and credential/routes regrouping follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rWwmp19QhhZf6JpT6y5Xs