### PR TITLE
Build /admin/audit — paginated audit log viewer for superusers

### DIFF
--- a/src/domain/routes/README.md
+++ b/src/domain/routes/README.md
@@ -37,6 +37,7 @@ The grammar fits resource-shaped CRUD. These stay hand-written. A hand-written *
 | `POST/DELETE /users/me/favorites/{clinician_id}` | `favorites.py` | M:N edge add/remove toggle via `mount_edge_routes` (no `list_handler` → no list page; favorited clinicians are browsed via `/clinicians?favorited=me`). |
 | `GET /users/me/access`, `GET /users/me/access/capabilities/{name}` | `access.py` | Derived read view — capability posture, no stored row. |
 | `GET /users/me/email/form` | `user_email.py` | Email field-cluster subresource form — self-only; surfaces verification status, hosts the unverified-viewer / post-resend inbox CTA, and the resend-verification action. |
+| `GET /admin/audit` | `admin.py` | Derived read view over the framework-owned audit log — superuser-only, paginated, no stored resource. |
 | `GET /`, `GET /health` | `../../main.py` | Utility endpoints. |
 
 ## Tests

--- a/src/domain/routes/admin.py
+++ b/src/domain/routes/admin.py
@@ -1,0 +1,47 @@
+"""Bespoke read-only route for the `/admin/audit` page.
+
+    GET /admin/audit    paginated audit log, superusers only
+
+Derived read view over the framework-owned `audit_log` table — no
+stored admin resource, no writes, no `EntitySpec` (the audit log has no
+owner filter or CRUD face, so a bespoke handler is simpler than
+spec-driven mounting). `current_admin_user` 403s any non-superuser
+before the handler runs.
+
+Follows the bespoke-route pattern documented in
+`src/domain/routes/README.md § Bespoke routes`.
+"""
+
+from fastapi import APIRouter, Depends, Request
+
+from src.auth_config import current_admin_user
+from src.domain.models import User
+from src.framework.audit.repository import AuditRepository
+from src.framework.dispatch.pagination import offset_for, paginate, parse_page
+from src.framework.http.responses import APIResponse
+from src.framework.persistence.dependencies import get_audit_repository
+
+admin_router = APIRouter(prefix="/admin", tags=["admin"])
+
+# Denser than DEFAULT_PAGE_SIZE (15): audit rows are one-line log
+# entries scanned in bulk, not cards browsed one at a time.
+AUDIT_PAGE_SIZE = 50
+
+
+@admin_router.get("/audit", name="admin:audit")
+async def get_audit_log(
+    request: Request,
+    requesting_user: User = Depends(current_admin_user),
+    audit_repo: AuditRepository = Depends(get_audit_repository),
+):
+    page = parse_page(request)
+    rows = await audit_repo.list_all(
+        offset=offset_for(page, AUDIT_PAGE_SIZE), limit=AUDIT_PAGE_SIZE + 1
+    )
+    rows, page_meta = paginate(rows, page=page, per_page=AUDIT_PAGE_SIZE)
+    return APIResponse.html_response(
+        template_name="admin/audit.html",
+        context={"rows": rows, "page_meta": page_meta},
+        request=request,
+        current_user=requesting_user,
+    )

--- a/src/domain/routes/test_admin.py
+++ b/src/domain/routes/test_admin.py
@@ -1,0 +1,115 @@
+"""Tests for `GET /admin/audit` — the superuser-only audit log viewer.
+
+Pins the auth ladder (anonymous → login, non-admin → 403, admin → 200),
+the newest-first row rendering, and the `?page=` pagination seam.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from selectolax.parser import HTMLParser
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.domain.models import User
+from src.framework.audit.repository import AuditRepository
+from tests.helpers import promote_to_admin
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _record_rows(
+    db_test_session_manager: async_sessionmaker[AsyncSession], n: int
+) -> None:
+    """Seed n system-actor rows with distinct, ascending `created_at`.
+
+    `created_at`'s server default has second resolution on SQLite, so
+    same-second rows order arbitrarily (stable `id` tie-break only) —
+    explicit timestamps make newest-first assertable."""
+    base = datetime.now(timezone.utc) - timedelta(hours=1)
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        for i in range(n):
+            row = await repo.record(
+                actor_id=None,
+                resource_type="post",
+                resource_id=uuid.uuid4(),
+                action=f"test_action_{i}",
+                after={"marker": i},
+            )
+            row.created_at = base + timedelta(seconds=i)
+        await session.commit()
+
+
+async def test_anonymous_gets_401_and_browser_redirects_to_login(
+    test_client: AsyncClient,
+):
+    """API-shaped requests get the raw 401; browser-shaped requests ride
+    the global 401 handler to `/auth/login?next=...`."""
+    response = await test_client.get("/admin/audit")
+    assert response.status_code == 401
+
+    response = await test_client.get("/admin/audit", headers={"accept": "text/html"})
+    assert response.status_code == 302
+    assert response.headers["location"] == "/auth/login?next=/admin/audit"
+
+
+async def test_non_superuser_gets_403(authenticated_client: AsyncClient):
+    """`current_admin_user` rejects a regular signed-in user before the
+    handler runs — no audit data leaks to non-admins."""
+    response = await authenticated_client.get("/admin/audit")
+    assert response.status_code == 403
+
+
+async def test_superuser_sees_rows_newest_first(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await _record_rows(db_test_session_manager, 3)
+
+    response = await authenticated_client.get("/admin/audit")
+    assert response.status_code == 200
+
+    tree = HTMLParser(response.text)
+    actions = [c.text(strip=True) for c in tree.css("#audit-list td code")]
+    # Our three rows render newest-first. The fixture user's own
+    # registration may also have audit rows, so assert relative order
+    # of the seeded markers rather than an exact full-table match.
+    seeded = [a for a in actions if a.startswith("test_action_")]
+    assert seeded == ["test_action_2", "test_action_1", "test_action_0"]
+    # The system-actor rows render the "system" placeholder.
+    assert "system" in response.text
+
+
+async def test_pagination_slices_pages(
+    authenticated_client: AsyncClient,
+    logged_in_user: User,
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """With more rows than one page holds, page 1 links to page 2 and
+    page 2 holds the remainder — the `+1` probe / `paginate` seam wired
+    through `AUDIT_PAGE_SIZE`."""
+    from src.domain.routes.admin import AUDIT_PAGE_SIZE
+
+    await promote_to_admin(db_test_session_manager, logged_in_user.email)
+    await _record_rows(db_test_session_manager, AUDIT_PAGE_SIZE + 1)
+
+    response = await authenticated_client.get("/admin/audit")
+    assert response.status_code == 200
+    page_one = HTMLParser(response.text)
+    assert len(page_one.css("#audit-list tbody tr")) == AUDIT_PAGE_SIZE
+    next_link = page_one.css_first('.pagination-nav a[rel="next"]')
+    assert next_link is not None
+    assert next_link.attributes.get("href") == "?page=2"
+
+    response = await authenticated_client.get("/admin/audit?page=2")
+    assert response.status_code == 200
+    page_two = HTMLParser(response.text)
+    # The remainder: our +1 row plus whatever fixture-registration rows
+    # spilled over — a non-empty, less-than-full page.
+    remainder = page_two.css("#audit-list tbody tr")
+    assert 0 < len(remainder) < AUDIT_PAGE_SIZE
+    assert page_two.css_first('.pagination-nav a[rel="prev"]') is not None

--- a/src/domain/templates/admin/audit.html
+++ b/src/domain/templates/admin/audit.html
@@ -1,0 +1,61 @@
+{# `/admin/audit` — read-only, superuser-only audit log viewer.
+   Plain table, not cards: audit rows are one-line log entries scanned
+   in bulk. Resource cells are text, not links — `resource_type` spans
+   spec-less types (e.g. job rows), so there is no URL to resolve.
+#}
+{% extends "views/list.html" %}
+{%- from "_shared/pagination.html" import pagination -%}
+{% block resource_label %}Audit log{% endblock %}
+{% block list_body %}
+  <section id="audit-list">
+    {% if rows %}
+      <div class="overflow-auto">
+        <table>
+          <thead>
+            <tr>
+              <th>When</th>
+              <th>Actor</th>
+              <th>Action</th>
+              <th>Resource</th>
+              <th>Changes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in rows %}
+              <tr>
+                <td>
+                  <time datetime="{{ row.created_at.isoformat() }}">
+                    {{ row.created_at.strftime("%Y-%m-%d %H:%M") }}
+                  </time>
+                </td>
+                <td>{{ row.actor_id or "system" }}</td>
+                <td>
+                  <code>{{ row.action }}</code>
+                </td>
+                <td>{{ row.resource_type }} {{ row.resource_id | string | truncate(8, True, '') }}</td>
+                <td>
+                  {% if row.before and row.after %}
+                    {% for key in row.after %}
+                      {% if row.before.get(key) != row.after[key] %}
+                        <div>
+                          <strong>{{ key }}</strong>: {{ row.before.get(key) }} → {{ row.after[key] }}
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  {% elif row.after %}
+                    <em>created</em>
+                  {% elif row.before %}
+                    <em>deleted</em>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <p>No audit rows yet.</p>
+    {% endif %}
+  </section>
+  {{ pagination(page_meta) }}
+{% endblock %}

--- a/src/framework/audit/README.md
+++ b/src/framework/audit/README.md
@@ -28,7 +28,7 @@ The discipline check accepts any of the three. If a handler `commit`s without on
 
 - `core.py` — `AuditAction` enum, `AuditedResource` / `EdgeAudit` dataclasses, `record_audit`, `record_audit_for`, the `mutate(...)` context manager, `make_audited_resource(...)` factory, `make_snapshotter(...)`.
 - `log.py` — the `AuditLog` SQLAlchemy model (append-only; FK to `users.id` with `SET NULL`; `(resource_type, resource_id)` lookups).
-- `repository.py` — `AuditRepository`, deliberately exposing only writes + read-by-id. No `update_*` / `delete_*` — audit rows are immutable.
+- `repository.py` — `AuditRepository`, deliberately exposing only writes + reads (`list_for_resource`, the newest-first `list_all` behind the superuser-only `/admin/audit` viewer in `src/domain/routes/admin.py`). No `update_*` / `delete_*` — audit rows are immutable.
 
 ## System actor
 

--- a/src/framework/audit/repository.py
+++ b/src/framework/audit/repository.py
@@ -1,6 +1,6 @@
 """Append-only data access for the audit log per `RESOURCE_GRAMMAR.md:135`.
 
-Deliberately exposes only writes and read-by-id — there is no `update_*` or
+Deliberately exposes only writes and reads — there is no `update_*` or
 `delete_*`. Audit rows are immutable; the discipline relies on it.
 """
 
@@ -51,4 +51,15 @@ class AuditRepository(BaseRepository):
                 AuditLog.resource_id == resource_id,
             )
             .order_by(AuditLog.created_at.asc())
+        )
+
+    async def list_all(self, *, offset: int = 0, limit: int = 50) -> Sequence[AuditLog]:
+        """Newest-first page across all resources — the `/admin/audit`
+        read path. `created_at` has second resolution, so same-second
+        rows tie-break on `id` to keep pagination stable."""
+        return await self._list(
+            select(AuditLog)
+            .order_by(AuditLog.created_at.desc(), AuditLog.id.desc())
+            .offset(offset)
+            .limit(limit)
         )

--- a/src/framework/audit/test_repository.py
+++ b/src/framework/audit/test_repository.py
@@ -212,3 +212,47 @@ async def test_actor_set_null_when_user_deleted(
         fetched = await repo.get_by_model_id(AuditLog, written.id)
         assert fetched is not None  # row not deleted
         assert fetched.actor_id is None  # actor reference nulled
+
+
+async def test_list_all_pages_newest_first(
+    db_test_session_manager: async_sessionmaker[AsyncSession],
+):
+    """`list_all` is the `/admin/audit` read path: newest-first across
+    every resource type, offset/limit paging, same-second rows kept in
+    a stable order by the `id` tie-break."""
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+        written_ids = []
+        for i in range(5):
+            row = await repo.record(
+                actor_id=None,
+                resource_type="post" if i % 2 else "user",
+                resource_id=uuid.uuid4(),
+                action=f"action_{i}",
+            )
+            written_ids.append(row.id)
+        await session.commit()
+
+    async with db_test_session_manager() as session:
+        repo = AuditRepository(session)
+
+        rows = await repo.list_all(limit=50)
+        assert len(rows) == 5
+        # Newest first; the five writes share a created_at second, so
+        # ordering falls to the id tie-break — descending and stable.
+        assert [r.created_at for r in rows] == sorted(
+            (r.created_at for r in rows), reverse=True
+        )
+        assert {r.id for r in rows} == set(written_ids)
+        # Spans resource types — no implicit filter.
+        assert {r.resource_type for r in rows} == {"post", "user"}
+
+        # Offset/limit slice consecutive pages without overlap or gaps.
+        first_page = await repo.list_all(offset=0, limit=3)
+        second_page = await repo.list_all(offset=3, limit=3)
+        assert len(first_page) == 3
+        assert len(second_page) == 2
+        assert {r.id for r in first_page} | {r.id for r in second_page} == set(
+            written_ids
+        )
+        assert {r.id for r in first_page} & {r.id for r in second_page} == set()

--- a/src/framework/templates/_shared/_page_header.html
+++ b/src/framework/templates/_shared/_page_header.html
@@ -84,6 +84,11 @@ and the constant-boundary rationale (one source of truth).
                   <a href="{{ entity_url('user', id='me') }}"
                      {% if _on_users_me %}aria-current="page"{% endif %}>Account</a>
                 </li>
+                {% if is_admin %}
+                  <li>
+                    <a href="/admin/audit">Audit log</a>
+                  </li>
+                {% endif %}
                 <li>
                   <a href="#" hx-post="/auth/sign-out">Sign out</a>
                 </li>

--- a/src/framework/templates/test_page_header.py
+++ b/src/framework/templates/test_page_header.py
@@ -234,9 +234,11 @@ def test_authenticated_nav_has_post_link_and_avatar_dropdown() -> None:
 
 
 def test_avatar_menu_items_are_my_posts_account_sign_out() -> None:
-    """The profile dropdown's items are exactly My posts (→ the viewer's own
-    posts via `?owner=me`), Account (→ the self user page), and Sign out
-    (`hx-post`). "Saved" is deferred and must not appear."""
+    """For a non-admin viewer the profile dropdown's items are exactly
+    My posts (→ the viewer's own posts via `?owner=me`), Account (→ the
+    self user page), and Sign out (`hx-post`). "Saved" is deferred and
+    must not appear. Admins get one extra item — see
+    `test_avatar_menu_shows_audit_log_for_admins_only`."""
     env = _make_env()
     _add_child(env, "detailstub.html", _DETAIL_STUB)
     tree = HTMLParser(_render(env, "detailstub.html", **_AUTHED_CTX))
@@ -254,6 +256,26 @@ def test_avatar_menu_items_are_my_posts_account_sign_out() -> None:
     assert by_label["My posts"].attributes.get("href") == "/posts?owner=me"
     assert by_label["Account"].attributes.get("href") == "/users/me"
     assert by_label["Sign out"].attributes.get("hx-post") == "/auth/sign-out"
+
+
+def test_avatar_menu_shows_audit_log_for_admins_only() -> None:
+    """Superusers get an Audit log item (→ `/admin/audit`) between
+    Account and Sign out. The gate is the `is_admin` chrome scalar from
+    `base_context`, which a handler cannot override — so the item can
+    never render for a non-admin (whose exact item set is pinned by
+    `test_avatar_menu_items_are_my_posts_account_sign_out`)."""
+    env = _make_env()
+    _add_child(env, "detailstub.html", _DETAIL_STUB)
+    tree = HTMLParser(_render(env, "detailstub.html", is_admin=True, **_AUTHED_CTX))
+
+    menu = tree.css_first("details.dropdown#nav-menu")
+    assert menu is not None
+    items = menu.css("ul li a")
+    labels = [a.text(strip=True) for a in items]
+    assert labels == ["My posts", "Account", "Audit log", "Sign out"]
+
+    by_label = {a.text(strip=True): a for a in items}
+    assert by_label["Audit log"].attributes.get("href") == "/admin/audit"
 
 
 def test_anonymous_nav_is_brand_only() -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.domain.logic.users.schema import UserRead
 from src.domain.logic.users.view import onboarding_readiness
 from src.domain.routes import (
     access,
+    admin,
     user_email,
     verifications,
 )
@@ -223,6 +224,7 @@ app.include_router(
 app.include_router(verifications.verifications_api_router)
 app.include_router(access.access_router)
 app.include_router(user_email.user_email_router)
+app.include_router(admin.admin_router)
 
 # Every entity route file calls `register_entity(SPEC)` at import time
 # (see `src/framework/dispatch/registry.py`). The package import above


### PR DESCRIPTION
Closes #765.

Read-only page at `/admin/audit` over the framework-owned `audit_log` table: newest-first, 50 rows per page through the existing `+1`-probe pagination seam, gated by `current_admin_user` (403 for signed-in non-superusers; anonymous browser requests ride the global 401 handler to `/auth/login?next=/admin/audit`). Bespoke route per the routes README table — the audit log has no `EntitySpec`, owner filter, or CRUD face, so spec-driven mounting buys nothing.

- `AuditRepository.list_all` — newest-first with an `id` tie-break so same-second rows paginate stably (`created_at`'s server default has second resolution on SQLite).
- `admin/audit.html` — plain table under `views/list.html` chrome, changed-keys diff cell with created/deleted fallbacks; resource cells are text, not links, since `resource_type` spans spec-less types.
- Avatar menu gains an "Audit log" item gated on the `is_admin` chrome scalar from `base_context`, which handlers can't override; the non-admin menu's exact item set stays pinned by the existing template test.

Deliberately skipped from the issue sketch (simplicity): the `AuditLogRead` schema (nothing consumes it — the page renders ORM rows) and `count_all` (the pagination framework uses the `+1` probe, not counts).

Tests: auth ladder (401/302, 403, 200), newest-first rendering, `?page=2` slicing, `list_all` ordering/paging, admin-menu variant. Full suite 2916 passed, contract 41 passed, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rWwmp19QhhZf6JpT6y5Xs